### PR TITLE
fix(news): read category and q from the URL so the homepage topic pills filter

### DIFF
--- a/apps/mouth/src/app/(blog)/NewsPageClient.tsx
+++ b/apps/mouth/src/app/(blog)/NewsPageClient.tsx
@@ -10,6 +10,8 @@ import { RUMAH_VARS, RUMAH_CLASS } from "@/lib/theme/rumahVars";
 
 interface NewsPageClientProps {
   articles: ArticleListItem[];
+  /** Seeded from /news?q= on the server, so the filter runs on first paint. */
+  initialQuery?: string;
 }
 
 const SECTIONS = [
@@ -98,8 +100,9 @@ const CATEGORY_ACCENT: Record<string, string> = {
 
 export default function NewsPageClient({
   articles: serverArticles,
+  initialQuery,
 }: NewsPageClientProps) {
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState(initialQuery ?? "");
 
   const articles = serverArticles || [];
 

--- a/apps/mouth/src/app/(blog)/news/page.tsx
+++ b/apps/mouth/src/app/(blog)/news/page.tsx
@@ -40,12 +40,29 @@ export const metadata: Metadata = {
   },
 };
 
+interface NewsRouteProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
 /**
  * /news route - Same editorial layout as homepage
  * Uses real MDX articles from filesystem via ISR
+ *
+ * The homepage topic pills link here with ?category= or ?q=; both are read
+ * server-side. `category` filters the fetch, `q` is seeded into the client
+ * search box so the text filter runs on first paint (no Suspense boundary,
+ * no flash of the unfiltered list).
  */
-export default async function NewsRoute() {
-  const { articles } = await getAllArticles({});
+export default async function NewsRoute({ searchParams }: NewsRouteProps) {
+  const sp = await searchParams;
 
-  return <NewsPageClient articles={articles} />;
+  const rawCategory = Array.isArray(sp.category) ? sp.category[0] : sp.category;
+  const category = rawCategory?.trim() ? rawCategory : undefined;
+
+  const rawQuery = Array.isArray(sp.q) ? sp.q[0] : sp.q;
+  const initialQuery = rawQuery ?? "";
+
+  const { articles } = await getAllArticles(category ? { category } : {});
+
+  return <NewsPageClient articles={articles} initialQuery={initialQuery} />;
 }


### PR DESCRIPTION
Nine topic pills on the homepage link to `/news?category=…` and `/news?q=…`; the route
ignored both, so every pill landed on the same unfiltered page.

# Insight

The nine pills were never broken — the route was. All nine hrefs are correct and all nine
have content behind them. `/news` simply threw the query string away: the page function
took no props at all, so `searchParams` never arrived, and the client's search box was
hardcoded to `""`. Four pills that carry `?category=` and five that carry `?q=` therefore
all rendered byte-identical output.

```
SCOPE — /news query-string handling

GOAL : /news honours ?category= and ?q=, so the nine homepage topic pills land on the filtered list they promise.
NON-GOAL : TopicPills.tsx, lib/blog/articles.ts, packages/core, sitemap.ts and the /news metadata block are not touched; category strings are not normalised.
FILES : apps/mouth/src/app/(blog)/news/page.tsx · apps/mouth/src/app/(blog)/NewsPageClient.tsx
MEASURED BY : curl against rendered HTML for all nine URLs — unique article hrefs per category page, result counter and seeded input value per query page, with a zzzznomatch control.
ROLLBACK : revert this PR. Two files, no migration, no data change.
DONE WHEN : state 6 — api/health serves this commit and the nine URLs return filtered results in production.
```

# Studio

To a reader the nine topic pills under the homepage masthead stop being decorative. Tapping "Trends" now opens a `/news` listing carrying trends articles instead of the same mixed list every pill produced before, and tapping "KITAS" opens `/news` with the search box already holding `kitas` and the counter reading `60 results for "kitas"` instead of an empty box above the full list. Nothing else moves: same layout, same cards, same chrome — only the list underneath is the one the pill named. The change lives in the `/news` server route at `apps/mouth/src/app/(blog)/news/page.tsx`, which now reads `searchParams` and forwards `category` to `getAllArticles`, and in its client component `apps/mouth/src/app/(blog)/NewsPageClient.tsx`, which seeds its search input from a new `initialQuery` prop. Both files sit in `apps/mouth/**`, zone VERDE.

## Source / Reference

- `apps/mouth/src/app/v2/_components/TopicPills.tsx:13-21` — the nine hrefs.
- `apps/mouth/src/app/(blog)/[category]/[slug]/page.tsx:31,77` — the in-repo precedent for
  a Next 16 server `searchParams: Promise<…>` prop, in this same route group.
- `apps/mouth/src/lib/blog/categories.ts:37-64` — `CATEGORY_MAP`, folder/legacy → public category.

## Methodology

Measured on `origin/main cf50aae962`, then re-measured against a local production build
(`next start -p 3411`) after the change. Article counts come from `curl` against the
rendered HTML — the on-page result counter and the set of unique article hrefs — not from
reading the code. Backend counts come from `curl` against `nuzantara-rag.fly.dev/api/news`
directly. MDX counts come from counting `.mdx` files per folder and folding folders onto
public categories with `CATEGORY_MAP`.

## Raw Observations

Before (code, at `cf50aae962`):

- `(blog)/news/page.tsx:47` — `NewsRoute()` declared no parameters, so `searchParams` was discarded.
- `(blog)/news/page.tsx:48` — `getAllArticles({})`, unconditionally unfiltered.
- `(blog)/NewsPageClient.tsx:102` — `useState("")`, hardcoded; no `useSearchParams` in the file.
- `(blog)/news/page.tsx:6` — already `export const dynamic = "force-dynamic"`, so no rendering-mode change was needed.
- `lib/blog/articles.ts:804` — `getAllArticles` already accepts `{ category, limit, offset }`. No filter had to be built.
- `TopicPills.tsx:13-21` — 4× `?category=` (trends, visas, taxes, property), 5× `?q=`
  (golden visa, pt pma, kitas, digital nomad, work permit).

After (rendered, local `next start`, unique article hrefs per page):

| URL | unique article links | dominant category |
|---|---|---|
| `/news` (baseline) | 18 | mixed: business 5, taxes 10, visas 2, property 1 |
| `/news?category=visas` | 18 | visas 17 |
| `/news?category=trends` | 18 | trends 17 |
| `/news?category=taxes` | 18 | taxes 17 |
| `/news?category=property` | 18 | property 18 |

After, the five `?q=` pills — on-page result counter, and the seeded input's `value`:

| URL | counter | input value |
|---|---|---|
| `/news?q=golden+visa` | 21 results | `golden visa` |
| `/news?q=pt+pma` | 59 results | `pt pma` |
| `/news?q=kitas` | 60 results | `kitas` |
| `/news?q=digital+nomad` | 27 results | `digital nomad` |
| `/news?q=work+permit` | 8 results | `work permit` |
| `/news?q=zzzznomatch` (control) | 0 results | `zzzznomatch` |

The control proves the filter is actually running rather than the counter echoing the full
list. The seeded `value` proves the query reached the client through the prop.

Content inventory behind the four category pills (MDX files per public category, after
folding folders through `CATEGORY_MAP`):

- visas 309 · business 246 · taxes 116 · living 60 · trends 47 · property 30

All four category pills have content. None of the nine links lands on an empty page.

## Reasoning Path

Two decisions are worth naming.

`q` is seeded server-side into the client as a prop rather than read client-side with
`useSearchParams()`. `useSearchParams` in a client component forces a Suspense boundary,
and the first paint would show the full unfiltered list before hydration corrected it —
a visible flash on exactly the nine entry points this PR exists to fix. Passing it as a
prop means the filter is correct on first paint. The filter logic itself
(`NewsPageClient.tsx:107-115`) is unchanged; only its initial input changed.

`category` is passed through verbatim — not lowercased, not coerced to a known value. An
unknown category yields an empty list, which is honest. Silently normalising would be a
separate decision about what `/news?category=Visas` means, and it belongs in its own PR.

## Risk

`category` is passed through verbatim, so a hand-typed `/news?category=Visas` renders an empty list rather than falling back to the full one. That is deliberate — see Reasoning Path — but it is the one way this change can show a reader less than before. No pill produces it: all nine hrefs are lowercase.

`/news` was already `force-dynamic`, so no page moved from static to dynamic
and no caching behaviour changed. `getAllArticles` is `unstable_cache`-wrapped and keys on
its arguments, so the added `{ category }` argument produces its own cache entry rather
than polluting the unfiltered one.

Blast radius is one route. No shared component, no token, no `packages/core` file is touched.

## Implication

One pre-existing defect became visible while measuring this, and is **not** fixed here because `lib/blog/articles.ts` was out of scope for this change:

`fetchBackendArticles` (`articles.ts:416-431`) forwards `category` to the backend
**before** normalisation, while backend rows are normalised **after** the fetch
(`articles.ts:356`, via `normalizeCategory`). The backend stores the legacy vocabulary;
the pills send the public one. Measured against the live backend:

| query | backend rows |
|---|---|
| `?category=trends` | 0 |
| `?category=visas` | 0 |
| `?category=taxes` | 0 |
| `?category=property` | 2 |
| no filter | 32 (lifestyle 10, business 7, tax 5, tech 4, immigration 4, property 2) |

So a filtered page currently serves MDX articles only, and drops the handful of backend
articles that belong in it. The blast radius is small — 32 backend rows against 800+ MDX
articles — and the pages are correct, just not maximal. It is a real bug and should get
its own PR that maps the public category back to the backend vocabulary before the fetch.

# Recommendation

Merge. The change is 24 added lines across two files, touches no shared component, and the
nine entry points it repairs are the site's primary editorial discovery layer.

Local gates, run on this branch, reported as-is:

- `npm run build -w apps/mouth` → RC 0; `/news` still listed as `ƒ` (dynamic).
- `npm run lint -w apps/mouth` → RC 0; 183 warnings, 0 errors — identical to the
  pre-existing baseline, none from these files.
- `npx prettier --check` on both files → RC 0.
- pre-commit hook ran `tsc --noEmit` across `apps/mouth` → passed.

CI is the real gate; nothing here should be read as a CI result. Nothing in this PR has
been observed in production — the production hash was not re-measured in this session.

# Next Action

1. Open a follow-up for the backend category-vocabulary mismatch described under
   Implication — map public → backend category in `fetchBackendArticles` before
   the request, so filtered pages stop dropping backend rows.
2. After this deploys, re-run the same nine URLs against production and confirm the
   counters, since every number above is from a local build.
