### PR TITLE
docs(service-accounts): name the read-only census wrapper by description, not by path

### DIFF
--- a/apps/backend-rag/backend/app/utils/service_accounts.py
+++ b/apps/backend-rag/backend/app/utils/service_accounts.py
@@ -69,9 +69,16 @@ def normalize_role(role: str | None) -> str:
 
 #: Every role a colleague can hold, normalised. The census of 2026-09-06 over
 #: the live ``team_members`` rows (job titles, free text; ``SELECT lower(role),
-#: active, count(*) ... GROUP BY 1, 2`` through ``scripts/pg.sh``, active and
-#: inactive rows alike — an inactive colleague can be reactivated and must not
-#: find the door shut) plus the repo roster (``backend/data/team_members.json``)
+#: active, count(*) ... GROUP BY 1, 2``, active and inactive rows alike — an
+#: inactive colleague can be reactivated and must not find the door shut) run
+#: through the repo's read-only Postgres wrapper, the ``nuzantara_readonly``
+#: one-true-way documented in ``docs/runbooks/prod-db-writes.md``. That wrapper
+#: is named by description and not by file path on purpose: the CI coupling
+#: census counts a literal repo-root script path anywhere under ``apps/`` as a
+#: runtime coupling, comments included, and nothing in this module imports or
+#: invokes one — recording it would make every future change to a read-only
+#: query wrapper buy the six heavy backend suites. Plus the repo roster
+#: (``backend/data/team_members.json``)
 #: plus the two legacy tokens fixtures and older code paths still use. A
 #: superset of ``services/crm/partners/service.py::INTERNAL_ROLES_ALWAYS_ALLOWED``
 #: (CATA-6), which the tests pin so the two cannot drift apart.


### PR DESCRIPTION
## What

Comment-only. `apps/backend-rag/backend/app/utils/service_accounts.py` described the 2026-09-06
production census by naming the repo-root read-only Postgres wrapper with its literal path. The
coupling census counts a literal `scripts/<…>.py|.sh` path anywhere under `apps/` as a runtime
coupling — comments included, by design — so that one prose reference turned `SCRIPTS_COUPLING`
stale on `main` (landed with #5817, `5f1cd92f32`).

Nothing in this module imports or invokes that wrapper: the census the comment describes was a
one-off read-only measurement taken while writing it. The provenance stays intact and findable — the
statement is still quoted, the role and database are still named — and the reader is now sent to
`docs/runbooks/prod-db-writes.md` (merged as #5829), which documents that wrapper, its Keychain
credential and the owner-run write path.

## Why not `--write`

`scripts_coupling_census.py --write` is one command and would also clear the staleness, but it
records a coupling that does not exist at runtime: afterwards every change to a read-only query
wrapper buys the six heavy `tests.yml` suites, and a generated constant becomes the place where prose
is mistaken for an import. #5824's `cac3e4216f` made the identical change to its own docstring for
the identical reason. The owner ruled this route.

## Scope of the red this clears — measured, not assumed

**CI is not red from this, and was not.** On #5842, whose base still carries the stale mention, the
`Change map` and `Change map (security)` checks are SUCCESS: `tests.yml:299` runs
`python3 "$CLASSIFIER_DIR/test_change_map.py"` from an isolated extracted classifier directory, so
the census's `REPO_ROOT` (`Path(__file__).parents[2]`) does not point at the checkout and the scan
finds nothing. An earlier claim by this seat — that the staleness failed a required check for every
PR opened from current main — was wrong, and is corrected on the loop board and in #5842's body.

What IS red, and exactly where:

| command | before | after |
| --- | --- | --- |
| `python3 scripts/ci/scripts_coupling_census.py --check` | `STALE`, rc=1, `+ newly coupled (1): scripts/pg.sh` | `SCRIPTS_COUPLING is up to date.`, rc=0 |
| `PYTHONPATH=. pytest scripts/ci/test_change_map.py -k coupling` | 1 failed, 1 passed | **2 passed**, 69 deselected |
| pre-push `quickcheck` (advisory) | `[scripts-coupling] STALE (rc=1)` on every push from current main | silent |

So this is hygiene, not an unblock. It stops the local gate and the advisory from crying wolf on
every push, and it means a future CI change that runs that test against the checkout does not inherit
a red nobody can attribute.

## Bites

The consumers are the local gate and the advisory hook, and both were observed in this session:

- `python3 scripts/ci/scripts_coupling_census.py --check` → `SCRIPTS_COUPLING is up to date.`, rc=0
- `PYTHONPATH=. pytest scripts/ci/test_change_map.py -k coupling` → 2 passed, 69 deselected
- `PYTHONPATH=. pytest backend/tests/unit/utils/test_service_accounts.py` → **60 passed** — the
  allow-list, its refusals and the CATA-6 pin are untouched by a comment
- `ruff check` + `ruff format --diff` on the file → clean
- `git diff --cached --numstat` → 1 file, +10/−3, no executable line changed

Post-merge observation for the shipping seat: `python3 scripts/ci/scripts_coupling_census.py --check`
on fresh `origin/main` → `up to date`, rc=0. It is STALE on main today, which is the whole point.

## Not in scope

No executable line, no generated constant, no `scripts/ci/change_map.py` edit, no other lane's file.
Auto-merge deliberately not armed by this seat.
