### PR TITLE
feat(visa-engine): land the SIGNED seq-20 bundle and re-pin the walk census onto it

### DIFF
--- a/.agents/skills/visaoracle/SKILL.md
+++ b/.agents/skills/visaoracle/SKILL.md
@@ -131,6 +131,41 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
 
 ## LIVE STATE (update on every state change — whoever changes state updates this section)
 
+- 2026-09-06 (M5, consul session — seq-20 SIGNED + ACTIVATED): **SEQ-20 IS THE ACTIVE PRODUCTION
+  PACK, under ENFORCE.** seq-20 = seq-19 + the five decisiveness edits of fold PR #5854
+  (`dc7189f4`): stay-day caps raised to the lawful extendable total on 22 rules,
+  `review.e33g.income-evidence` retired, the eight `family.sponsor_status_code` rules made
+  `NO_EFFECT`, a `known` premise conjoined onto the four BRIDGING rules, and CL-D2-01 compiled as
+  the new EXCLUDE `hf.d2.indonesia-source-compensation`. Signed on M5 (`sign_pack.py` offline, kid
+  `prod-2026-07-1`, `signed_at 2026-09-06T14:59:27.320080Z`, payload_sha256
+  `df02287b7fc8f572a9e6674fdf3445a2131c428e8a1492ab8a388dee5bf01a4d`, rule_pack_id
+  `ac0a792d-a38d-512e-9ead-54a5d008fb68`, version `2026.9.6`, 109 rules, previous
+  `bac5da8e…`); digest re-verified UNCHANGED after `prettier --write`, and the signed payload is
+  byte-identical to `rulepack-prod-020.source.json` under JCS. **Activated** with
+  `activate_pack.py --yes`, actor `consul-session-m5`, reason `seq20-decisiveness-260906`,
+  `activation_id e08ebea9-d50f-48a6-989e-b7e4698f96ad`; two DISTINCT ephemeral logins
+  (`visa_pack_writer_ceremony_260906c`, `visa_activation_ceremony_260906c`, `VALID UNTIL` +3h)
+  minted and dropped by the session on the PG primary `0801696b541568`, leftover 0, tunnel and
+  `flyctl proxy` closed on both M5 and Pro.
+  **PROVE-LIVE** (`probe_evaluate.py --traffic-source synthetic_driver`, walks replayed from the
+  PR-0 corpus): prod answers `sequence=20 version=2026.9.6 rule_pack_id=ac0a792d…`;
+  `offshore/tourism` and `onshore/tourism` now return `SUPPORTED_CANDIDATES` where seq-19
+  dead-ended; `offshore/business` and `offshore/remote` still `NEEDS_INPUT` — PR-2/PR-3's mandate,
+  not a regression. Walk census re-measured on the signed pack: **36 dead ends / 7 answers →
+  21 / 22**.
+  **ORDER NOTE, recorded because it inverts the wave spec:** the ceremony ran BEFORE the bundle
+  PR landed, on Zero's explicit instruction. The window was closed by verifying that the blob
+  committed in that PR is byte-identical to the artifact already live (same digest, same
+  `rule_pack_id`) — never by assuming it.
+  **CEREMONY GOTCHAS measured this run, all new since seq-19.** (1) The two ephemeral roles
+  CANNOT `SELECT` `visa_ruleset_activations` — least privilege is real, so "exactly one open
+  activation" must be confirmed through the readonly role or through the live probe, never
+  through the ceremony logins. (2) Fly auth lives ONLY on Pro: `flyctl` on M5 is a shell function
+  that proxies over ssh, and the real binary (`/opt/homebrew/bin/flyctl`) has no token on either
+  M5 or Mini — so Pro being offline blocks the whole ceremony. (3) Killing the local `ssh` that
+  started `flyctl proxy` does NOT kill the proxy on Pro; it survived and had to be killed
+  remotely by PID. Check with `ssh pro "pgrep -fl 'flyctl proxy'"` before declaring cleanup done.
+
 - 2026-09-06 (M5, owner decision — ENFORCE + GARUDA VOA public): **this is an owner decision
   recorded by the session, not a session-inferred authorization.** (1) Production evaluate mode
   measured `mode='ENGINE'` at 01:1xZ via `probe_evaluate.py` (was `CURATED`), rule pack seq-19

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-020.signed.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-020.signed.json
@@ -1,0 +1,9293 @@
+{
+  "canonicalization": "RFC8785",
+  "payload": {
+    "created_at": "2026-09-06T00:00:00Z",
+    "created_by": "agent.air-m5.backend-rag.visa-oracle-decisiveness-seq20.fold-2026-09-06",
+    "decision_domain": "IMMIGRATION_VISA",
+    "engine_contract_version": "1.0.0",
+    "engine_max_version": "1.0.0",
+    "engine_min_version": "1.0.0",
+    "environment": "PRODUCTION",
+    "hit_policy": {
+      "eligibility": "COVER_ALL_DECLARED_PURPOSES",
+      "hard_filter": "COLLECT_ALL",
+      "human_review": "COLLECT_ALL",
+      "ranking": "SUM_TRUE_INTEGER_WEIGHTS"
+    },
+    "jurisdiction": "ID",
+    "previous_payload_sha256": "bac5da8e4727e7f639c947c50211e6f95e15c1403cf6aef0dd57a92014d6e6ea",
+    "products": [
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["INVESTMENT"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 100,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": ["B211"],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Visa (E28A)",
+          "id": "Visa Investor (E28A)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Investor KITAS 2 Years (Offshore)"
+        },
+        "product_code": "E28A",
+        "product_version_id": "c8277316-c29d-5fde-bf9f-2611099a0029",
+        "prohibited_activities": [
+          "operational_work_beyond_management_and_ownership"
+        ],
+        "public_catalog": true,
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INVESTMENT"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 730,
+          "minimum_days": 730
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["INVESTMENT"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Golden Visa \u2014 Company Establishment (E28B)",
+          "id": "Visa Investor Pendirian Perusahaan (E28B)"
+        },
+        "pricing_key": null,
+        "product_code": "E28B",
+        "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
+        "prohibited_activities": ["operational_work"],
+        "public_catalog": true,
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INVESTMENT"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["INVESTMENT"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Golden Visa \u2014 Capital Market (E28C)",
+          "id": "Visa Investor Tanpa Mendirikan Perusahaan (E28C)"
+        },
+        "pricing_key": null,
+        "product_code": "E28C",
+        "product_version_id": "b074270f-fa7c-598b-a728-81ca89432364",
+        "prohibited_activities": [
+          "operational_work",
+          "corporate_establishment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["INVESTMENT"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Golden Visa \u2014 Branch or Subsidiary (E28D)",
+          "id": "Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D)"
+        },
+        "pricing_key": null,
+        "product_code": "E28D",
+        "product_version_id": "ee4fef98-3497-507c-8486-225932364e26",
+        "prohibited_activities": [
+          "operational_work_outside_managing_subsidiary"
+        ],
+        "public_catalog": true,
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INVESTMENT"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["INVESTMENT"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Golden Visa \u2014 New Capital (IKN) Subsidiary (E28F)",
+          "id": "Visa Investor Anak Perusahaan Ibukota Nusantara (E28F)"
+        },
+        "pricing_key": null,
+        "product_code": "E28F",
+        "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
+        "prohibited_activities": ["operational_work"],
+        "public_catalog": true,
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INVESTMENT"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["SECOND_HOME", "TOURISM"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Visa (E33)",
+          "id": "Visa Rumah Kedua (E33)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E33 Second Home (5 Years)"
+        },
+        "product_code": "E33",
+        "product_version_id": "cf4d7f3d-1253-5036-8953-79ab3d3e7009",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services",
+          "guarantee_value_below_commitment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 1825,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["EMPLOYMENT", "TOURISM", "FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Visa \u2014 Special-Expertise Government Invitation (E33A)",
+          "id": "Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A)"
+        },
+        "pricing_key": null,
+        "product_code": "E33A",
+        "product_version_id": "5c18e265-ddb2-5010-8d24-a2f19df89850",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": ["GOVERNMENT"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "EMPLOYMENT",
+          "BUSINESS_MEETINGS",
+          "INVESTMENT",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Golden Visa \u2014 Special-Expertise Collaboration (E33B)",
+          "id": "Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B)"
+        },
+        "pricing_key": null,
+        "product_code": "E33B",
+        "product_version_id": "32b6fb5f-5a24-5763-95f9-0b77be18353c",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "INVESTMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Golden Visa \u2014 World-Figure Government Invitation (E33C)",
+          "id": "Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C)"
+        },
+        "pricing_key": null,
+        "product_code": "E33C",
+        "product_version_id": "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": ["GOVERNMENT"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": ["E311A"],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Golden Visa \u2014 Elderly 5-Year (E33E)",
+          "id": "Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa (E33E)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Retirement (Offshore)"
+        },
+        "product_code": "E33E",
+        "product_version_id": "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services",
+          "deposit_value_below_commitment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 1825,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "RETIREMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": ["E311A"],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Visa \u2014 Elderly 1-Year (E33F)",
+          "id": "Visa Rumah Kedua Lansia untuk 1 Tahun (E33F)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E33F Second Home Senior (1 Year, Offshore)"
+        },
+        "product_code": "E33F",
+        "product_version_id": "7c1da88f-f7cd-571a-95c2-7da32463d3e6",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Visa \u2014 Remote Worker (E33G)",
+          "id": "Visa Rumah Kedua Pekerja Jarak Jauh (E33G)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E33G Remote Worker (Offshore)"
+        },
+        "product_code": "E33G",
+        "product_version_id": "51e023ea-3229-5233-b88f-cb204b5df713",
+        "prohibited_activities": [
+          "work_for_indonesian_entity",
+          "indonesian_source_compensation_including_in_kind",
+          "indonesian_company_ownership",
+          "sale_of_goods_or_services_beyond_remote_work"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["TOURISM", "TRANSIT"],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visa-Free Tourism Visit (A1)",
+          "id": "Bebas Visa Kunjungan Wisata (A1)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "A1 Visa-Free Tourism"
+        },
+        "product_code": "A1",
+        "product_version_id": "aee1a12d-3285-526e-8a6f-3d8467fe5d72",
+        "prohibited_activities": [
+          "paid_employment",
+          "business_meetings",
+          "study",
+          "journalism"
+        ],
+        "public_catalog": true,
+        "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 30,
+          "minimum_days": 30
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["TOURISM"],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 30,
+          "maximum_extensions": 1,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": ["B213"],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visa on Arrival \u2014 Tourism (B1)",
+          "id": "Visa Saat Kedatangan Wisata (B1)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "B1 Visa on Arrival (VOA)"
+        },
+        "product_code": "B1",
+        "product_version_id": "4e30cbe0-c4bf-59be-9bf8-513e66946e44",
+        "prohibited_activities": [
+          "paid_employment",
+          "business_meetings",
+          "study",
+          "journalism"
+        ],
+        "public_catalog": true,
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 30,
+          "minimum_days": 30
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["TOURISM", "FAMILY"],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": ["B211A"],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Tourist Visit Visa (C1)",
+          "id": "Visa Kunjungan Wisata (C1)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "C1 Tourism"
+        },
+        "product_code": "C1",
+        "product_version_id": "7a07cbb0-564f-5c3f-9720-6ad62c4789cd",
+        "prohibited_activities": [
+          "paid_employment",
+          "business_meetings",
+          "journalism"
+        ],
+        "public_catalog": true,
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["NONE", "INDIVIDUAL", "EMPLOYER"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": ["B211B", "B211A"],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Business Visit Visa (C2)",
+          "id": "Visa Kunjungan Bisnis (C2)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "C2 Business"
+        },
+        "product_code": "C2",
+        "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
+        "prohibited_activities": ["paid_employment"],
+        "public_catalog": true,
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["EMPLOYER"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["OTHER"],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": ["B211A"],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Social Activity Visit Visa (C6)",
+          "id": "Visa Kunjungan Kegiatan Sosial (C6)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "C6 Social Activity"
+        },
+        "product_code": "C6",
+        "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
+        "prohibited_activities": ["paid_employment", "business_meetings"],
+        "public_catalog": true,
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INDIVIDUAL", "EMPLOYER"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "OTHER",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": ["OTHER"],
+        "entry_policy": {
+          "entry_count": "NOT_APPLICABLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Bridging Visa \u2014 Transitional Stay Permit",
+          "id": "Izin Tinggal Peralihan"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "Bridging Visa"
+        },
+        "product_code": "BRIDGING",
+        "product_version_id": "760025cf-d51d-5687-9e98-b921010b9018",
+        "prohibited_activities": [
+          "employment_relationship",
+          "exit_terminates_permit"
+        ],
+        "public_catalog": false,
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b",
+          "3da72c7b-783e-51e3-9168-6c54bce709ed",
+          "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
+        ],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": null
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["EMPLOYMENT", "TOURISM"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 1,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Working Visa (E23)",
+          "id": "Visa Kerja (E23)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Working KITAS (Offshore)"
+        },
+        "product_code": "E23",
+        "product_version_id": "e1d761e9-56c5-57c3-9c01-986d3c333157",
+        "prohibited_activities": [
+          "work_for_non_sponsor_entity",
+          "hr_personnel_positions",
+          "passive_investment_management"
+        ],
+        "public_catalog": true,
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "sponsor_types": ["EMPLOYER"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["EMPLOYMENT"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Working Visa \u2014 Foreign Diplomat House Assistant (E23U)",
+          "id": "Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U)"
+        },
+        "pricing_key": null,
+        "product_code": "E23U",
+        "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
+        "prohibited_activities": ["work_for_non_diplomat_employer"],
+        "public_catalog": true,
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["EMPLOYMENT"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Working Visa \u2014 Trade and Economic Office (E23V)",
+          "id": "Visa Kerja Kantor Dagang dan Ekonomi (E23V)"
+        },
+        "pricing_key": null,
+        "product_code": "E23V",
+        "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
+        "prohibited_activities": ["work_for_standard_corporate_employers"],
+        "public_catalog": true,
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "sponsor_types": ["GOVERNMENT"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": ["C317"],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Spouse of Indonesian Citizen (E31A)",
+          "id": "Visa Keluarga Suami/Istri WNI (E31A)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Spouse 1 Year (Offshore)"
+        },
+        "product_code": "E31A",
+        "product_version_id": "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce",
+        "prohibited_activities": [],
+        "public_catalog": true,
+        "source_refs": [
+          "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 730,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": ["C318"],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Spouse of ITAS/ITAP Holder (E31B)",
+          "id": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31B",
+        "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
+        "prohibited_activities": ["paid_employment"],
+        "public_catalog": true,
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Child of Legal Mixed Marriage (E31C)",
+          "id": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31C",
+        "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
+        "prohibited_activities": ["paid_employment"],
+        "public_catalog": true,
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Stepchild of Foreigner in Legal Mixed Marriage (E31D)",
+          "id": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31D",
+        "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
+        "prohibited_activities": ["paid_employment"],
+        "public_catalog": true,
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Child of ITAS/ITAP Holder (E31E)",
+          "id": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31E",
+        "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
+        "prohibited_activities": ["paid_employment"],
+        "public_catalog": true,
+        "source_refs": [
+          "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Child of Indonesian Citizen Parent (E31F)",
+          "id": "Visa Keluarga Anak dengan Orang Tua WNI (E31F)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31F",
+        "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
+        "prohibited_activities": ["paid_employment"],
+        "public_catalog": true,
+        "source_refs": [
+          "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Parent of Indonesian Citizen Child (E31G)",
+          "id": "Visa Keluarga Orang Tua dari Anak WNI (E31G)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31G",
+        "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
+        "prohibited_activities": ["paid_employment"],
+        "public_catalog": true,
+        "source_refs": [
+          "86880290-68c2-5220-8f9e-2350678e5f09",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Parent of Child ITAS/ITAP Holder (E31H)",
+          "id": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31H",
+        "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
+        "prohibited_activities": ["paid_employment"],
+        "public_catalog": true,
+        "source_refs": [
+          "153beca1-a24b-5440-bac0-b46c3d19da6f",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Child Joining Sibling ITAS/ITAP Holder (E31J)",
+          "id": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31J",
+        "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
+        "prohibited_activities": ["paid_employment"],
+        "public_catalog": true,
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "MULTIPLE_ENTRY",
+        "clock_policy": {
+          "anchor": "ENTRY_DATE",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY",
+          "TRANSIT",
+          "BUSINESS_MEETINGS"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visit Visa Tourism \u2014 Multiple Entry (D1)",
+          "id": "Visa Kunjungan Wisata \u2014 Beberapa Kali Perjalanan (D1)"
+        },
+        "pricing_key": {
+          "category": "multiple_entry_visas",
+          "item_key": "D1 Tourism (1 Year)"
+        },
+        "product_code": "D1",
+        "product_version_id": "374e79e0-f0bf-5291-8cba-974e794e210a",
+        "prohibited_activities": [
+          "selling_goods_services",
+          "indonesian_source_remuneration"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "MULTIPLE_ENTRY",
+        "clock_policy": {
+          "anchor": "ENTRY_DATE",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["BUSINESS_MEETINGS", "TOURISM", "FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visit Visa Business \u2014 Multiple Entry (D2)",
+          "id": "Visa Kunjungan Bisnis (D2)"
+        },
+        "pricing_key": {
+          "category": "multiple_entry_visas",
+          "item_key": "D2 Business (1 Year)"
+        },
+        "product_code": "D2",
+        "product_version_id": "306725c1-7269-5c45-a4b8-188265fcf4d8",
+        "prohibited_activities": [
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "continuous_supervision_production_sales"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "MULTIPLE_ENTRY",
+        "clock_policy": {
+          "anchor": "ENTRY_DATE",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["INVESTMENT", "TOURISM", "FAMILY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 180,
+          "maximum_extensions": 1,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visit Visa Pre-Investment \u2014 Multiple Entry (D12)",
+          "id": "Visa Kunjungan Pra-Investasi (D12)"
+        },
+        "pricing_key": {
+          "category": "multiple_entry_visas",
+          "item_key": "D12 Business Investigation (1 Year)"
+        },
+        "product_code": "D12",
+        "product_version_id": "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91",
+        "prohibited_activities": [
+          "selling_goods_services",
+          "indonesian_source_remuneration"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "sponsor_types": ["NONE"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 180,
+          "minimum_days": 180
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["STUDY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Education Visa (E30)",
+          "id": "Visa Pendidikan (E30)"
+        },
+        "pricing_key": null,
+        "product_code": "E30",
+        "product_version_id": "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": false,
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "VARIABLE_BY_GRANT",
+          "maximum_days": null,
+          "minimum_days": null
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["STUDY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Primary/Secondary Education Visa (E30A)",
+          "id": "Visa Pendidikan Dasar dan Menengah (E30A)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E30A Education Visa (1 Year)"
+        },
+        "product_code": "E30A",
+        "product_version_id": "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 730,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["STUDY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Higher Education Visa (E30B)",
+          "id": "Visa Pendidikan Tinggi (E30B)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E30B Higher Education (1 Year)"
+        },
+        "product_code": "E30B",
+        "product_version_id": "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "31850f85-8d19-58df-bb66-b04968c9aff0"
+        ],
+        "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 1460,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["STUDY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "SEZ Education Visa (E30E)",
+          "id": "Visa Pendidikan Kawasan Ekonomi Khusus (E30E)"
+        },
+        "pricing_key": null,
+        "product_code": "E30E",
+        "product_version_id": "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["EDUCATION"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "VARIABLE_BY_GRANT",
+          "maximum_days": null,
+          "minimum_days": null
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": ["STUDY"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Student Exchange Visa (E30F)",
+          "id": "Visa Pertukaran Pelajar (E30F)"
+        },
+        "pricing_key": null,
+        "product_code": "E30F",
+        "product_version_id": "235f5dfc-2feb-5d5b-ab09-0f4e4122819e",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": ["EDUCATION"],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "VARIABLE_BY_GRANT",
+          "maximum_days": null,
+          "minimum_days": null
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      }
+    ],
+    "rollback_of_payload_sha256": null,
+    "rule_pack_id": "ac0a792d-a38d-512e-9ead-54a5d008fb68",
+    "rules": [
+      {
+        "effect": {
+          "reason_code": "APPLICANT_IS_INDONESIAN_CITIZEN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.citizen",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": ["derived.has_indonesian_citizenship"],
+        "rule_id": "hf.citizen",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "derived.has_indonesian_citizenship",
+          "op": "eq",
+          "value": true
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "OVERSTAY_EXCEEDS_60_DAYS",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.overstay-exceeds-60-days",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": ["immigration.overstay_days"],
+        "rule_id": "hf.overstay-exceeds-60-days",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.overstay_days",
+          "op": "gt",
+          "value": 60
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "CALLING_VISA_REVIEW",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.calling-visa",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": ["person.nationalities"],
+        "rule_id": "review.calling-visa",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": ["bc309fa9-d14e-5625-b914-72fe4a68c19d"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "person.nationalities",
+          "op": "intersects",
+          "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "ACTIVE_OVERSTAY",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.active-overstay",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": ["immigration.overstay_days"],
+        "rule_id": "review.active-overstay",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.overstay_days",
+          "op": "gt",
+          "value": 0
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BVK_NATIONALITY_ONLY",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.a1.not-bvk-nationality",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"],
+        "required_facts": ["person.nationalities"],
+        "rule_id": "hf.a1.not-bvk-nationality",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "arg": {
+            "fact": "person.nationalities",
+            "op": "intersects",
+            "values": [
+              "BN",
+              "MY",
+              "TH",
+              "SG",
+              "PH",
+              "KH",
+              "LA",
+              "MM",
+              "VN",
+              "TL",
+              "SR",
+              "CO",
+              "HK",
+              "TR",
+              "BR",
+              "PE",
+              "MO",
+              "KZ",
+              "BY"
+            ]
+          },
+          "op": "not"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["TOURISM", "TRANSIT"],
+          "reason_code": "A1_BVK_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.a1.tourism",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days",
+          "person.nationalities"
+        ],
+        "rule_id": "el.a1.tourism",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["TOURISM", "TRANSIT"]
+            },
+            {
+              "fact": "person.nationalities",
+              "op": "intersects",
+              "values": [
+                "BN",
+                "MY",
+                "TH",
+                "SG",
+                "PH",
+                "KH",
+                "LA",
+                "MM",
+                "VN",
+                "TL",
+                "SR",
+                "CO",
+                "HK",
+                "TR",
+                "BR",
+                "PE",
+                "MO",
+                "KZ",
+                "BY"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 30
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["TOURISM"],
+          "reason_code": "B1_VOA_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.b1.tourism",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days",
+          "person.nationalities"
+        ],
+        "rule_id": "el.b1.tourism",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["TOURISM"]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 60
+            },
+            {
+              "fact": "person.nationalities",
+              "op": "intersects",
+              "values": [
+                "ZA",
+                "AL",
+                "US",
+                "AD",
+                "SA",
+                "AR",
+                "AM",
+                "AU",
+                "AT",
+                "AZ",
+                "BH",
+                "NL",
+                "BY",
+                "BE",
+                "BR",
+                "BN",
+                "BA",
+                "BG",
+                "CZ",
+                "CL",
+                "DK",
+                "EC",
+                "EE",
+                "PH",
+                "FI",
+                "GT",
+                "HK",
+                "HU",
+                "IN",
+                "GB",
+                "IE",
+                "IT",
+                "IS",
+                "JP",
+                "DE",
+                "KH",
+                "CA",
+                "KZ",
+                "KE",
+                "CO",
+                "KR",
+                "HR",
+                "KW",
+                "LA",
+                "LV",
+                "LI",
+                "LT",
+                "LU",
+                "MV",
+                "MY",
+                "MT",
+                "MA",
+                "MU",
+                "MX",
+                "EG",
+                "MC",
+                "MN",
+                "MZ",
+                "MM",
+                "NO",
+                "OM",
+                "PS",
+                "PG",
+                "FR",
+                "PE",
+                "PL",
+                "PT",
+                "QA",
+                "RO",
+                "RU",
+                "RW",
+                "NZ",
+                "RS",
+                "SC",
+                "SG",
+                "CY",
+                "SK",
+                "SI",
+                "ES",
+                "SR",
+                "SE",
+                "CH",
+                "TW",
+                "TZ",
+                "TH",
+                "TL",
+                "CN",
+                "TN",
+                "TR",
+                "AE",
+                "UZ",
+                "UA",
+                "VA",
+                "VE",
+                "VN",
+                "JO",
+                "GR"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["TOURISM", "FAMILY"],
+          "reason_code": "C1_VISIT_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.c1.tourism-family",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["7a07cbb0-564f-5c3f-9720-6ad62c4789cd"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.c1.tourism-family",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["TOURISM", "FAMILY"]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
+          "reason_code": "C2_BUSINESS_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.c2.business",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"],
+        "required_facts": [
+          "family.sponsor_confirmed",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.c2.business",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+            },
+            {
+              "fact": "family.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["OTHER"],
+          "reason_code": "C6_SOCIAL_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.c6.social",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["8cf5e09b-6e02-536f-aeca-4aaecaca09c7"],
+        "required_facts": [
+          "family.sponsor_confirmed",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.c6.social",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["OTHER"]
+            },
+            {
+              "fact": "family.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28A_PAID_CAPITAL_BELOW_MIN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e28a.paid-capital-below-min",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"],
+        "required_facts": ["investment.paid_up_capital_idr"],
+        "rule_id": "hf.e28a.paid-capital-below-min",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "investment.paid_up_capital_idr",
+          "op": "lt",
+          "value": 2500000000
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28A_TOTAL_INVESTMENT_BELOW_MIN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e28a.total-investment-below-min",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"],
+        "required_facts": ["investment.investment_capital_idr"],
+        "rule_id": "hf.e28a.total-investment-below-min",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "investment.investment_capital_idr",
+          "op": "lt",
+          "value": 10000000000
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["INVESTMENT"],
+          "reason_code": "E28A_INVESTMENT_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e28a.investment",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"],
+        "required_facts": [
+          "intent.purposes",
+          "investment.investment_capital_idr",
+          "investment.paid_up_capital_idr",
+          "investment.proposed_role",
+          "investment.pt_pma_committed"
+        ],
+        "rule_id": "el.e28a.investment",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "investment.pt_pma_committed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "investment.proposed_role",
+              "op": "in",
+              "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+            },
+            {
+              "fact": "investment.paid_up_capital_idr",
+              "op": "gte",
+              "value": 2500000000
+            },
+            {
+              "fact": "investment.investment_capital_idr",
+              "op": "gte",
+              "value": 10000000000
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28B_USD_THRESHOLD_MANUAL_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e28b.usd-threshold-manual",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["ca8c1177-ad94-5261-82a6-68bc912d31bb"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "review.e28b.usd-threshold-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E28B"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e28c.usd-threshold-manual",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["b074270f-fa7c-598b-a728-81ca89432364"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "review.e28c.usd-threshold-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E28C"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["ee4fef98-3497-507c-8486-225932364e26"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "review.e28d.usd-threshold-turnover-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E28D"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28F_IKN_THRESHOLD_MANUAL_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e28f.ikn-threshold-manual",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["2df6f723-7fc3-585a-b26f-0e8c060a2d8d"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "review.e28f.ikn-threshold-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E28F"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["SECOND_HOME", "TOURISM"],
+          "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33.deposit-basis",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
+        "required_facts": [
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd"
+        ],
+        "rule_id": "el.e33.deposit-basis",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["SECOND_HOME"]
+            },
+            {
+              "fact": "secondhome.bank_deposit_usd",
+              "op": "gte",
+              "value": 130000
+            },
+            {
+              "fact": "secondhome.bank_deposit_at_state_bank",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "secondhome.bank_deposit_in_own_name",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["SECOND_HOME", "TOURISM"],
+          "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33.property-basis",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
+        "required_facts": [
+          "intent.purposes",
+          "secondhome.qualifying_property_value_usd"
+        ],
+        "rule_id": "el.e33.property-basis",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["SECOND_HOME"]
+            },
+            {
+              "fact": "secondhome.qualifying_property_value_usd",
+              "op": "gte",
+              "value": 1000000
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["SECOND_HOME", "TOURISM"],
+          "reason_code": "E33_PROPERTY_QUALIFICATION_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33.property-qualification",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
+        "required_facts": [
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd",
+          "secondhome.qualifying_property_value_usd"
+        ],
+        "rule_id": "el.e33.property-qualification",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["SECOND_HOME"]
+                },
+                {
+                  "fact": "secondhome.qualifying_property_value_usd",
+                  "op": "gte",
+                  "value": 1000000
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": ["SECOND_HOME"]
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_usd",
+                      "op": "gte",
+                      "value": 130000
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_at_state_bank",
+                      "op": "eq",
+                      "value": true
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_in_own_name",
+                      "op": "eq",
+                      "value": true
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": ["SECOND_HOME"]
+                    },
+                    {
+                      "fact": "secondhome.qualifying_property_value_usd",
+                      "op": "gte",
+                      "value": 1000000
+                    }
+                  ],
+                  "op": "all"
+                }
+              ],
+              "op": "any"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["SECOND_HOME", "TOURISM"],
+          "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33.guarantee-maintenance",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
+        "required_facts": [
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd",
+          "secondhome.qualifying_property_value_usd"
+        ],
+        "rule_id": "el.e33.guarantee-maintenance",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["SECOND_HOME"]
+                },
+                {
+                  "args": [
+                    {
+                      "fact": "secondhome.bank_deposit_usd",
+                      "op": "gte",
+                      "value": 130000
+                    },
+                    {
+                      "fact": "secondhome.qualifying_property_value_usd",
+                      "op": "gte",
+                      "value": 1000000
+                    }
+                  ],
+                  "op": "any"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": ["SECOND_HOME"]
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_usd",
+                      "op": "gte",
+                      "value": 130000
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_at_state_bank",
+                      "op": "eq",
+                      "value": true
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_in_own_name",
+                      "op": "eq",
+                      "value": true
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": ["SECOND_HOME"]
+                    },
+                    {
+                      "fact": "secondhome.qualifying_property_value_usd",
+                      "op": "gte",
+                      "value": 1000000
+                    }
+                  ],
+                  "op": "all"
+                }
+              ],
+              "op": "any"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33_WORK_RANGKAP_KEGIATAN_GATED",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
+        "required_facts": ["intent.purposes"],
+        "rule_id": "review.e33.work-rangkap-kegiatan",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["SECOND_HOME"]
+            },
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["EMPLOYMENT"]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "GOVT_INVITATION_REQUIRED",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33a.central-government-invitation",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "review.e33a.central-government-invitation",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["EMPLOYMENT"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E33A"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33B_EXPERTISE_QUALIFICATION_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33b.expertise-qualification",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "review.e33b.expertise-qualification",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["EMPLOYMENT"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E33B"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "GOVT_INVITATION_REQUIRED",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33c.central-government-invitation",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "review.e33c.central-government-invitation",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E33C"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "AGE_BELOW_55",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33e.age-below-55",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"],
+        "required_facts": ["derived.age_years"],
+        "rule_id": "hf.e33e.age-below-55",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "derived.age_years",
+          "op": "lt",
+          "value": 55
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY",
+            "RETIREMENT",
+            "SECOND_HOME",
+            "TOURISM"
+          ],
+          "reason_code": "E33E_AGE_55_59_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33e.age-55-59-disputed-band",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"],
+        "required_facts": [
+          "derived.age_years",
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd",
+          "secondhome.passive_monthly_income_usd"
+        ],
+        "rule_id": "el.e33e.age-55-59-disputed-band",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["RETIREMENT"]
+                },
+                {
+                  "fact": "derived.age_years",
+                  "lower": 55,
+                  "op": "between",
+                  "upper": 59
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["RETIREMENT"]
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "gte",
+                  "value": 55
+                },
+                {
+                  "args": [
+                    {
+                      "fact": "secondhome.bank_deposit_usd",
+                      "op": "gte",
+                      "value": 50000
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_at_state_bank",
+                      "op": "eq",
+                      "value": true
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_in_own_name",
+                      "op": "eq",
+                      "value": true
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "secondhome.passive_monthly_income_usd",
+                  "op": "gte",
+                  "value": 3000
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "RETIREMENT",
+            "SECOND_HOME",
+            "TOURISM",
+            "FAMILY"
+          ],
+          "reason_code": "E33E_RETIREMENT_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33e.retirement",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"],
+        "required_facts": [
+          "derived.age_years",
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd",
+          "secondhome.passive_monthly_income_usd"
+        ],
+        "rule_id": "el.e33e.retirement",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["RETIREMENT"]
+            },
+            {
+              "fact": "derived.age_years",
+              "op": "gte",
+              "value": 55
+            },
+            {
+              "args": [
+                {
+                  "fact": "secondhome.bank_deposit_usd",
+                  "op": "gte",
+                  "value": 50000
+                },
+                {
+                  "fact": "secondhome.bank_deposit_at_state_bank",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "secondhome.bank_deposit_in_own_name",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "fact": "secondhome.passive_monthly_income_usd",
+              "op": "gte",
+              "value": 3000
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "SPONSOR_REQUIRED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33f.sponsor-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"],
+        "required_facts": ["family.sponsor_confirmed"],
+        "rule_id": "hf.e33f.sponsor-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "family.sponsor_confirmed",
+          "op": "eq",
+          "value": false
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "RETIREMENT",
+            "BUSINESS_MEETINGS",
+            "TOURISM",
+            "FAMILY"
+          ],
+          "reason_code": "E33F_RETIREMENT_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33f.retirement",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"],
+        "required_facts": [
+          "family.sponsor_confirmed",
+          "intent.purposes",
+          "secondhome.passive_monthly_income_usd"
+        ],
+        "rule_id": "el.e33f.retirement",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["RETIREMENT"]
+            },
+            {
+              "fact": "secondhome.passive_monthly_income_usd",
+              "op": "gte",
+              "value": 3000
+            },
+            {
+              "fact": "family.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "INDONESIAN_EMPLOYER_NOT_ALLOWED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33g.indonesian-employer",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
+        "required_facts": ["work.employer_is_indonesian_entity"],
+        "rule_id": "hf.e33g.indonesian-employer",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "work.employer_is_indonesian_entity",
+          "op": "eq",
+          "value": true
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "INDONESIAN_SOURCE_COMPENSATION_BANNED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
+        "required_facts": ["work.indonesia_source_compensation"],
+        "rule_id": "hf.e33g.indonesian-source-compensation",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "work.indonesia_source_compensation",
+          "op": "eq",
+          "value": true
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "LOCAL_MARKET_ACTIVITY_REVIEW",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33g.local-market",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
+        "required_facts": ["intent.purposes", "work.serves_indonesian_clients"],
+        "rule_id": "review.e33g.local-market",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["REMOTE_WORK"]
+            },
+            {
+              "fact": "work.serves_indonesian_clients",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33g.local-company-ownership",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
+        "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+        "rule_id": "review.e33g.local-company-ownership",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["REMOTE_WORK"]
+            },
+            {
+              "fact": "investment.pt_pma_committed",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
+          "reason_code": "REMOTE_WORK_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33g.remote-work",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
+        "required_facts": [
+          "intent.purposes",
+          "work.employer_is_indonesian_entity",
+          "work.indonesia_source_compensation",
+          "work.serves_indonesian_clients"
+        ],
+        "rule_id": "el.e33g.remote-work",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["REMOTE_WORK"]
+            },
+            {
+              "fact": "work.employer_is_indonesian_entity",
+              "op": "eq",
+              "value": false
+            },
+            {
+              "fact": "work.serves_indonesian_clients",
+              "op": "eq",
+              "value": false
+            },
+            {
+              "fact": "work.indonesia_source_compensation",
+              "op": "eq",
+              "value": false
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BRIDGING_ONSHORE_ONLY",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.bridging.offshore",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": ["immigration.currently_in_indonesia"],
+        "rule_id": "hf.bridging.offshore",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.currently_in_indonesia",
+          "op": "eq",
+          "value": false
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BRIDGING_FROM_VISIT_ITK_PROHIBITED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.bridging.from-visit-itk",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": ["immigration.current_status_code"],
+        "rule_id": "hf.bridging.from-visit-itk",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b",
+          "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.current_status_code",
+          "op": "in",
+          "values": [
+            "ITK_FROM_BVK",
+            "ITK_FROM_VISIT_C",
+            "ITK_FROM_VISIT_D",
+            "A1",
+            "C1",
+            "C2",
+            "C6"
+          ]
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BRIDGING_TO_BRIDGING_PROHIBITED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.bridging.to-bridging",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": ["immigration.current_status_code"],
+        "rule_id": "hf.bridging.to-bridging",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.current_status_code",
+          "op": "eq",
+          "value": "ITK_PERALIHAN"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["OTHER"],
+          "reason_code": "BRIDGING_T3_WINDOW_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.bridging.t3-window-manual",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": [
+          "immigration.current_status_expiry",
+          "immigration.currently_in_indonesia",
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "el.bridging.t3-window-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "immigration.currently_in_indonesia",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "immigration.current_status_expiry",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["OTHER"]
+                },
+                {
+                  "fact": "intent.requested_product_code",
+                  "op": "neq",
+                  "value": "BRIDGING"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "known"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["OTHER"],
+          "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.bridging.overstay-shield-payment",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": [
+          "immigration.current_status_expiry",
+          "immigration.currently_in_indonesia",
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "el.bridging.overstay-shield-payment",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "immigration.currently_in_indonesia",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "immigration.current_status_expiry",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["OTHER"]
+                },
+                {
+                  "fact": "intent.requested_product_code",
+                  "op": "neq",
+                  "value": "BRIDGING"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "known"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["OTHER"],
+          "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.bridging.source-status-verify",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": [
+          "immigration.current_status_code",
+          "immigration.currently_in_indonesia",
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "el.bridging.source-status-verify",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "immigration.currently_in_indonesia",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "immigration.current_status_code",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["OTHER"]
+                },
+                {
+                  "fact": "intent.requested_product_code",
+                  "op": "neq",
+                  "value": "BRIDGING"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "known"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BRIDGING_ADVERSE_HISTORY",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.bridging.adverse-history",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": [
+          "immigration.currently_in_indonesia",
+          "immigration.violation_history"
+        ],
+        "rule_id": "review.bridging.adverse-history",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "immigration.currently_in_indonesia",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "immigration.violation_history",
+              "op": "intersects",
+              "values": [
+                "OVERSTAY",
+                "DEPORTATION",
+                "BLACKLIST",
+                "IMMIGRATION_INVESTIGATION"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["OTHER"],
+          "reason_code": "BRIDGING_DESTINATION_STATED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.bridging.destination-stated",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "el.bridging.destination-stated",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["OTHER"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "neq",
+              "value": "BRIDGING"
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "known"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["EMPLOYMENT", "TOURISM"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e23-employment-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"],
+        "required_facts": [
+          "intent.purposes",
+          "work.employer_is_indonesian_entity",
+          "work.indonesian_work_sponsor_confirmed"
+        ],
+        "rule_id": "el.e23-employment-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["EMPLOYMENT"]
+            },
+            {
+              "fact": "work.employer_is_indonesian_entity",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "work.indonesian_work_sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["EMPLOYMENT", "TOURISM"],
+          "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e23-operational-work-boundary",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"],
+        "required_facts": [
+          "intent.purposes",
+          "investment.proposed_role",
+          "work.employer_is_indonesian_entity",
+          "work.indonesian_work_sponsor_confirmed"
+        ],
+        "rule_id": "el.e23-operational-work-boundary",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["EMPLOYMENT"]
+                },
+                {
+                  "fact": "investment.proposed_role",
+                  "op": "in",
+                  "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["EMPLOYMENT"]
+                },
+                {
+                  "fact": "work.employer_is_indonesian_entity",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "work.indonesian_work_sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31a-spouse-wni-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "family.marriage_registered"
+        ],
+        "rule_id": "el.e31a-spouse-wni-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "SPOUSE"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": ["ID"]
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "REQ_FUNDS_2000",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31a-funds-2000",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31a-funds-2000",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": ["ID"]
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": ["ID"]
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "SPOUSAL_WORK_ARTICLE_61_CONTEXT",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31a-spousal-work-article-61",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31a-spousal-work-article-61",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": ["ID"]
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": ["ID"]
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "KITAP_TWO_YEAR_MARRIAGE_AND_INTEGRATION_NOT_VERIFIED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31a-kitap-prerequisites",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes",
+          "process.wants_onshore_conversion"
+        ],
+        "rule_id": "el.e31a-kitap-prerequisites",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "process.wants_onshore_conversion",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": ["ID"]
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31b-spouse-itas-support",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.marriage_registered",
+          "family.sponsor_status_code"
+        ],
+        "rule_id": "el.e31b-spouse-itas-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "SPOUSE"
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "in",
+              "values": [
+                "E23",
+                "E23U",
+                "E23V",
+                "E28A",
+                "E28B",
+                "E28C",
+                "E28D",
+                "E28F",
+                "E30",
+                "E30A",
+                "E30B",
+                "E30E",
+                "E30F",
+                "E31A",
+                "E31B",
+                "E31C",
+                "E31D",
+                "E31E",
+                "E31F",
+                "E31G",
+                "E31H",
+                "E31J",
+                "E33",
+                "E33A",
+                "E33B",
+                "E33C",
+                "E33E",
+                "E33F",
+                "E33G"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31b-sponsor-itas-itap",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31b-sponsor-itas-itap",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "E23",
+                    "E23U",
+                    "E23V",
+                    "E28A",
+                    "E28B",
+                    "E28C",
+                    "E28D",
+                    "E28F",
+                    "E30",
+                    "E30A",
+                    "E30B",
+                    "E30E",
+                    "E30F",
+                    "E31A",
+                    "E31B",
+                    "E31C",
+                    "E31D",
+                    "E31E",
+                    "E31F",
+                    "E31G",
+                    "E31H",
+                    "E31J",
+                    "E33",
+                    "E33A",
+                    "E33B",
+                    "E33C",
+                    "E33E",
+                    "E33F",
+                    "E33G"
+                  ]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"],
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31c-child-mixed-marriage-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": ["ID"]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "REQ_MIXED_MARRIAGE_PARENTS",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31c-mixed-marriage-parents",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31c-mixed-marriage-parents",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": ["ID"]
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31d-stepchild-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_confirmed",
+          "family.stepchild_birth_certificate_confirmed",
+          "family.stepchild_marriage_certificate_confirmed"
+        ],
+        "rule_id": "el.e31d-stepchild-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "STEPCHILD"
+            },
+            {
+              "fact": "family.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "family.stepchild_birth_certificate_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "family.stepchild_marriage_certificate_confirmed",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "REQ_UNDER_18",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e31e-adult-excluded",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"],
+        "required_facts": ["derived.age_years"],
+        "rule_id": "hf.e31e-adult-excluded",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "derived.age_years",
+          "op": "gte",
+          "value": 18
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "REQ_UNMARRIED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e31e-married-excluded",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"],
+        "required_facts": ["person.marital_status"],
+        "rule_id": "hf.e31e-married-excluded",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "person.marital_status",
+          "op": "neq",
+          "value": "SINGLE"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31e-child-itas-support",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "derived.age_years",
+          "person.marital_status"
+        ],
+        "rule_id": "el.e31e-child-itas-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "in",
+              "values": [
+                "E23",
+                "E23U",
+                "E23V",
+                "E28A",
+                "E28B",
+                "E28C",
+                "E28D",
+                "E28F",
+                "E30",
+                "E30A",
+                "E30B",
+                "E30E",
+                "E30F",
+                "E31A",
+                "E31B",
+                "E31C",
+                "E31D",
+                "E31E",
+                "E31F",
+                "E31G",
+                "E31H",
+                "E31J",
+                "E33",
+                "E33A",
+                "E33B",
+                "E33C",
+                "E33E",
+                "E33F",
+                "E33G"
+              ]
+            },
+            {
+              "fact": "derived.age_years",
+              "op": "lt",
+              "value": 18
+            },
+            {
+              "fact": "person.marital_status",
+              "op": "eq",
+              "value": "SINGLE"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31e-sponsor-itas-itap",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"],
+        "required_facts": [
+          "derived.age_years",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes",
+          "person.marital_status"
+        ],
+        "rule_id": "el.e31e-sponsor-itas-itap",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ecd22722-3e42-5808-be18-45fbb7d8e9c5"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "E23",
+                    "E23U",
+                    "E23V",
+                    "E28A",
+                    "E28B",
+                    "E28C",
+                    "E28D",
+                    "E28F",
+                    "E30",
+                    "E30A",
+                    "E30B",
+                    "E30E",
+                    "E30F",
+                    "E31A",
+                    "E31B",
+                    "E31C",
+                    "E31D",
+                    "E31E",
+                    "E31F",
+                    "E31G",
+                    "E31H",
+                    "E31J",
+                    "E33",
+                    "E33A",
+                    "E33B",
+                    "E33C",
+                    "E33E",
+                    "E33F",
+                    "E33G"
+                  ]
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "lt",
+                  "value": 18
+                },
+                {
+                  "fact": "person.marital_status",
+                  "op": "eq",
+                  "value": "SINGLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31f-child-wni-parent-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities"
+        ],
+        "rule_id": "el.e31f-child-wni-parent-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": ["ID"]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "E31F_ADULT_AGE_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31f-adult-age-review",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"],
+        "required_facts": [
+          "derived.age_years",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31f-adult-age-review",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "f9306203-0bdc-5dd8-9603-554e7eefedc8"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": ["ID"]
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "gte",
+                  "value": 18
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": ["ID"]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31g-parent-wni-child-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["fbc980d5-47b6-5f16-974d-25158dfffc06"],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities"
+        ],
+        "rule_id": "el.e31g-parent-wni-child-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "86880290-68c2-5220-8f9e-2350678e5f09",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "CHILD"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": ["ID"]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31h-parent-itas-child-support",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code"
+        ],
+        "rule_id": "el.e31h-parent-itas-child-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "153beca1-a24b-5440-bac0-b46c3d19da6f",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "CHILD"
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "in",
+              "values": [
+                "E23",
+                "E23U",
+                "E23V",
+                "E28A",
+                "E28B",
+                "E28C",
+                "E28D",
+                "E28F",
+                "E30",
+                "E30A",
+                "E30B",
+                "E30E",
+                "E30F",
+                "E31A",
+                "E31B",
+                "E31C",
+                "E31D",
+                "E31E",
+                "E31F",
+                "E31G",
+                "E31H",
+                "E31J",
+                "E33",
+                "E33A",
+                "E33B",
+                "E33C",
+                "E33E",
+                "E33F",
+                "E33G"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31h-sponsor-itas-itap",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"],
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31h-sponsor-itas-itap",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "153beca1-a24b-5440-bac0-b46c3d19da6f",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "CHILD"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "CHILD"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "E23",
+                    "E23U",
+                    "E23V",
+                    "E28A",
+                    "E28B",
+                    "E28C",
+                    "E28D",
+                    "E28F",
+                    "E30",
+                    "E30A",
+                    "E30B",
+                    "E30E",
+                    "E30F",
+                    "E31A",
+                    "E31B",
+                    "E31C",
+                    "E31D",
+                    "E31E",
+                    "E31F",
+                    "E31G",
+                    "E31H",
+                    "E31J",
+                    "E33",
+                    "E33A",
+                    "E33B",
+                    "E33C",
+                    "E33E",
+                    "E33F",
+                    "E33G"
+                  ]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31j-sibling-itas-support",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code"
+        ],
+        "rule_id": "el.e31j-sibling-itas-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "SIBLING"
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "in",
+              "values": [
+                "E23",
+                "E23U",
+                "E23V",
+                "E28A",
+                "E28B",
+                "E28C",
+                "E28D",
+                "E28F",
+                "E30",
+                "E30A",
+                "E30B",
+                "E30E",
+                "E30F",
+                "E31A",
+                "E31B",
+                "E31C",
+                "E31D",
+                "E31E",
+                "E31F",
+                "E31G",
+                "E31H",
+                "E31J",
+                "E33",
+                "E33A",
+                "E33B",
+                "E33C",
+                "E33E",
+                "E33F",
+                "E33G"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31j-sponsor-itas-itap",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"],
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31j-sponsor-itas-itap",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "E23",
+                    "E23U",
+                    "E23V",
+                    "E28A",
+                    "E28B",
+                    "E28C",
+                    "E28D",
+                    "E28F",
+                    "E30",
+                    "E30A",
+                    "E30B",
+                    "E30E",
+                    "E30F",
+                    "E31A",
+                    "E31B",
+                    "E31C",
+                    "E31D",
+                    "E31E",
+                    "E31F",
+                    "E31G",
+                    "E31H",
+                    "E31J",
+                    "E33",
+                    "E33A",
+                    "E33B",
+                    "E33C",
+                    "E33E",
+                    "E33F",
+                    "E33G"
+                  ]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["FAMILY"],
+          "reason_code": "E31J_DEPENDENCY_AGE_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31j-dependency-age",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"],
+        "required_facts": [
+          "derived.age_years",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31j-dependency-age",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "gte",
+                  "value": 18
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["FAMILY"]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "E23",
+                    "E23U",
+                    "E23V",
+                    "E28A",
+                    "E28B",
+                    "E28C",
+                    "E28D",
+                    "E28F",
+                    "E30",
+                    "E30A",
+                    "E30B",
+                    "E30E",
+                    "E30F",
+                    "E31A",
+                    "E31B",
+                    "E31C",
+                    "E31D",
+                    "E31E",
+                    "E31F",
+                    "E31G",
+                    "E31H",
+                    "E31J",
+                    "E33",
+                    "E33A",
+                    "E33B",
+                    "E33C",
+                    "E33E",
+                    "E33F",
+                    "E33G"
+                  ]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "TOURISM",
+            "FAMILY",
+            "TRANSIT",
+            "BUSINESS_MEETINGS"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-multi-entry-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days",
+          "intent.entry_pattern"
+        ],
+        "rule_id": "el.d1-multi-entry-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "fact": "intent.entry_pattern",
+              "op": "eq",
+              "value": "MULTIPLE"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-passport-validity",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-passport-validity",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 180
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "PROOF_OF_FUNDS_D1",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-funds-usd-2000",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-funds-usd-2000",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 180
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "CV_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-cv-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-cv-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 180
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "ITINERARY_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-itinerary-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-itinerary-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 180
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-support-letter",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-support-letter",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 180
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["BUSINESS_MEETINGS"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-multi-entry-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d2-multi-entry-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["BUSINESS_MEETINGS"]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["BUSINESS_MEETINGS"],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-passport-validity",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d2-passport-validity",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["BUSINESS_MEETINGS"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["BUSINESS_MEETINGS"]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["BUSINESS_MEETINGS"],
+          "reason_code": "PROOF_OF_FUNDS_D2",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-funds-usd-2000",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d2-funds-usd-2000",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["BUSINESS_MEETINGS"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["BUSINESS_MEETINGS"]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["BUSINESS_MEETINGS"],
+          "reason_code": "CV_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-cv-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d2-cv-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["BUSINESS_MEETINGS"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["BUSINESS_MEETINGS"]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["BUSINESS_MEETINGS"],
+          "reason_code": "ITINERARY_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-itinerary-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d2-itinerary-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["BUSINESS_MEETINGS"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["BUSINESS_MEETINGS"]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["BUSINESS_MEETINGS"],
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-support-letter",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d2-support-letter",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["BUSINESS_MEETINGS"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["BUSINESS_MEETINGS"]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["INVESTMENT"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-multi-entry-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d12-multi-entry-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 360
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["INVESTMENT"],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-passport-validity",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d12-passport-validity",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 360
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["INVESTMENT"],
+          "reason_code": "PROOF_OF_FUNDS_D12",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-funds-usd-5000",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d12-funds-usd-5000",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 360
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["INVESTMENT"],
+          "reason_code": "CV_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-cv-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d12-cv-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 360
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["INVESTMENT"],
+          "reason_code": "ITINERARY_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-itinerary-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d12-itinerary-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 360
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["INVESTMENT"],
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-support-letter",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
+        "rule_id": "el.d12-support-letter",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["INVESTMENT"]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 360
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "D12_NOT_CONVERTIBLE",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["process.wants_onshore_conversion"],
+        "rule_id": "hf.d12-onshore-conversion-excluded",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "process.wants_onshore_conversion",
+          "op": "eq",
+          "value": true
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-student-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+          "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-student-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "fact": "study.admission_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "study.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "LIVING_COST_USD2000",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-living-cost-2000.e30",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-living-cost-2000.e30",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["STUDY"]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "LIVING_COST_USD2000",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-living-cost-2000.e30a",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-living-cost-2000.e30a",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["STUDY"]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "LIVING_COST_USD2000",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-living-cost-2000.e30b",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-living-cost-2000.e30b",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["STUDY"]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-passport-validity.e30",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-passport-validity.e30",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["STUDY"]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-passport-validity.e30a",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-passport-validity.e30a",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["STUDY"]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-passport-validity.e30b",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-passport-validity.e30b",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["STUDY"]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "LEVEL_BAND_DASMEN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e30a-level-band",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"],
+        "required_facts": ["intent.purposes", "study.level"],
+        "rule_id": "hf.e30a-level-band",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "fact": "study.level",
+              "op": "not_in",
+              "values": ["PRIMARY", "SECONDARY"]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "LEVEL_BAND_DIKTI",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e30b-level-band",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"],
+        "required_facts": ["intent.purposes", "study.level"],
+        "rule_id": "hf.e30b-level-band",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "fact": "study.level",
+              "op": "not_in",
+              "values": ["VOCATIONAL", "UNDERGRADUATE", "POSTGRADUATE"]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "STUDY_PERMIT_KEMDIKBUD",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30b-izin-belajar",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30b-izin-belajar",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": ["STUDY"]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "VOA_NATIONALITY_ONLY",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.b1.not-voa-nationality",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"],
+        "required_facts": ["person.nationalities"],
+        "rule_id": "hf.b1.not-voa-nationality",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": ["38a6cb08-041f-51e4-86e4-9e73243acd3a"],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "arg": {
+            "fact": "person.nationalities",
+            "op": "intersects",
+            "values": [
+              "ZA",
+              "AL",
+              "US",
+              "AD",
+              "SA",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "NL",
+              "BY",
+              "BE",
+              "BR",
+              "BN",
+              "BA",
+              "BG",
+              "CZ",
+              "CL",
+              "DK",
+              "EC",
+              "EE",
+              "PH",
+              "FI",
+              "GT",
+              "HK",
+              "HU",
+              "IN",
+              "GB",
+              "IE",
+              "IT",
+              "IS",
+              "JP",
+              "DE",
+              "KH",
+              "CA",
+              "KZ",
+              "KE",
+              "CO",
+              "KR",
+              "HR",
+              "KW",
+              "LA",
+              "LV",
+              "LI",
+              "LT",
+              "LU",
+              "MV",
+              "MY",
+              "MT",
+              "MA",
+              "MU",
+              "MX",
+              "EG",
+              "MC",
+              "MN",
+              "MZ",
+              "MM",
+              "NO",
+              "OM",
+              "PS",
+              "PG",
+              "FR",
+              "PE",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "NZ",
+              "RS",
+              "SC",
+              "SG",
+              "CY",
+              "SK",
+              "SI",
+              "ES",
+              "SR",
+              "SE",
+              "CH",
+              "TW",
+              "TZ",
+              "TH",
+              "TL",
+              "CN",
+              "TN",
+              "TR",
+              "AE",
+              "UZ",
+              "UA",
+              "VA",
+              "VE",
+              "VN",
+              "JO",
+              "GR"
+            ]
+          },
+          "op": "not"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "CITIZENSHIP_LIST_DIVERGENCE",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.citizenship-conflict",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": ["person.nationalities"],
+        "rule_id": "review.citizenship-conflict",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": [
+          "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+          "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "person.nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "ZA",
+                    "AL",
+                    "US",
+                    "AD",
+                    "SA",
+                    "AR",
+                    "AM",
+                    "AU",
+                    "AT",
+                    "AZ",
+                    "BH",
+                    "NL",
+                    "BY",
+                    "BE",
+                    "BR",
+                    "BN",
+                    "BA",
+                    "BG",
+                    "CZ",
+                    "CL",
+                    "DK",
+                    "EC",
+                    "EE",
+                    "PH",
+                    "FI",
+                    "GT",
+                    "HK",
+                    "HU",
+                    "IN",
+                    "GB",
+                    "IE",
+                    "IT",
+                    "IS",
+                    "JP",
+                    "DE",
+                    "KH",
+                    "CA",
+                    "KZ",
+                    "KE",
+                    "CO",
+                    "KR",
+                    "HR",
+                    "KW",
+                    "LA",
+                    "LV",
+                    "LI",
+                    "LT",
+                    "LU",
+                    "MV",
+                    "MY",
+                    "MT",
+                    "MA",
+                    "MU",
+                    "MX",
+                    "EG",
+                    "MC",
+                    "MN",
+                    "MZ",
+                    "MM",
+                    "NO",
+                    "OM",
+                    "PS",
+                    "PG",
+                    "FR",
+                    "PE",
+                    "PL",
+                    "PT",
+                    "QA",
+                    "RO",
+                    "RU",
+                    "RW",
+                    "NZ",
+                    "RS",
+                    "SC",
+                    "SG",
+                    "CY",
+                    "SK",
+                    "SI",
+                    "ES",
+                    "SR",
+                    "SE",
+                    "CH",
+                    "TW",
+                    "TZ",
+                    "TH",
+                    "TL",
+                    "CN",
+                    "TN",
+                    "TR",
+                    "AE",
+                    "UZ",
+                    "UA",
+                    "VA",
+                    "VE",
+                    "VN",
+                    "JO",
+                    "GR"
+                  ]
+                },
+                {
+                  "fact": "person.nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "AF",
+                    "AG",
+                    "AI",
+                    "AO",
+                    "AQ",
+                    "AS",
+                    "AW",
+                    "AX",
+                    "BB",
+                    "BD",
+                    "BF",
+                    "BI",
+                    "BJ",
+                    "BL",
+                    "BM",
+                    "BO",
+                    "BQ",
+                    "BS",
+                    "BT",
+                    "BV",
+                    "BW",
+                    "BZ",
+                    "CC",
+                    "CD",
+                    "CF",
+                    "CG",
+                    "CI",
+                    "CK",
+                    "CM",
+                    "CR",
+                    "CU",
+                    "CV",
+                    "CW",
+                    "CX",
+                    "DJ",
+                    "DM",
+                    "DO",
+                    "DZ",
+                    "EH",
+                    "ER",
+                    "ET",
+                    "FJ",
+                    "FK",
+                    "FM",
+                    "FO",
+                    "GA",
+                    "GD",
+                    "GE",
+                    "GF",
+                    "GG",
+                    "GH",
+                    "GI",
+                    "GL",
+                    "GM",
+                    "GN",
+                    "GP",
+                    "GQ",
+                    "GS",
+                    "GU",
+                    "GW",
+                    "GY",
+                    "HM",
+                    "HN",
+                    "HT",
+                    "ID",
+                    "IL",
+                    "IM",
+                    "IO",
+                    "IQ",
+                    "IR",
+                    "JE",
+                    "JM",
+                    "KG",
+                    "KI",
+                    "KM",
+                    "KN",
+                    "KP",
+                    "KY",
+                    "LB",
+                    "LC",
+                    "LK",
+                    "LR",
+                    "LS",
+                    "LY",
+                    "MD",
+                    "ME",
+                    "MF",
+                    "MG",
+                    "MH",
+                    "MK",
+                    "ML",
+                    "MO",
+                    "MP",
+                    "MQ",
+                    "MR",
+                    "MS",
+                    "MW",
+                    "NA",
+                    "NC",
+                    "NE",
+                    "NF",
+                    "NG",
+                    "NI",
+                    "NP",
+                    "NR",
+                    "NU",
+                    "PA",
+                    "PF",
+                    "PK",
+                    "PM",
+                    "PN",
+                    "PR",
+                    "PW",
+                    "PY",
+                    "RE",
+                    "SB",
+                    "SD",
+                    "SH",
+                    "SJ",
+                    "SL",
+                    "SM",
+                    "SN",
+                    "SO",
+                    "SS",
+                    "ST",
+                    "SV",
+                    "SX",
+                    "SY",
+                    "SZ",
+                    "TC",
+                    "TD",
+                    "TF",
+                    "TG",
+                    "TJ",
+                    "TK",
+                    "TM",
+                    "TO",
+                    "TT",
+                    "TV",
+                    "UG",
+                    "UM",
+                    "UY",
+                    "VC",
+                    "VG",
+                    "VI",
+                    "VU",
+                    "WF",
+                    "WS",
+                    "YE",
+                    "YT",
+                    "ZM",
+                    "ZW"
+                  ]
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "person.nationalities",
+                  "op": "intersects",
+                  "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+                },
+                {
+                  "fact": "person.nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "AD",
+                    "AE",
+                    "AG",
+                    "AI",
+                    "AL",
+                    "AM",
+                    "AO",
+                    "AQ",
+                    "AR",
+                    "AS",
+                    "AT",
+                    "AU",
+                    "AW",
+                    "AX",
+                    "AZ",
+                    "BA",
+                    "BB",
+                    "BD",
+                    "BE",
+                    "BF",
+                    "BG",
+                    "BH",
+                    "BI",
+                    "BJ",
+                    "BL",
+                    "BM",
+                    "BN",
+                    "BO",
+                    "BQ",
+                    "BR",
+                    "BS",
+                    "BT",
+                    "BV",
+                    "BW",
+                    "BY",
+                    "BZ",
+                    "CA",
+                    "CC",
+                    "CD",
+                    "CF",
+                    "CG",
+                    "CH",
+                    "CI",
+                    "CK",
+                    "CL",
+                    "CM",
+                    "CN",
+                    "CO",
+                    "CR",
+                    "CU",
+                    "CV",
+                    "CW",
+                    "CX",
+                    "CY",
+                    "CZ",
+                    "DE",
+                    "DJ",
+                    "DK",
+                    "DM",
+                    "DO",
+                    "DZ",
+                    "EC",
+                    "EE",
+                    "EG",
+                    "EH",
+                    "ER",
+                    "ES",
+                    "ET",
+                    "FI",
+                    "FJ",
+                    "FK",
+                    "FM",
+                    "FO",
+                    "FR",
+                    "GA",
+                    "GB",
+                    "GD",
+                    "GE",
+                    "GF",
+                    "GG",
+                    "GH",
+                    "GI",
+                    "GL",
+                    "GM",
+                    "GN",
+                    "GP",
+                    "GQ",
+                    "GR",
+                    "GS",
+                    "GT",
+                    "GU",
+                    "GW",
+                    "GY",
+                    "HK",
+                    "HM",
+                    "HN",
+                    "HR",
+                    "HT",
+                    "HU",
+                    "ID",
+                    "IE",
+                    "IM",
+                    "IN",
+                    "IO",
+                    "IQ",
+                    "IR",
+                    "IS",
+                    "IT",
+                    "JE",
+                    "JM",
+                    "JO",
+                    "JP",
+                    "KE",
+                    "KG",
+                    "KH",
+                    "KI",
+                    "KM",
+                    "KN",
+                    "KR",
+                    "KW",
+                    "KY",
+                    "KZ",
+                    "LA",
+                    "LB",
+                    "LC",
+                    "LI",
+                    "LK",
+                    "LS",
+                    "LT",
+                    "LU",
+                    "LV",
+                    "LY",
+                    "MA",
+                    "MC",
+                    "MD",
+                    "ME",
+                    "MF",
+                    "MG",
+                    "MH",
+                    "MK",
+                    "ML",
+                    "MM",
+                    "MN",
+                    "MO",
+                    "MP",
+                    "MQ",
+                    "MR",
+                    "MS",
+                    "MT",
+                    "MU",
+                    "MV",
+                    "MW",
+                    "MX",
+                    "MY",
+                    "MZ",
+                    "NA",
+                    "NC",
+                    "NE",
+                    "NF",
+                    "NI",
+                    "NL",
+                    "NO",
+                    "NP",
+                    "NR",
+                    "NU",
+                    "NZ",
+                    "OM",
+                    "PA",
+                    "PE",
+                    "PF",
+                    "PG",
+                    "PH",
+                    "PK",
+                    "PL",
+                    "PM",
+                    "PN",
+                    "PR",
+                    "PS",
+                    "PT",
+                    "PW",
+                    "PY",
+                    "QA",
+                    "RE",
+                    "RO",
+                    "RS",
+                    "RU",
+                    "RW",
+                    "SA",
+                    "SB",
+                    "SC",
+                    "SD",
+                    "SE",
+                    "SG",
+                    "SH",
+                    "SI",
+                    "SJ",
+                    "SK",
+                    "SL",
+                    "SM",
+                    "SN",
+                    "SR",
+                    "SS",
+                    "ST",
+                    "SV",
+                    "SX",
+                    "SY",
+                    "SZ",
+                    "TC",
+                    "TD",
+                    "TF",
+                    "TG",
+                    "TH",
+                    "TJ",
+                    "TK",
+                    "TL",
+                    "TM",
+                    "TN",
+                    "TO",
+                    "TR",
+                    "TT",
+                    "TV",
+                    "TW",
+                    "TZ",
+                    "UA",
+                    "UG",
+                    "UM",
+                    "US",
+                    "UY",
+                    "UZ",
+                    "VA",
+                    "VC",
+                    "VE",
+                    "VG",
+                    "VI",
+                    "VN",
+                    "VU",
+                    "WF",
+                    "WS",
+                    "YE",
+                    "YT",
+                    "ZA",
+                    "ZM",
+                    "ZW"
+                  ]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "any"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "MINOR_WITHOUT_CONFIRMED_GUARDIAN",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.minor-without-guardian",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": ["derived.is_minor", "family.sponsor_confirmed"],
+        "rule_id": "review.minor-without-guardian",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-08-09T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "derived.is_minor",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "family.sponsor_confirmed",
+              "op": "eq",
+              "value": false
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "AGE_BELOW_55",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33f.age-below-55",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"],
+        "required_facts": ["derived.age_years"],
+        "rule_id": "hf.e33f.age-below-55",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "derived.age_years",
+          "op": "lt",
+          "value": 55
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30e-student-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["19e3ea6c-95c6-5998-b9d7-efc77f583589"],
+        "required_facts": [
+          "intent.purposes",
+          "sponsor.type",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30e-student-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "fact": "study.admission_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "study.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "sponsor.type",
+              "op": "in",
+              "values": ["EDUCATION", "INDIVIDUAL"]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": ["STUDY"],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30f-student-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["235f5dfc-2feb-5d5b-ab09-0f4e4122819e"],
+        "required_facts": [
+          "intent.purposes",
+          "sponsor.type",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30f-student-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["STUDY"]
+            },
+            {
+              "fact": "study.admission_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "study.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "sponsor.type",
+              "op": "eq",
+              "value": "EDUCATION"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33A_SPONSOR_NOT_GOVERNMENT",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33a.sponsor-not-government",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"],
+        "required_facts": ["sponsor.type"],
+        "rule_id": "hf.e33a.sponsor-not-government",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "sponsor.type",
+          "op": "neq",
+          "value": "GOVERNMENT"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33B_SPONSOR_NOT_GOVERNMENT_OR_NONE",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33b.sponsor-not-government-or-none",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"],
+        "required_facts": ["sponsor.type"],
+        "rule_id": "hf.e33b.sponsor-not-government-or-none",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "sponsor.type",
+          "op": "not_in",
+          "values": ["GOVERNMENT", "NONE"]
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33C_SPONSOR_NOT_GOVERNMENT_OR_NONE",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33c.sponsor-not-government-or-none",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"],
+        "required_facts": ["sponsor.type"],
+        "rule_id": "hf.e33c.sponsor-not-government-or-none",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "sponsor.type",
+          "op": "not_in",
+          "values": ["GOVERNMENT", "NONE"]
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E23U_DIPLOMATIC_HOUSEHOLD_STAFF_REVIEW",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e23u.requested-product",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "review.e23u.requested-product",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["EMPLOYMENT"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E23U"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E23V_TRADE_OFFICE_STAFF_REVIEW",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e23v.requested-product",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
+        "rule_id": "review.e23v.requested-product",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["EMPLOYMENT"]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E23V"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "REQ_PARENTS_MARRIAGE_REGISTERED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e31c-marriage-not-registered",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "intent.purposes"
+        ],
+        "rule_id": "hf.e31c-marriage-not-registered",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": false
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "REQ_PARENT_SPONSOR_INDONESIAN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e31c-sponsor-not-indonesian",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"],
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "hf.e31c-sponsor-not-indonesian",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-23T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["FAMILY"]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "arg": {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              "op": "not"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BUSINESS_LOCAL_COMPENSATION_NOT_ALLOWED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.d2.indonesia-source-compensation",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "de433757-f7af-5762-ad65-41bc16bc2ae1",
+          "374e79e0-f0bf-5291-8cba-974e794e210a",
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "work.indonesia_source_compensation"
+        ],
+        "rule_id": "hf.d2.indonesia-source-compensation",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-09-06T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": ["BUSINESS_MEETINGS"]
+            },
+            {
+              "fact": "work.indonesia_source_compensation",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      }
+    ],
+    "sequence": 20,
+    "source_records": [
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia",
+        "content_sha256": "be6bf44d2d6f8ee8e766ac3b8007c274b84fe7773a516a59ce2f9629049ec3f9",
+        "document_number": "Kepmen M.IP-08.GR.01.01/2025",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28A"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28B"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28C"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28D"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28F"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33A"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33B"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33C"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33E"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33F"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33G"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/B1"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/C1"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/C2"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/C6"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "kepmen-mip-08-gr-01-01-2025-visa-catalog",
+        "source_record_id": "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Kepmen M.IP-08.GR.01.01/2025 \u2014 Indeks Visa Indonesia (katalog daftar-visa imigrasi.go.id)",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://peraturan.bpk.go.id/Details/285156/permenkumham-no-11-tahun-2024",
+        "content_sha256": "052dfa1315385c57d2d92140000a140f99adac25f1449fbddcaca19ca2e4ce1a",
+        "document_number": "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2024-04-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 33(2)(j)"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 61"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 62"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 63"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 86A"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 94A"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 94B"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 113"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 185"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 39"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 40"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 57"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 58"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 59"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "permenkumham-22-2023-jo-11-2024-stay-permits",
+        "source_record_id": "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permenkumham 22/2023 jo. Permenkumham 11/2024 \u2014 Izin Tinggal Keimigrasian (Ps. 33/61/62/63, 86A, 94A, 94B, 113, 185)",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+        "content_sha256": "af7287e82df4f96f162ee094608aa40c3d3ce40899fdb685509743597cbd0ff3",
+        "document_number": "Permen Imipas Nomor 10 Tahun 2026",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-09T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "permen-imipas-10-2026-bvk-nationality-list",
+        "source_record_id": "808d691c-374e-5581-8186-9eb54d0ca7ab",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permen Imipas 10/2026 \u2014 Daftar Negara Bebas Visa Kunjungan (BVK)",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "PRIMARY_LAW",
+        "canonical_url": "https://www.imigrasi.go.id/id/visa-kunjungan/",
+        "content_sha256": "30aeb54b897b32b07a91f7ce1fdef58cd33f495bffb52e049f0031fd87221428",
+        "document_number": "UU 6/2011 jo. UU 63/2024",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "uu-6-2011-jo-uu-63-2024-keimigrasian",
+        "source_record_id": "e76bf823-2b36-522f-b2f7-e51eb7715e44",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "UU 6/2011 jo. UU 63/2024 tentang Keimigrasian \u2014 kewarganegaraan dan ketentuan overstay",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+        "content_sha256": "cfc36c1b65af69564e9a56b69c3b680288ece3d17350b6b46e9b396b3888f305",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "SECTION",
+            "value": "Calling Visa country list; national Ditjen Imigrasi display"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi-calling-visa-country-list",
+        "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "cd613d5b-83da-5150-a7b5-759eb4d224fe",
+        "title": "Daftar Negara Calling Visa \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+        "content_sha256": "26ab52ca35af9e1d1b18fedff1df355f1cada57a710f49c816d4fe2708447848",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2024-04-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+        "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "65ffed8d-ccb2-512b-b093-60733b31269d",
+        "title": "Siaran Pers Ditjen Imigrasi 2024-04-24 \u2014 Izin Tinggal Peralihan Jembatani Proses Transisi Izin Tinggal WNA di RI",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://peraturan.bpk.go.id/Download/378168/Permen%20Imipas%20Nomor%205%20Tahun%202025.pdf",
+        "content_sha256": "b1c33d5ca2d6fa582ce827dc7caa3b512728186ae40c21c60ec7106ebe9bc759",
+        "document_number": "Permen Imipas 5/2025",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-02-07T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 1"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "permen-imipas-5-2025-penjamin-revocation",
+        "source_record_id": "2eabe49e-b71b-575a-b2e8-2be3f8e5b718",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permen Imipas 5/2025 \u2014 Pencabutan Permenkumham 36/2021 tentang Penjamin Keimigrasian",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+        "content_sha256": "19fb4a4eba22194a3a14fa3a6be76e704835dc4a8fd27b2f2f0536495ead09ce",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi-alih-status-itk-itas-service-page",
+        "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "0b9d2466-a9e1-556f-8585-7ef501c3c837",
+        "title": "Layanan Alih Status \u2014 Izin Tinggal Kunjungan Menjadi Izin Tinggal Terbatas",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://kemenimipas.go.id/attachments/2025/peraturan/20250813_09_Kepmen_No_M.IP-08.GR.01.01_Th_2025_Tentang_Klasifikasi_Visa.pdf",
+        "content_sha256": "b8e326667c892ab2dfb52be220c82a0716bab6a516fe925c5e45096e9ef81c33",
+        "document_number": "M.IP-08.GR.01.01/2025",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "SECTION",
+            "value": "Lampiran"
+          }
+        ],
+        "publisher": "Kementerian Imigrasi dan Pemasyarakatan (Kemenimipas)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "kemenimipas.kepmen-mip-08-gr-01-01-2025.klasifikasi-visa",
+        "source_record_id": "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Keputusan Menteri Imigrasi dan Pemasyarakatan M.IP-08.GR.01.01/2025 tentang Klasifikasi Visa",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a2",
+        "version": 1
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://peraturan.bpk.go.id/Download/330147/Permenkumham%20Nomor%2022%20Tahun%202023.pdf",
+        "content_sha256": "2e9165804c38e9a60b4f1c4a046bd727a97043d7386be90d608c68db31c015d4",
+        "document_number": "22/2023",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2023-08-22T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 42"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 105"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 113"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 33"
+          }
+        ],
+        "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "peraturan-bpk.permenkumham-22-2023.visa-izin-tinggal",
+        "source_record_id": "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permenkumham Nomor 22 Tahun 2023 tentang Visa dan Izin Tinggal",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a2",
+        "version": 1
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://peraturan.bpk.go.id/Download/344251/Permenkumham%20Nomor%2011%20Tahun%202024.pdf",
+        "content_sha256": "ecbbeccc196145f47f24e68473a27c19d6f0408e607abb365ce9acd22cbf5f02",
+        "document_number": "11/2024",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2024-04-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 105 ayat (7)"
+          }
+        ],
+        "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "peraturan-bpk.permenkumham-11-2024.perubahan-22-2023",
+        "source_record_id": "31850f85-8d19-58df-bb66-b04968c9aff0",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permenkumham Nomor 11 Tahun 2024 tentang Perubahan atas Permenkumham 22/2023",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a2",
+        "version": 1
+      },
+      {
+        "authority_type": "PRIMARY_LAW",
+        "canonical_url": "https://peraturan.bpk.go.id/Home/Download/28550/UU%206%20Tahun%202011.pdf",
+        "content_sha256": "63708ca9b50ac067834a50c395385fdc6abda22e6e51def88983cd1ad685edc4",
+        "document_number": "UU 6/2011",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2011-05-05T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 60 ayat (2)"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 61"
+          }
+        ],
+        "publisher": "Badan Pemeriksa Keuangan Republik Indonesia",
+        "recorded_period": {
+          "from": "2026-08-10T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-10T00:00:00Z",
+        "source_key": "peraturan.bpk.go.id.uu-6-2011-keimigrasian",
+        "source_record_id": "5a0d367b-bf64-535d-83e4-f40c45de2008",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian \u2014 Pasal 60 ayat (2) dan Pasal 61",
+        "verified_at": "2026-08-10T00:00:00Z",
+        "verified_by": "agent.air-m5.visa-seq6-semantics",
+        "version": 1
+      },
+      {
+        "authority_type": "PRIMARY_LAW",
+        "canonical_url": "https://www.imigrasi.go.id/uu_imigrasi/bab-5",
+        "content_sha256": "7585f108f2ec029b954f42951dcb56c4afa3aca09eb018c02134782661664272",
+        "document_number": "UU 6/2011",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2011-05-05T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 61"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "imigrasi.go.id.uu-6-2011-keimigrasian.bab-5",
+        "source_record_id": "4886ebe6-41ae-5c6f-bf5d-b98e182be435",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian \u2014 Bab V (Izin Tinggal), reproduksi Ditjen Imigrasi",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a2",
+        "version": 1
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A",
+        "content_sha256": "7ee2871fa937249756d8f8048067e3444b1aa738ec41737832180807a674932c",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+        "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "9ed9ed7a-5998-557f-ac98-ceaf2cb520df",
+        "title": "Visa Keluarga Suami/Istri WNI (E31A) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B",
+        "content_sha256": "178c059aa106c9e9a338f1c9980e66ca7a3f74b961ebccb372ad07aa20d6102f",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+        "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "c89c8de0-b131-5491-a604-f0ee79f18fe9",
+        "title": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C",
+        "content_sha256": "4cd930e3f7b9ed99a92e0a11b025532d53a2405766fee2d9d8153cc97e129473",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+        "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "a88e1fe2-b363-5541-94bd-c7bd62ff1649",
+        "title": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D",
+        "content_sha256": "f957654b7f9c1ece0c6f162812ff0384e3dab195af1f7ebb7cce30ce458af78e",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+        "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "8b9a48dc-2f86-5b0c-be51-5dba1e7a64fc",
+        "title": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E",
+        "content_sha256": "4dcd01efc33454f722aa01fd3273fd8cca112bc161e4b3edd71710e4751beca5",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+        "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "8062c9aa-44d7-5aee-8bca-a8446af0c4a0",
+        "title": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F",
+        "content_sha256": "44054b731caef383470f56dc318c7ff6a9b3e222b513296f777ec61a0def5f0b",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+        "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "b251f6cb-14df-5997-92b7-37f235a33e89",
+        "title": "Visa Keluarga Anak dengan Orang Tua WNI (E31F) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G",
+        "content_sha256": "64a3d8c4af611cd072d82abde72f0213e19aa121e367f4c9c58d5a791d86a34b",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+        "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "6da01441-8a97-5192-89f8-6384486ba4e9",
+        "title": "Visa Keluarga Orang Tua dari Anak WNI (E31G) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H",
+        "content_sha256": "19dcb960b348bc7a51986fae48e8ae8a08c18ccc65958065c3cbb99c7f30fd1b",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+        "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "4a6e547e-1a2a-50c4-981d-64638564d546",
+        "title": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J",
+        "content_sha256": "fdba98fd4fc827b87d4ae11fd6365fcd7330b174d4e737a6c4d416066055e4c3",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+        "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "be01ea72-a43d-578d-83fd-6da4f27c0f71",
+        "title": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1",
+        "content_sha256": "6e918e1fa848260b2fab7673bfe99aef37c248c0b248c35c667238d5e2eaf497",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+        "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "28775be4-5726-53d2-9126-eea1bd9ef27f",
+        "title": "Visa Kunjungan Wisata Beberapa Kali Perjalanan (D1) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2",
+        "content_sha256": "24519738205bc39a0befb8f4f0d6dde3ca13dca72add2163ace0b79726882bb0",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+        "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "4b47cdb0-db95-585d-9d8c-6bba92fe50bb",
+        "title": "Visa Kunjungan Bisnis (D2) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12",
+        "content_sha256": "2961a6046e9efa279e4e2411012b41206f502a8db1c7819c2422cca95a93148e",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+        "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "4ca7cfef-4e5f-51d4-869f-46e9a9c36022",
+        "title": "Visa Kunjungan Pra-Investasi (D12) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A",
+        "content_sha256": "a97d5b1c108ffc886d222174b4026e5dc6ad920fdb1f2cb17a0a2b6718f63e2f",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+        "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "d0218b81-27bf-524b-bf31-6c398844f601",
+        "title": "Visa Pendidikan Dasar dan Menengah (E30A) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B",
+        "content_sha256": "34a8958e439b38e8666d965fb60b64ba5cb04cb3facf92ba2d97ebf7e7c382ad",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+        "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "49e11be4-32ec-57fd-bd4b-f6e6a8e914e5",
+        "title": "Visa Pendidikan Tinggi (E30B) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+        "content_sha256": "41fe2acb27c70180a8269736abe7eb605e4dfd7f55b4d4bd31b1cbd4b480f265",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 2764800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "SECTION",
+            "value": "Daftar Negara, Pemerintah Dari Daerah Administrasi Khusus Suatu Negara, dan Entitas Tertentu (97 entries); cross-verified detik.com d-8322745 and depok.imigrasi.go.id/47666-2"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-08-08T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-08T00:00:00Z",
+        "source_key": "imigrasi-voa-country-list",
+        "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Daftar Negara Subjek Visa on Arrival (VoA) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-30T13:18:00Z",
+        "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+        "version": 1
+      }
+    ],
+    "valid_period": {
+      "from": "2026-07-25T00:00:00Z",
+      "to": null
+    },
+    "version": "2026.9.6"
+  },
+  "payload_sha256": "df02287b7fc8f572a9e6674fdf3445a2131c428e8a1492ab8a388dee5bf01a4d",
+  "protected": {
+    "alg": "Ed25519",
+    "domain": "balizero.visa-rulepack.v1",
+    "environment": "PRODUCTION",
+    "kid": "prod-2026-07-1",
+    "schema_version": "1.0.0",
+    "signed_at": "2026-09-06T14:59:27.320080Z"
+  },
+  "signature": "xkDzQ45QWwvqMbQi2WlyLJMkk-wD-nAguh8eTPNw0honiOsU3R7iQzfs5Ro4G9xbte7s-lTUWRaeG1lNys8uCg"
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
@@ -7,21 +7,42 @@ path through ``flow.ts``'s two-arm spine and ``getCategoryQuestionIds``'
 ten categories, each answered through the real ``fact-mapper.ts`` — against
 the highest signed PRODUCTION pack, and pin the outcome census.
 
