### PR TITLE
fix(garuda): pin the assignee-enumeration contract — no second normalization in SQL

### DIFF
--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -239,7 +239,7 @@ def include_routers(api: FastAPI) -> None:
 
     from backend.app.routers import garuda_assignment_targets
 
-    api.include_router(garuda_assignment_targets.router)  # GET /api/crm/garuda/assignment-targets — the staff surface's assignee picker, kept CRM-side of the frozen /api/visa/voa contract prefix; same actor resolution and admin test as assignPractice
+    api.include_router(garuda_assignment_targets.router)  # GARUDA assignee picker (CRM-side)
 
     # CRM routers
     api.include_router(crm_clients.router)
@@ -701,7 +701,7 @@ def include_light_routers(api: FastAPI) -> None:
 
     from backend.app.routers import garuda_assignment_targets
 
-    api.include_router(garuda_assignment_targets.router)  # GET /api/crm/garuda/assignment-targets — the staff surface's assignee picker, kept CRM-side of the frozen /api/visa/voa contract prefix; same actor resolution and admin test as assignPractice
+    api.include_router(garuda_assignment_targets.router)  # GARUDA assignee picker (CRM-side)
 
     # Genome-backed registries (light: SQLite via cell-core, no ML deps)
     api.include_router(experience.router)  # [EXP] Experience Library (PR #54)

--- a/apps/backend-rag/backend/services/garuda_portal/assignment_targets.py
+++ b/apps/backend-rag/backend/services/garuda_portal/assignment_targets.py
@@ -42,14 +42,25 @@ non-client rows against 525 active ``client`` rows, per the census above), on a
 response the UI holds for 5 minutes. Cheap enough not to need a cache of its
 own, and no cache means no second place to invalidate.
 
+Admins are candidates whatever their role says.
+`is_valid_garuda_assignment_target` accepts an email in
+`staff_auth.garuda_practice_admin_emails()` BEFORE it reads any role or any
+row, so a role-only prefilter silently drops accepted targets: an ACTIVE admin
+row whose role is ``client`` or ``monitoring``, and any row whose role is NULL —
+where SQL's three-valued `role <> ALL(...)` is UNKNOWN and `WHERE` discards it.
+`_CANDIDATE_SQL` therefore carries an `OR LOWER(email) = ANY($2)` arm fed from
+that accessor: the set is READ, never restated, and the decision still belongs
+to the validator, which every surviving row is put through. (Codex Gear-2 grade
+of 0ead993f3b1b, finding 1 MEDIUM — the first candidate query had no such arm
+and dropped exactly those rows.)
+
 Known boundary, stated rather than left silent: candidates come from
-`team_members`, so an email in `staff_auth._garuda_practice_admin_emails()`
-that has NO active row there is accepted by the validator but not offered here.
-The census shows every admin-class role (``founder``, ``ceo``, ``board member``)
-holding an active row, so the set is empty today; widening the candidate query
-to union the admin constant would mean either importing that private helper or
-restating it — a second copy of a policy set, which is the exact drift this
-module exists to avoid.
+`team_members`, so an admin email with NO active row there is accepted by the
+validator but not offered here — there is no name to show and no row to order
+by. The census shows every admin-class role (``founder``, ``ceo``, ``board
+member``) holding an active row, so that set is empty today, and
+`test_admin_boundary_is_the_documented_one` pins the behaviour instead of
+leaving it to chance.
 """
 
 from __future__ import annotations
@@ -59,24 +70,38 @@ from typing import Any
 import asyncpg
 
 from backend.app.utils.service_accounts import non_human_roles_sql_array
-from backend.services.garuda_portal.staff_auth import is_valid_garuda_assignment_target
+from backend.services.garuda_portal.staff_auth import (
+    garuda_practice_admin_emails,
+    is_valid_garuda_assignment_target,
+)
 
 __all__ = ["list_garuda_assignment_targets"]
 
-#: PERFORMANCE PREFILTER, never the authority. `NON_HUMAN_ROLES`
-#: ({``client``, ``monitoring``}) is a subset of everything
-#: `is_valid_garuda_assignment_target` refuses — both roles are in
+#: PERFORMANCE PREFILTER, never the authority — and safe only because it has
+#: TWO arms. `NON_HUMAN_ROLES` ({``client``, ``monitoring``}) is a subset of
+#: what `is_valid_garuda_assignment_target` refuses BY ROLE (both are in
 #: `NON_TEAM_ROLES` today, and neither is a team role under the census
-#: allow-list PR #5817 introduces — so dropping them here cannot drop a row the
-#: validator would accept. It exists because `team_members` holds 525 active
-#: `client` rows next to ~25 staff rows, and asking the validator about a
-#: client is a wasted query. The validator still sees every remaining row and
-#: is still the only thing that decides.
+#: allow-list PR #5817 introduces), but that validator accepts an admin email
+#: BEFORE reading any role. So arm 1 alone would drop accepted rows — an active
+#: admin whose role is ``client``/``monitoring``, and any NULL role, where
+#: `role <> ALL(...)` is UNKNOWN — and arm 2 (`OR LOWER(email) = ANY($2)`, fed
+#: from `staff_auth.garuda_practice_admin_emails()`) keeps exactly those. What
+#: the two arms together exclude is therefore only what the validator refuses
+#: for the same reason; every surviving row is still put through the validator,
+#: which remains the only thing that decides.
+#:
+#: The prefilter exists because `team_members` holds 525 active ``client`` rows
+#: next to ~25 staff rows (read-only census 2026-09-06), and each candidate costs
+#: one round-trip through the Fly proxy: asking the validator about a client is
+#: a wasted query. Note the comparison is SQL's, on the RAW role value — a
+#: ``'Client'`` or ``'client '`` row stays a candidate and is refused later by
+#: the validator's own `normalize_role`. Over-inclusion is safe here by design;
+#: under-inclusion is the bug arm 2 closes.
 _CANDIDATE_SQL = """
     SELECT email, name, full_name, role
       FROM team_members
      WHERE active = TRUE
-       AND role <> ALL($1::text[])
+       AND (role <> ALL($1::text[]) OR LOWER(email) = ANY($2::text[]))
      ORDER BY name ASC
 """
 
@@ -102,7 +127,11 @@ async def list_garuda_assignment_targets(conn: asyncpg.Connection) -> list[dict[
     person picking one, and picking wrong assigns a practice to the wrong
     colleague.
     """
