### PR TITLE
Enforce Damar editorial publishing protocol

### DIFF
--- a/.agents/skills/editorial-publishing/SKILL.md
+++ b/.agents/skills/editorial-publishing/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: editorial-publishing
+description: Publish or verify Bali Zero News Room articles and WR2 Instagram carousels for Zero or Damar. Load when asked to list editorial items, publish News Room content, choose homepage placement, publish a carousel, verify live URLs, or register an already-published Instagram post.
+---
+
+# Editorial Publishing
+
+Apply this protocol only to explicit requests received through an authenticated session from
+Zero or Damar. It covers News Room articles and WR2 Instagram carousels. It does not authorize
+client messages, email, WhatsApp, other social channels, manual merges, deploys, destructive
+operations, or bypassing an artefact gate.
+
+## Shared rules
+
+- Treat an explicit publish order as the human act allowed by Legge 5; never initiate it.
+- Read current state from the canonical service. Never edit staging or WR2 queue JSON directly.
+- Never infer an editorial choice from a UI/API default or from an earlier item.
+- If one mandatory choice is missing, ask one short, specific question and do not submit.
+- Stop on a red fact, approval, completeness, duplicate, credential, or eligibility gate.
+- Do not retry a failed gate blindly and do not treat verbal confirmation as a bypass.
+- Keep states honest: `queued`/`publication_pending` is not `published`; `live` requires proof.
+
+## News Room
+
+When listing, include a stable response number, technical ID, title, date/source, category,
+editorial status, fact-gate result, cover status, assigned position, and publication URL/state
+when present.
+
+Before publishing, require one explicit position from:
+
+- `Latest`
+- `Hero Main`
+- `Hero 2`, `Hero 3`, `Hero 4`, `Hero 5`
+- `Insight 1`, `Insight 2`, `Insight 3`
+
+If it is missing, ask exactly: “Dove lo pubblico: Latest, Hero Main, Hero 2–5 oppure Insight
+1–3?” Do not send the publish request until answered.
+
+For a batch, require either one common position or a complete article-to-position map. `Latest`
+may repeat; each Hero or Insight slot may appear only once in the operation. If a selected slot
+is occupied, show its current title and URL and obtain explicit replacement confirmation.
+Serialize homepage-slot changes so each one is integrated and verified before the next.
+
+Preflight the current item: eligibility, fact gate, cover, slug uniqueness, public category,
+explicit position, and slot conflicts. Submit through the canonical publisher. Record operation
+ID, PR, expected URL, and position. Say `IN CODA` while the PR/checks are pending. Never merge or
+force a gate. Say `LIVE` and provide the link only after the public URL opens and the expected
+title/content matches.
+
+## WR2 carousel
+
+When listing, include stable response number, slug/title, approval state, slide completeness,
+caption readiness, render status, publish eligibility, Instagram URL, and metrics state.
+
+Before real publication:
+
+1. Verify `approval_state=approved`, eligible status, complete ordered slides, successful
+   renderer output, no existing Instagram publication, and an empty anti-double-post ledger.
+2. Generate/load the deterministic caption and show the exact final text plus character count.
+3. Obtain explicit approval of that exact caption. An edit invalidates the approval and dry-run.
+4. Execute the canonical publisher with `confirm=false` and report the actual validation result.
+5. Only after a green dry-run ask: “Verifica superata. Pubblico ora su @balizero0?”
+6. Send `confirm=true` only after the subsequent explicit yes in the same flow.
+7. Report success only with the Instagram permalink and persisted ledger/queue state.
+
+“Segna come pubblicato” is a separate registration flow for a post already published outside
+WR2. Require its real Instagram URL, canonicalize and deduplicate it, then clearly report that
+the action recorded an external post and did not publish anything.
+
+## Failure result
+
+Return `BLOCCATO`, name the exact failed gate, state that nothing was published, and give only
+the safe corrective next action.

