### PR TITLE
feat(conductor): prepare offline native consul packets

### DIFF
--- a/docs/architecture/dual-consul/broker-activation.md
+++ b/docs/architecture/dual-consul/broker-activation.md
@@ -10,6 +10,10 @@ model fallback. This document describes prepared code and activation steps;
 it does not assert that the privileged helper has been installed or a live
 broker-authorized turn has completed.
 
+For window responsibilities and the offline `consul_packet prepare/assemble`
+commands, see [dual-consul windows](../../runbooks/dual-consul-windows.md).
+The preparation CLI never issues approvals or installs protected grants.
+
 The [runtime qualification](../../../evidence/dual-consul-broker/runtime/README.md)
 records strict isolated launch and complete hidden-inclusive catalogs on the
 exact Pro 0.149.0, Mini 0.148.0, and M5 0.147.0 executables. **Astra was absent on

--- a/docs/runbooks/dual-consul-windows.md
+++ b/docs/runbooks/dual-consul-windows.md
@@ -1,0 +1,128 @@
+# Dual-consul windows: preparation and activation boundaries
+
+Status: 2026-09-06. This runbook connects the existing components; it does not
+qualify a general-purpose native executor or transfer mission ownership.
+Authority: [accepted v4 contract](../architecture/dual-consul/common-contract.md).
+The owner ruling in [PR #5821](https://github.com/Bali-Zero/Teman2/pull/5821)
+assigns Astra and Fable equal consul powers and reciprocal review. It retains
+the existing mechanical gates, including Opus, until explicitly superseded.
+Fable is opened by the owner, not auto-routed by this procedure.
+
+## Window arrangement
+
+Start with four windows, not four copies of the complete campaign context:
+
+| Window       | Responsibility                           | Context passed                                                   |
+| ------------ | ---------------------------------------- | ---------------------------------------------------------------- |
+| Consul lead  | Own the mission and integration decision | Mission ID, scope, acceptance tests, dependencies                |
+| Other consul | Independently review frozen work         | Exact tree/artifact hashes, diff, evidence, unresolved questions |
+| Worker A     | One disjoint implementation lane         | Owned files, interfaces, bounded task, tests                     |
+| Worker B     | Another independent lane                 | Its own files and interfaces; no duplicate task ownership        |
+
+There is one lead per mission and at most four workers **across all windows**.
+The ceiling is not a target. Child agents count toward it. Additional windows
+do not provide additional authority or automatically share conversation memory.
+
+Create each writer's worktree through the existing broker:
+
+```bash
+"$PROJECT_PYTHON" scripts/agent_start.py --lane ops --task-id campaign-lane-a --ttl-min 120
+"$PROJECT_PYTHON" scripts/agent_start.py --lane infra --task-id campaign-lane-b --ttl-min 120
+```
+
+`PROJECT_PYTHON` must name the existing virtualenv executable on this host.
+On Air-M5, the inspected activation script contains an obsolete Pro path;
+verify the interpreter instead of relying on that activation script. Open each
+writer in its returned worktree. The review window reads the frozen producer
+tree and must not edit it. Shared lockfiles require serialized PRs.
+
+Record the mission ID, role, native session ID, exact worktree/branch/head,
+owned files, acceptance command, evidence references, and next action in the
+handoff. Use only opaque IDs and redacted metadata. Do not copy whole chat
+transcripts or client data. Do not resume by choosing a global "latest" file.
+
+When a canonical Research OS handoff exists, validate it with the existing CLI:
+
+```bash
+PYTHONPATH=packages/research-os-core "$PROJECT_PYTHON" -m research_os.cli validate \
+  --contract conductor_handoff --file "$MISSION_HANDOFF"
+```
+
+Schema validity and a local handoff are **not** an ownership transfer. Lab owns
+lifecycle; Research OS owns immutable evidence; PostgreSQL owns current grants,
+leases, revocations and fences. Resume/takeover requires fresh authoritative
+checks. A text handoff cannot enable privileged execution while that broker is
+uninstalled. Interactive worktree collaboration remains a distinct mode.
+
+## Prepare the existing text canary
+
+The only native consumer covered here asks for `DUAL_CONSUL_NATIVE_OK`, with
+tools disabled. It is not an arbitrary-prompt launcher. Discovery spends no
+inference and returns the runtime, config, host and authentication-context
+digests, requested model/effort and an unbound thread.
+
+```bash
+PYTHONPATH=.:apps/backend-rag:packages/research-os-core "$PROJECT_PYTHON" \
+  -m scripts.conductor.consul_native --discover \
+  --mission-id "$MISSION_UUID" --model gpt-6-astra --effort medium
+```
+
+Keep its exact JSON as a local discovery artifact. All packet-tool paths below
+must be absolute, have existing real directories, and contain no symlink
+components. On macOS use `/private/tmp`, not its `/tmp` symlink. Outputs must
+not already exist and are created mode 0600. Inputs must be bounded JSON.
+
+First obtain the IDs and exact hashes of the existing canonical ActionItem and
+RequestedActionSpec. Do not generate placeholder references to get past a gate.
+The offline tool checks their shape, not their existence in Research OS.
+
+```bash
+PYTHONPATH=.:apps/backend-rag:packages/research-os-core "$PROJECT_PYTHON" \
+  -m scripts.conductor.consul_packet prepare \
+  --discovery "$DISCOVERY_FILE" --producer astra \
+  --action-item-id "$ACTION_ITEM_ID" --action-item-hash "$ACTION_ITEM_HASH" \
+  --requested-action-spec-id "$SPEC_ID" --requested-action-spec-hash "$SPEC_HASH" \
+  --output "$PREPARED_FILE"
+```
+
+This creates only a canonical ActionIntent and its binding. `--producer fable`
+supports the reverse producer/reviewer direction; it does not select or launch
+a Claude runtime and is not proof that Fable wrote or reviewed anything.
+
+The other consul reviews the **exact intent hash**. Obtain authentic canonical
+VerificationReceipt and ApprovalReceipt from their authorized producers, with
+the native criteria version and required scope. Never use test fixtures as
+real receipts. After that, assemble their content:
+
+```bash
+PYTHONPATH=.:apps/backend-rag:packages/research-os-core "$PROJECT_PYTHON" \
+  -m scripts.conductor.consul_packet assemble \
+  --prepared "$PREPARED_FILE" --approval "$APPROVAL_FILE" --review "$REVIEW_FILE" \
+  --grant-id "$GRANT_UUID" --output "$GRANT_FILE"
+```
+
+Assembly reuses NativeGrant validation at the current UTC time. Changed
+bindings, self-review, mismatched hashes, invalid IDs and expired receipts are
+refused. It does not certify issuer authenticity, establish record existence,
+check live revocation, install a grant, connect to PostgreSQL or invoke a model.
+Only the protected issuer can establish provenance and install the artifact.
+
+## Activation, observation and rollback
+
+Follow [broker activation](../architecture/dual-consul/broker-activation.md)
+and the [provisioning instructions](../../infra/conductor/consul-broker/README.md).
+Build the isolated bundle on Pro from a reviewed worktree; verify its exact
+manifest digest. The dedicated OS identity, metadata-only database role,
+protected service configuration and genuine grant are separate prerequisites.
+No administrator credential is passed to a model or stored in these packets.
+
+Only after those steps does `consul_native --grant-id "$GRANT_UUID"` admit a
+single invocation through the protected Pro helper. The final receipt must
+distinguish completed, failed and reconciliation-required outcomes. Never
+retry an uncertain invocation merely because the first terminal window died.
+Rollback rebinds a previously installed immutable release; it does not revive
+revoked grants. No prior release means no rollback target.
+
+The full campaign still requires qualified multi-turn/resume adapters, observed
+delegation under the global worker limit, and live ownership-transfer proof.
+Passing this canary or the offline packet tests does not establish those claims.

--- a/evidence/2026-09/agent-air-m5-ops-dual-consul-readiness-2a36edbb/brief.yml
+++ b/evidence/2026-09/agent-air-m5-ops-dual-consul-readiness-2a36edbb/brief.yml
@@ -1,0 +1,39 @@
+task_id: dual-consul-readiness
+gear: 2
+l_level: L2
+gate_class: opus
+objective: >-
+  Prepare canonical, offline packets for the existing native text canary and
+  document the dual-consul multi-window workflow without claiming activation.
+constraints:
+  - No model invocation, DB access, receipt issuance, or privileged installation in the CLI.
+  - Reuse NativeGrant and Research OS contracts; no parallel ledger or scheduler.
+  - Fixed marker, Astra/medium, opaque UUID mission, exact runtime and binding hashes.
+  - New mode-0600 artifacts only; no symlink path traversal or overwritten outputs.
+  - Existing mechanical gates and owner-only boundaries remain unchanged.
+acceptance:
+  - text: >-
+      Both producer/reviewer directions validate; changed bindings, self-review,
+      expired receipts and noncanonical identifiers are refused.
+    probe: >-
+      PYTHONPATH=.:apps/backend-rag:packages/research-os-core python -m pytest
+      scripts/tests/test_consul_packet.py -q
+  - text: >-
+      Existing native transport, broker client, gateway and provisioning
+      regression suites remain green without installing the service.
+    probe: >-
+      PYTHONPATH=.:apps/backend-rag:packages/research-os-core python -m pytest
+      scripts/tests/test_consul_broker_client.py scripts/tests/test_consul_broker_gateway.py
+      scripts/tests/test_provision_consul_broker.py scripts/tests/test_codex_shadow.py
+      scripts/tests/test_codex_shadow_launch.py scripts/tests/test_conductor_app_server_rpc.py -q
+  - text: >-
+      The runbook distinguishes offline validation from issuer provenance,
+      authoritative ownership, broker activation and full multi-turn qualification.
+    probe: Independent frozen-diff Opus review, recorded in PR body.
+assumptions:
+  - assumption: Referenced ActionItem and RequestedActionSpec already exist in Research OS.
+    verification: Protected issuer verifies existence and provenance before installation.
+  - assumption: Packet inputs contain only redacted metadata and canonical receipts.
+    verification: No free-form operator field; generic CLI failure output and privacy tests.
+appetite:
+  wall_clock_hours: 1

--- a/scripts/conductor/consul_packet.py
+++ b/scripts/conductor/consul_packet.py
@@ -1,0 +1,275 @@
+"""Prepare an Astra/medium marker intent; assemble supplied canonical receipts.
+
+No native calls, database access, issuance, installation, or approval creation.
+Assembly validates receipt content, NOT issuer authenticity or current revocation.
+The protected issuer must verify provenance before installing the resulting grant.
+Mission IDs are opaque UUIDs. References must identify existing ROS objects; this
+offline tool does not establish their existence. Producers use the native consul
+names/version 4.0.0; lineage uses exact hashes and retention is audit/no legal hold,
+as in the existing v4 contracts. Output is exclusively a new mode-0600 artifact.
+
+Run: PYTHONPATH=apps/backend-rag:packages/research-os-core:. python -m scripts.conductor.consul_packet
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+from typing import Any
+from uuid import UUID, uuid4
+
+from backend.services.autonomous_lab.consul_executor import seal
+from backend.services.autonomous_lab.consul_native_broker import (
+    AUTHORITY,
+    EFFECT,
+    NativeGrant,
+    _binding,
+    _digest,
+)
+from research_os.models.action_intent import ActionIntent
+from research_os.models.action_item import ActionItemRef, RequestedActionSpecRef
+from scripts.conductor.codex_shadow_launch import validate_runtime_binding
+from scripts.conductor.consul_native import CANARY_TEXT
+from scripts.conductor.protected_grants import MAX_GRANT_BYTES, grant_name, strict_json
+
+
+def _uuid(value: str) -> str:
+    if str(UUID(value)) != value:
+        raise ValueError("canonical_uuid_required")
+    return value
+
+
+def _parent(path: Path) -> int:
+    """Open every absolute path component without following any symlink."""
+    if not path.is_absolute() or ".." in path.parts or not path.name:
+        raise ValueError("absolute_artifact_path_required")
+    fd = os.open(path.anchor, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        for component in path.parts[1:-1]:
+            child = os.open(
+                component, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd
+            )
+            os.close(fd)
+            fd = child
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    directory = _parent(path)
+    try:
+        fd = os.open(
+            path.name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=directory
+        )
+        with os.fdopen(fd, "rb") as handle:
+            info = os.fstat(handle.fileno())
+            if (
+                not stat.S_ISREG(info.st_mode)
+                or not 0 < info.st_size <= MAX_GRANT_BYTES
+            ):
+                raise ValueError("input_size_or_type")
+            raw = handle.read(MAX_GRANT_BYTES + 1)
+            if len(raw) > MAX_GRANT_BYTES:
+                raise ValueError("input_size")
+            return strict_json(raw)
+    finally:
+        os.close(directory)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    raw = (json.dumps(payload, allow_nan=False, separators=(",", ":")) + "\n").encode()
+    if len(raw) > MAX_GRANT_BYTES:
+        raise ValueError("output_size")
+    directory = _parent(path)
+    try:
+        fd = os.open(
+            path.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=directory,
+        )
+        with os.fdopen(fd, "wb") as handle:
+            os.fchmod(handle.fileno(), 0o600)
+            handle.write(raw)
+            handle.flush()
+            os.fsync(handle.fileno())
+    finally:
+        os.close(directory)
+
+
+def canary_binding(value: dict[str, Any]) -> dict[str, Any]:
+    binding = _binding(value)
+    _uuid(binding["mission_id"])
+    key = binding["discovery_key"]
+    version, separator, digest = key["runtime_version"].rpartition("@")
+    if not separator:
+        raise ValueError("runtime_binding_required")
+    validate_runtime_binding(version, digest)
+    if (
+        binding["thread_id"] is not None
+        or binding["model"] != "gpt-6-astra"
+        or binding["effort"] != "medium"
+        or binding["input_hash"] != sha256(CANARY_TEXT.encode()).hexdigest()
+        or key["host"].lower().removesuffix(".local")
+        not in {"air-m5", "nuzantara", "mini-pro2"}
+    ):
+        raise ValueError("fixed_canary_required")
+    return binding
+
+
+def prepare(
+    discovery: dict[str, Any],
+    *,
+    producer: str,
+    action_item_ref: dict[str, str],
+    requested_action_spec_ref: dict[str, str],
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if (
+        set(discovery) != {"mode", "binding", "inference_performed"}
+        or discovery["mode"] != "discovery"
+        or discovery["inference_performed"] is not False
+        or producer not in {"astra", "fable"}
+    ):
+        raise ValueError("discovery_or_producer_invalid")
+    binding = canary_binding(discovery["binding"])
+    item = ActionItemRef.model_validate(action_item_ref)
+    spec = RequestedActionSpecRef.model_validate(requested_action_spec_ref)
+    packet_hash, identifier = _digest(binding), str(uuid4())
+    intent = seal(
+        ActionIntent,
+        {
+            "action_intent_id": identifier,
+            "contract_version": "research-os/v1.0.0",
+            "tenant": "bali-zero",
+            "action_item_ref": item.model_dump(mode="json"),
+            "requested_action_spec_ref": spec.model_dump(mode="json"),
+            "action_type": EFFECT,
+            "target": {
+                "system": "com.balizero.autonomous_lab",
+                "object_ref": {
+                    "object_kind": "com.balizero.lab_run",
+                    "object_id": binding["mission_id"],
+                    "object_hash": packet_hash,
+                },
+            },
+            "arguments_ref": "native:" + binding["mission_id"],
+            "arguments_hash": _digest(
+                {"effect": EFFECT, "max_invocations": 1, "binding": binding}
+            ),
+            "input_revision_hash": packet_hash,
+            "risk_class": "green",
+            "sensitivity": "internal",
+            "authority_required": {
+                "role": AUTHORITY,
+                "scope": binding["mission_id"],
+                "expires_after_seconds": 3600,
+            },
+            "idempotency_key": identifier,
+            "expected_outcome_types": [EFFECT],
+            "created_at": (now or datetime.now(timezone.utc))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "producer": {"name": "com.balizero.consul." + producer, "version": "4.0.0"},
+            "lineage": {
+                "input_hashes": [packet_hash, item.object_hash, spec.object_hash]
+            },
+            "retention": {"retention_class": "audit", "legal_hold": False},
+        },
+    )
+    return {
+        "version": 1,
+        "binding": binding,
+        "intent": intent.model_dump(mode="json", exclude_unset=True),
+    }
+
+
+def assemble(
+    prepared: dict[str, Any],
+    approval: dict[str, Any],
+    review: dict[str, Any],
+    *,
+    grant_id: str,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if (
+        set(prepared) != {"version", "binding", "intent"}
+        or type(prepared["version"]) is not int
+        or prepared["version"] != 1
+    ):
+        raise ValueError("prepared_shape")
+    grant_name(grant_id)
+    payload = {
+        "grant_id": grant_id,
+        "binding": canary_binding(prepared["binding"]),
+        "intent": prepared["intent"],
+        "approval": approval,
+        "review": review,
+    }
+    grant = NativeGrant.from_payload(payload)
+    grant.validate(now or datetime.now(timezone.utc))
+    return payload
+
+
+class Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise ValueError("arguments_invalid")
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        parser = Parser(description=__doc__)
+        modes = parser.add_subparsers(dest="mode", required=True)
+        draft = modes.add_parser("prepare")
+        draft.add_argument("--discovery", type=Path, required=True)
+        draft.add_argument("--producer", choices=("astra", "fable"), required=True)
+        for name in (
+            "action-item-id",
+            "action-item-hash",
+            "requested-action-spec-id",
+            "requested-action-spec-hash",
+        ):
+            draft.add_argument("--" + name, required=True)
+        draft.add_argument("--output", type=Path, required=True)
+        finish = modes.add_parser("assemble")
+        for name in ("prepared", "approval", "review", "output"):
+            finish.add_argument("--" + name, type=Path, required=True)
+        finish.add_argument("--grant-id", required=True)
+        args = parser.parse_args(argv)
+        if args.mode == "prepare":
+            result = prepare(
+                read_json(args.discovery),
+                producer=args.producer,
+                action_item_ref={
+                    "action_item_id": _uuid(args.action_item_id),
+                    "object_hash": args.action_item_hash,
+                },
+                requested_action_spec_ref={
+                    "requested_action_spec_id": _uuid(args.requested_action_spec_id),
+                    "object_hash": args.requested_action_spec_hash,
+                },
+            )
+        else:
+            result = assemble(
+                read_json(args.prepared),
+                read_json(args.approval),
+                read_json(args.review),
+                grant_id=args.grant_id,
+            )
+        write_json(args.output, result)
+        return 0
+    except Exception:
+        sys.stderr.write("consul_packet_refused\n")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_consul_packet.py
+++ b/scripts/tests/test_consul_packet.py
@@ -1,0 +1,382 @@
+"""Offline preparation does not invent authority or leak rejected input."""
+
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+import json
+from pathlib import Path
+import stat
+from uuid import uuid4
+
+import pytest
+
+from backend.services.autonomous_lab.consul_native_broker import NativeGrant
+from backend.tests.unit.services.autonomous_lab.consul_fixtures import reseal
+from backend.tests.unit.services.autonomous_lab.native_consul_fixtures import (
+    make_native_grant,
+)
+from scripts.conductor import consul_packet as packet
+from scripts.conductor.codex_shadow_launch import QUALIFIED_BINARY_SHA256
+from scripts.conductor.consul_native import CANARY_TEXT
+
+NOW = datetime(2026, 9, 6, 12, tzinfo=timezone.utc)
+
+
+def discovery():
+    return {
+        "mode": "discovery",
+        "inference_performed": False,
+        "binding": {
+            "mission_id": str(uuid4()),
+            "input_hash": sha256(CANARY_TEXT.encode()).hexdigest(),
+            "discovery_key": {
+                "runtime_version": "codex-cli 0.153.4@"
+                + QUALIFIED_BINARY_SHA256["codex-cli 0.153.4"],
+                "config_hash": "a" * 64,
+                "host": "Air-M5",
+                "auth_context_hash": "b" * 64,
+            },
+            "model": "gpt-6-astra",
+            "effort": "medium",
+            "thread_id": None,
+        },
+    }
+
+
+def prepared(producer="astra", observed=None):
+    return packet.prepare(
+        observed or discovery(),
+        producer=producer,
+        action_item_ref={"action_item_id": str(uuid4()), "object_hash": "c" * 64},
+        requested_action_spec_ref={
+            "requested_action_spec_id": str(uuid4()),
+            "object_hash": "d" * 64,
+        },
+        now=NOW - timedelta(seconds=20),
+    )
+
+
+def authority(draft):
+    """Test-only receipts; production never imports this synthetic builder."""
+    binding = draft["binding"]
+    grant = make_native_grant(
+        NOW,
+        binding["mission_id"],
+        binding=binding,
+        builder=draft["intent"]["producer"]["name"].rsplit(".", 1)[-1],
+    )
+    intent = draft["intent"]
+    approval = reseal(
+        grant.approval,
+        subject={
+            "kind": "action_intent",
+            "object_id": intent["action_intent_id"],
+            "object_hash": intent["object_hash"],
+        },
+        context={"action_item_ref": intent["action_item_ref"]},
+    )
+    review = reseal(
+        grant.review,
+        target_objects=[
+            {
+                "object_kind": "action_intent",
+                "object_id": intent["action_intent_id"],
+                "object_hash": intent["object_hash"],
+            }
+        ],
+    )
+    return approval.model_dump(mode="json", exclude_unset=True), review.model_dump(
+        mode="json", exclude_unset=True
+    )
+
+
+@pytest.mark.parametrize("producer", ["astra", "fable"])
+def test_prepare_and_assemble_both_producer_directions(producer):
+    draft = prepared(producer)
+    assert set(draft) == {"version", "binding", "intent"}
+    assert draft["intent"]["producer"]["name"] == "com.balizero.consul." + producer
+    approval, review = authority(draft)
+    result = packet.assemble(draft, approval, review, grant_id=str(uuid4()), now=NOW)
+    NativeGrant.from_payload(result).validate(NOW)
+    assert result["approval"] == approval
+    assert result["review"] == review
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"input_hash": "f" * 64},
+        {"model": "gpt-5.6-terra"},
+        {"effort": "ultra"},
+        {"thread_id": "already-started"},
+        {"mission_id": "client-name"},
+    ],
+)
+def test_prepare_refuses_any_widening_of_fixed_canary(change):
+    value = discovery()
+    value["binding"].update(change)
+    with pytest.raises((ValueError, PermissionError)):
+        prepared(observed=value)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"mode": "invoke"},
+        {"inference_performed": 0},
+        {"unexpected": "private"},
+    ],
+)
+def test_prepare_refuses_non_discovery_and_extra_fields(change):
+    value = discovery()
+    value.update(change)
+    with pytest.raises(ValueError):
+        prepared(observed=value)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("config_hash", "e" * 64),
+        ("auth_context_hash", "f" * 64),
+        ("host", "Nuzantara"),
+        ("runtime_version", "codex-cli 0.153.4@" + "0" * 64),
+    ],
+)
+def test_assemble_rejects_binding_drift(field, value):
+    draft = prepared()
+    approval, review = authority(draft)
+    draft["binding"]["discovery_key"][field] = value
+    with pytest.raises((ValueError, PermissionError)):
+        packet.assemble(draft, approval, review, grant_id=str(uuid4()), now=NOW)
+
+
+@pytest.mark.parametrize("producer", ["astra", "fable"])
+def test_assemble_rejects_same_family_review_and_corrupt_intent(producer):
+    draft = prepared(producer)
+    approval, review = authority(draft)
+    model = packet.NativeGrant.from_payload(
+        {
+            "grant_id": str(uuid4()),
+            "binding": draft["binding"],
+            "intent": draft["intent"],
+            "approval": approval,
+            "review": review,
+        }
+    ).review
+    wrong = reseal(
+        model,
+        verifier={**review["verifier"], "name": "com.balizero.consul." + producer},
+    )
+    with pytest.raises(PermissionError, match="native_review"):
+        packet.assemble(
+            draft,
+            approval,
+            wrong.model_dump(mode="json", exclude_unset=True),
+            grant_id=str(uuid4()),
+            now=NOW,
+        )
+    draft["intent"]["arguments_hash"] = "0" * 64
+    with pytest.raises(ValueError):
+        packet.assemble(draft, approval, review, grant_id=str(uuid4()), now=NOW)
+
+
+@pytest.mark.parametrize("reference", ["action_item_ref", "requested_action_spec_ref"])
+@pytest.mark.parametrize("bad_hash", ["", "a" * 63, "g" * 64, "A" * 64])
+def test_prepare_rejects_malformed_source_reference_hashes(reference, bad_hash):
+    refs = {
+        "action_item_ref": {"action_item_id": str(uuid4()), "object_hash": "a" * 64},
+        "requested_action_spec_ref": {
+            "requested_action_spec_id": str(uuid4()),
+            "object_hash": "b" * 64,
+        },
+    }
+    refs[reference]["object_hash"] = bad_hash
+    with pytest.raises(ValueError):
+        packet.prepare(discovery(), producer="astra", now=NOW, **refs)
+
+
+@pytest.mark.parametrize("offset", [-60, 241, 301])
+def test_assemble_checks_current_time_not_approval_issue_time(offset):
+    draft = prepared()
+    approval, review = authority(draft)
+    with pytest.raises((ValueError, PermissionError)):
+        packet.assemble(
+            draft,
+            approval,
+            review,
+            grant_id=str(uuid4()),
+            now=NOW + timedelta(seconds=offset),
+        )
+
+
+@pytest.mark.parametrize("grant_id", ["slug", str(uuid4()).upper(), "../private", ""])
+def test_assemble_requires_canonical_uuid_grant(grant_id):
+    draft = prepared()
+    approval, review = authority(draft)
+    with pytest.raises((ValueError, PermissionError)):
+        packet.assemble(draft, approval, review, grant_id=grant_id, now=NOW)
+
+
+def test_file_io_exclusive_private_and_no_symlinks(tmp_path):
+    root = tmp_path.resolve()
+    output = root / "prepared.json"
+    packet.write_json(output, prepared())
+    original = output.read_bytes()
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+    assert packet.read_json(output)["version"] == 1
+    with pytest.raises(FileExistsError):
+        packet.write_json(output, {})
+    assert output.read_bytes() == original
+    link = root / "linked.json"
+    link.symlink_to(output)
+    for operation in (
+        lambda: packet.read_json(link),
+        lambda: packet.write_json(link, {}),
+    ):
+        with pytest.raises(OSError):
+            operation()
+    alias = root / "alias"
+    alias.symlink_to(root, target_is_directory=True)
+    with pytest.raises(OSError):
+        packet.write_json(alias / "new.json", {})
+    assert not (root / "new.json").exists()
+    with pytest.raises(ValueError):
+        packet.write_json(Path("relative.json"), {})
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b'{"secret":1,"secret":2}',
+        b'{"secret":NaN}',
+        b"private fixture not json",
+        b'"private fixture"',
+        b" " * (packet.MAX_GRANT_BYTES + 1),
+    ],
+)
+def test_input_read_errors_are_redacted(raw, tmp_path, capsys):
+    root = tmp_path.resolve()
+    path, output = root / "private-fixture.json", root / "out.json"
+    path.write_bytes(raw)
+    code = packet.main(
+        [
+            "assemble",
+            "--prepared",
+            str(path),
+            "--approval",
+            str(path),
+            "--review",
+            str(path),
+            "--grant-id",
+            str(uuid4()),
+            "--output",
+            str(output),
+        ]
+    )
+    assert code == 1 and not output.exists()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "consul_packet_refused\n"
+
+
+def test_cli_argument_errors_do_not_echo_values(capsys):
+    assert packet.main(["prepare", "--producer", "private-invalid-value"]) == 1
+    assert capsys.readouterr().err == "consul_packet_refused\n"
+
+
+def test_cli_prepare_writes_only_new_artifact(tmp_path, capsys):
+    root = tmp_path.resolve()
+    source, output = root / "discovery.json", root / "prepared.json"
+    source.write_text(json.dumps(discovery()))
+    argv = [
+        "prepare",
+        "--discovery",
+        str(source),
+        "--producer",
+        "astra",
+        "--action-item-id",
+        str(uuid4()),
+        "--action-item-hash",
+        "a" * 64,
+        "--requested-action-spec-id",
+        str(uuid4()),
+        "--requested-action-spec-hash",
+        "b" * 64,
+        "--output",
+        str(output),
+    ]
+    assert packet.main(argv) == 0
+    assert capsys.readouterr().out == ""
+    assert packet.read_json(output)["intent"]["action_type"] == packet.EFFECT
+    assert packet.main(argv) == 1
+    assert capsys.readouterr().err == "consul_packet_refused\n"
+
+
+def test_cli_assemble_uses_actual_clock_and_preserves_supplied_receipts(
+    tmp_path, monkeypatch, capsys
+):
+    root = tmp_path.resolve()
+    draft = prepared()
+    approval, review = authority(draft)
+    paths = {
+        name: root / (name + ".json") for name in ("prepared", "approval", "review")
+    }
+    for name, payload in (
+        ("prepared", draft),
+        ("approval", approval),
+        ("review", review),
+    ):
+        paths[name].write_text(json.dumps(payload))
+
+    class Clock:
+        current = NOW
+
+        @classmethod
+        def now(cls, tz):
+            assert tz is timezone.utc
+            return cls.current
+
+    monkeypatch.setattr(packet, "datetime", Clock)
+    output = root / "grant.json"
+    argv = ["assemble", "--grant-id", str(uuid4()), "--output", str(output)]
+    for name, path in paths.items():
+        argv.extend(["--" + name, str(path)])
+    assert packet.main(argv) == 0
+    assert capsys.readouterr().out == ""
+    result = packet.read_json(output)
+    assert result["approval"] == approval and result["review"] == review
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+    Clock.current += timedelta(minutes=10)
+    argv[4] = str(root / "expired.json")
+    assert packet.main(argv) == 1
+    assert not (root / "expired.json").exists()
+    assert capsys.readouterr().err == "consul_packet_refused\n"
+
+
+def test_missing_file_path_is_not_echoed(tmp_path, capsys):
+    missing = str(tmp_path.resolve() / "private-fixture-missing.json")
+    assert (
+        packet.main(
+            [
+                "assemble",
+                "--prepared",
+                missing,
+                "--approval",
+                missing,
+                "--review",
+                missing,
+                "--grant-id",
+                str(uuid4()),
+                "--output",
+                missing,
+            ]
+        )
+        == 1
+    )
+    captured = capsys.readouterr()
+    assert captured.out == "" and captured.err == "consul_packet_refused\n"
+
+
+def test_preparation_is_separate_from_issuer_authenticity():
+    assert "NOT issuer authenticity" in packet.__doc__
+    assert "offline tool does not establish their existence" in packet.__doc__


### PR DESCRIPTION
## Scope

Adds `consul_packet prepare/assemble` using the existing Research OS and NativeGrant contracts, plus the multi-window runbook. Fixed Astra/medium text canary only. No invocation, database access, receipt issuance, grant installation, new ledger, scheduler or authority change.

Companion doctrine already exists in #5821; this PR does not duplicate or supersede it. Full multi-turn/resume/delegation qualification and protected broker activation remain separate. Draft is intentional: external builder prepares, independent owning consul ships.

## Verification

- 208 targeted tests passed (42 new packet tests plus existing native, gateway, protected-grant and provisioning suites).
- Ruff, Prettier and pre-commit/pre-push gates passed without bypass.
- Recomputed gear floor: 2; branch-specific brief included.
- Independent `claude-opus-5`, xhigh, OAuth CLI frozen-diff review: PASS, no blocking findings; session `51bf3283-6cd0-4910-a882-260173bb5926`. Static review, no reviewer tools or test-execution claim; not a Fable cross-consul receipt or formal shipping status.
- Reviewed production source SHA256: `4a0b438f484c0be049fb766101a78cb8044e467a442324f254507a4023cfa777`.

Bites: consumer = scripts/tests/test_consul_packet.py and existing native broker regression suites; observation = the CLI prepares an intent without inventing approval, then refuses mismatched/expired/self-reviewed supplied receipts (208 targeted tests passed on this tree).

## Operational boundary observed separately

A fresh Pro bundle passed manifest, relocation/import and read-only installer checks, but the protected helper and service UID are absent; sudo requires operator authentication. The mandated local read-only DB role is absent, so no elevated DB credential was substituted. No live broker-authorized mission is claimed.