-    rows = await conn.fetch(_CANDIDATE_SQL, non_human_roles_sql_array())
+    # The admin set is read at CALL time and never cached here, so the candidate
+    # query and the validator's own admin shortcut cannot disagree about who is
+    # an admin — one source, read twice per request, same answer.
+    admin_emails = sorted(garuda_practice_admin_emails())
+    rows = await conn.fetch(_CANDIDATE_SQL, non_human_roles_sql_array(), admin_emails)
 
     accepted: list[tuple[str, str]] = []
     seen: set[str] = set()

--- a/apps/backend-rag/backend/services/garuda_portal/assignment_targets.py
+++ b/apps/backend-rag/backend/services/garuda_portal/assignment_targets.py
@@ -29,30 +29,59 @@ shared with the CRM clients/partners surfaces, where the read-only accounting
 viewer legitimately belongs and where a partner's own colleagues may need to
 appear. Only the GARUDA assignment dropdown needs the narrower set.
 
+CONTRACT — the two properties this module owes, pinned as an executable
+property test (`test_candidate_selection_is_complete_and_sound`), not as prose:
+
+  C1 COMPLETENESS. For every ACTIVE `team_members` row that
+     `is_valid_garuda_assignment_target` accepts, its normalized email IS
+     offered. Dropping an accepted target is the defect this module exists to
+     end: the picker shows a colleague who cannot be picked, and a practice
+     already assigned to them renders as "not assignable" over an assignment
+     the gate would have accepted.
+  C2 SOUNDNESS. Every offered email is one the validator accepts, so
+     `listed ∩ refused = ∅` and no option in the picker can produce a 422.
+
 **This module does not restate the predicate — it CALLS it**, once per
-candidate row. `listed ∩ refused = ∅` therefore holds by construction, and
-keeps holding when the predicate changes under it (PR #5817 is turning
-`service_accounts.is_human_team_member` from a denylist into a census
-allow-list at the time of writing): an enumeration that copied the rule would
-drift the day the rule moves, one that asks cannot. The same reasoning is why
+candidate row, so C2 holds by construction and keeps holding when the predicate
+changes under it (`is_human_team_member` became a census allow-list in #5817
+while this was being written): an enumeration that copied the rule would drift
+the day the rule moves, one that asks cannot. The same reasoning is why
 `staff_auth._is_staff_role` delegates instead of keeping its own exclusion set.
 
-Cost: one candidate query plus one point query per candidate row (~25 active
-non-client rows against 525 active ``client`` rows, per the census above), on a
-response the UI holds for 5 minutes. Cheap enough not to need a cache of its
-own, and no cache means no second place to invalidate.
+WHY CANDIDATE SELECTION IS PYTHON, NOT SQL. C1 is the property that failed
+twice, both times for the same reason: a `WHERE` clause has its own idea of
+equality and normalization, and it disagreed with the validator's.
 
-Admins are candidates whatever their role says.
-`is_valid_garuda_assignment_target` accepts an email in
-`staff_auth.garuda_practice_admin_emails()` BEFORE it reads any role or any
-row, so a role-only prefilter silently drops accepted targets: an ACTIVE admin
-row whose role is ``client`` or ``monitoring``, and any row whose role is NULL —
-where SQL's three-valued `role <> ALL(...)` is UNKNOWN and `WHERE` discards it.
-`_CANDIDATE_SQL` therefore carries an `OR LOWER(email) = ANY($2)` arm fed from
-that accessor: the set is READ, never restated, and the decision still belongs
-to the validator, which every surviving row is put through. (Codex Gear-2 grade
-of 0ead993f3b1b, finding 1 MEDIUM — the first candidate query had no such arm
-and dropped exactly those rows.)
+* Round 1 (codex Gear-2 grade of 0ead993f3b1b, finding 1 MEDIUM): the query
+  filtered on role alone, but the validator accepts an admin email BEFORE it
+  reads any role — so active admin rows whose role was ``client``/``monitoring``
+  were dropped, and NULL roles were dropped because `role <> ALL(...)` is
+  UNKNOWN in SQL's three-valued logic and `WHERE` discards UNKNOWN.
+* Round 2 (same grader, cure head 2ec67edde2): the arm added to fix that
+  compared `LOWER(email) = ANY($2)`, but `LOWER` does not trim, while the
+  validator normalizes with `.strip().lower()` — so an admin row stored with
+  surrounding spaces was still dropped. Its verdict: the fix-of-a-fix had
+  reached depth 1, so the correction loop was to be suspended and the contract
+  pinned before implementing against it. That is what this file is.
+
+Two rounds, one cause: a second normalization living in SQL. So there is no
+second normalization any more. The query is `WHERE active = TRUE` and nothing
+else — no role predicate, no email predicate, no three-valued logic to model —
+and the narrowing happens in `_candidate_email`, in the same language as the
+validator, reading both authorities (`non_human_roles_sql_array()` and
+`garuda_practice_admin_emails()`) instead of copying either. A test fake now has
+to model one trivial query rather than SQL's comparison semantics, which is what
+let the round-2 divergence hide: the fake stripped emails the way Python does,
+and SQL did not.
+
+Cost, measured against the census above rather than assumed: the query now
+returns every active row (~550, of which 525 are ``client``) instead of ~25, and
+the validator is still called once per surviving candidate, so the round-trip
+count through the Fly proxy is unchanged. The price is transferring a few
+hundred small rows on a response the UI holds for 5 minutes; what it buys is the
+removal of the surface that produced both findings. Skipping the ``client`` rows
+before the validator sees them is still worth that transfer, because asking the
+validator about 525 clients would mean 525 extra round-trips.
 
 Known boundary, stated rather than left silent: candidates come from
 `team_members`, so an admin email with NO active row there is accepted by the
@@ -65,6 +94,7 @@ leaving it to chance.
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from typing import Any
 
 import asyncpg
