### PR TITLE
fix(hooks): enforce worktree isolation for native Codex patches

### DIFF
--- a/evidence/2026-09/agent-air-m5-infra-codex-patch-guard-5fa44cd9/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-codex-patch-guard-5fa44cd9/brief.yml
@@ -1,0 +1,19 @@
+task_id: codex-patch-guard
+gear: 1
+l_level: L2
+gate_class: opus
+objective: Recognize canonical Codex apply_patch events in the existing worktree guard.
+constraints:
+  - Preserve existing Claude event behavior and worktree admission policy.
+  - Check every Add, Update, Delete and Move source/destination against event cwd.
+  - Refuse ambiguous patches without echoing input content or paths.
+  - Do not change global hook registration or shipping authority.
+acceptance:
+  - text: All 85 innocence/guilt cases pass through the actual CI entry point.
+    probe: PYTHONPATH=. python infra/claude-hooks/test_hook_innocence.py
+  - text: Installed registration and official canonical hook schema agree.
+    probe: >-
+      Confirm Edit|Write matcher aliases apply_patch and that tool_input.command
+      carries the patch in the current OpenAI hook reference before local installation.
+appetite:
+  wall_clock_hours: 1

--- a/infra/claude-hooks/test_hook_innocence.py
+++ b/infra/claude-hooks/test_hook_innocence.py
@@ -157,6 +157,95 @@ CASES: dict[str, list[tuple[dict, str, str]]] = {
 }
 
 
+def _codex_patch_payload(cwd: str, *sections: str) -> dict:
+    return {
+        "hook_event_name": "PreToolUse", "tool_name": "apply_patch", "cwd": cwd,
+        "tool_input": {"command": "*** Begin Patch\n" + "\n".join(sections) + "\n*** End Patch"},
+    }
+
+
+def _codex_patch_cases() -> list[tuple[dict, str, str]]:
+    """Native payload cases join the same matrix the CI script actually runs."""
+    cases: list[tuple[dict, str, str]] = []
+    for operation, body in (("Add", "\n+fixture"), ("Update", "\n@@\n-old\n+new"), ("Delete", "")):
+        for cwd, expect in ((REPO_ROOT, "BLOCK"), (WT, "ALLOW")):
+            for target in ("fixture.py", cwd + "/fixture.py"):
+                cases.append((_codex_patch_payload(cwd, f"*** {operation} File: {target}{body}"), expect,
+                              f"Codex {operation}: relative/absolute path resolved from event cwd"))
+    for source in (REPO_ROOT + "/old.py", WT + "/old.py"):
+        for destination in (REPO_ROOT + "/new.py", WT + "/new.py"):
+            expect = "ALLOW" if source.startswith(WT + "/") and destination.startswith(WT + "/") else "BLOCK"
+            cases.append((_codex_patch_payload(WT, f"*** Update File: {source}\n*** Move to: {destination}\n@@\n-old\n+new"),
+                          expect, "Codex move checks both source and destination"))
+    cases.extend([
+        (_codex_patch_payload(WT, "*** Add File: okay.py\n+fixture", "*** Delete File: ../../main.py"), "BLOCK", "Codex mixed patch cannot hide main target"),
+        (_codex_patch_payload(WT, "*** Update File: okay.py\n*** Move to: ../../main.py\n@@\n-old\n+new"), "BLOCK", "Codex relative move uses event cwd"),
+        (_codex_patch_payload(REPO_ROOT, "*** Add File: .worktrees/lane-x/okay.py\n+fixture", f"*** Delete File: {_TMP / 'outside.py'}"), "ALLOW", "Codex multiple allowed targets, including outside repo"),
+        (_codex_patch_payload(WT, "*** Update File: okay.py\n@@ context\n-old\n+*** Delete File: ../../main.py\n@@\n unchanged\n+new\n*** End of File"), "ALLOW", "Codex hunk content is not a target directive"),
+    ])
+    pathlib.Path(WT, "patch-escape").symlink_to(_SYN, target_is_directory=True)
+    cases.append((_codex_patch_payload(WT, "*** Add File: patch-escape/main.py\n+fixture"), "BLOCK", "Codex symlink cannot escape worktree"))
+    malformed = [
+        None, {}, "", "*** Begin Patch\n*** End Patch",
+        "*** Begin Patch\n*** Add File: okay.py\n+fixture",
+        "*** Begin Patch\n*** Delete File: okay.py\n+unexpected\n*** End Patch",
+        "*** Begin Patch\n*** Add File: \n+fixture\n*** End Patch",
+        "*** Begin Patch\n*** Add File: okay.py\n*** Move to: elsewhere.py\n*** End Patch",
+        "*** Begin Patch\n*** Update File: okay.py\n@@\n*** End Patch",
+        "*** Begin Patch\n*** Update File: okay.py\n@@\n@@\n-old\n+new\n*** End Patch",
+        "*** Begin Patch\n*** Add File: okay.py\ninvalid body\n*** End Patch",
+        "*** Begin Patch\n*** Mystery File: okay.py\n*** End Patch",
+        "*** Begin Patch\n*** Add File: okay.py\n+fixture\n*** End Patch\nignored tail",
+        "*** Begin Patch\n*** Add File: bad\x00path\n+fixture\n*** End Patch",
+    ]
+    for command in malformed:
+        payload = _codex_patch_payload(WT)
+        payload["tool_input"]["command"] = command
+        cases.append((payload, "BLOCK", "Codex malformed/ambiguous patch fails closed"))
+    for cwd in (None, "relative/path", 123):
+        payload = _codex_patch_payload(WT, "*** Add File: okay.py\n+fixture")
+        payload["cwd"] = cwd
+        cases.append((payload, "BLOCK", "Codex ambiguous event cwd fails closed"))
+    for tool_input in (None, [], "patch", {"patch": "wrong field"}):
+        payload = _codex_patch_payload(WT)
+        payload["tool_input"] = tool_input
+        cases.append((payload, "BLOCK", "Codex malformed canonical tool_input fails closed"))
+    for tool in ("Edit", "Write", "MultiEdit"):
+        for directory, expect in ((REPO_ROOT, "BLOCK"), (WT, "ALLOW")):
+            cases.append(({"tool_name": tool, "tool_input": {"file_path": directory + "/legacy.py"}},
+                          expect, "Claude file_path compatibility remains unchanged"))
+    cases.append(({"tool_name": "Read", "tool_input": {"file_path": REPO_ROOT + "/main.py"}},
+                  "ALLOW", "Unrelated tools remain unchanged"))
+    return cases
+
+
+CASES["worktree_file_write_check.py"].extend(_codex_patch_cases())
+
+
+def _codex_patch_extra_checks() -> list[str]:
+    """Check actual stdout/stderr privacy and the pre-existing explicit escape."""
+    failures: list[str] = []
+    fixture = "fixture.person@example.invalid"
+    payload = _codex_patch_payload(REPO_ROOT, f"*** Add File: {fixture}.py\n+{fixture}")
+    env = dict(os.environ)
+    env["NUZ_REPO_ROOT"] = REPO_ROOT
+    env.pop("AGENT_WORKTREE_ENFORCEMENT", None)
+    for disabled, expected in ((False, 2), (True, 0)):
+        if disabled:
+            env["AGENT_WORKTREE_ENFORCEMENT"] = "false"
+        try:
+            result = subprocess.run(
+                [sys.executable, str(_hook_path("worktree_file_write_check.py"))],
+                input=json.dumps(payload), capture_output=True, text=True, env=env, timeout=15,
+            )
+        except subprocess.TimeoutExpired:
+            failures.append("[Codex patch] privacy/escape check timed out")
+            continue
+        if result.returncode != expected or fixture in result.stdout + result.stderr:
+            failures.append("[Codex patch] privacy/escape contract failed")
+    return failures
+
+
 def run_hook(hook: str, payload: dict) -> tuple[int, str]:
     """Invoke the real hook file as Claude Code does: JSON on stdin. Returns
     (exit_code, stderr)."""