-Measured 2026-09-06 on ``rulepack-prod-019.signed.json``:
-**36 NEEDS_INPUT / 7 SUPPORTED_CANDIDATES / 0 NO_SUPPORTED_PATH**. The
-engine is fail-closed and no wrong answer ships — but 36 of 43 walks end by
-asking for a fact the interview HAS NO QUESTION FOR, which is a dead end,
-not an answer (research/visa/2026-09-06-visa-oracle-decisiveness-investigation.md §1-§2).
+Measured 2026-09-06 on ``rulepack-prod-020.signed.json``:
+**21 NEEDS_INPUT / 22 SUPPORTED_CANDIDATES / 0 NO_SUPPORTED_PATH**. The
+engine is fail-closed and no wrong answer ships — but 21 of 43 walks still
+end by asking for a fact the interview HAS NO QUESTION FOR, which is a dead
+end, not an answer (research/visa/2026-09-06-visa-oracle-decisiveness-investigation.md §1-§2).
+
+Re-pinned from seq-19's **36/7** when the signed seq-20 bundle landed. Two
+things moved, both traceable to the fold's edit 1 (the lawful stay-day
+totals) rather than to any change in this test:
+
+* **15 walks gained an answer.** ``el.c1.tourism-family``'s bound went
+  60 → 180 days, so the corpus's 121-stay-day walks now satisfy C1 and the
+  whole tourism/family arm answers instead of dead-ending. Their allowlist
+  rows are DELETED below, not loosened.
+* **9 walks moved their block to** ``family.sponsor_confirmed``. The same
+  widening (60 → 180) on ``el.c2.business`` made C2 reachable for the
+  business/investment arm, and C2's own ``family.sponsor_confirmed == true``
+  premise is now the smallest missing-fact set, so it wins ``evaluator.py``'s
+  ``min(len(missing_facts))`` tie-break ahead of the old blockers. The block
+  is genuinely still there: no invest/business/other branch asks
+  ``family_sponsor_confirmed`` (flow.ts:708 emits it only in the family arm,
+  657-659 in retirement), so this is a NEW dead-end shape, not a cure. Curing
+  it is PR-3's mandate.
+
+Edits 2 and 3 of the fold show up here too: ``review.e33g.income-evidence``
+is gone and the eight ``family.sponsor_status_code`` rules are ``NO_EFFECT``,
+which is why ``onshore/family`` no longer dead-ends on that fact at all.
 
 The invariant this file exists to arm is one sentence:
 
     no walk may end in NEEDS_INPUT on a fact for which the interview has no
     reachable question in that walk's own history.
 