@@ -77,33 +107,63 @@ from backend.services.garuda_portal.staff_auth import (
 
 __all__ = ["list_garuda_assignment_targets"]
 
-#: PERFORMANCE PREFILTER, never the authority — and safe only because it has
-#: TWO arms. `NON_HUMAN_ROLES` ({``client``, ``monitoring``}) is a subset of
-#: what `is_valid_garuda_assignment_target` refuses BY ROLE (both are in
-#: `NON_TEAM_ROLES` today, and neither is a team role under the census
-#: allow-list PR #5817 introduces), but that validator accepts an admin email
-#: BEFORE reading any role. So arm 1 alone would drop accepted rows — an active
-#: admin whose role is ``client``/``monitoring``, and any NULL role, where
-#: `role <> ALL(...)` is UNKNOWN — and arm 2 (`OR LOWER(email) = ANY($2)`, fed
-#: from `staff_auth.garuda_practice_admin_emails()`) keeps exactly those. What
-#: the two arms together exclude is therefore only what the validator refuses
-#: for the same reason; every surviving row is still put through the validator,
-#: which remains the only thing that decides.
-#:
-#: The prefilter exists because `team_members` holds 525 active ``client`` rows
-#: next to ~25 staff rows (read-only census 2026-09-06), and each candidate costs
-#: one round-trip through the Fly proxy: asking the validator about a client is
-#: a wasted query. Note the comparison is SQL's, on the RAW role value — a
-#: ``'Client'`` or ``'client '`` row stays a candidate and is refused later by
-#: the validator's own `normalize_role`. Over-inclusion is safe here by design;
-#: under-inclusion is the bug arm 2 closes.
-_CANDIDATE_SQL = """
+#: The ONLY query this module makes for candidates, and deliberately the whole
+#: of its SQL semantics: every active row, nothing filtered. See the module
+#: docstring's "WHY CANDIDATE SELECTION IS PYTHON, NOT SQL" — two independent
+#: grade rounds found the validator and a `WHERE` clause disagreeing about
+#: roles and about email normalization, so the narrowing moved to
+#: `_candidate_email`, where the validator's own idiom can be used and tested.
+_ACTIVE_ROSTER_SQL = """
     SELECT email, name, full_name, role
       FROM team_members
      WHERE active = TRUE
-       AND (role <> ALL($1::text[]) OR LOWER(email) = ANY($2::text[]))
      ORDER BY name ASC
 """
+
+
+def _normalized_email(value: Any) -> str:
+    """`staff_auth`'s own email idiom — `(email or "").strip().lower()`, the
+    exact expression `is_valid_garuda_assignment_target` opens with — kept in
+    one place in this module because C1 depends on the enumeration and the
+    validator agreeing about what the same stored string MEANS. Round 2 is what
+    happens when they do not: SQL's `LOWER` does not trim, Python's `.strip()`
+    does, and an admin row stored with surrounding spaces vanished from the
+    picker while the validator would have accepted it.
+    """
+    return value.strip().lower() if isinstance(value, str) else ""
+
+
+def _candidate_email(
+    row: Any,
+    admin_emails: Collection[str],
+    excluded_roles: Collection[str],
+) -> str | None:
+    """The normalized email of a row worth asking the validator about, or None.
+
+    Narrowing only, never deciding — the validator still sees every row this
+    returns True for, so an error here can only cost a wasted query (C2 is
+    untouched) while an error in the OTHER direction costs a colleague their
+    place in the picker (C1). Every branch is therefore written to be too
+    generous rather than too strict:
+
+    * an admin email is a candidate whatever its role, mirroring the order the
+      validator itself uses (admin shortcut BEFORE any role or row lookup);
+    * a NULL or empty role is a candidate — `None not in {...}` is False in
+      Python, where the same row was UNKNOWN and dropped in SQL — and the
+      validator refuses it, so nothing is offered that should not be;
+    * a role is compared RAW, exactly as the denylist holds it: ``'Client'`` or
+      ``'client '`` stays a candidate and is refused downstream by the
+      validator's own `normalize_role`. Case-folding here would be a third
+      opinion about what a role string means.
+    """
+    email = _normalized_email(row["email"])
+    if not email:
+        return None
+    if email in admin_emails:
+        return email
+    if row["role"] in excluded_roles:
+        return None
+    return email
 
 
 def _base_label(row: Any, email: str) -> str:
@@ -127,18 +187,18 @@ async def list_garuda_assignment_targets(conn: asyncpg.Connection) -> list[dict[
     person picking one, and picking wrong assigns a practice to the wrong
     colleague.
     """
-    # The admin set is read at CALL time and never cached here, so the candidate
-    # query and the validator's own admin shortcut cannot disagree about who is
-    # an admin — one source, read twice per request, same answer.
-    admin_emails = sorted(garuda_practice_admin_emails())
-    rows = await conn.fetch(_CANDIDATE_SQL, non_human_roles_sql_array(), admin_emails)
+    # Both authorities are read at CALL time and never cached here, so this
+    # function and the validator cannot disagree about who is an admin or which
+    # roles are non-human: one source each, read per request, same answer.
+    admin_emails = frozenset(garuda_practice_admin_emails())
+    excluded_roles = frozenset(non_human_roles_sql_array())
+    rows = await conn.fetch(_ACTIVE_ROSTER_SQL)
 
     accepted: list[tuple[str, str]] = []
     seen: set[str] = set()
     for row in rows:
-        raw_email = row["email"]
-        email = raw_email.strip().lower() if isinstance(raw_email, str) else ""
-        if not email or email in seen:
+        email = _candidate_email(row, admin_emails, excluded_roles)
+        if email is None or email in seen:
             continue
         seen.add(email)
         if not await is_valid_garuda_assignment_target(conn, email):

--- a/apps/backend-rag/backend/services/garuda_portal/staff_auth.py
+++ b/apps/backend-rag/backend/services/garuda_portal/staff_auth.py
@@ -84,6 +84,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "can_manage_garuda_practices",
+    "garuda_practice_admin_emails",
     "is_valid_garuda_assignment_target",
     "require_garuda_staff",
     "verify_staff_session",
@@ -119,6 +120,27 @@ def _garuda_practice_admin_emails() -> frozenset[str]:
     else:
         base = frozenset()
     return base | _GARUDA_PRACTICE_ADMIN_EXTRA_EMAILS
+
+
+def garuda_practice_admin_emails() -> frozenset[str]:
+    """PUBLIC accessor for the GARUDA practice-admin set: the set
+    `is_valid_garuda_assignment_target` accepts BEFORE it ever reads a role or a
+    `team_members` row.
+
+    `assignment_targets.list_garuda_assignment_targets` needs the set to widen
+    its candidate query, because a role-only prefilter is unsafe on its own:
+    the admin shortcut below precedes the role query, so an ACTIVE row whose
+    email is in this set is an accepted target even when its role is one a
+    denylist excludes (``client``, ``monitoring``) or NULL — where SQL's
+    three-valued `role <> ALL(...)` is UNKNOWN and `WHERE` drops the row.
+
+    Exposing the set is not a second copy of any policy. The DECISION stays with
+    `is_valid_garuda_assignment_target`, which every candidate row is still put
+    through; this only stops an enumeration from discarding a row before that
+    decision has been asked. (Codex Gear-2 grade of 0ead993f3b1b, finding 1
+    MEDIUM: the first candidate query dropped exactly these rows.)
+    """
+    return _garuda_practice_admin_emails()
 
 
 def _is_staff_role(role: str | None) -> bool:

--- a/apps/backend-rag/backend/tests/services/garuda_portal/test_assignment_targets.py
+++ b/apps/backend-rag/backend/tests/services/garuda_portal/test_assignment_targets.py
@@ -56,6 +56,12 @@ _GHOST_ADMIN_EMAIL = "ghost-admin@example.test"
 _ADMIN_CLIENT_EMAIL = "admin-client@example.test"
 _ADMIN_MONITORING_EMAIL = "admin-monitoring@example.test"
 _ADMIN_NULL_ROLE_EMAIL = "admin-null-role@example.test"
+#: Admin addresses as the VALIDATOR normalizes them. The corpus below stores
+#: them padded with spaces / a tab / a newline and in upper case, because round
+#: 2 of the grade found exactly that shape disappearing: SQL's `LOWER` does not
+#: trim, the validator's `.strip().lower()` does.
+_PADDED_ADMIN_EMAIL = "padded-admin@example.test"
+_TAB_ADMIN_EMAIL = "tab-admin@example.test"
 
 #: Pinned in ONE place: the fixture below patches
 #: `staff_auth._garuda_practice_admin_emails` with this set, and both the
@@ -68,6 +74,8 @@ _ADMIN_SET = frozenset(
         _ADMIN_CLIENT_EMAIL,
         _ADMIN_MONITORING_EMAIL,
         _ADMIN_NULL_ROLE_EMAIL,
+        _PADDED_ADMIN_EMAIL,
+        _TAB_ADMIN_EMAIL,
     }
 )
 