@@ -195,6 +284,9 @@ def evaluate() -> list[str]:
             if code < 0:
                 failures.append(f"[{hook}] {desc}: hook error ({err.strip()[:80]})")
                 continue
+            if payload.get("tool_name") == "apply_patch" and code not in (0, 2):
+                failures.append(f"[Codex patch] unexpected hook exit {code}")
+                continue
             blocked = code == 2
             if expect == "BLOCK":
                 if not blocked:
@@ -206,6 +298,7 @@ def evaluate() -> list[str]:
                         f"        payload={json.dumps(payload)[:160]}\n"
                         f"        stderr={err.strip()[:160]}"
                     )
+    failures.extend(_codex_patch_extra_checks())
     return failures
 
 
@@ -216,7 +309,7 @@ def test_hook_innocence():
 
 if __name__ == "__main__":
     fails = evaluate()
-    total = sum(len(v) for v in CASES.values())
+    total = sum(len(v) for v in CASES.values()) + 2  # Codex privacy + explicit escape
     if fails:
         print(f"=== {len(fails)}/{total} FAIL ===")
         for f in fails:

--- a/infra/claude-hooks/worktree_file_write_check.py
+++ b/infra/claude-hooks/worktree_file_write_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PreToolUse hook (Edit|Write|MultiEdit) — block file writes to main checkout.
+"""PreToolUse hook (Edit|Write|MultiEdit|apply_patch) — protect main checkout.
 
 L5.1 SOTA wave 2026-05-25 — Codex unique amendment (P0).
 
@@ -163,6 +163,83 @@ def _increment_block_counter():
         pass
 
 
+def _patch_targets(command: object) -> list[str]:
+    """Read canonical apply_patch targets, never patch content or shell text.
+
+    Codex normalizes apply_patch to tool_input.command (not file_path). A
+    malformed/unknown envelope cannot establish the write boundary: reject it.
+    """
+    if not isinstance(command, str):
+        raise ValueError("invalid patch")
+    lines = command.strip("\r\n").split("\n")
+    lines = [line.removesuffix("\r") for line in lines]
+    if not lines or lines[0] != "*** Begin Patch" or lines[-1] != "*** End Patch":
+        raise ValueError("invalid patch")
+    targets: list[str] = []
+    operation, body_seen, move_allowed, at_end = "", False, False, False
+    marker_pending = False
+    for line in lines[1:-1]:
+        header = re.fullmatch(r"\*\*\* (Add File|Update File|Delete File|Move to): (.+)", line)
+        if header:
+            kind, target = header.groups()
+            if target != target.strip() or any(ord(char) < 32 for char in target):
+                raise ValueError("ambiguous path")
+            if kind == "Move to":
+                if not move_allowed:
+                    raise ValueError("ambiguous move")
+                move_allowed = False
+            else:
+                if operation == "Update File" and not body_seen:
+                    raise ValueError("empty update")
+                operation, body_seen, at_end, marker_pending = kind, False, False, False
+                move_allowed = kind == "Update File"
+            targets.append(target)
+            continue
+        move_allowed = False
+        if at_end:
+            raise ValueError("unexpected patch content")
+        if operation == "Add File" and line.startswith("+"):
+            body_seen = True
+        elif operation == "Update File":
+            if line == "@@" or line.startswith("@@ "):
+                if marker_pending:
+                    raise ValueError("empty hunk")
+                body_seen = False
+                marker_pending = True
+            elif line == "*** End of File" and body_seen:
+                at_end = True
+            elif not line or line[0] in " +-":
+                body_seen = True
+                marker_pending = False
+            else:
+                raise ValueError("invalid update")
+        else:
+            raise ValueError("invalid patch body")
+    if not targets or (operation == "Update File" and not body_seen):
+        raise ValueError("empty patch")
+    return targets
+
+
+def _guard_patch(payload: dict) -> int:
+    """Check every source/destination against event cwd; emit no patch data."""
+    try:
+        cwd = payload.get("cwd")
+        if not isinstance(cwd, str) or not pathlib.Path(cwd).is_absolute():
+            raise ValueError("ambiguous cwd")
+        targets = _patch_targets(payload.get("tool_input", {}).get("command"))
+        repo_real = pathlib.Path(REPO_ROOT).resolve()
+        for target in targets:
+            path_real = (pathlib.Path(cwd) / target).resolve()
+            if path_real.is_relative_to(repo_real) and not _is_path_under_allowed_worktree(path_real):
+                _increment_block_counter()
+                sys.stderr.write("WORKTREE ISOLATION VIOLATION: apply_patch targets main checkout. Use a dedicated worktree.\n")
+                return 2
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+        sys.stderr.write("WORKTREE ISOLATION: cannot establish apply_patch targets; provide a canonical patch and absolute cwd.\n")
+        return 2
+    return 0
+
+
 def main():
     if _kill_switch_active():
         sys.exit(0)
@@ -173,6 +250,8 @@ def main():
         sys.exit(0)
 
     tool_name = payload.get("tool_name", "")
+    if tool_name == "apply_patch":
+        sys.exit(_guard_patch(payload))
     if tool_name not in {"Edit", "Write", "MultiEdit"}:
         sys.exit(0)
 


### PR DESCRIPTION
## Scope

Teach the existing worktree file-write guard to recognize canonical Codex `apply_patch` events with patch text in `tool_input.command`. Check every Add/Update/Delete/Move source and destination against the event cwd, and refuse ambiguous input without echoing patch content or paths. Existing Claude handlers and worktree policy remain unchanged.

## Verification and review

- Existing CI consumer `python infra/claude-hooks/test_hook_innocence.py`: ALL 85 OK (34 existing and 51 new cases). Tests integrated into CASES/evaluate, not a disconnected pytest file.
- Ruff, diff check, pre-commit and pre-push checks passed without bypass. Recomputed gear floor 1; branch-specific brief included.
- Independent Opus 5 xhigh OAuth review of frozen diff and original hook: parser PASS, conditional on native matcher/payload reachability. Session `322ec8a2-ad03-40e3-b786-9e4f22ed23f8`.
- Reachability condition checked: installed matcher `Edit|Write|MultiEdit`; current official docs explicitly support Edit/Write aliases for apply_patch while delivering `tool_name=apply_patch` and `tool_input.command`: https://learn.chatgpt.com/docs/hooks#pretooluse . This is documented event compatibility, not an end-to-end runtime bypass test.
- Reviewed production source SHA256 `61b0cf0e8cb35788f36b0faf6626d9c6e4cdee38b4c05efe99bd643d0f85b4a1`.

Bites: consumer = existing hook-innocence-gate.yml direct execution of test_hook_innocence.py; observation = 85 actual subprocess-based guilt/innocence checks pass, including canonical patch events that the baseline parser missed.

## Local activation and limits

After independent review, only the reviewed new helpers/main dispatch were applied to the personal Air-M5 Codex hook, with a recoverable backup. Its pre-existing fallback-path and scratch-worktree differences were preserved; no global matcher/config changes. No Pro/Mini hook deployment or production shipping.

Case-insensitive filesystem path comparison, hook/application TOCTOU and general sandbox enforcement remain pre-existing limits; this patch is not a new security boundary. Draft for independent owning-session integration; no auto-merge armed.