-Today it is violated 36 times, so it ships as an EXPLICIT allowlist of the
-36 known dead ends. Each subsequent PR of the decisiveness wave deletes the
-rows it cures (the evaluator reorder removes 27 of them; the four seq-20
-pack edits and the four new interview questions remove the rest). **When
+Today it is violated 21 times, so it ships as an EXPLICIT allowlist of the
+21 known dead ends. Each subsequent PR of the decisiveness wave deletes the
+rows it cures (PR-3's four new interview questions remove the rest). **When
 ``WALK_DEAD_END_ALLOWLIST`` is empty the invariant becomes unconditional** —
 ``_dead_end_violations`` needs no change for that, it simply stops finding
 an excuse for any NEEDS_INPUT walk.
@@ -89,9 +110,13 @@ class DeadEnd:
     why_unaskable: str
 
 
-# The six dead-end shapes measured on seq-19, with the anchor that explains
+# The five dead-end shapes measured on seq-20, with the anchor that explains
 # each. A wave PR retires a shape by deleting its rows below, never by
-# loosening a count.
+# loosening a count. Seq-20 retired two of seq-19's seven shapes outright:
+# `family.sponsor_status_code` (fold edit 3 made its eight rules NO_EFFECT)
+# and `intent.requested_product_code` (fold edit 4 guarded the four BRIDGING
+# rules on a `known` premise), so their DeadEnd rows are gone rather than
+# merely unused.
 _ONSHORE_CONVERSION = DeadEnd(
     # flow.ts:539-542 emits `wants_onshore_conversion` only when
     # `in_indonesia === "yes"`; every offshore walk is blocked by
@@ -129,62 +154,45 @@ _PAID_UP_CAPITAL = DeadEnd(
     "investment_paid_up_capital_idr",
     QUESTION_NOT_IN_THIS_WALK,
 )
-_SPONSOR_STATUS_CODE = DeadEnd(
-    # asked as `family_sponsor_status_code`, and fact-mapper.ts:505-520
-    # returns unknownFact(UNVERIFIED) for EVERY answer by design: a
-    # self-declared status label must never satisfy `op: known`. A permanent
-    # wall, so the eight rules reading it must not ask (seq-20 edit 3).
-    "family.sponsor_status_code",
-    "family_sponsor_status_code",
-    ANSWER_NEVER_CERTIFIED,
-)
-_REQUESTED_PRODUCT_CODE = DeadEnd(
-    # hardcoded `unknownFact(NOT_ASKED)` at fact-mapper.ts:596 — no question
-    # in tree.ts can ever set it, and no sentinel is safe (§6 R2).
-    "intent.requested_product_code",
-    None,
-    NO_QUESTION_IN_TREE,
+_FAMILY_SPONSOR_CONFIRMED = DeadEnd(
+    # NEW on seq-20, and it is a MOVE, not a regression: `el.c2.business`'s
+    # stay-day bound went 60 -> 180 (fold edit 1), so C2 became reachable for
+    # the business/investment arm at the corpus's 121 days — and C2's own
+    # `family.sponsor_confirmed == true` premise is now the smallest missing
+    # set, winning `evaluator.py`'s `min(len(missing_facts))` tie-break over
+    # the blockers these walks used to report. `family_sponsor_confirmed` is
+    # emitted only by the family arm (flow.ts:708) and by retirement
+    # (flow.ts:657-659); no invest/business/other branch asks it, so the
+    # funnel genuinely cannot supply it here. PR-3's mandate.
+    "family.sponsor_confirmed",
+    "family_sponsor_confirmed",
+    QUESTION_NOT_IN_THIS_WALK,
 )
 
-#: The 36 known dead ends. DELETE rows as the wave cures them; never add one
+#: The 21 known dead ends. DELETE rows as the wave cures them; never add one
 #: without an anchor showing the fact is genuinely unaskable in that walk.
 WALK_DEAD_END_ALLOWLIST: dict[str, tuple[DeadEnd, ...]] = {
     "offshore/business": (_ONSHORE_CONVERSION,),
     "offshore/diaspora": (_DIASPORA_PURPOSE,),
-    "offshore/family/CHILD/spNat=IT": (_ONSHORE_CONVERSION,),
-    "offshore/family/DEPENDENT/spNat=ID": (_ONSHORE_CONVERSION,),
-    "offshore/family/DEPENDENT/spNat=IT": (_ONSHORE_CONVERSION,),
-    "offshore/family/OTHER/spNat=ID": (_ONSHORE_CONVERSION,),
-    "offshore/family/OTHER/spNat=IT": (_ONSHORE_CONVERSION,),
-    "offshore/family/PARENT/spNat=IT": (_ONSHORE_CONVERSION,),
-    "offshore/family/SIBLING/spNat=ID": (_ONSHORE_CONVERSION,),
-    "offshore/family/SIBLING/spNat=IT": (_ONSHORE_CONVERSION,),
-    "offshore/family/SPOUSE/spNat=IT": (_ONSHORE_CONVERSION,),
-    "offshore/holdsPermit/current/tourism": (_ONSHORE_CONVERSION,),
-    "offshore/invest/bank_deposit": (_ONSHORE_CONVERSION,),
-    "offshore/invest/family": (_ONSHORE_CONVERSION,),
-    "offshore/invest/merit": (_ONSHORE_CONVERSION,),
-    "offshore/invest/property": (_ONSHORE_CONVERSION,),
-    "offshore/invest/pt_pma": (_ONSHORE_CONVERSION,),
-    "offshore/invest/undecided": (_ONSHORE_CONVERSION,),
-    "offshore/other": (_ONSHORE_CONVERSION,),
+    "offshore/invest/bank_deposit": (_FAMILY_SPONSOR_CONFIRMED,),
+    "offshore/invest/family": (_FAMILY_SPONSOR_CONFIRMED,),
+    "offshore/invest/merit": (_FAMILY_SPONSOR_CONFIRMED,),
+    "offshore/invest/property": (_FAMILY_SPONSOR_CONFIRMED,),
+    "offshore/invest/pt_pma": (_FAMILY_SPONSOR_CONFIRMED,),
+    "offshore/invest/undecided": (_FAMILY_SPONSOR_CONFIRMED,),
+    "offshore/other": (_FAMILY_SPONSOR_CONFIRMED,),
     "offshore/remote": (_ONSHORE_CONVERSION,),
     "offshore/retirement/bank_deposit": (_ONSHORE_CONVERSION,),
     "offshore/retirement/family_sponsor": (_ONSHORE_CONVERSION,),
     "offshore/retirement/passive_income": (_ONSHORE_CONVERSION,),
     "offshore/retirement/property": (_ONSHORE_CONVERSION,),
     "offshore/retirement/undecided": (_ONSHORE_CONVERSION,),
-    "offshore/tourism": (_ONSHORE_CONVERSION,),
     "onshore/business": (_SPONSOR_TYPE,),
     "onshore/diaspora": (_DIASPORA_PURPOSE,),
-    "onshore/family": (_SPONSOR_STATUS_CODE,),
-    "onshore/holdsPermit/current/tourism": (_SPONSOR_TYPE,),
-    "onshore/holdsPermit/expired/tourism": (_SPONSOR_TYPE,),
-    "onshore/invest": (_REQUESTED_PRODUCT_CODE,),
-    "onshore/other": (_SPONSOR_TYPE,),
+    "onshore/invest": (_FAMILY_SPONSOR_CONFIRMED,),
+    "onshore/other": (_FAMILY_SPONSOR_CONFIRMED,),
     "onshore/remote": (_INVESTMENT_CAPITAL, _PAID_UP_CAPITAL),
     "onshore/retirement": (_INVESTMENT_CAPITAL, _PAID_UP_CAPITAL),
-    "onshore/tourism": (_SPONSOR_TYPE,),
 }
 
 #: Per-walk outcome pin: state plus the candidate products, in rank order.
@@ -194,19 +202,19 @@ WALK_DEAD_END_ALLOWLIST: dict[str, tuple[DeadEnd, ...]] = {
 EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "offshore/business": ("NEEDS_INPUT", ()),
     "offshore/diaspora": ("NEEDS_INPUT", ()),
-    "offshore/family/CHILD/spNat=ID": ("SUPPORTED_CANDIDATES", ("E31G",)),
-    "offshore/family/CHILD/spNat=IT": ("NEEDS_INPUT", ()),
-    "offshore/family/DEPENDENT/spNat=ID": ("NEEDS_INPUT", ()),
-    "offshore/family/DEPENDENT/spNat=IT": ("NEEDS_INPUT", ()),
-    "offshore/family/OTHER/spNat=ID": ("NEEDS_INPUT", ()),
-    "offshore/family/OTHER/spNat=IT": ("NEEDS_INPUT", ()),
-    "offshore/family/PARENT/spNat=ID": ("SUPPORTED_CANDIDATES", ("E31C", "E31F")),
-    "offshore/family/PARENT/spNat=IT": ("NEEDS_INPUT", ()),
-    "offshore/family/SIBLING/spNat=ID": ("NEEDS_INPUT", ()),
-    "offshore/family/SIBLING/spNat=IT": ("NEEDS_INPUT", ()),
-    "offshore/family/SPOUSE/spNat=ID": ("SUPPORTED_CANDIDATES", ("E31A",)),
-    "offshore/family/SPOUSE/spNat=IT": ("NEEDS_INPUT", ()),
-    "offshore/holdsPermit/current/tourism": ("NEEDS_INPUT", ()),
+    "offshore/family/CHILD/spNat=ID": ("SUPPORTED_CANDIDATES", ("C1", "E31G")),
+    "offshore/family/CHILD/spNat=IT": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "offshore/family/DEPENDENT/spNat=ID": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "offshore/family/DEPENDENT/spNat=IT": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "offshore/family/OTHER/spNat=ID": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "offshore/family/OTHER/spNat=IT": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "offshore/family/PARENT/spNat=ID": ("SUPPORTED_CANDIDATES", ("C1", "E31C", "E31F")),
+    "offshore/family/PARENT/spNat=IT": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "offshore/family/SIBLING/spNat=ID": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "offshore/family/SIBLING/spNat=IT": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "offshore/family/SPOUSE/spNat=ID": ("SUPPORTED_CANDIDATES", ("C1", "E31A")),
+    "offshore/family/SPOUSE/spNat=IT": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "offshore/holdsPermit/current/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
     "offshore/invest/bank_deposit": ("NEEDS_INPUT", ()),
     "offshore/invest/family": ("NEEDS_INPUT", ()),
     "offshore/invest/merit": ("NEEDS_INPUT", ()),
@@ -221,19 +229,19 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "offshore/retirement/property": ("NEEDS_INPUT", ()),
     "offshore/retirement/undecided": ("NEEDS_INPUT", ()),
     "offshore/study": ("SUPPORTED_CANDIDATES", ("E30", "E30A")),
-    "offshore/tourism": ("NEEDS_INPUT", ()),
+    "offshore/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
     "offshore/work": ("SUPPORTED_CANDIDATES", ("E23",)),
     "onshore/business": ("NEEDS_INPUT", ()),
     "onshore/diaspora": ("NEEDS_INPUT", ()),
-    "onshore/family": ("NEEDS_INPUT", ()),
-    "onshore/holdsPermit/current/tourism": ("NEEDS_INPUT", ()),
-    "onshore/holdsPermit/expired/tourism": ("NEEDS_INPUT", ()),
+    "onshore/family": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "onshore/holdsPermit/current/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
+    "onshore/holdsPermit/expired/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
     "onshore/invest": ("NEEDS_INPUT", ()),
     "onshore/other": ("NEEDS_INPUT", ()),
     "onshore/remote": ("NEEDS_INPUT", ()),
     "onshore/retirement": ("NEEDS_INPUT", ()),
     "onshore/study": ("SUPPORTED_CANDIDATES", ("E30", "E30A")),
-    "onshore/tourism": ("NEEDS_INPUT", ()),
+    "onshore/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
     "onshore/work": ("SUPPORTED_CANDIDATES", ("E23",)),
 }
 
@@ -248,13 +256,12 @@ EXPECTED_STATE_CENSUS: dict[str, int] = dict(
 #: between blocking facts instead of removing the block goes red here even if
 #: the total happens to stay the same.
 EXPECTED_DEAD_END_FACT_CENSUS: dict[str, int] = {
-    "process.wants_onshore_conversion": 25,
-    "sponsor.type": 5,
+    "family.sponsor_confirmed": 9,
+    "process.wants_onshore_conversion": 7,
     "intent.purposes": 2,
     "investment.investment_capital_idr": 2,
     "investment.paid_up_capital_idr": 2,
-    "family.sponsor_status_code": 1,
-    "intent.requested_product_code": 1,
+    "sponsor.type": 1,
 }
 
 
@@ -376,14 +383,17 @@ def test_every_walk_ends_in_its_pinned_outcome(outcomes: dict[str, dict[str, Any
     assert not violations, "interview-walk outcomes moved:\n  " + "\n  ".join(violations)
 
 
-def test_walk_state_census_is_36_dead_ends_and_7_answers(
+def test_walk_state_census_is_21_dead_ends_and_22_answers(
     outcomes: dict[str, dict[str, Any]],
 ) -> None:
     """The headline number of the decisiveness wave. Every PR that changes it
-    updates this literal and says which walks moved, in its own body."""
+    updates this literal and says which walks moved, in its own body.
+
+    Was 36/7 on seq-19; the signed seq-20 bundle's stay-day widening turned 15
+    of the dead ends into answers (module docstring)."""
 
     census = dict(Counter(outcome["state"] for outcome in outcomes.values()))
-    assert census == EXPECTED_STATE_CENSUS == {"NEEDS_INPUT": 36, "SUPPORTED_CANDIDATES": 7}
+    assert census == EXPECTED_STATE_CENSUS == {"NEEDS_INPUT": 21, "SUPPORTED_CANDIDATES": 22}
     assert census.get("NO_SUPPORTED_PATH", 0) == 0
     assert census.get("HUMAN_REVIEW_REQUIRED", 0) == 0
 
@@ -405,8 +415,8 @@ def test_no_walk_dead_ends_outside_the_allowlist(outcomes: dict[str, dict[str, A
     assert not violations, "walk-census invariant broken:\n  " + "\n  ".join(violations)
 
 
-def test_allowlist_is_exactly_the_36_known_dead_ends() -> None:
-    assert len(WALK_DEAD_END_ALLOWLIST) == 36
+def test_allowlist_is_exactly_the_21_known_dead_ends() -> None:
+    assert len(WALK_DEAD_END_ALLOWLIST) == 21
     assert set(WALK_DEAD_END_ALLOWLIST) <= set(EXPECTED_OUTCOME)
 
 
@@ -440,32 +450,39 @@ def test_every_allowlisted_dead_end_is_genuinely_unaskable_in_its_own_walk(
 def test_guilt_a_cured_dead_end_that_only_moves_the_block_is_caught(
     walks: dict[str, dict[str, Any]],
 ) -> None:
-    """GUILT, on the real engine: hand ``onshore/tourism`` the very fact it
+    """GUILT, on the real engine: hand ``onshore/business`` the very fact it
     dead-ends on (``sponsor.type`` KNOWN) and watch the block MOVE rather than
-    lift — measured 2026-09-06, the walk stays NEEDS_INPUT and now blocks on
-    ``investment.{investment,paid_up}_capital_idr`` instead, because the next
-    zero-SUPPORT product wins ``evaluator.py``'s ``min(len(missing_facts))``
-    tie-break.
+    lift — measured 2026-09-06 on seq-20, the walk stays NEEDS_INPUT and now
+    blocks on ``investment.{investment,paid_up}_capital_idr`` instead, because
+    the next zero-SUPPORT product wins ``evaluator.py``'s
+    ``min(len(missing_facts))`` tie-break.
+
+    Re-anchored from ``onshore/tourism`` on seq-20: that walk now ANSWERS
+    (C1), so the mutation would have had nothing left to move.
 
     That is the whole reason the allowlist compares FACTS and not a count: the
     state census alone would call this cure a no-op (still NEEDS_INPUT, still
     no candidates), and only the per-fact comparison sees it."""
 
-    mutated = dict(walks["onshore/tourism"]["overrides"])
+    mutated = dict(walks["onshore/business"]["overrides"])
     mutated["sponsor.type"] = {"status": "KNOWN", "value": "NONE"}
-    actual = _evaluate(mutated, "onshore/tourism", as_of=_AS_OF)["actual"]
+    actual = _evaluate(mutated, "onshore/business", as_of=_AS_OF)["actual"]
 
+    assert actual["state"] == "NEEDS_INPUT", (
+        "the guilt mutation now LIFTS the block instead of moving it — this "
+        "test no longer exercises the shape it was written for"
+    )
     assert actual["missing_facts"] != ["sponsor.type"], (
         "the guilt mutation no longer changes what blocks this walk — the "
         "corpus or the pack moved and this test proves nothing"
     )
-    assert _dead_end_violations({"onshore/tourism": actual})
+    assert _dead_end_violations({"onshore/business": actual})
 
 
 def test_guilt_a_walk_that_loses_its_answer_is_caught(
     walks: dict[str, dict[str, Any]],
 ) -> None:
-    """GUILT: ``offshore/work`` is one of the 7 walks that DO answer (E23).
+    """GUILT: ``offshore/work`` is one of the 22 walks that DO answer (E23).
     Take its ``work.indonesian_work_sponsor_confirmed`` away and both halves
     of the gate must fire — the outcome pin (SUPPORTED → NEEDS_INPUT) and the
     invariant (a dead end with no allowlist row)."""
@@ -500,10 +517,16 @@ def test_guilt_a_dead_end_on_an_unlisted_fact_is_caught() -> None:
 
 def test_guilt_a_stale_allowlist_row_is_caught() -> None:
     """GUILT: the cure lands, the walk answers, and the allowlist row stays —
-    the way an allowlist normally outlives its defect. Must be red."""
+    the way an allowlist normally outlives its defect. Must be red.
 
+    Anchored on ``offshore/business``, which IS still allowlisted on seq-20;
+    the seq-19 anchor (``offshore/tourism``) was cured by this very fold, so
+    reusing it would have made this guilt test pass for the wrong reason —
+    an unlisted walk, not a stale row."""
+
+    assert "offshore/business" in WALK_DEAD_END_ALLOWLIST
     cured = {
-        "offshore/tourism": {
+        "offshore/business": {
             "state": "SUPPORTED_CANDIDATES",
             "candidates": ["C1"],
             "missing_facts": [],

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq20_signed_bundle.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq20_signed_bundle.py
@@ -1,0 +1,411 @@
+"""Gates for the SIGNED seq-20 artifact
+(``rulepack-prod-020.signed.json``) — the consul's ceremony output, distinct
+from ``test_seq20_pack.py`` (which gates the unsigned fold/source file and
+never claims a signature).
+
+Signed 2026-09-06 by the owner on M5, offline (``sign_pack.py``, never this
+process — see ``bundle.py``'s FIREBREAK docstring), key id ``prod-2026-07-1``
+(the same pinned production Ed25519 key that verified seq-17/seq-18/seq-19).
+``rule_pack_id=ac0a792d-a38d-512e-9ead-54a5d008fb68`` matches ``fold_pack_
+seq20.py``'s ``_rule_pack_id(20)`` UUID5 convention; this module does not
+re-derive it, only asserts the signed envelope carries the same value the
+source file does.
+
+This module verifies the bundle with the REPO'S OWN Ed25519 verification
+code (``bundle.verify_rule_pack``) against the pinned production trust
+store — never trusting the signer's self-reported digest/kid/sequence.
+Every literal below (digest, kid, sequence, previous-sha, rule count) is
+re-derived from disk or from ``verify_rule_pack``'s own return value, not
+copied from a print statement.
+
+Beyond the seq-19 mirror, this module pins the FIVE EDITS this fold made,
+against the signed bytes: a signed artifact is the last place a wrong edit
+can still be caught, and every one of these is a decision that changes what
+the public funnel answers. The rule id lists are IMPORTED from
+``fold_pack_seq20`` rather than retyped — a retyped list drifts silently the
+moment the fold's own constants move.
+
+ACTIVATION IS OUT OF SCOPE HERE. This module never calls
+``activate_pack.py`` (it needs a live Postgres DSN even in its default
+dry-run mode — see that script's ``asyncpg.create_pool`` calls — which this
+test suite must never touch) and never calls ``validate_activation`` either:
+promoting this bundle into the currently-active production sequence is a
+separate, Zero-only ceremony. What this module proves is narrower and
+sufficient for a PR gate: the bytes on disk are a validly signed,
+untampered, correctly-chained PRODUCTION candidate.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.scripts.visa_engine.fold_pack_seq20 import (
+    BRIDGING_RULE_IDS,
+    NEW_RULE_ID,
+    REMOVED_RULE_IDS,
+    REQUESTED_PRODUCT_FACT,
+    SEQ19_PAYLOAD_SHA256,
+    SPONSOR_STATUS_NO_EFFECT_RULE_IDS,
+)
+from backend.services.visa_engine.bundle import (
+    StaticTrustStore,
+    canonicalize_json,
+    verify_rule_pack,
+)
+from backend.services.visa_engine.errors import RulePackVerificationError
+from backend.services.visa_engine.models import RulePackPayload
+
+_PACKS_DIR = (
+    Path(__file__).resolve().parents[3] / "services" / "visa_engine" / "contracts" / "packs"
+)
+_SEQ20_SIGNED_PATH = _PACKS_DIR / "rulepack-prod-020.signed.json"
+_SEQ20_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-020.source.json"
+
+
+def test_signed_bundle_is_present_on_disk() -> None:
+    """A deleted/missing artifact must turn this gate RED, never skip it.
+
+    The seq-19 module carried a module-level
+    ``pytestmark = pytest.mark.skipif(not <path>.exists(), ...)`` until it was
+    removed, because that meant an accidentally deleted (or never-landed)
+    signed bundle produced a silent, all-green-looking SKIP rather than a
+    failure — the gate would not have noticed its own consumer disappearing.
+    This hard assertion is the replacement, carried forward here from the
+    start: no file on disk means this test (and every other test below, which
+    will error out trying to read it) fails loudly.
+    """
+    assert _SEQ20_SIGNED_PATH.exists(), (
+        "rulepack-prod-020.signed.json does not exist on disk — the "
+        "operator's offline signing ceremony (sign_pack.py) has not "
+        "produced it, or it was deleted. This must FAIL, not skip."
+    )
+
+
+#: The pinned production Ed25519 public key — the same one that verifies
+#: seq-17/seq-18/seq-19 (see ``test_seq19_signed_bundle.py``).
+PROD_TRUST_STORE_JSON = json.dumps(
+    [
+        {
+            "kid": "prod-2026-07-1",
+            "public_key": "gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA",
+            "environment": "PRODUCTION",
+            "valid_from": "2026-07-19T00:00:00Z",
+            "valid_to": None,
+            "revoked_at": None,
+        }
+    ]
+)
+
+#: seq-20's own verified payload digest, recomputed off disk below and
+#: cross-checked against ``verify_rule_pack``'s return value.
+SEQ20_PAYLOAD_SHA256 = "df02287b7fc8f572a9e6674fdf3445a2131c428e8a1492ab8a388dee5bf01a4d"
+
+#: Shortly after the bundle's own ``signed_at`` (2026-09-06T14:59:27.320080Z)
+#: — fixed, never ``datetime.now()``, so this test never rots.
+OBSERVED_AT = datetime(2026, 9, 6, 15, 0, 0, tzinfo=timezone.utc)
+
+#: The two live HUMAN_REVIEW gates that must survive every fold onto the
+#: signed production chain — re-asserted here against the SIGNED bytes.
+_EXPECTED_REVIEW_GATE_IDS = frozenset(
+    {"review.e23u.requested-product", "review.e23v.requested-product"}
+)
+
+#: Edit 5's reason code, as the fold writes it. A literal here on purpose:
+#: ``fold_pack_seq20`` inlines it in the rule body rather than naming it, so
+#: pinning it in the test is what makes a silent reason-code edit visible.
+_NEW_RULE_REASON_CODE = "BUSINESS_LOCAL_COMPENSATION_NOT_ALLOWED"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def signed_envelope() -> dict[str, Any]:
+    return _read_json(_SEQ20_SIGNED_PATH)
+
+
+@pytest.fixture(scope="module")
+def source_payload() -> dict[str, Any]:
+    return _read_json(_SEQ20_SOURCE_PATH)
+
+
+@pytest.fixture
+def prod_trust_store_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VISA_ENGINE_TRUST_STORE_KEYS_JSON", PROD_TRUST_STORE_JSON)
+
+
+@pytest.fixture
+def verified_pack(prod_trust_store_env: None, signed_envelope: dict[str, Any]):
+    return verify_rule_pack(
+        signed_envelope,
+        trust_store=StaticTrustStore.from_env(),
+        observed_at=OBSERVED_AT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cryptographic verification (innocence) — the repo's own code, never the
+# signer's self-report.
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureVerifies:
+    def test_the_committed_bundle_verifies_against_the_pinned_production_key(
+        self, verified_pack
+    ) -> None:
+        assert verified_pack.unsigned_dev is False
+        assert verified_pack.pack.protected.kid == "prod-2026-07-1"
+
+    def test_kid_and_environment(self, verified_pack) -> None:
+        assert verified_pack.pack.protected.environment == "PRODUCTION"
+        assert verified_pack.pack.payload.environment == "PRODUCTION"
+
+    def test_sequence_is_20(self, verified_pack) -> None:
+        assert verified_pack.pack.payload.sequence == 20
+
+    def test_rule_pack_id_matches_the_source_fold(
+        self, verified_pack, source_payload: dict[str, Any]
+    ) -> None:
+        assert str(verified_pack.pack.payload.rule_pack_id) == source_payload["rule_pack_id"]
+        assert source_payload["rule_pack_id"] == "ac0a792d-a38d-512e-9ead-54a5d008fb68"
+
+    def test_payload_sha256_is_the_pinned_digest(self, verified_pack) -> None:
+        assert verified_pack.payload_sha256.hex() == SEQ20_PAYLOAD_SHA256
+
+    def test_chain_anchor_matches_seq19(self, verified_pack) -> None:
+        assert verified_pack.pack.payload.previous_payload_sha256 == SEQ19_PAYLOAD_SHA256
+
+    def test_rule_count_is_109(self, verified_pack) -> None:
+        assert len(verified_pack.pack.payload.rules) == 109
+
+    def test_the_two_e23_review_gates_are_present(self, verified_pack) -> None:
+        rule_ids = {rule.rule_id for rule in verified_pack.pack.payload.rules}
+        assert _EXPECTED_REVIEW_GATE_IDS <= rule_ids
+
+
+# ---------------------------------------------------------------------------
+# Digest recomputation — independent of verify_rule_pack, straight off disk.
+# ---------------------------------------------------------------------------
+
+
+class TestDigestRecomputedIndependently:
+    def test_sha256_of_canonicalized_source_matches_the_pinned_digest(
+        self, source_payload: dict[str, Any]
+    ) -> None:
+        assert hashlib.sha256(canonicalize_json(source_payload)).hexdigest() == SEQ20_PAYLOAD_SHA256
+
+    def test_sha256_of_canonicalized_signed_payload_matches_the_declared_field(
+        self, signed_envelope: dict[str, Any]
+    ) -> None:
+        recomputed = hashlib.sha256(canonicalize_json(signed_envelope["payload"])).hexdigest()
+        assert recomputed == signed_envelope["payload_sha256"]
+
+    def test_signed_payload_is_byte_identical_to_source_under_jcs(
+        self, signed_envelope: dict[str, Any], source_payload: dict[str, Any]
+    ) -> None:
+        """The artifact that was signed is the same artifact in version
+        control — a divergence here would mean the tracked source.json is
+        not what the operator actually signed."""
+        assert canonicalize_json(signed_envelope["payload"]) == canonicalize_json(source_payload)
+
+    def test_source_validates_against_the_payload_model(
+        self, source_payload: dict[str, Any]
+    ) -> None:
+        payload = RulePackPayload.model_validate(source_payload)
+        assert payload.sequence == 20
+        assert payload.previous_payload_sha256 == SEQ19_PAYLOAD_SHA256
+
+
+# ---------------------------------------------------------------------------
+# What THIS fold changed, asserted against the SIGNED bytes. Ids come from
+# fold_pack_seq20's own constants — never retyped here.
+# ---------------------------------------------------------------------------
+
+
+class TestSeq20EditsSurvivedTheSigningCeremony:
+    """Edits 2-5, each read back off the verified pack.
+
+    Edit 1 (the stay-day cap widening) is not re-pinned here: ``test_seq20_
+    pack.py`` already compares every ``STAY_DAY_CAPS`` bound against the
+    source file, and this module's JCS-equality test proves the signed payload
+    IS that source file byte-for-byte. What is pinned below is what a wrong
+    fold would still produce a *validly signed* artifact for.
+    """
+
+    @staticmethod
+    def _by_id(verified_pack) -> dict[str, Any]:
+        return {rule.rule_id: rule for rule in verified_pack.pack.payload.rules}
+
+    def test_edit2_the_retired_e33g_review_gate_is_absent(self, verified_pack) -> None:
+        """``review.e33g.income-evidence`` was retired because its ``when``
+        was a byte-copy of its SUPPORT twin's — a gate that could only ever
+        fire when the product was already supported."""
+        assert REMOVED_RULE_IDS == frozenset({"review.e33g.income-evidence"})
+        assert REMOVED_RULE_IDS.isdisjoint(self._by_id(verified_pack))
+
+    def test_edit3_the_eight_sponsor_status_rules_are_no_effect_on_unknown(
+        self, verified_pack
+    ) -> None:
+        """``family.sponsor_status_code`` can never be certified by the
+        browser (fact-mapper returns ``unknownFact(UNVERIFIED)`` for every
+        answer), so these eight must not block the whole decision on it."""
+        rules = self._by_id(verified_pack)
+        assert len(SPONSOR_STATUS_NO_EFFECT_RULE_IDS) == 8
+        for rule_id in SPONSOR_STATUS_NO_EFFECT_RULE_IDS:
+            assert rule_id in rules, f"{rule_id} vanished from the signed pack"
+            assert rules[rule_id].on_unknown == "NO_EFFECT", (
+                f"{rule_id}: on_unknown is {rules[rule_id].on_unknown!r}, not NO_EFFECT — "
+                "the seq-20 edit did not survive into the signed bytes"
+            )
+
+    def test_edit4_each_bridging_rule_carries_exactly_one_known_premise(
+        self, verified_pack, signed_envelope: dict[str, Any]
+    ) -> None:
+        """The four BRIDGING SUPPORT rules were guarded so they only fire once
+        the applicant has actually named a product. Read off the raw signed
+        payload (not the model) because the premise shape is what is signed."""
+        raw = {rule["rule_id"]: rule for rule in signed_envelope["payload"]["rules"]}
+        assert len(BRIDGING_RULE_IDS) == 4
+        for rule_id in BRIDGING_RULE_IDS:
+            assert rule_id in raw, f"{rule_id} vanished from the signed pack"
+            known_premises = [
+                arg
+                for arg in raw[rule_id]["when"]["args"]
+                if arg.get("fact") == REQUESTED_PRODUCT_FACT and arg.get("op") == "known"
+            ]
+            assert len(known_premises) == 1, (
+                f"{rule_id}: expected exactly one {REQUESTED_PRODUCT_FACT} `known` premise, "
+                f"found {len(known_premises)}"
+            )
+            assert rule_id in self._by_id(verified_pack)
+
+    def test_edit5_the_new_d2_compensation_hard_filter_is_present_and_excludes(
+        self, verified_pack
+    ) -> None:
+        rules = self._by_id(verified_pack)
+        assert NEW_RULE_ID == "hf.d2.indonesia-source-compensation"
+        assert NEW_RULE_ID in rules, "the seq-20 hard filter is missing from the signed pack"
+        rule = rules[NEW_RULE_ID]
+        assert rule.effect.type == "EXCLUDE"
+        assert rule.effect.reason_code == _NEW_RULE_REASON_CODE
+
+
+# ---------------------------------------------------------------------------
+# Guilt — a tampered COPY must fail verification. Never mutates the
+# committed file; every mutation is applied to an in-memory `copy.deepcopy`.
+# ---------------------------------------------------------------------------
+
+
+class TestTamperingIsRejected:
+    def test_flipping_one_base64url_character_of_the_signature_fails(
+        self, prod_trust_store_env: None, signed_envelope: dict[str, Any]
+    ) -> None:
+        tampered = copy.deepcopy(signed_envelope)
+        sig = tampered["signature"]
+        # Flip the first character to a different, still-valid base64url
+        # character — guarantees a different byte string, never an
+        # accidental no-op.
+        flipped_char = "A" if sig[0] != "A" else "B"
+        tampered["signature"] = flipped_char + sig[1:]
+        with pytest.raises(RulePackVerificationError):
+            verify_rule_pack(
+                tampered, trust_store=StaticTrustStore.from_env(), observed_at=OBSERVED_AT
+            )
+
+    def test_mutating_one_payload_field_fails_both_digest_and_signature(
+        self, prod_trust_store_env: None, signed_envelope: dict[str, Any]
+    ) -> None:
+        tampered = copy.deepcopy(signed_envelope)
+        tampered["payload"]["sequence"] = 21
+        with pytest.raises(RulePackVerificationError):
+            verify_rule_pack(
+                tampered, trust_store=StaticTrustStore.from_env(), observed_at=OBSERVED_AT
+            )
+
+    def test_mutating_a_rule_inside_the_payload_fails(
+        self, prod_trust_store_env: None, signed_envelope: dict[str, Any]
+    ) -> None:
+        tampered = copy.deepcopy(signed_envelope)
+        tampered["payload"]["rules"][0]["priority"] = 999999
+        with pytest.raises(RulePackVerificationError):
+            verify_rule_pack(
+                tampered, trust_store=StaticTrustStore.from_env(), observed_at=OBSERVED_AT
+            )
+
+    def test_reverting_one_seq20_edit_fails(
+        self, prod_trust_store_env: None, signed_envelope: dict[str, Any]
+    ) -> None:
+        """The fold-specific twin of the mutation above: put edit 3 back the
+        way seq-19 had it (``on_unknown: NEEDS_INPUT``) and the signature must
+        reject it. Proves the eight NO_EFFECT values above are inside the
+        signed envelope, not merely inside a file this test happens to read."""
+        tampered = copy.deepcopy(signed_envelope)
+        target = SPONSOR_STATUS_NO_EFFECT_RULE_IDS[0]
+        for rule in tampered["payload"]["rules"]:
+            if rule["rule_id"] == target:
+                rule["on_unknown"] = "NEEDS_INPUT"
+                break
+        else:  # pragma: no cover - the id is imported from the fold itself
+            raise AssertionError(f"{target} not in the signed pack")
+        with pytest.raises(RulePackVerificationError):
+            verify_rule_pack(
+                tampered, trust_store=StaticTrustStore.from_env(), observed_at=OBSERVED_AT
+            )
+
+    def test_wrong_trust_store_key_fails(
+        self, signed_envelope: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A DIFFERENT (but validly-shaped) Ed25519 public key must never
+        verify this bundle — proves the check is against the real pinned
+        key, not merely "a key that parses". ``monkeypatch.setenv`` (not a
+        raw ``os.environ`` mutation) so a pre-existing value of this env var
+        in the invoking process is restored, never clobbered, once the test
+        ends."""
+        wrong_key_json = json.dumps(
+            [
+                {
+                    "kid": "prod-2026-07-1",
+                    # 32 zero bytes, base64url, unpadded — a different,
+                    # validly-shaped Ed25519 public key.
+                    "public_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "environment": "PRODUCTION",
+                    "valid_from": "2026-07-19T00:00:00Z",
+                    "valid_to": None,
+                    "revoked_at": None,
+                }
+            ]
+        )
+        monkeypatch.setenv("VISA_ENGINE_TRUST_STORE_KEYS_JSON", wrong_key_json)
+        with pytest.raises(RulePackVerificationError):
+            verify_rule_pack(
+                signed_envelope,
+                trust_store=StaticTrustStore.from_env(),
+                observed_at=OBSERVED_AT,
+            )
+
+
+# ---------------------------------------------------------------------------
+# The committed file itself is untouched by any of the guilt tests above —
+# proven by re-reading it from disk and re-verifying, after the tampering
+# section has run.
+# ---------------------------------------------------------------------------
+
+
+def test_the_committed_file_on_disk_is_unchanged_and_still_verifies(
+    prod_trust_store_env: None,
+) -> None:
+    fresh = _read_json(_SEQ20_SIGNED_PATH)
+    verified = verify_rule_pack(
+        fresh, trust_store=StaticTrustStore.from_env(), observed_at=OBSERVED_AT
+    )
+    assert verified.pack.payload.sequence == 20
+    assert verified.payload_sha256.hex() == SEQ20_PAYLOAD_SHA256
+    assert NEW_RULE_ID in {rule.rule_id for rule in verified.pack.payload.rules}

--- a/evidence/2026-09/agent-air-m5-backend-rag-visa-seq20-sign-5717d691/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-visa-seq20-sign-5717d691/brief.yml
@@ -1,0 +1,110 @@
+task_id: visa-seq20-sign
+gear: 3
+l_level: L2
+gate_class: opus
+# Floor computed this run: `python3 scripts/evidence_pack_lint.py --print-floor
+# --print-floor-source --numstat-file <numstat> --changed-files-file <changed>`
+# returns `3` / `size`. The size is one file: rulepack-prod-020.signed.json is
+# 9,293 lines of GENERATED, signed artifact. That alone floors the PR at Gear 3
+# regardless of the authored footprint, which is 411 lines of new test, a
+# 112/89 re-pin of an existing census, and 41/2 across the secrets-triage pair.
+objective: >-
+  Land the SIGNED seq-20 production RulePack bundle
+  (`rulepack-prod-020.signed.json`) produced by the owner's offline Ed25519
+  ceremony on M5, and land the three gates that make it observable: a
+  signed-bundle test module that verifies the bytes with the repo's own
+  `verify_rule_pack` against the pinned production trust store, the
+  content-keyed secrets-triage rule that keeps that module's public-key and
+  digest literals out of the unaudited residue, and the re-pin of
+  `test_interview_walk_census.py` — which reads the HIGHEST SIGNED pack on
+  disk and therefore MOVES the moment this bundle lands. Signing seq-20 is
+  what turns the fold (PR #5854, merged) from a file into the pack the
+  funnel actually evaluates against.
+constraints:
+  - >-
+    NO ACTIVATION IN THIS PR. The bundle is a validly signed PRODUCTION
+    CANDIDATE; promoting it into the active sequence is `activate_pack.py`,
+    a separate Zero-only ceremony that needs a live Postgres DSN. This seat
+    ran neither `activate_pack.py` nor `validate_activation`, and passed
+    `--yes` to nothing.
+  - >-
+    NO SIGNING IN THIS SESSION EITHER. The signed artifact arrived in the
+    worktree already produced by the offline ceremony; this seat read no key
+    material, holds no private key, and only VERIFIES — against the pinned
+    PUBLIC key, with the repo's own code.
+  - >-
+    The census must be RE-PINNED to what seq-20 measures, never LOOSENED to
+    make a red test green. The 21 surviving dead ends are real and are PR-3's
+    mandate; every surviving allowlist row keeps an honest reason naming its
+    blocking fact and whether a source question exists, and the module's own
+    `test_guilt_*` suite must stay non-vacuous.
+  - >-
+    Every census number is MEASURED by running the evaluator against the
+    signed pack in this session, never carried over from the fold PR's
+    prediction and never guessed.
+acceptance:
+  - text: >-
+      A1: WHEN the committed `rulepack-prod-020.signed.json` is verified with
+      `bundle.verify_rule_pack` against the PINNED production trust store
+      (kid `prod-2026-07-1`), it SHALL verify with `unsigned_dev=False`, and
+      SHALL declare sequence 20, environment PRODUCTION, 109 rules, the
+      seq-19 chain anchor `bac5da8e…e6ea` and payload digest
+      `df02287b…1a4d` — read out of `verify_rule_pack`'s own return value,
+      never out of the signer's self-report.
+    probe: >-
+      backend/tests/services/visa_engine/test_seq20_signed_bundle.py
+  - text: >-
+      A2: WHERE the digest is recomputed INDEPENDENTLY of `verify_rule_pack`
+      — `hashlib.sha256(canonicalize_json(...))` straight off disk — the
+      signed payload and `rulepack-prod-020.source.json` SHALL both hash to
+      `df02287b…1a4d`, and their JCS-canonical bytes SHALL be equal. This is
+      what proves the artifact in version control is the artifact that was
+      signed.
+    probe: >-
+      backend/tests/services/visa_engine/test_seq20_signed_bundle.py
+  - text: >-
+      A3: FOR EACH tampering shape — a flipped base64url character of the
+      signature, a mutated payload field, a mutated rule, one seq-20 edit
+      reverted to its seq-19 value, and a WRONG but validly-shaped Ed25519
+      trust-store key — verification SHALL raise
+      `RulePackVerificationError`. Every mutation SHALL be applied to an
+      in-memory `copy.deepcopy`, and a final test SHALL re-read the committed
+      file from disk and re-verify it, proving the guilt tests mutated
+      nothing.
+    probe: >-
+      backend/tests/services/visa_engine/test_seq20_signed_bundle.py
+  - text: >-
+      A4: WHERE this fold's five edits are asserted against the SIGNED bytes,
+      the rule ids SHALL be IMPORTED from
+      `backend.scripts.visa_engine.fold_pack_seq20`, never retyped: a retyped
+      list drifts the moment the fold's own constants move. Specifically
+      `review.e33g.income-evidence` SHALL be ABSENT,
+      `hf.d2.indonesia-source-compensation` SHALL be present with
+      `effect.type == EXCLUDE` and reason code
+      `BUSINESS_LOCAL_COMPENSATION_NOT_ALLOWED`, the eight
+      `family.sponsor_status_code` SUPPORT rules SHALL carry
+      `on_unknown == NO_EFFECT`, and each of the four BRIDGING rules SHALL
+      carry exactly one `intent.requested_product_code` `known` premise.
+    probe: >-
+      backend/tests/services/visa_engine/test_seq20_signed_bundle.py
+  - text: >-
+      A5: WHEN the 43 real interview walks are replayed against the HIGHEST
+      SIGNED pack — which this PR moves from seq-19 to seq-20 — the census
+      SHALL be re-pinned to the MEASURED 21 NEEDS_INPUT / 22
+      SUPPORTED_CANDIDATES / 0 NO_SUPPORTED_PATH, with every stale allowlist
+      row DELETED and every moved blocking fact CORRECTED, and the module's
+      guilt tests SHALL stay non-vacuous — re-anchored onto walks that still
+      dead-end where the seq-19 anchors were cured by this very pack.
+    probe: >-
+      backend/tests/services/visa_engine/test_interview_walk_census.py
+  - text: >-
+      A6: WHEN `detect-secrets` scans the new test module, its two findings
+      (the pinned PUBLIC verification key and the seq-20 payload digest)
+      SHALL be auto-approved by a CONTENT-KEYED, end-anchored rule pinned to
+      the exact assignment AND the exact value, leaving ZERO unaudited
+      residue — and a credential typed onto any other line of that file SHALL
+      still reach human review.
+    probe: >-
+      scripts/tests/test_detect_secrets_auto_triage.py
+appetite:
+  wall_clock_hours: 3

--- a/evidence/2026-09/agent-air-m5-backend-rag-visa-seq20-sign-5717d691/pack.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-visa-seq20-sign-5717d691/pack.yml
@@ -1,0 +1,334 @@
+task_id: visa-seq20-sign
+gear: 3
+gate_class: opus
+brief_ref: evidence/2026-09/agent-air-m5-backend-rag-visa-seq20-sign-5717d691/brief.yml
+date: 2026-09-06
+machine: M5
+lanes:
+  - lane: seq-20 signed bundle + signed-bundle gate + census re-pin + triage rule
+    role: build
+    seat: claude-opus-5 (builder seat in worktree .worktrees/backend-rag-visa-seq20-sign, branch agent/air-m5/backend-rag/visa-seq20-sign)
+    note: >-
+      Landed the SIGNED seq-20 bundle produced by the owner's offline Ed25519 ceremony
+      and the three gates that make it observable. (a) test_seq20_signed_bundle.py:
+      verification through the repo's own bundle.verify_rule_pack against the PINNED
+      production trust store, independent digest recomputation off disk for both the
+      source and the signed payload, JCS equality between them, the five fold edits
+      asserted against the SIGNED bytes with their rule ids IMPORTED from
+      fold_pack_seq20 rather than retyped, five tampering shapes rejected on in-memory
+      deepcopies, and a final re-read-from-disk test proving the guilt tests mutated
+      nothing. No pytest.mark.skipif anywhere: a missing artifact must be RED, not a
+      false green. (b) test_interview_walk_census.py re-pinned from seq-19's 36/7 to
+      seq-20's MEASURED 21/22, with 15 cured allowlist rows DELETED, 9 moved rows
+      CORRECTED onto family.sponsor_confirmed, and two guilt tests re-anchored because
+      this very pack cured their seq-19 subjects. (c) a content-keyed secrets-triage
+      rule for the new test module's two entropy findings, with the count-bump test.
+      NOTHING WAS SIGNED OR ACTIVATED IN THIS SESSION: this seat holds no private key,
+      read no key material, and passed `--yes` to nothing.
+
+seat_diversity: exempt
+seat_diversity_note: >-
+  One build lane, so D3's seat-diversity requirement does not attach (it binds packs
+  with >= 2 build lanes). No review lane is declared because this is an EXTERNAL-shaped
+  build handoff under CLAUDE.md §5: this seat prepares and never ships — it does not
+  merge, arm or deploy — and a separate Consul session reads the diff and grades it.
+  Declaring a review lane here would put the grader inside the generator's own pack,
+  which is the boundary that separation exists to hold. The Consul's read is the
+  review; it is not this seat's to record.
+
+seat_override: >-
+  R8 ground_truth: this diff hits GROUND_TRUTH_PATH_PATTERNS (`*/visa_engine/*`), but
+  it introduces NO regulatory claim of its own — it introduces no rule, no bound and no
+  reason code. Every legal proposition inside rulepack-prod-020.signed.json was authored
+  and ruled BEFORE this PR and merged in #5854 as the UNSIGNED source; this PR adds the
+  operator's signature over bytes that are PROVEN byte-identical to that already-reviewed
+  source under JCS (receipt below). The census re-pin is a MEASUREMENT of what those
+  already-ruled rules produce, not a new claim. A fresh NB/ground-truth lane would be
+  re-litigating the fold PR's own reviewed content.
+  .
+  R9 council_run: no council journal is declared either, and for the same reason plus
+  one more. This PR compiles no claim to adversarially review — the bytes were reviewed
+  and merged as #5854, and this diff proves them unchanged rather than restating them —
+  and, under CLAUDE.md §5's external-builder exception, this seat is a PREPARER that does
+  not merge, arm or deploy. A separate Consul session reads and grades the diff. Running
+  council seats from inside the generator's own pack would move the adversarial read to
+  the wrong side of the generator-is-never-grader boundary, not add one.
+
+outcome: >-
+  The signed seq-20 bundle is on the branch as a verified PRODUCTION CANDIDATE, and it
+  is verified by the repo's own code rather than by the signer's self-report: sequence
+  20, environment PRODUCTION, kid prod-2026-07-1, 109 rules, chain anchor
+  bac5da8e…e6ea (seq-19), payload digest df02287b…1a4d, unsigned_dev False. The digest
+  is recomputed independently off disk from both the signed payload and
+  rulepack-prod-020.source.json and the two are JCS-equal, so the artifact in version
+  control IS the artifact that was signed. Landing it moves
+  test_interview_walk_census.py off seq-19 by itself — that module reads the HIGHEST
+  SIGNED pack on disk — and the census is re-pinned to the measured
+  21 NEEDS_INPUT / 22 SUPPORTED_CANDIDATES / 0 NO_SUPPORTED_PATH, up from 36/7. The
+  guard was re-pinned, never weakened: the 21 surviving dead ends keep an honest reason
+  naming the blocking fact and its source question, and the two guilt tests whose
+  seq-19 subjects this pack CURED were re-anchored onto walks that still dead-end, so
+  neither passes vacuously. Nothing was activated; promoting this bundle into the
+  active sequence remains a separate Zero-only ceremony.
+diff:
+  files: 7
+  net_lines: >-
+    9293/0 rulepack-prod-020.signed.json (the SIGNED artifact — generated by the offline
+    ceremony, not review surface, and the entire Gear-3 size floor by itself), 411/0
+    test_seq20_signed_bundle.py (new), 112/89 test_interview_walk_census.py (re-pin),
+    38/0 scripts/detect_secrets_auto_triage.py (one content-keyed rule + its rationale),
+    3/2 scripts/tests/test_detect_secrets_auto_triage.py (count bump + audit-trail line),
+    84/0 scripts/ci/observe_visa_seq20_signed.py (new, bites-observable), plus this
+    evidence pack — +9941/-91 in total. The generated signed artifact is 93 percent of
+    that by itself; strip it and the authored review surface is six hundred and
+    forty-eight added lines against ninety-one removed, all of it test and tooling.
+  measured_at: >-
+    `git diff --numstat $(git merge-base HEAD origin/main)` for the tracked files plus
+    `wc -l` for the untracked new files, merge-base dc7189f4af09857a6d7fbe26e33f3f553921c216
+    — the commit this branch was cut from, which is also the seq-20 FOLD merge (#5854).
+    Anchoring on the merge-base rather than on the moving origin/main tip keeps these
+    numbers this PR's own diff instead of inflated by drift.
+  shape: >-
+    One signed pack artifact, one new gate suite for it, one re-pin of an existing
+    downstream census the artifact MOVES, one content-keyed secrets-triage rule with its
+    count-bump test, and one bites-observable CI wrapper. No visa_engine CODE file is
+    touched: the engine, the evaluator, the interview tree and the fold script are all
+    untouched by design — curing the 21 surviving dead ends is PR-3 of this wave.
+pii_scan: clean
+bites:
+  consumer: >-
+    apps/backend-rag's test_interview_walk_census.py — the module that reads the HIGHEST
+    SIGNED production pack on disk via `select_highest_repository_pack`, so landing this
+    bundle moves it off seq-19 without anything else changing — AND
+    test_seq20_signed_bundle.py, the gate that verifies the bundle itself. Both ship in
+    this PR; neither is a future job.
+  where: ci
+  observe: python3 scripts/ci/observe_visa_seq20_signed.py
+  expect: exit0
+bites_note: >-
+  scripts/ci/observe_visa_seq20_signed.py takes NO arguments — every path and command in
+  it is a literal, the bar scripts/ci/bites_parse.py::_guard_observable_script sets. Run
+  in this worktree at the head this pack describes: 23 passed (signed bundle), 11 passed
+  (walk census), "observe_visa_seq20_signed: both consumers green", exit 0. The census
+  consumer is not decorative: BEFORE this PR re-pinned it, that same module ran 4 FAILED
+  / 7 passed against the seq-20 bundle sitting in this worktree — the concrete proof that
+  landing a signed pack is observed by a downstream gate rather than merely present on
+  disk. That red output is recorded verbatim as a receipt below.
+receipts:
+  - claim: >-
+      the gear floor for this PR's changed-file list is Gear 3, sourced from size — the
+      9,293-line signed artifact floors it by itself
+    cmd: >-
+      python3 scripts/evidence_pack_lint.py --print-floor --print-floor-source
+      --numstat-file <numstat of the 7 changed files> --changed-files-file <their paths>
+    result: "3 / size"
+    ts: "2026-09-06T15:05:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: >-
+      the committed rulepack-prod-020.signed.json verifies against the PINNED production
+      Ed25519 key with the repo's own verify_rule_pack, and every declared field is read
+      out of that call's return value rather than out of the signer's self-report; five
+      tampering shapes are rejected and the file on disk is provably unmutated afterwards
+    cmd: >-
+      PYTHONPATH=. .venv/bin/python3 -m pytest
+      backend/tests/services/visa_engine/test_seq20_signed_bundle.py
+    result: >-
+      23 passed — unsigned_dev False, kid prod-2026-07-1, environment PRODUCTION,
+      sequence 20, rule_pack_id ac0a792d-a38d-512e-9ead-54a5d008fb68, 109 rules,
+      previous_payload_sha256 bac5da8e…e6ea, payload_sha256 df02287b…1a4d
+    ts: "2026-09-06T15:03:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: >-
+      the signed payload and the tracked rulepack-prod-020.source.json are the SAME
+      document — the artifact in version control is the artifact that was signed
+    cmd: >-
+      TestDigestRecomputedIndependently inside the module above —
+      hashlib.sha256(canonicalize_json(...)).hexdigest() computed straight off disk for
+      the source file and for the signed envelope's payload, plus a JCS byte-equality
+      assertion between them, none of it going through verify_rule_pack
+    result: >-
+      both hash to df02287b7fc8f572a9e6674fdf3445a2131c428e8a1492ab8a388dee5bf01a4d and
+      canonicalize_json(signed["payload"]) == canonicalize_json(source) — green inside
+      the 23
+    ts: "2026-09-06T15:03:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: >-
+      landing this bundle MOVES a downstream gate — test_interview_walk_census.py reads
+      the highest SIGNED pack on disk and went red against seq-20 before the re-pin
+    cmd: >-
+      PYTHONPATH=. .venv/bin/python3 -m pytest
+      backend/tests/services/visa_engine/test_interview_walk_census.py
+      (run with the signed bundle present and the census still pinned to seq-19)
+    result: >-
+      4 failed, 7 passed — test_every_walk_ends_in_its_pinned_outcome (18 walks moved),
+      test_walk_state_census_is_36_dead_ends_and_7_answers
+      ("{'NEEDS_INPUT': 21, 'SUPPORTED_CANDIDATES': 22}" != "{'NEEDS_INPUT': 36,
+      'SUPPORTED_CANDIDATES': 7}"), test_dead_end_fact_census_matches_the_blocking_fact_table,
+      and test_no_walk_dead_ends_outside_the_allowlist (24 violations: 15 "stale allowlist
+      row, delete it in the PR that cured it" and 9 "dead-ends on ['family.sponsor_confirmed'],
+      allowlist says [...]")
+    ts: "2026-09-06T14:47:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 1
+  - claim: >-
+      every re-pinned census number is MEASURED against the seq-20 signed pack, per walk,
+      never carried over from the fold PR's prediction and never guessed
+    cmd: >-
+      a scratch script importing _load_walks/_evaluate_walks/_AS_OF from the census module
+      itself and printing (state, candidates, missing_facts) for all 43 walks plus both
+      Counter totals, run under PYTHONPATH=. .venv/bin/python3
+    result: >-
+      pack selected = sequence 20, signed_at 2026-09-06T14:59:27.320080Z;
+      STATE_CENSUS {'NEEDS_INPUT': 21, 'SUPPORTED_CANDIDATES': 22};
+      FACT_CENSUS {'family.sponsor_confirmed': 9, 'process.wants_onshore_conversion': 7,
+      'intent.purposes': 2, 'investment.investment_capital_idr': 2,
+      'investment.paid_up_capital_idr': 2, 'sponsor.type': 1}
+    ts: "2026-09-06T14:52:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: >-
+      the 9 walks whose block MOVED to family.sponsor_confirmed are genuinely still dead
+      ends — the reason recorded in the allowlist is CHECKED, not asserted
+    cmd: >-
+      for each of the 9 walks, printed `"family_sponsor_confirmed" in walk["asked"]` and
+      the walk's own wire override for that fact; then grepped flow.ts for every site that
+      emits the question id
+    result: >-
+      asked=False for all 9, override={'status': 'UNKNOWN', 'reason': 'NOT_ASKED'} for all
+      9; flow.ts emits family_sponsor_confirmed only at :708 (family arm) and :657-659
+      (retirement) — no invest/business/other branch asks it. QUESTION_NOT_IN_THIS_WALK is
+      therefore the accurate reason, and the module's own
+      test_every_allowlisted_dead_end_is_genuinely_unaskable_in_its_own_walk re-checks it
+      against each walk's `asked` history on every run.
+    ts: "2026-09-06T14:55:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: >-
+      the guard was RE-PINNED, not weakened — the two guilt tests whose seq-19 subjects
+      this pack cured were re-anchored onto walks that still dead-end, so neither passes
+      vacuously
+    cmd: >-
+      measured the re-anchored mutation on the real engine before editing the test —
+      onshore/business with sponsor.type set KNOWN, and checked that offshore/business is
+      still in the post-re-pin allowlist
+    result: >-
+      onshore/business + sponsor.type=NONE -> still NEEDS_INPUT, block MOVES to
+      ['investment.investment_capital_idr', 'investment.paid_up_capital_idr'] — the exact
+      block-moves-rather-than-lifts shape the seq-19 anchor (onshore/tourism, now
+      SUPPORTED [C1]) used to exercise. The stale-row guilt test was re-anchored onto
+      offshore/business, which IS still allowlisted, and now asserts that membership
+      explicitly so a future cure cannot silently turn it into an unlisted-walk test.
+    ts: "2026-09-06T14:56:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: >-
+      the re-pinned census module is fully green, including all five test_guilt_* tests
+    cmd: >-
+      PYTHONPATH=. .venv/bin/python3 -m pytest
+      backend/tests/services/visa_engine/test_interview_walk_census.py
+    result: "11 passed (was 4 failed / 7 passed before the re-pin)"
+    ts: "2026-09-06T15:01:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: >-
+      the new test module's entropy findings are exactly two, and the new content-keyed
+      rule auto-approves both with ZERO unaudited residue
+    cmd: >-
+      detect-secrets scan on the new module, then detect_secrets_auto_triage.triage(...,
+      apply=True) over those findings in a scratch baseline copy
+    result: >-
+      scan: 2 findings — line 97 Base64 High Entropy String (the pinned PUBLIC
+      verification key) and line 108 Hex High Entropy String (SEQ20_PAYLOAD_SHA256).
+      triage: {'auto_approved': 2, 'hard_blocked': 0, 'no_rule': 0, 'total': 2},
+      residue []. The tracked .secrets.baseline is NOT touched by this PR — CI's own scan
+      step updates it in place before the triage step runs, exactly as it did for
+      test_seq19_signed_bundle.py, which is likewise absent from the tracked baseline.
+    ts: "2026-09-06T15:00:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: the secrets-triage guard suite is green with the bumped rule count
+    cmd: python3 -m pytest scripts/tests/test_detect_secrets_auto_triage.py
+    result: "107 passed — CONTENT_KEYED_RULES is now 26 (was 25)"
+    ts: "2026-09-06T14:58:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: the evidence-pack contract's own guilt+innocence suite is green, as CI runs it
+    cmd: >-
+      python3 -m pytest scripts/tests/test_evidence_pack_lint.py;
+      python3 scripts/evidence_pack_lint.py --selftest
+      (both taken from .github/workflows/guard-conformance.yml, not invented)
+    result: "344 passed; SELFTEST PASS"
+    ts: "2026-09-06T15:07:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: >-
+      the bites observe target drives BOTH named consumers and exits 0 only when both are
+      green
+    cmd: python3 scripts/ci/observe_visa_seq20_signed.py
+    result: >-
+      "23 passed" (test_seq20_signed_bundle.py), "11 passed"
+      (test_interview_walk_census.py), "observe_visa_seq20_signed: both consumers green"
+    ts: "2026-09-06T15:11:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+  - claim: >-
+      nothing was signed and nothing was activated by THIS session — the bundle arrived
+      already produced by the owner's offline ceremony
+    cmd: >-
+      grep of this session's own command history for sign_pack.py / activate_pack.py /
+      `--yes`, and inspection of the artifact's protected.signed_at against the session
+      start
+    result: >-
+      zero invocations of either script; protected.signed_at is 2026-09-06T14:59:27.320080Z,
+      produced outside this seat. No private key was read, held or written; the only key
+      material anywhere in this diff is the PUBLIC verification key already pinned in four
+      other committed modules.
+    ts: "2026-09-06T15:12:00Z"
+    seat: claude-opus-5 (this worktree session)
+    exit: 0
+dissent:
+  - seat: claude-opus-5 (this worktree session), self-caught
+    status: CONFIRMED
+    objection: >-
+      The mandate for this lane specified a THREE-alternative secrets-triage rule (public
+      key, seq-19 chain anchor, seq-20 payload digest), mirroring the seq-19 rule. Only TWO
+      of those literals exist in the new test module: it IMPORTS SEQ19_PAYLOAD_SHA256 from
+      fold_pack_seq20 rather than retyping it, which is the anti-drift shape the rest of
+      this module follows for rule ids. The rule therefore ships with two alternatives, and
+      the audit-trail line says so rather than repeating the three-anchor wording. A third
+      alternative would be regex that can never match — a pre-authorisation of a line
+      nobody has written, which is exactly what a content-keyed list must not carry. The
+      seq-19 anchor is already covered by fold_pack_seq20.py's own rule in the same list.
+      Verified empirically, not argued: detect-secrets finds exactly 2 findings in the file
+      and the rule auto-approves exactly those 2, residue [].
+  - seat: claude-opus-5 (this worktree session), self-caught
+    status: PLAUSIBLE
+    objection: >-
+      21 of 43 interview walks still dead-end, and 9 of them dead-end on a NEW fact
+      (family.sponsor_confirmed) that no walk blocked on under seq-19. Read carelessly that
+      looks like a regression this PR introduced. It is not: those 9 walks dead-ended
+      before too, on process.wants_onshore_conversion / intent.requested_product_code /
+      sponsor.type. What moved is WHICH fact is smallest-missing, because edit 1's stay-day
+      widening made C2 reachable for the business/investment arm and C2 carries a
+      family.sponsor_confirmed premise. Zero walks lost an answer. Deliberately NOT cured
+      here: the cure is a new interview question in the invest/other branches, which is
+      PR-3's mandate and a different app (apps/mouth's tree.ts/flow.ts) with its own walk-
+      corpus regeneration. Folding it in would break one-PR-one-concern. Recorded so the
+      new shape is on the record as a known, owned gap rather than a silence — the
+      allowlist row carries the same explanation with the flow.ts line anchors.
+  - seat: claude-opus-5 (this worktree session), self-caught
+    status: PLAUSIBLE
+    objection: >-
+      This pack declares no independent review lane, so the diff it describes has been read
+      only by the seat that wrote it. That is a real limit on this artifact and it is stated
+      rather than papered over. It is also the intended shape here: CLAUDE.md §5's external-
+      builder exception makes this seat a preparer that never merges, arms or deploys, and
+      a separate Consul session grades the diff and ships it. Generator is never grader —
+      so the grading is deliberately NOT in this pack.
+spend:
+  wall_clock_hours: 1.5
+  adversarial_rounds: 0
+appetite_exceeded: ""

--- a/evidence/2026-09/agent-air-m5-backend-rag-visa-seq20-sign-5717d691/pack.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-visa-seq20-sign-5717d691/pack.yml
@@ -1,7 +1,7 @@
 task_id: visa-seq20-sign
 gear: 3
 gate_class: opus
-brief_ref: evidence/2026-09/agent-air-m5-backend-rag-visa-seq20-sign-5717d691/brief.yml
+brief_ref: evidence/brief.yml
 date: 2026-09-06
 machine: M5
 lanes:
@@ -68,8 +68,14 @@ outcome: >-
   guard was re-pinned, never weakened: the 21 surviving dead ends keep an honest reason
   naming the blocking fact and its source question, and the two guilt tests whose
   seq-19 subjects this pack CURED were re-anchored onto walks that still dead-end, so
-  neither passes vacuously. Nothing was activated; promoting this bundle into the
-  active sequence remains a separate Zero-only ceremony.
+  neither passes vacuously. CORRECTED BY THE GRADING SESSION: the sentence that stood
+  here said "nothing was activated", which was true when the builder seat wrote it and
+  is FALSE now. The activation ceremony ran BEFORE this PR, on the owner's explicit
+  instruction, inverting the wave spec's order — seq-20 is the ACTIVE production pack
+  (activation_id e08ebea9-d50f-48a6-989e-b7e4698f96ad). The auditability window that
+  inversion opens is closed by measurement: the blob committed here was read back out
+  of git and verified with verify_rule_pack against the pinned production trust store,
+  and it carries the same payload_sha256 and rule_pack_id the live engine reports.
 diff:
   files: 7
   net_lines: >-
@@ -78,10 +84,14 @@ diff:
     test_seq20_signed_bundle.py (new), 112/89 test_interview_walk_census.py (re-pin),
     38/0 scripts/detect_secrets_auto_triage.py (one content-keyed rule + its rationale),
     3/2 scripts/tests/test_detect_secrets_auto_triage.py (count bump + audit-trail line),
-    84/0 scripts/ci/observe_visa_seq20_signed.py (new, bites-observable), plus this
-    evidence pack — +9941/-91 in total. The generated signed artifact is 93 percent of
-    that by itself; strip it and the authored review surface is six hundred and
-    forty-eight added lines against ninety-one removed, all of it test and tooling.
+    84/0 scripts/ci/observe_visa_seq20_signed.py (new, bites-observable), plus the
+    LIVE STATE record in .agents/skills/visaoracle/SKILL.md and this evidence pack. No
+    total is narrated here on purpose: the grading session added commits after the
+    builder measured, so any literal written into this file is stale the moment the
+    file itself changes. The shape is what matters and it is stable — the generated
+    signed artifact is the overwhelming majority of the diff by itself; strip it and
+    the authored review surface is a few hundred added lines against ninety-one
+    removed, all of it test, record and tooling.
   measured_at: >-
     `git diff --numstat $(git merge-base HEAD origin/main)` for the tracked files plus
     `wc -l` for the untracked new files, merge-base dc7189f4af09857a6d7fbe26e33f3f553921c216

--- a/scripts/ci/observe_visa_seq20_signed.py
+++ b/scripts/ci/observe_visa_seq20_signed.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""observe_visa_seq20_signed.py — bites: observation for the seq-20 SIGNING lane.
+
+# bites-observable — this script takes NO arguments: every path and command
+# below is a literal in this file, so nothing an invoker types can name a
+# program to run, a file to write, or a database to reach (the exact bar
+# `scripts/ci/bites_parse.py::_guard_observable_script` sets for a script
+# reachable from a pack.yml `observe:` line).
+
+Sibling of ``observe_visa_seq20_fold.py``, which observed the UNSIGNED source
+pack. This one observes the SIGNED bundle, and runs the two consumers named
+in this lane's ``Bites:`` line, in order, failing loud on the first red one:
+
+1. ``test_seq20_signed_bundle.py`` — verifies ``rulepack-prod-020.signed.json``
+   with the repo's own ``bundle.verify_rule_pack`` against the PINNED
+   production trust store, recomputes both digests off disk independently,
+   pins the five fold edits inside the signed bytes, and proves five
+   tampering shapes are rejected.
+2. ``test_interview_walk_census.py`` — the consumer that makes this bundle's
+   arrival OBSERVABLE rather than merely present: it reads the HIGHEST SIGNED
+   production pack on disk via ``select_highest_repository_pack``, so landing
+   seq-20 moves it off seq-19 by itself. Four of its assertions were red
+   against the seq-20 bundle before this PR re-pinned them; the walk census
+   moved 36 NEEDS_INPUT / 7 SUPPORTED to 21 / 22. A future PR that lands a
+   seq-21 bundle without re-pinning this census goes red here, which is the
+   whole point of pinning it against "highest signed" rather than a literal
+   filename.
+
+Both run inside ``apps/backend-rag`` with ``PYTHONPATH=.`` (the repo's
+mandatory invocation shape). No trust-store env var is exported here: the
+signed-bundle module sets its own via ``monkeypatch.setenv`` so a
+pre-existing value in the invoking process is restored rather than clobbered,
+and the census module never verifies a signature.
+
+Exit 0 only if both are green.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_RAG_DIR = REPO_ROOT / "apps" / "backend-rag"
+
+TEST_MODULES = (
+    "backend/tests/services/visa_engine/test_seq20_signed_bundle.py",
+    "backend/tests/services/visa_engine/test_interview_walk_census.py",
+)
+
+
+def _backend_rag_python() -> str:
+    """Prefer the project's own venv (CLAUDE.md: `apps/backend-rag/.venv/`) —
+    fall back to whatever interpreter is running this script if the venv is
+    absent (e.g. a CI image that installs deps onto the system interpreter
+    directly rather than into a checked-out venv)."""
+    venv_python = BACKEND_RAG_DIR / ".venv" / "bin" / "python3"
+    if venv_python.is_file():
+        return str(venv_python)
+    return sys.executable
+
+
+def main() -> int:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "."
+    interpreter = _backend_rag_python()
+
+    for module in TEST_MODULES:
+        cmd = [interpreter, "-m", "pytest", module]
+        print(f"observe_visa_seq20_signed: running {' '.join(cmd)} (cwd={BACKEND_RAG_DIR})")
+        rc = subprocess.run(cmd, cwd=BACKEND_RAG_DIR, env=env, check=False).returncode
+        if rc != 0:
+            print(f"observe_visa_seq20_signed: {module} FAILED")
+            return rc
+
+    print("observe_visa_seq20_signed: both consumers green")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -580,6 +580,44 @@ CONTENT_KEYED_RULES: list[tuple[re.Pattern[str], re.Pattern[str], str]] = [
         "exact assignment/comparison and value pinned per constant, never a "
         "credential",
     ),
+    # test_seq20_signed_bundle.py: the seq-19 rule's twin, one sequence on.
+    # Same two entity classes: the pinned Ed25519 PUBLIC verification key
+    # already covered for gold_replay_driver.py above (private key stays
+    # off-repo, offline key ceremony per docs/runbooks/visa-engine-key-
+    # ceremony.md), and the seq-20 payload_sha256 — a content-derived digest
+    # the test recomputes independently via bundle.canonicalize_json and
+    # cross-checks against `verify_rule_pack`'s own return value, never
+    # trusted from the signer's print output.
+    #
+    # TWO alternatives here where the seq-19 rule has three: that module
+    # RETYPED its predecessor's chain anchor as a local SEQ18_PAYLOAD_SHA256
+    # literal, while this one IMPORTS `SEQ19_PAYLOAD_SHA256` from
+    # fold_pack_seq20 instead — so the seq-19 anchor is not a literal in this
+    # file and is already covered by fold_pack_seq20.py's own rule above. A
+    # third alternative would be regex that can never match, which is exactly
+    # the pre-authorisation of an unwritten line this list must not carry.
+    # Content-keyed (not path-only) to the exact value per constant, one
+    # alternative each, so a real credential typed onto any other line of
+    # this test stays unaudited for human review.
+    (
+        re.compile(
+            r"^apps/backend-rag/backend/tests/services/visa_engine/"
+            r"test_seq20_signed_bundle\.py$"
+        ),
+        re.compile(
+            r'^\s*(?:'
+            r'"public_key"\s*:\s*"gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA"\s*,?'
+            r'|SEQ20_PAYLOAD_SHA256\s*=\s*"df02287b7fc8f572a9e6674fdf3445a2131c428e8a1492ab8a388dee5bf01a4d"'
+            r')\s*$'
+        ),
+        "test_seq20_signed_bundle.py: seq-20 signed-bundle trust anchors — "
+        "the pinned production Ed25519 public verification key (private key "
+        "off-repo) and the seq-20 payload_sha256 recomputed and cross-checked "
+        "in the test itself; the seq-19 chain anchor is imported from "
+        "fold_pack_seq20, not retyped, so it is covered by that module's own "
+        "rule; exact assignment and value pinned per constant, never a "
+        "credential",
+    ),
     # scripts/kbli_bench/results/p2b_score.json (PR #4422, KBLI Navigator
     # Phase 2b benchmark run): corpus_sha256 is the content-derived sha256 of
     # the frozen benchmark corpus (scripts/kbli_bench/p2b_corpus.json), the

--- a/scripts/tests/test_detect_secrets_auto_triage.py
+++ b/scripts/tests/test_detect_secrets_auto_triage.py
@@ -322,8 +322,8 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     # trail are derived from the live registry post-merge, not summed by
     # hand (team-lead's call: a rule appears once in the trail regardless of
     # how many PRs tried to add it).
-    assert len(CONTENT_KEYED_RULES) == 25, (
-        f"CONTENT_KEYED_RULES now has {len(CONTENT_KEYED_RULES)} entries, not 25. "
+    assert len(CONTENT_KEYED_RULES) == 26, (
+        f"CONTENT_KEYED_RULES now has {len(CONTENT_KEYED_RULES)} entries, not 26. "
         "If you just ADDED a rule: bump this number AND append a `# +1: <what> "
         "(<date>, PR #NNNN)` line below, matching the existing trail's format — "
         "that comment IS the audit record this assert exists to force. "
@@ -350,6 +350,7 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     # +1: fold_pack_seq19.py seq-18/seq-13/seq-15 chain-of-custody exact-value pins (2026-09-05, #5784)
     # +1: test_seq19_signed_bundle.py signed-bundle trust anchors (public key, seq-18 chain anchor, seq-19 payload_sha256) (2026-09-06)
     # +1: fold_pack_seq20.py seq-19 chain anchor exact-value pin (2026-09-06)
+    # +1: test_seq20_signed_bundle.py signed-bundle trust anchors (public key, seq-20 payload_sha256; seq-19 chain anchor is imported, not a literal) (2026-09-06)
     #
     # Note (2026-08-23): "appended last" is no longer a constraint. It was
     # true only because this test and the two Google-OAuth tests below


### PR DESCRIPTION
## What lands here

The **signed** seq-20 production bundle (`rulepack-prod-020.signed.json`), the gates that prove it, and the walk census re-pinned onto it.

Signed offline on M5 with `sign_pack.py`, kid `prod-2026-07-1`:

| field | value |
| --- | --- |
| `payload_sha256` | `df02287b7fc8f572a9e6674fdf3445a2131c428e8a1492ab8a388dee5bf01a4d` |
| `rule_pack_id` | `ac0a792d-a38d-512e-9ead-54a5d008fb68` |
| `previous_payload_sha256` | `bac5da8e…` (seq-19) |
| `signed_at` | `2026-09-06T14:59:27.320080Z` |
| rules | 109 |

The digest was recomputed **after** `prettier --write` and is unchanged, and the signed payload is byte-identical to the already-merged `rulepack-prod-020.source.json` under JCS — so this PR adds a signature over bytes `main` already carries, not new content.

## The order was inverted, deliberately, and here is how the window was closed

The activation ceremony ran **before** this PR, on the owner's explicit instruction — the wave spec had it the other way round. That leaves an auditability window: for that interval the pack serving production had no signed bytes in version control.

It is closed by measurement, not by assumption: the blob committed here was read back out of git and verified with the repo's own `verify_rule_pack` against the pinned production trust store, and it carries the **same** `payload_sha256` and `rule_pack_id` the live engine reports. Same artifact, no divergence.

## Census re-pinned: 36/7 → 21/22

Landing a signed seq-20 moves `test_interview_walk_census.py` from the seq-19 signed pack to this one, so its four pinned assertions had to be re-measured.

- **15 walks gained an answer.** `el.c1.tourism-family` went 60 → 180 stay-days (fold edit 1), so the corpus's 121-day walks satisfy C1. Their allowlist rows are **deleted**, not loosened.
- **9 walks moved their block** onto `family.sponsor_confirmed`. The same widening made `el.c2.business` reachable, exposing its own `family.sponsor_confirmed == true` premise, which now wins `evaluator.py`'s `min(len(missing_facts))` tie-break. This is a **move, not a cure** — no invest/business/other branch asks that question (`flow.ts:708` family, `657-659` retirement), and the existing `test_every_allowlisted_dead_end_is_genuinely_unaskable_in_its_own_walk` proves it per-walk against the corpus rather than taking the comment's word.
- Two dead-end shapes are retired outright by fold edits 3 and 4: `family.sponsor_status_code` and `intent.requested_product_code`.

Allowlist: **36 → 21 rows, 0 added.** Every count stayed an exact equality; nothing became a range.

Both guilt tests had to be re-anchored because seq-20 cured their seq-19 subjects, which would have made them pass for the wrong reason. They were **strengthened** in the process: the block-moves test now asserts `state == NEEDS_INPUT` up front, and the stale-row test asserts its subject is still in the allowlist.

## Review

An independent verifier seat (not the builder) ran every suite and answered five falsification questions. It did not take the guilt tests on their names: it copied `test_seq20_signed_bundle.py` to a scratch path, neutralised the tampering line in `test_mutating_one_payload_field_fails_both_digest_and_signature`, and measured the result flip from `1 passed` to `1 failed — DID NOT RAISE`. The green depends on the tampering, not on the test's shape.

It also found and reported one honest limit rather than hiding it: `test_sha256_of_canonicalized_signed_payload_matches_the_declared_field` compares two fields of the same file, so in isolation it has no independent anchor. It is not vacuous in context — the two neighbouring tests chain the signed payload to the separately tracked source file and that file to a pinned literal — but the limit is real and is recorded here rather than in a comment nobody reads.

## Local

| suite | result |
| --- | --- |
| `test_seq20_signed_bundle.py` | 23 passed |
| `test_interview_walk_census.py` | 11 passed |
| `test_seq20_pack.py` | 109 passed |
| `scripts/tests/test_detect_secrets_auto_triage.py` | 107 passed |
| `scripts/ci/observe_visa_seq20_signed.py` | exit 0 |

`Bites:` `scripts/ci/observe_visa_seq20_signed.py` is the consumer and it ships here — it drives `test_seq20_signed_bundle.py` (which verifies the committed signature against the pinned trust store) and `test_interview_walk_census.py` (which reads the highest **signed** pack, so it exercises this file and no other), and exits 0 only if both are green. Observed at this head before opening: exit 0, "both consumers green". The second, stronger observation is already made in production: `probe_evaluate.py` returns `rule_pack sequence=20 rule_pack_id=ac0a792d…`, and `offshore/tourism` / `onshore/tourism` — dead ends on seq-19 — now return `SUPPORTED_CANDIDATES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K49cJhM7o89sKffgK8pU1Y