@@ -146,20 +154,17 @@ def _roster() -> list[dict[str, Any]]:
 
 
 class _FakeConn:
-    """The two queries this code path issues, emulated from the bind parameters
-    actually passed AND from SQL's three-valued logic — never from a restatement
-    of what the SQL is for.
+    """The two queries this code path issues.
 
-    * `fetch(_CANDIDATE_SQL, denylist, admins)` stands for
-      `WHERE active = TRUE AND (role <> ALL($1::text[]) OR LOWER(email) =
-      ANY($2::text[]))`. A NULL `role` makes the first comparison UNKNOWN, so
-      the row survives only when the admin arm is TRUE; `UNKNOWN OR FALSE` is
-      UNKNOWN and `WHERE` drops it. The role comparison is on the RAW value, as
-      SQL does it — no lowercasing, no trimming. Grade finding 2 (LOW, codex on
-      0ead993f3b1b): the first version of this fake coerced NULL to `""` and
-      lowercased before comparing, i.e. it was MORE GENEROUS than the SQL it
-      stands in for, and that generosity is exactly what masked the admin
-      under-match. A fake may be less generous than the real thing; never more.
+    * `fetch(_ACTIVE_ROSTER_SQL)` stands for `WHERE active = TRUE` and nothing
+      else, because that is now the whole of the SQL this module asks for. There
+      is deliberately no comparison semantics left to emulate: round 1 (codex
+      grade of 0ead993f3b1b) found a NULL role surviving the fake but not SQL's
+      three-valued `role <> ALL(...)`, and round 2 (cure head 2ec67edde2) found
+      the fake stripping stored emails the way Python does while SQL's `LOWER`
+      does not — in both cases the fake was MORE GENEROUS than the query it
+      stood in for, which is precisely how an under-match hides. A fake that
+      models one predicate cannot be kinder than it.
     * `fetchrow(... WHERE LOWER(email) = $1 AND active = TRUE)` is the
       validator's own role lookup, which does lowercase — so this one does too.
 
@@ -177,18 +182,7 @@ class _FakeConn:
     async def fetch(self, _sql: str, *args: Any) -> list[dict[str, Any]]:
         self.fetch_calls += 1
         self.fetch_args = args
-        excluded = tuple(args[0]) if args else ()
-        admins = {str(email).strip().lower() for email in (args[1] if len(args) > 1 else ())}
-        candidates: list[dict[str, Any]] = []
-        for row in self._rows:
-            if not row["active"]:
-                continue
-            admin_arm = str(row["email"] or "").strip().lower() in admins
-            role = row["role"]
-            role_arm: bool | None = None if role is None else (role not in excluded)
-            if admin_arm or role_arm is True:
-                candidates.append(row)
-        return candidates
+        return [row for row in self._rows if row["active"]]
 
     async def fetchrow(self, _sql: str, *args: Any) -> dict[str, Any] | None:
         self.fetchrow_calls += 1