--- a/.claude/skills/editorial-publishing
+++ b/.claude/skills/editorial-publishing
@@ -1,0 +1,1 @@
+../../.agents/skills/editorial-publishing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,24 @@ work, and a Claude session verifies it. Generator is never grader, in either dir
    one line and take the narrowest reading — do NOT invent adjacent work (this is aimed
    especially at K3's known over-proactivity).
 
+### Damar editorial publishing protocol (News Room + WR2)
+
+When an authenticated Zero or Damar session explicitly asks to publish a News Room article
+or WR2 carousel, load `.agents/skills/editorial-publishing/SKILL.md` and follow it end to end.
+These editorial decisions are mandatory and may never come from a UI or API default:
+
+- **News Room:** obtain an explicit destination (`Latest`, `Hero Main`, `Hero 2–5`, or
+  `Insight 1–3`) before sending any publish request. For a batch, require a common destination
+  or a complete article-to-position map; reject duplicate Hero/Insight slots.
+- **WR2 carousel:** show the exact caption, obtain approval of that caption, run the
+  `confirm=false` dry-run, and only after it succeeds ask for the final explicit publish act
+  before `confirm=true`. Editing the caption invalidates the dry-run.
+
+Report an opened article PR as **queued**, never published. Report **live** only after opening
+the public URL and verifying the expected title/content. A red artefact gate blocks publication;
+verbal confirmation never overrides it. “Mark as published” only records an external post and
+must never be represented as publishing to Instagram.
+
 ## 0. Machine Identification (IMPORTANT)
 
 **You MUST identify which machine you are running on at session start.**

--- a/apps/backend-rag/backend/app/routers/intel.py
+++ b/apps/backend-rag/backend/app/routers/intel.py
@@ -182,11 +182,24 @@ class RegisterNotificationRequest(BaseModel):
     title: str = Field("", description="Article title for display")
 
 
-class PublishToSiteRequest(BaseModel):
-    """Optional request body for publish with homepage position."""
+HomepagePosition = Literal[
+    "latest",
+    "hero_main",
+    "hero_2",
+    "hero_3",
+    "hero_4",
+    "hero_5",
+    "insight_1",
+    "insight_2",
+    "insight_3",
+]
 
-    position: str = Field(
-        default="latest",
+
+class PublishToSiteRequest(BaseModel):
+    """Explicit homepage position for a publication request."""
+
+    position: HomepagePosition = Field(
+        ...,
         description="Homepage position: hero_main, hero_2-5, insight_1-3, or latest",
     )
 
@@ -195,7 +208,7 @@ class WorkspaceNewsPublishRequest(BaseModel):
     """Explicit authorization carried by the Damar workspace agent."""
 
     confirmation: Literal["DAMAR_CONFIRMED"]
-    position: Literal["latest", "hero_main", "hero_2", "hero_3", "hero_4", "hero_5"] = "latest"
+    position: HomepagePosition
 
 
 class WorkspaceNewsUpdateRequest(BaseModel):

--- a/apps/backend-rag/backend/app/routers/intel_scraper.py
+++ b/apps/backend-rag/backend/app/routers/intel_scraper.py
@@ -684,7 +684,8 @@ async def publish_staging_item(
     """
     Publish approved item to Qdrant knowledge base and register in anti-duplicate system.
 
-    Optional body: {"position": "hero_main"} to set homepage position.
+    News Room requests must carry an explicit body such as
+    ``{"position": "hero_main"}``; there is no editorial placement default.
 
     This endpoint:
     1. Ingests article to Qdrant (knowledge base)
@@ -700,6 +701,11 @@ async def publish_staging_item(
     which names the actor explicitly rather than bypassing the gate.
     """
     _require_publish_admin(current_user)
+    if type == "news" and body is None:
+        raise HTTPException(
+            status_code=422,
+            detail="News Room publication requires an explicit homepage position",
+        )
     return await _publish_staging_item(
         type=type,
         item_id=item_id,
@@ -1310,6 +1316,7 @@ async def _publish_staging_item(
         return {
             "success": github_published,
             "github_published": github_published,
+            "status": data["status"],
             "message": message,
             "id": item_id,
             "title": title,

--- a/apps/backend-rag/backend/tests/unit/routers/test_caseos_r3_admin_gates.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_caseos_r3_admin_gates.py
@@ -61,9 +61,24 @@ async def test_publish_allowed_for_admin() -> None:
 
     with patch.object(intel_scraper.staging_service, "load_staging_item", return_value=None):
         async with _client(intel_scraper.router, ADMIN_USER) as client:
-            resp = await client.post("/api/intel/staging/publish/news/item-1")
+            resp = await client.post(
+                "/api/intel/staging/publish/news/item-1",
+                json={"position": "latest"},
+            )
 
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_news_publish_requires_explicit_position_for_admin() -> None:
+    """A privileged caller still cannot inherit an editorial placement default."""
+    from backend.app.routers import intel_scraper
+
+    async with _client(intel_scraper.router, ADMIN_USER) as client:
+        resp = await client.post("/api/intel/staging/publish/news/item-1")
+
+    assert resp.status_code == 422
+    assert "explicit homepage position" in resp.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_coverage.py
@@ -700,6 +700,7 @@ async def test_publish_staging_item_qdrant_failure(client_with_auth, mock_db_con
         async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as ac:
             response = await ac.post(
                 "/api/intel/staging/publish/news/test-item-123",
+                json={"position": "latest"},
             )
 
     assert response.status_code == 500
@@ -737,6 +738,7 @@ async def test_publish_staging_item_success(client_with_auth, mock_db_conn):
         async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as ac:
             response = await ac.post(
                 "/api/intel/staging/publish/news/test-item-123",
+                json={"position": "latest"},
             )
 
     # Accept 200 or 500 (500 if article_composer import fails in test env — that's OK)

--- a/apps/backend-rag/backend/tests/unit/routers/test_workspace_marketing_bridge.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_workspace_marketing_bridge.py
@@ -285,7 +285,9 @@ async def test_workspace_publish_uses_named_actor_and_existing_cover_only(
     request.scope["app"] = app
     result = await intel.workspace_marketing_publish_news(
         "news_1",
-        intel.WorkspaceNewsPublishRequest(confirmation="DAMAR_CONFIRMED"),
+        intel.WorkspaceNewsPublishRequest(
+            confirmation="DAMAR_CONFIRMED", position="latest"
+        ),
         request=request,
     )
 
@@ -328,7 +330,9 @@ async def test_workspace_publish_recovers_expired_lease_with_same_operation(
 
     result = await intel.workspace_marketing_publish_news(
         "news_1",
-        intel.WorkspaceNewsPublishRequest(confirmation="DAMAR_CONFIRMED"),
+        intel.WorkspaceNewsPublishRequest(
+            confirmation="DAMAR_CONFIRMED", position="latest"
+        ),
     )
 
     assert result["success"] is True
@@ -584,7 +588,9 @@ async def test_workspace_publish_blocks_incomplete_or_already_published_items(
     with pytest.raises(HTTPException) as exc_info:
         await intel.workspace_marketing_publish_news(
             "news_1",
-            intel.WorkspaceNewsPublishRequest(confirmation="DAMAR_CONFIRMED"),
+            intel.WorkspaceNewsPublishRequest(
+                confirmation="DAMAR_CONFIRMED", position="latest"
+            ),
         )
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail["missing"] == ["cover_image"]
@@ -595,7 +601,9 @@ async def test_workspace_publish_blocks_incomplete_or_already_published_items(
     monkeypatch.setattr(intel.staging_service, "load_staging_item", lambda *_: published)
     replay = await intel.workspace_marketing_publish_news(
         "news_1",
-        intel.WorkspaceNewsPublishRequest(confirmation="DAMAR_CONFIRMED"),
+        intel.WorkspaceNewsPublishRequest(
+            confirmation="DAMAR_CONFIRMED", position="latest"
+        ),
     )
     assert replay["idempotent"] is True
     assert replay["status"] == "published"
@@ -698,7 +706,7 @@ def test_http_boundary_requires_exact_dedicated_key(monkeypatch) -> None:
     }
 
     publish_path = "/api/workspace-marketing/news/news_1/publish"
-    publish_body = {"confirmation": "DAMAR_CONFIRMED"}
+    publish_body = {"confirmation": "DAMAR_CONFIRMED", "position": "latest"}
     assert client.post(publish_path, json=publish_body).status_code == 401
     assert (
         client.post(
@@ -715,6 +723,13 @@ def test_http_boundary_requires_exact_dedicated_key(monkeypatch) -> None:
     )
     assert published.status_code == 200
     assert published.json()["published_url"].startswith("https://balizero.com/")
+
+    missing_position = client.post(
+        publish_path,
+        json={"confirmation": "DAMAR_CONFIRMED"},
+        headers={"X-Workspace-Marketing-Key": "dedicated-key"},
+    )
+    assert missing_position.status_code == 422
 
 
 def test_all_bridge_routes_reach_their_dedicated_route_auth(monkeypatch) -> None:

--- a/apps/mouth/src/app/(workspace)/intelligence/news-room/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/intelligence/news-room/page.test.tsx
@@ -190,6 +190,21 @@ describe("NewsRoomPage", () => {
     });
   });
 
+  it("should block article publication until a position is chosen", async () => {
+    render(<NewsRoomPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Publish" })).toHaveLength(
+        3,
+      );
+    });
+
+    for (const button of screen.getAllByRole("button", { name: "Publish" })) {
+      expect(button).toBeDisabled();
+    }
+    expect(intelligenceApi.publishItem).not.toHaveBeenCalled();
+  });
+
   it("should display source names for each item", async () => {
     render(<NewsRoomPage />);
 
@@ -353,7 +368,7 @@ describe("NewsRoomPage", () => {
       }
     });
 
-    it("should handle bulk publish", async () => {
+    it("should block bulk publish until every item has a position", async () => {
       vi.mocked(intelligenceApi.publishItem)
         .mockResolvedValueOnce({
           success: true,
@@ -398,6 +413,8 @@ describe("NewsRoomPage", () => {
       if (bulkPublishButton) {
         await userEvent.click(bulkPublishButton);
       }
+
+      expect(intelligenceApi.publishItem).not.toHaveBeenCalled();
     });
 
     it("should not show bulk actions when no items selected", async () => {

--- a/apps/mouth/src/app/(workspace)/intelligence/news-room/page.tsx
+++ b/apps/mouth/src/app/(workspace)/intelligence/news-room/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
-import { intelligenceApi, StagingItem } from "@/lib/api/intelligence.api";
+import { intelligenceApi } from "@/lib/api/intelligence.api";
+import type { PublishPosition, StagingItem } from "@/lib/api/intelligence.api";
 import {
   Select,
   SelectContent,
@@ -46,6 +47,17 @@ import { getArticlePalette } from "./article-palette";
 type FilterType = "all" | "NEW" | "UPDATED" | "critical";
 type SortType = "date-desc" | "date-asc" | "title-asc" | "title-desc";
 
+const UNIQUE_HOMEPAGE_POSITIONS = new Set<PublishPosition>([
+  "hero_main",
+  "hero_2",
+  "hero_3",
+  "hero_4",
+  "hero_5",
+  "insight_1",
+  "insight_2",
+  "insight_3",
+]);
+
 export default function NewsRoomPage() {
   const [items, setItems] = useState<StagingItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -62,9 +74,9 @@ export default function NewsRoomPage() {
   );
   const toast = useToast();
   const [publishPosition, setPublishPosition] = useState<
-    Record<string, string>
+    Record<string, PublishPosition>
   >({});
-  const getPosition = (id: string) => publishPosition[id] || "latest";
+  const getPosition = (id: string) => publishPosition[id];
 
   // Filtered and sorted items
   const filteredAndSortedItems = useMemo(() => {
@@ -180,13 +192,36 @@ export default function NewsRoomPage() {
       return;
     }
 
+    const ids = Array.from(selectedItems);
+    const missingPositions = ids.filter((id) => !getPosition(id));
+    if (missingPositions.length > 0) {
+      toast.error(
+        "Position required",
+        "Choose Latest, a Hero slot, or an Insight slot for every selected article.",
+      );
+      return;
+    }
+
+    const assignedUniqueSlots = ids
+      .map((id) => getPosition(id))
+      .filter(
+        (position): position is PublishPosition =>
+          position !== undefined && UNIQUE_HOMEPAGE_POSITIONS.has(position),
+      );
+    if (new Set(assignedUniqueSlots).size !== assignedUniqueSlots.length) {
+      toast.error(
+        "Duplicate homepage slot",
+        "Each Hero or Insight slot can be assigned only once per operation.",
+      );
+      return;
+    }
+
     logger.info("Starting bulk publish", {
       component: "NewsRoomPage",
       action: "bulk_publish_start",
       metadata: { count: selectedItems.size },
     });
 
-    const ids = Array.from(selectedItems);
     const results = { success: 0, failed: 0 };
 
     for (const id of ids) {
@@ -197,7 +232,11 @@ export default function NewsRoomPage() {
       try {
         await intelligenceApi.publishItem(item.type, id, getPosition(id));
         results.success++;
-        setItems((prev) => prev.filter((i) => i.id !== id));
+        setItems((prev) =>
+          prev.map((i) =>
+            i.id === id ? { ...i, status: "publication_pending" } : i,
+          ),
+        );
       } catch (error) {
         results.failed++;
         logger.error(
@@ -220,8 +259,8 @@ export default function NewsRoomPage() {
 
     setSelectedItems(new Set());
     toast.success(
-      "Bulk publish completed",
-      `${results.success} published, ${results.failed} failed.`,
+      "Bulk publication requests completed",
+      `${results.success} queued, ${results.failed} failed.`,
     );
 
     logger.info("Bulk publish completed", {
@@ -229,8 +268,6 @@ export default function NewsRoomPage() {
       action: "bulk_publish_complete",
       metadata: results,
     });
-
-    loadNews();
   };
 
   const handlePreview = async (item: StagingItem) => {
@@ -260,6 +297,13 @@ export default function NewsRoomPage() {
 
   const handlePublish = async (item: StagingItem) => {
     const position = getPosition(item.id);
+    if (!position) {
+      toast.error(
+        "Position required",
+        "Choose Latest, a Hero slot, or an Insight slot before publishing.",
+      );
+      return;
+    }
 
     logger.info("Publishing item", {
       component: "NewsRoomPage",
@@ -278,7 +322,7 @@ export default function NewsRoomPage() {
         position,
       );
 
-      logger.info("Item published successfully", {
+      logger.info("Item queued for publication", {
         component: "NewsRoomPage",
         action: "publish_success",
         itemId: item.id,
@@ -286,14 +330,14 @@ export default function NewsRoomPage() {
       });
 
       toast.success(
-        "Published!",
-        `"${response.title}" published${position !== "latest" ? ` to ${position.replace("_", " ")}` : ""}`,
+        "Queued for publication",
+        `"${response.title}" is queued${position !== "latest" ? ` for ${position.replace("_", " ")}` : ""}. It is not live until verification succeeds.`,
       );
 
-      // Mark as published locally (keep card visible with "Published" ribbon)
+      // A successful request opens a PR. Only the live verifier may mark it published.
       setItems((prev) =>
         prev.map((i) =>
-          i.id === item.id ? { ...i, status: "published" as const } : i,
+          i.id === item.id ? { ...i, status: "publication_pending" } : i,
         ),
       );
     } catch (error) {
@@ -555,8 +599,10 @@ export default function NewsRoomPage() {
                   </div>
                 )}
 
-                {/* Published diagonal ribbon */}
-                {item.status === "published" && (
+                {/* Honest publication-state ribbon */}
+                {(item.status === "published" ||
+                  item.status === "publication_pending" ||
+                  item.status === "publishing") && (
                   <div
                     className="absolute z-20 pointer-events-none"
                     style={{
@@ -582,7 +628,7 @@ export default function NewsRoomPage() {
                         textTransform: "uppercase",
                       }}
                     >
-                      Published
+                      {item.status === "published" ? "Published" : "Queued"}
                     </span>
                   </div>
                 )}
@@ -716,7 +762,9 @@ export default function NewsRoomPage() {
 
                 {/* Footer — position select + publish (or published badge) */}
                 <div className="px-3 pb-3 space-y-1.5">
-                  {item.status === "published" ? (
+                  {item.status === "published" ||
+                  item.status === "publication_pending" ||
+                  item.status === "publishing" ? (
                     <div
                       className="w-full flex items-center justify-center gap-1.5 py-2 rounded-xl text-[10px] font-semibold tracking-wide"
                       style={{
@@ -727,7 +775,8 @@ export default function NewsRoomPage() {
                           "1px solid color-mix(in srgb, var(--state-success) 20%, transparent)",
                       }}
                     >
-                      <Check className="w-3 h-3" /> Published
+                      <Check className="w-3 h-3" />
+                      {item.status === "published" ? "Published" : "Queued"}
                     </div>
                   ) : (
                     <>
@@ -736,7 +785,7 @@ export default function NewsRoomPage() {
                         onValueChange={(v) =>
                           setPublishPosition((prev) => ({
                             ...prev,
-                            [item.id]: v,
+                            [item.id]: v as PublishPosition,
                           }))
                         }
                       >
@@ -752,7 +801,7 @@ export default function NewsRoomPage() {
                             className="w-3 h-3 mr-1"
                             style={{ color: pal.accent }}
                           />
-                          <SelectValue />
+                          <SelectValue placeholder="Choose position" />
                         </SelectTrigger>
                         <SelectContent
                           className="rounded-xl"
@@ -775,7 +824,9 @@ export default function NewsRoomPage() {
                       </Select>
                       <button
                         onClick={() => handlePublish(item)}
-                        disabled={publishingIds.has(item.id)}
+                        disabled={
+                          publishingIds.has(item.id) || !getPosition(item.id)
+                        }
                         className="w-full flex items-center justify-center gap-1 py-2 rounded-xl text-[10px] font-bold tracking-wide transition-all duration-300 disabled:opacity-50"
                         style={{
                           background: `linear-gradient(135deg, ${pal.accentSoft}, ${pal.glow})`,
@@ -916,12 +967,12 @@ export default function NewsRoomPage() {
           )}
           <div className="flex gap-2 mt-6">
             <Select
-              value={previewItem ? getPosition(previewItem.id) : "latest"}
+              value={previewItem ? getPosition(previewItem.id) : undefined}
               onValueChange={(value) =>
                 previewItem &&
                 setPublishPosition((prev) => ({
                   ...prev,
-                  [previewItem.id]: value,
+                  [previewItem.id]: value as PublishPosition,
                 }))
               }
             >
@@ -937,7 +988,7 @@ export default function NewsRoomPage() {
                   className="w-3 h-3 mr-1 shrink-0"
                   style={{ color: "var(--bz-text-3)" }}
                 />
-                <SelectValue />
+                <SelectValue placeholder="Choose position" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="latest">Latest</SelectItem>
@@ -961,7 +1012,12 @@ export default function NewsRoomPage() {
                   "1px solid color-mix(in srgb, var(--bz-accent) 20%, transparent)",
               }}
               onClick={() => previewItem && handlePublish(previewItem)}
-              disabled={previewItem ? publishingIds.has(previewItem.id) : false}
+              disabled={
+                previewItem
+                  ? publishingIds.has(previewItem.id) ||
+                    !getPosition(previewItem.id)
+                  : true
+              }
             >
               {previewItem && publishingIds.has(previewItem.id) ? (
                 <>

--- a/apps/mouth/src/lib/api/intelligence.api.test.ts
+++ b/apps/mouth/src/lib/api/intelligence.api.test.ts
@@ -465,7 +465,11 @@ describe("intelligence.api", () => {
 
       vi.mocked(api.request).mockResolvedValue(mockResponse);
 
-      const result = await intelligenceApi.publishItem("news", "news-456");
+      const result = await intelligenceApi.publishItem(
+        "news",
+        "news-456",
+        "latest",
+      );
 
       expect(api.request).toHaveBeenCalledWith(
         "/api/intel/staging/publish/news/news-456",
@@ -480,6 +484,14 @@ describe("intelligence.api", () => {
         "news-456",
       );
       expect(result).toEqual(mockResponse);
+    });
+
+    it("should reject news publication without an explicit position", async () => {
+      await expect(
+        intelligenceApi.publishItem("news", "news-without-position"),
+      ).rejects.toThrow("requires an explicit homepage position");
+
+      expect(api.request).not.toHaveBeenCalled();
     });
 
     it("should handle and log errors", async () => {

--- a/apps/mouth/src/lib/api/intelligence.api.ts
+++ b/apps/mouth/src/lib/api/intelligence.api.ts
@@ -5,7 +5,13 @@ export interface StagingItem {
   id: string;
   type: "visa" | "news";
   title: string;
-  status: "pending" | "approved" | "rejected" | "published";
+  status:
+    | "pending"
+    | "approved"
+    | "rejected"
+    | "publishing"
+    | "publication_pending"
+    | "published";
   detected_at: string;
   source: string;
   detection_type: "NEW" | "UPDATED";
@@ -32,10 +38,25 @@ export interface PublishResponse {
   message: string;
   id: string;
   title: string;
-  published_url: string;
-  published_at: string;
+  status?: StagingItem["status"];
+  published_url: string | null;
+  published_at: string | null;
+  publication_requested_at?: string | null;
   collection: string;
+  pull_request_number?: number | null;
+  auto_merge_enabled?: boolean | null;
 }
+
+export type PublishPosition =
+  | "latest"
+  | "hero_main"
+  | "hero_2"
+  | "hero_3"
+  | "hero_4"
+  | "hero_5"
+  | "insight_1"
+  | "insight_2"
+  | "insight_3";
 
 export interface SystemMetrics {
   agent_status: "active" | "idle" | "error";
@@ -241,8 +262,14 @@ export const intelligenceApi = {
   publishItem: async (
     type: "visa" | "news",
     id: string,
-    position: string = "latest",
+    position?: PublishPosition,
   ): Promise<PublishResponse> => {
+    if (type === "news" && !position) {
+      throw new Error(
+        "News Room publication requires an explicit homepage position",
+      );
+    }
+    const resolvedPosition = position ?? "latest";
     const endpoint = `/api/intel/staging/publish/${type}/${id}`;
     const startTime = performance.now();
 
@@ -250,13 +277,13 @@ export const intelligenceApi = {
       itemType: type,
       itemId: id,
       action: "publish",
-      metadata: { position },
+      metadata: { position: resolvedPosition },
     });
 
     try {
       const response = await api.request<PublishResponse>(endpoint, {
         method: "POST",
-        body: JSON.stringify({ position }),
+        body: JSON.stringify({ position: resolvedPosition }),
       });
       const responseTime = performance.now() - startTime;
 

--- a/apps/wr2-control-app/Sources/AppState.swift
+++ b/apps/wr2-control-app/Sources/AppState.swift
@@ -451,18 +451,26 @@ final class AppState: ObservableObject {
     /// in, uploads the slides, and POSTs the operator-approved caption.
     /// The completion is surfaced via the same `ioNotice` banner as Re-render.
     func publishToInstagram(
-        slug: String, caption: String, lang: LanguageManager, confirm: Bool
+        slug: String,
+        caption: String,
+        lang: LanguageManager,
+        confirm: Bool,
+        completion: @escaping (Bool) -> Void = { _ in }
     ) {
         let s = slug.trimmingCharacters(in: .whitespaces)
         guard s.isEmpty == false,
               InstagramCaption.isPublishable(caption),
-              isPublishingSlug == nil else { return }
+              isPublishingSlug == nil else {
+            completion(false)
+            return
+        }
 
         let captionFile: URL
         do {
             captionFile = try InstagramCaption.writeTemporaryFile(caption)
         } catch {
             notice("⚠︎ \(error.localizedDescription)")
+            completion(false)
             return
         }
 
@@ -512,6 +520,7 @@ final class AppState: ObservableObject {
                         .map(String.init) ?? "exit \(code)"
                     self.notice("⚠︎ " + lastLine)
                 }
+                completion(code == 0)
             }
         }
 
@@ -521,6 +530,7 @@ final class AppState: ObservableObject {
             try? FileManager.default.removeItem(at: captionFile)
             isPublishingSlug = nil
             notice("⚠︎ \(error.localizedDescription)")
+            completion(false)
         }
     }
 

--- a/apps/wr2-control-app/Sources/Localization.swift
+++ b/apps/wr2-control-app/Sources/Localization.swift
@@ -161,7 +161,7 @@ enum L10n {
         "detail.rerender":     [.it: "Ri-renderizza",                                   .id: "Render ulang"],
         "detail.publishIG":    [.it: "Pubblica su IG",                                  .id: "Terbitkan ke IG"],
         "detail.publishIGTitle":[.it: "Pubblicare su Instagram?",                        .id: "Terbitkan ke Instagram?"],
-        "detail.publishIGInfo":[.it: "Il carosello + caption andranno LIVE su @balizero0. Controlla prima con «Verifica».", .id: "Karosel + caption akan TAYANG di @balizero0. Cek dulu dengan «Periksa»."],
+        "detail.publishIGInfo":[.it: "Il carosello + questa caption andranno LIVE su @balizero0. «Pubblica ora» si abilita solo dopo una Verifica riuscita; ogni modifica alla caption la annulla.", .id: "Karosel + caption ini akan TAYANG di @balizero0. «Terbitkan sekarang» aktif hanya setelah Periksa berhasil; perubahan caption membatalkannya."],
         "detail.publishIGCheck":[.it: "Verifica (dry-run)",                              .id: "Periksa (dry-run)"],
         "detail.publishIGConfirm":[.it: "Pubblica ora",                                  .id: "Terbitkan sekarang"],
         "detail.publishIGCancel":[.it: "Annulla",                                        .id: "Batal"],

--- a/apps/wr2-control-app/Sources/Views/CarouselDetailView.swift
+++ b/apps/wr2-control-app/Sources/Views/CarouselDetailView.swift
@@ -29,6 +29,7 @@ struct CarouselDetailView: View {
     @State private var publishCaption = ""
     @State private var captionIsLoading = false
     @State private var captionLoadError: String?
+    @State private var publishDryRunPassed = false
     // Live console: tail of <carousel>/.run.log, refreshed while a run is in flight.
     @State private var logTail: [String] = []
     @State private var showConsole = false
@@ -600,6 +601,7 @@ struct CarouselDetailView: View {
                 publishCaption = ""
                 captionLoadError = nil
                 captionIsLoading = true
+                publishDryRunPassed = false
                 state.loadInstagramCaption(slug: carousel.slug) { result in
                     captionIsLoading = false
                     switch result {
@@ -686,6 +688,9 @@ struct CarouselDetailView: View {
                         RoundedRectangle(cornerRadius: 8)
                             .strokeBorder(Theme.hairline, lineWidth: 1)
                     )
+                    .onChange(of: publishCaption) { _ in
+                        publishDryRunPassed = false
+                    }
 
                 HStack(spacing: 8) {
                     if publishCaption.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -708,9 +713,15 @@ struct CarouselDetailView: View {
             HStack(spacing: 10) {
                 // Dry-run: exercises upload + backend validation, posts NOTHING.
                 Button {
+                    let checkedCaption = publishCaption
                     state.publishToInstagram(
-                        slug: carousel.slug, caption: publishCaption, lang: lang, confirm: false
-                    )
+                        slug: carousel.slug,
+                        caption: checkedCaption,
+                        lang: lang,
+                        confirm: false
+                    ) { passed in
+                        publishDryRunPassed = passed && publishCaption == checkedCaption
+                    }
                 } label: {
                     Text(lang.t("detail.publishIGCheck"))
                         .font(.system(size: 13, weight: .semibold))
@@ -745,6 +756,7 @@ struct CarouselDetailView: View {
                         || InstagramCaption.isPublishable(publishCaption) == false
                         || state.isPublishingSlug != nil
                         || carousel.isPublishEligible == false
+                        || publishDryRunPassed == false
                 )
 
                 Button(lang.t("detail.publishIGCancel")) { showPublishIGConfirm = false }


### PR DESCRIPTION
## Summary
- persist the shared News Room + WR2 publishing protocol for authenticated Zero/Damar sessions
- require an explicit News Room placement and preserve honest queued/live states
- require a successful WR2 dry-run before the real Instagram publish control is enabled

## Verification
- 48 targeted frontend tests passed
- 35 workspace bridge tests passed
- 79 publisher/admin-gate tests passed
- WR2 test harness: 209 passed plus QueueWriter and launch-agent checks
- frontend typecheck, targeted lint, backend ruff, skill validation, Swift syntax parse, and door-canon parity passed
- full SwiftUI bundle build unavailable on Mini because Xcode macros are absent; Pro was unreachable during verification

Bites: Damar publishing from Codex Remote — a News Room request without an explicit position is rejected, a successful article request displays Queued until live verification, and WR2 Pubblica ora stays disabled until the exact caption passes dry-run.