@@ -347,33 +341,119 @@ async def test_active_admin_row_is_offered_whatever_its_role(email: str, role: s
     assert [item["email"] for item in listed] == [email]
 
 
-async def test_non_admin_null_role_is_dropped_by_the_query_not_by_the_predicate() -> None:
-    """Grade finding 2 (LOW): the fake must not be more generous than the SQL it
-    stands in for. A NULL role makes `role <> ALL(...)` UNKNOWN, so WHERE drops
-    the row and the validator is never asked — asserted through the fake's own
-    call counter, because "not offered" alone would also pass with an unfaithful
-    fake that handed the row over and let the predicate refuse it."""
+async def test_padded_and_upper_case_admin_rows_are_offered_normalized() -> None:
+    """Round 2's exact shape, as its own case: the STORED value is padded and
+    upper case, the validator normalizes and accepts, so the picker must offer
+    the NORMALIZED address — the one `assignPractice` will be called with. A
+    comparison that lowercases without trimming offers nothing here, which is
+    what the cure head 2ec67edde2 did."""
+    rows = [
+        _row("  Padded-Admin@Example.Test ", "client"),
+        _row("\tTab-Admin@Example.Test\n", "monitoring"),
+    ]
+    listed = await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    assert [item["email"] for item in listed] == [_PADDED_ADMIN_EMAIL, _TAB_ADMIN_EMAIL]
+
+
+async def test_non_admin_null_role_is_refused_by_the_validator_not_by_a_prefilter() -> None:
+    """A NULL role is now a CANDIDATE — Python's `None not in {...}` is False,
+    where SQL's `role <> ALL(...)` was UNKNOWN and `WHERE` dropped the row — and
+    the validator refuses it, which is the decision that actually matters.
+    Asserted on the fake's own call counter so the row is provably ASKED ABOUT:
+    "not offered" alone would also pass if a prefilter had silently discarded it,
+    and that silent discard is exactly what round 1's finding was."""
     rows = [_row("null-role@example.test", None)]
     conn = _FakeConn(rows)
 
     assert await assignment_targets.list_garuda_assignment_targets(conn) == []
-    assert conn.fetchrow_calls == 0, "a NULL-role non-admin reached the validator's query"
+    assert conn.fetchrow_calls == 1, "the validator was never asked about the NULL-role row"
     assert not await staff_auth.is_valid_garuda_assignment_target(
         _FakeConn(rows), "null-role@example.test"
     )
 
 
-async def test_candidate_query_is_fed_the_admin_set_not_a_copy_of_it() -> None:
-    """The second bind parameter IS the admin set as `staff_auth` currently
-    defines it, read through the public accessor: a hardcoded list inside the
-    enumeration fails here the day the set moves, and the query's two arms cannot
-    drift apart from the shortcut they exist to match."""
-    conn = _FakeConn(_roster())
-    await assignment_targets.list_garuda_assignment_targets(conn)
+async def test_candidate_selection_reads_the_admin_set_from_its_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The admin set used for narrowing is whatever `staff_auth` publishes NOW:
+    no bind parameter, no module constant, no copy. Move the authority between
+    two calls and the candidate set moves with it — a remembered list would keep
+    the first answer. This is the other half of round 2's contract: the
+    enumeration READS the validator's inputs instead of restating them."""
+    late_admin = "late-admin@example.test"
+    rows = [_row(_ADMIN_CLIENT_EMAIL, "client"), _row(late_admin, "client")]
 
-    assert len(conn.fetch_args) == 2, "the candidate query must carry denylist AND admin set"
-    assert set(conn.fetch_args[1]) == set(_ADMIN_SET)
-    assert set(conn.fetch_args[1]) == set(staff_auth.garuda_practice_admin_emails())
+    first = await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    assert [item["email"] for item in first] == [_ADMIN_CLIENT_EMAIL]
+
+    monkeypatch.setattr(
+        staff_auth, "_garuda_practice_admin_emails", lambda: _ADMIN_SET | {late_admin}
+    )
+    second = await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    assert [item["email"] for item in second] == [_ADMIN_CLIENT_EMAIL, late_admin]
+
+
+async def test_candidate_selection_is_complete_and_sound() -> None:
+    """THE CONTRACT, as an executable property rather than a list of cases.
+
+    C1 COMPLETENESS — every ACTIVE row the validator accepts is offered.
+    C2 SOUNDNESS — every offered email is one the validator accepts.
+
+    This is the specification the round-2 verdict asked for before another
+    implementation attempt ("suspend the correction loop and pin the
+    email-normalization/candidate-completeness contract"). Per-case assertions
+    would have to anticipate the next way a stored value can differ from its
+    normalized form, and twice now that difference was the thing nobody
+    anticipated: first SQL's three-valued NULL, then `LOWER` without `TRIM`. A
+    property does not have to guess. The corpus below therefore carries the
+    shapes that broke it — padded, tabbed and upper-case stored emails for both
+    admins and ordinary staff, roles NULL / empty / case-varied / spaced /
+    denylisted / census-real, an inactive row, and the read-only viewer.
+    """
+    rows = [
+        _row("  Padded-Admin@Example.Test ", "client"),
+        _row(f"\t{_TAB_ADMIN_EMAIL.replace('tab-admin', 'Tab-Admin')}\n", None),
+        _row(_ADMIN_CLIENT_EMAIL, "client"),
+        _row(_ADMIN_MONITORING_EMAIL, "monitoring"),
+        _row(_ADMIN_NULL_ROLE_EMAIL, None),
+        _row("Padded-Staff@Example.Test", "founder"),
+        _row("Client@Example.Test", "Client"),
+        _row("spaced-role@example.test", " client "),
+        _row("empty-role@example.test", ""),
+        _row("null-role@example.test", None),
+        _row("partner-row@example.test", "partner"),
+        _row(_READONLY_VIEWER_EMAIL, "board member"),
+        _row("inactive-staff@example.test", "founder", active=False),
+        *[_row(f"{_slug(role)}@example.test", role) for role in _CENSUS_ROLES],
+    ]
+
+    listed = {
+        item["email"]
+        for item in await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    }
+
+    accepted: set[str] = set()
+    for row in rows:
+        if not row["active"]:
+            continue
+        email = str(row["email"] or "").strip().lower()
+        if not email:
+            continue
+        if await staff_auth.is_valid_garuda_assignment_target(_FakeConn(rows), email):
+            accepted.add(email)
+
+    # anchors: neither half may pass vacuously, and the padded shapes must be in
+    # play — a corpus that never exercises the normalization cannot police it
+    assert accepted, "the corpus accepts nobody: C1 would prove nothing"
+    assert len(rows) > len(accepted), "the corpus refuses nobody: C2 would prove nothing"
+    assert _PADDED_ADMIN_EMAIL in accepted and _TAB_ADMIN_EMAIL in accepted
+
+    missing = accepted - listed
+    offered_but_refused = listed - accepted
+    assert not missing, f"C1 COMPLETENESS broken — accepted targets not offered: {sorted(missing)}"
+    assert not offered_but_refused, (
+        f"C2 SOUNDNESS broken — offered but the validator refuses: {sorted(offered_but_refused)}"
+    )
 
 
 async def test_label_prefers_full_name_then_name_then_email() -> None:

--- a/apps/backend-rag/backend/tests/services/garuda_portal/test_assignment_targets.py
+++ b/apps/backend-rag/backend/tests/services/garuda_portal/test_assignment_targets.py
@@ -48,6 +48,28 @@ _ADMIN_EMAIL = "admin@example.test"
 #: In the admin set but with NO `team_members` row — the boundary the service
 #: module docstring states instead of leaving silent.
 _GHOST_ADMIN_EMAIL = "ghost-admin@example.test"
+#: Admin rows whose ROLE is one the candidate query's first arm excludes, or is
+#: NULL — where SQL's three-valued `role <> ALL(...)` is UNKNOWN. The validator
+#: accepts all three through its admin shortcut, which fires BEFORE it reads a
+#: role, so the enumeration must offer them: codex Gear-2 grade finding 1
+#: (MEDIUM) on 0ead993f3b1b, where the first candidate query dropped them.
+_ADMIN_CLIENT_EMAIL = "admin-client@example.test"
+_ADMIN_MONITORING_EMAIL = "admin-monitoring@example.test"
+_ADMIN_NULL_ROLE_EMAIL = "admin-null-role@example.test"
+
+#: Pinned in ONE place: the fixture below patches
+#: `staff_auth._garuda_practice_admin_emails` with this set, and both the
+#: validator's shortcut and the enumeration's public accessor read that patch,
+#: so the tests can never disagree with themselves about who is an admin.
+_ADMIN_SET = frozenset(
+    {
+        _ADMIN_EMAIL,
+        _GHOST_ADMIN_EMAIL,
+        _ADMIN_CLIENT_EMAIL,
+        _ADMIN_MONITORING_EMAIL,
+        _ADMIN_NULL_ROLE_EMAIL,
+    }
+)
 
 assert PRACTICES_EXTRA_VIEW_EMAILS, (
     "the read-only full-view set is empty; the guilt case below would pass vacuously"
@@ -99,6 +121,12 @@ def _roster() -> list[dict[str, Any]]:
     ]
     rows += [
         _row(_ADMIN_EMAIL, "founder", full_name="Admin Founder"),
+        # admins whose role the candidate query's first arm excludes, or leaves
+        # UNKNOWN — all three accepted by the validator's admin shortcut, so the
+        # enumeration must offer them (grade finding 1)
+        _row(_ADMIN_CLIENT_EMAIL, "client"),
+        _row(_ADMIN_MONITORING_EMAIL, "monitoring"),
+        _row(_ADMIN_NULL_ROLE_EMAIL, None),
         _row("partner-active@example.test", "partner"),
         _row("partner-inactive@example.test", "partner", active=False),
         _row("client-row@example.test", "client"),
@@ -118,23 +146,49 @@ def _roster() -> list[dict[str, Any]]:
 
 
 class _FakeConn:
-    """`fetch(_CANDIDATE_SQL, denylist)` and the validator's
-    `fetchrow(... WHERE LOWER(email) = $1 AND active = TRUE)`, emulated from the
-    parameter actually passed."""
+    """The two queries this code path issues, emulated from the bind parameters
+    actually passed AND from SQL's three-valued logic — never from a restatement
+    of what the SQL is for.
+
+    * `fetch(_CANDIDATE_SQL, denylist, admins)` stands for
+      `WHERE active = TRUE AND (role <> ALL($1::text[]) OR LOWER(email) =
+      ANY($2::text[]))`. A NULL `role` makes the first comparison UNKNOWN, so
+      the row survives only when the admin arm is TRUE; `UNKNOWN OR FALSE` is
+      UNKNOWN and `WHERE` drops it. The role comparison is on the RAW value, as
+      SQL does it — no lowercasing, no trimming. Grade finding 2 (LOW, codex on
+      0ead993f3b1b): the first version of this fake coerced NULL to `""` and
+      lowercased before comparing, i.e. it was MORE GENEROUS than the SQL it
+      stands in for, and that generosity is exactly what masked the admin
+      under-match. A fake may be less generous than the real thing; never more.
+    * `fetchrow(... WHERE LOWER(email) = $1 AND active = TRUE)` is the
+      validator's own role lookup, which does lowercase — so this one does too.
+
+    The SQL text itself is only proven against a real PostgreSQL, which this
+    machine does not have; what is proven here is the composition — which rows
+    get asked about, and what is done with the answers.
+    """
 
     def __init__(self, rows: list[dict[str, Any]]) -> None:
         self._rows = rows
         self.fetch_calls = 0
         self.fetchrow_calls = 0
+        self.fetch_args: tuple[Any, ...] = ()
 
     async def fetch(self, _sql: str, *args: Any) -> list[dict[str, Any]]:
         self.fetch_calls += 1
-        excluded = {str(role).strip().lower() for role in args[0]} if args else set()
-        return [
-            row
-            for row in self._rows
-            if row["active"] and str(row["role"] or "").strip().lower() not in excluded
-        ]
+        self.fetch_args = args
+        excluded = tuple(args[0]) if args else ()
+        admins = {str(email).strip().lower() for email in (args[1] if len(args) > 1 else ())}
+        candidates: list[dict[str, Any]] = []
+        for row in self._rows:
+            if not row["active"]:
+                continue
+            admin_arm = str(row["email"] or "").strip().lower() in admins
+            role = row["role"]
+            role_arm: bool | None = None if role is None else (role not in excluded)
+            if admin_arm or role_arm is True:
+                candidates.append(row)
+        return candidates
 
     async def fetchrow(self, _sql: str, *args: Any) -> dict[str, Any] | None:
         self.fetchrow_calls += 1
@@ -149,12 +203,10 @@ class _FakeConn:
 def _fixed_admin_set(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pin the admin constant so these tests do not depend on the machine's
     `ADMIN_EMAILS` env (the helper already tolerates a MagicMock `settings`, but
-    "tolerates" is not "asserts something known")."""
-    monkeypatch.setattr(
-        staff_auth,
-        "_garuda_practice_admin_emails",
-        lambda: frozenset({_ADMIN_EMAIL, _GHOST_ADMIN_EMAIL}),
-    )
+    "tolerates" is not "asserts something known"). Patched on the PRIVATE
+    helper, which the public `garuda_practice_admin_emails()` accessor delegates
+    to — so the same patch also proves the accessor does not keep its own copy."""
+    monkeypatch.setattr(staff_auth, "_garuda_practice_admin_emails", lambda: _ADMIN_SET)
 
 
 async def _validator_verdicts(rows: list[dict[str, Any]]) -> tuple[set[str], set[str]]:
@@ -268,6 +320,60 @@ async def test_admin_boundary_is_the_documented_one() -> None:
     assert _ADMIN_EMAIL in listed
     assert _GHOST_ADMIN_EMAIL not in listed
     assert await staff_auth.is_valid_garuda_assignment_target(conn, _GHOST_ADMIN_EMAIL)
+
+
+@pytest.mark.parametrize(
+    ("email", "role"),
+    [
+        (_ADMIN_EMAIL, "founder"),
+        (_ADMIN_CLIENT_EMAIL, "client"),
+        (_ADMIN_MONITORING_EMAIL, "monitoring"),
+        (_ADMIN_NULL_ROLE_EMAIL, None),
+    ],
+    ids=["staff-role", "client-role", "monitoring-role", "null-role"],
+)
+async def test_active_admin_row_is_offered_whatever_its_role(email: str, role: str | None) -> None:
+    """Grade finding 1 (MEDIUM, codex on 0ead993f3b1b) as a test: the validator
+    accepts an admin email BEFORE it reads a role, so an ACTIVE admin row is an
+    accepted target even when its role is one the candidate query's first arm
+    excludes — or NULL, where SQL's three-valued comparison is UNKNOWN. The
+    admin arm is what keeps those rows. Without it an accepted target vanished
+    from the picker, and a practice already assigned to one rendered as "not
+    assignable" over an assignment the gate would in fact have accepted."""
+    rows = [_row(email, role)]
+    assert await staff_auth.is_valid_garuda_assignment_target(_FakeConn(rows), email)
+
+    listed = await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    assert [item["email"] for item in listed] == [email]
+
+
+async def test_non_admin_null_role_is_dropped_by_the_query_not_by_the_predicate() -> None:
+    """Grade finding 2 (LOW): the fake must not be more generous than the SQL it
+    stands in for. A NULL role makes `role <> ALL(...)` UNKNOWN, so WHERE drops
+    the row and the validator is never asked — asserted through the fake's own
+    call counter, because "not offered" alone would also pass with an unfaithful
+    fake that handed the row over and let the predicate refuse it."""
+    rows = [_row("null-role@example.test", None)]
+    conn = _FakeConn(rows)
+
+    assert await assignment_targets.list_garuda_assignment_targets(conn) == []
+    assert conn.fetchrow_calls == 0, "a NULL-role non-admin reached the validator's query"
+    assert not await staff_auth.is_valid_garuda_assignment_target(
+        _FakeConn(rows), "null-role@example.test"
+    )
+
+
+async def test_candidate_query_is_fed_the_admin_set_not_a_copy_of_it() -> None:
+    """The second bind parameter IS the admin set as `staff_auth` currently
+    defines it, read through the public accessor: a hardcoded list inside the
+    enumeration fails here the day the set moves, and the query's two arms cannot
+    drift apart from the shortcut they exist to match."""
+    conn = _FakeConn(_roster())
+    await assignment_targets.list_garuda_assignment_targets(conn)
+
+    assert len(conn.fetch_args) == 2, "the candidate query must carry denylist AND admin set"
+    assert set(conn.fetch_args[1]) == set(_ADMIN_SET)
+    assert set(conn.fetch_args[1]) == set(staff_auth.garuda_practice_admin_emails())
 
 
 async def test_label_prefers_full_name_then_name_then_email() -> None:


### PR DESCRIPTION
Follow-up to **#5824** (merged `dfaa8010463d`), per the shipping seat's routing on the loop board at
02:40:55Z: *"#5824 is already MERGED and its branch has been frozen since 02:02:24Z. DO NOT push a
cure onto that merged/frozen branch. Any accepted follow-up starts from fresh origin/main in a NEW
task/PR, reviewed/shipped by Fable."* This branch starts from `9a36edab26` (current `origin/main`).

**Self-report, so the reviewer does not have to discover it:** before reading that line, this seat
pushed a cure commit (`2ec67edde2`) onto the frozen #5824 branch. `origin/main` was never affected
(the PR head stayed `0ead993f3b1b`, `refs/pull/5824/head` never moved, no force-push, no amend), and
that dangling commit is declared on the board rather than cleaned up, because cleaning it would need
a force-push. This PR is the sanctioned vehicle; its first commit is a cherry-pick of that cure and
its second supersedes it.

## Why a second attempt was not allowed, and what replaced it

An independent Gear-2 grade (codex-cli 0.153.4, `gpt-6-astra`, effort `ultra`, `workspace-write`
sandbox, no network) ran twice over this work:

| round | head | verdict | finding |
| --- | --- | --- | --- |
| 1 | `0ead993f3b1b` | CHANGES | **MEDIUM** — the candidate query filtered on role, but `is_valid_garuda_assignment_target` accepts an admin email *before* reading any role: active admin rows with role `client`/`monitoring` were dropped, and NULL roles were dropped because `role <> ALL(...)` is UNKNOWN and `WHERE` discards UNKNOWN. Probe: `validator_accepts=true, sql_comparison_listed=false`, `AssertionError: accepted active admin rows omitted for roles: ['client','monitoring',None]`. Plus **LOW**: the test fake coerced NULL to `""`, i.e. it was more generous than the SQL it stood for. |
| 2 | `2ec67edde2` | CHANGES | The arm added to cure round 1 compared `LOWER(email) = ANY($2)`; `LOWER` does not trim, the validator normalizes with `.strip().lower()` — so an admin row stored with surrounding spaces was still dropped, and the fake stripped too, masking it again. Round 1's cases now pass; the format-debt observation is cured (5 formatter hunks at base and at head, identical `+`/`-` lines, zero mentioning this router). |

Round 2's `ship_recommendation`, quoted: *"The fix-of-a-fix has reached depth 1: suspend the
correction loop and pin the email-normalization/candidate-completeness contract, then resume
implementation and independent grading against that specification."*

Two rounds, one cause: **a second idea of normalization living in SQL.** So this PR removes the
second idea instead of patching it again.

## The contract (written down, then implemented against)

In `assignment_targets.py`'s module docstring, and pinned as an executable property
(`test_candidate_selection_is_complete_and_sound`), not as prose:

- **C1 completeness** — every ACTIVE `team_members` row the validator accepts IS offered. Dropping
  an accepted target is the defect this module exists to end: the picker hides a colleague who can
  be picked, and a practice already assigned to them renders as "not assignable" over an assignment
  the gate would have accepted.
- **C2 soundness** — every offered email is one the validator accepts, so `listed ∩ refused = ∅` and
  no option in the picker can produce a 422.

## What changed

- **The candidate query is now `WHERE active = TRUE` and nothing else.** No role predicate, no email
  predicate, no three-valued logic left to model.
- Narrowing moved to `_candidate_email`, in the same language as the validator, reading both
  authorities (`service_accounts.non_human_roles_sql_array()`,
  `staff_auth.garuda_practice_admin_emails()`) and copying neither. Every branch is deliberately too
  generous rather than too strict: over-inclusion costs one wasted validator call, under-inclusion
  costs a colleague their place in the picker.
- `_normalized_email` holds the validator's own idiom (`.strip().lower()`) in ONE place, named as the
  thing C1 depends on.
- The test fake now models a single trivial predicate instead of SQL comparison semantics — the
  surface that hid round 2 is **removed, not better tested**.
- The property test runs over a corpus of the shapes that broke it: stored emails padded with spaces
  / a tab / a newline and upper-cased, for admins **and** ordinary staff; roles NULL, empty,
  `Client`, `" client "`, denylisted, partner, and every role named by
  `backend/data/team_members.json`; an inactive row; the read-only viewer. Anchors assert neither
  half can pass vacuously.
- Cost, declared rather than buried: the query returns every active row (~550 in production, 525 of
  them `client`) instead of ~25. Validator round-trips are unchanged and the UI caches the response
  for 5 minutes; the extra transfer is the price of not maintaining a second normalization.

## Bites

Consumer unchanged: the assignee `<select>` in
`apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.tsx` — it now also receives admin rows
whose stored email is padded or upper-cased, which head `2ec67edde2` silently omitted.

Observed on Air-M5 in this session (no local Postgres, so no live HTTP observation is claimed):

| command | result |
| --- | --- |
| `pytest backend/tests/services/garuda_portal/test_assignment_targets.py backend/tests/unit/services/garuda_portal/test_staff_auth_partner.py` | **51 passed** (was 49) |
| `pytest openapi_parity + staff_prefix_guard + backend/tests/setup/ + backend/tests/security/ + unit/utils/test_service_accounts.py` | **533 passed, 124 skipped** — on current `main`, i.e. against #5817's census allow-list, which is the predicate change this design was built to survive |
| mutation probe (throwaway, not committed): `_normalized_email` → non-trimming `lower()` | `C1 violated by mutation: True` (the padded admin disappears) while `C1 holds as shipped: True` — the property test can fail, so it is not theatre |
| `ruff check` + `ruff format` on the touched files | clean |
| `PYTHONPATH=.:../crm-cell python -c "from backend.app.dependencies import get_current_user"` | import chain OK |
| `git diff --numstat 9a36edab26...HEAD` → `evidence_pack_lint.py --print-floor` / `--print-floor-source` | net **297** → floor **1**, source `none`: no `evidence/brief.yml` needed, by computation not by omission |

Post-merge probe for the shipping seat (one HTTP observation, from the round-2 verdict): authenticated
admin `GET https://kita.balizero.com/api/crm/garuda/assignment-targets` → require `200` and
`Cache-Control: no-store, private`, then compare the returned emails against an independently
computed validator-accepted active-roster set (admin overrides and read-only exclusions included) and
report only the missing/refused counts — both must be zero.

## Declared, not mine — and CORRECTED: a local red this PR inherits, not a CI one

`python3 scripts/ci/scripts_coupling_census.py --check` is **STALE on current `origin/main`**
(`+ newly coupled (1): scripts/pg.sh`) because `apps/backend-rag/backend/app/utils/service_accounts.py:72`
— landed in **#5817** (`5f1cd92f32`) — names that wrapper by path in a comment, and the census counts
comments. This diff touches four files and none of them mentions a repo-root `scripts/` path.

**Correction of this section's first version, which claimed the staleness fails a required CI check
for every PR opened from current main. It does not.** Measured on this PR: the `Change map` and
`Change map (security)` checks are both **SUCCESS** (66 SUCCESS / 0 FAILURE, only `CodeQL Analysis
(python)` still running, at the time of writing). The cause is `tests.yml:299`: CI runs
`python3 "$CLASSIFIER_DIR/test_change_map.py"` from an *isolated extracted classifier directory*, so
the census's `REPO_ROOT` (`Path(__file__).parents[2]`) does not point at the checkout, the scan finds
nothing, and the check passes trivially.

What IS red, and exactly where: locally, `PYTHONPATH=. pytest scripts/ci/test_change_map.py -k
coupling` against the real tree gave **1 failed / 1 passed** before the cure and **2 passed** after
it; and the pre-push `quickcheck` reports the staleness as advisory. So no PR is blocked in CI by
this, and this PR does not depend on it. The owner-approved cure is a separate comment-only micro-PR
dropping the literal path from that comment — the remedy #5824's own `cac3e4216f` used for the
identical reason — rather than `scripts_coupling_census.py --write`, which would record a coupling
that does not exist at runtime and make every future change to a read-only query wrapper buy the six
heavy `tests.yml` suites. That micro-PR is hygiene, not an unblock.

## Also declared: the frontend typecheck environment on this machine

`npx tsc --noEmit` currently reports 4 errors in files this PR never touches (`FunnelChart.tsx`,
`OwnerCashoutCharts.tsx` cannot resolve `recharts`; `zod.ts`, `zod.test.ts` fail on `z.config`). The
round-2 grader reproduced and attributed this independently: both worktrees' `node_modules` is a
symlink to `/Users/balizero/nuzantara/node_modules` (mtime 11:19 today), `recharts` resolves
`MODULE_NOT_FOUND`, and installed zod is `3.25.76` against a required `^4.5.4`. Its words: *"I accept
dependency-environment mismatch as the explanation for these four failures, independent of this diff
… TypeScript remains red, not waived as green."* This PR changes no TypeScript. No `npm install` was
run: that tree is shared with every seat on this machine.

## Not in scope / not done by this seat

`team.py`, `service_accounts.py`, `useTeamMembers.ts` untouched; the frozen GARUDA contract
untouched (this endpoint stays CRM-side); no merge, no auto-merge armed, no deploy, no production
write. Review and ship belong to **fable** per the 02:40:55Z reassignment.

