### PR TITLE
fix(kbli): scroll the chat panel instead of the page on first render

### DIFF
--- a/apps/mouth/src/components/kbli/ZantaraChat.tsx
+++ b/apps/mouth/src/components/kbli/ZantaraChat.tsx
@@ -36,6 +36,7 @@ export function ZantaraChat({
       : "",
   );
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesBoxRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -44,8 +45,14 @@ export function ZantaraChat({
     }
   }, [sessionId]);
 
+  // Keep the newest message in view WITHOUT moving the page. scrollIntoView
+  // scrolls every scrollable ancestor including the document, which on first
+  // render dropped visitors ~85% down /kbli; setting scrollTop moves only this
+  // box. The empty-list guard keeps it silent on mount.
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (messages.length === 0) return;
+    const box = messagesBoxRef.current;
+    if (box) box.scrollTop = box.scrollHeight;
   }, [messages]);
 
   const sendMessage = useCallback(
@@ -139,7 +146,10 @@ export function ZantaraChat({
       </div>
 
       {/* Messages Area */}
-      <div className="relative z-10 max-h-96 min-h-[300px] space-y-5 overflow-y-auto p-5 scrollbar-thin scrollbar-thumb-white/10 scrollbar-track-transparent">
+      <div
+        ref={messagesBoxRef}
+        className="relative z-10 max-h-96 min-h-[300px] space-y-5 overflow-y-auto p-5 scrollbar-thin scrollbar-thumb-white/10 scrollbar-track-transparent"
+      >
         {opener && messages.length === 0 && (
           <div className="flex animate-fade-in-up">
             <div className="max-w-[85%] rounded-2xl rounded-tl-sm bg-white/5 border border-white/5 shadow-sm px-4 py-3">


### PR DESCRIPTION
The chat's scroll-to-latest effect ran on first render with an empty message list and
scrolled every scrollable ancestor, including the document, dropping first-time visitors
~85% down /kbli. It now scrolls only the chat panel, and not at all when there are no messages.

# Insight

Nothing was wrong with the page's layout, its anchors or its focus handling. One effect in
one component reached past its own box. `scrollIntoView` does not scroll an element's
container — it scrolls every scrollable ancestor until the target is visible, and the
document is an ancestor. The effect had `[messages]` as its dependency, and an effect with
a dependency array still runs on mount, so it fired once with `messages.length === 0`,
scrolled the empty sentinel into view, and took the whole page with it. Two independent
mistakes stacked into one symptom: it ran when it had nothing to show, and it moved more
than it owned. The fix corrects both, which is why it closes the class and not just the
instance.

```
SCOPE — /kbli first-render page scroll

GOAL : /kbli lands at the top for a first-time visitor, and the chat panel still follows its newest message.
NON-GOAL : KBLISearch.tsx, app/kbli/page.tsx, packages/core and every KBLI data model are untouched; the messagesEndRef sentinel stays where it is.
FILES : apps/mouth/src/components/kbli/ZantaraChat.tsx
MEASURED BY : Playwright against the local production build — instrumented scrollIntoView/focus/scrollTo trace, window.scrollY sampled at 200/600/1000/2000/3000ms, a positive control proving the document is scrollable, and a five-message conversation checking the panel stays pinned to the bottom.
ROLLBACK : revert this PR. One file, no migration, no data change.
DONE WHEN : state 6 — api/health serves this commit and /kbli loads at scrollY 0 in production.
```

# Studio

A first-time visitor opening /kbli currently arrives roughly 85% of the way down the page:
the hero, the headline and the search field are all above them, off-screen, and nothing
explains why. After this change the page is where it was loaded — top of the document,
hero visible, search field in view — and the visitor has to scroll to leave it. Nothing
about the page's appearance changes: the same hero, the same search, the same chat card
with the same opener bubble. What changes is where the viewport sits when it first
appears. Inside the chat card the behaviour a user actually wants is preserved — send a
message and the panel still follows the newest bubble — but that movement is now contained
in the message list itself instead of dragging the page with it. The change is in the chat
component `apps/mouth/src/components/kbli/ZantaraChat.tsx`: its scroll-to-latest effect at
`:47-49` and the messages container at `:142`, the scrollable box between the chat header
and the input row. Zone VERDE, `apps/mouth/**`.

## Source / Reference

- `apps/mouth/src/components/kbli/ZantaraChat.tsx:47-49` (at `cf50aae962`) — the effect that scrolled the document.
- `apps/mouth/src/components/kbli/ZantaraChat.tsx:142` — the messages container: `max-h-96 min-h-[300px] overflow-y-auto`, the only element that should have moved.
- `apps/mouth/src/components/kbli/ZantaraChat.tsx:209` — the `messagesEndRef` sentinel, left in place.
- `apps/mouth/src/components/kbli/ZantaraChat.tsx:103` (at `cf50aae962`) — `inputRef.current?.focus()` in the `finally` of `sendMessage`, unrelated to this fix and unchanged. See Implication.

## Methodology

Cause was established in an earlier session by an instrumented local repro on
`origin/main cf50aae962`: a dev server plus a Playwright `addInitScript` patching
`scrollIntoView`, `focus` and `scrollTo` from document-start, in a foreground tab with
`visibilityState=visible` and `hasFocus=true`. Those numbers are carried over and are not
re-measured here.

Verification of the fix was run against a **local production build** (`npm run build -w
apps/mouth` then `npx next start -p 3412`), not the dev server, because React StrictMode
double-invokes effects in dev and would have doubled every event. Chromium was driven
through Playwright 1.62.1 using the system Chrome channel, viewport 1440x900, one fresh
context per run. Three separate probes were used: an instrumented trace of every
`scrollIntoView` / `focus` / `scrollTo` call with its stack, a `window.scrollY` sampler
firing at 200/600/1000/2000/3000ms installed before page scripts, and a scripted
five-message conversation reading `scrollTop` and `scrollHeight - clientHeight` off the
messages container after each turn.

## Raw Observations

Before, from the earlier instrumented repro on `cf50aae962` — production symptom
reproduced exactly, `scrollY 2557`, `offsetSearch 2613`:

```
[3891ms] focus          INPUT  {"preventScroll":true}  y=0   stack: KBLISearch.useEffect
[3912ms] scrollIntoView DIV    {"behavior":"smooth"}   y=0   stack: ZantaraChat.useEffect
[4766ms] scroll y=72 · [4855ms] y=299 · [4974ms] y=967 · [5429ms] y=2557
```

Both `focus()` calls passed `preventScroll:true` and `scrollY` was still 0 after them, so
the focus path was clean. The scroll began after `scrollIntoView` and climbed in stages —
the `behavior:"smooth"` animation. Dev mode double-invoked the effects (StrictMode), which
is why each call appeared twice; the mechanism is identical in production.

After, same instrumentation against the local production build. The entire load phase
produced **one** event in the first 3s:

```
t=2006ms  focus  INPUT#  {"preventScroll":true}  y=0
          stack: .../chunks/app/kbli/page-7b4e2cdeb3970975.js
```

No `scrollIntoView`. No `scrollTo`. `window.scrollY` sampled independently:

| mark | 200ms | 600ms | 1000ms | 2000ms | 3000ms |
|---|---|---|---|---|---|
| `window.scrollY` | 0 | 0 | 0 | 0 | 0 |

Positive controls, so that `0` means "did not scroll" rather than "cannot scroll" or
"page did not load":

- `document.querySelectorAll('#search').length` → `1`
- `document.documentElement.scrollHeight - window.innerHeight` → `2974` (the page is scrollable)
- `window.scrollTo(0, 300)` → `window.scrollY` goes `0` → `300` (scrolling works, it just was not happening)
- `document.visibilityState` → `visible`, `document.hasFocus()` → `true` (same conditions as the repro)
- `document.activeElement` → `INPUT` (the search field is still focused; only the page movement is gone)

Regression check — five real messages sent through the chat, reading the messages
container after each turn:

| turn | bubbles | `scrollTop` | `scrollHeight - clientHeight` | pinned to bottom |
|---|---|---|---|---|
| start | 2 | 0 | 0 | yes |
| after send 1 | 3 | 0 | 0 | yes |
| after send 2 | 5 | 0 | 0 | yes |
| after send 3 | 7 | 64 | 64 | yes |
| after send 4 | 9 | 200 | 200 | yes |
| after send 5 | 11 | 336 | 336 | yes |

For the first two turns the content still fit the box, so there was nothing to scroll and
`0` is correct. From turn 3 the box overflows and `scrollTop` tracks the maximum exactly.
The panel still follows the newest message.

## Reasoning Path

Two changes, and the second is the one that matters.

The empty-list guard (`if (messages.length === 0) return;`) closes the measured symptom on
its own: an effect with a dependency array still runs on mount, and on mount there is no
newest message to scroll to, so the work was pointless as well as harmful.

Replacing `scrollIntoView` with `box.scrollTop = box.scrollHeight` closes the class. With
only the guard, the first message a visitor ever sends would still have dragged the
document, because `scrollIntoView` walks every scrollable ancestor by definition. Setting
`scrollTop` moves exactly one element and cannot reach the document. The guard alone would
have shipped a fix that passed today's test and failed on the first real conversation.

The `messagesEndRef` sentinel at `:209` is deliberately left in place. Removing it is an
unrequested change to JSX that costs nothing to keep, and keeping the diff to what was
diagnosed is worth more than deleting four characters of dead ref.

The smooth animation is gone with the API that carried it. `scrollTop` jumps. Inside a
384px panel that is the conventional behaviour and matches how the box behaves when a user
drags its scrollbar.

## Risk

The change removes an animation. A user who sends a message now sees the panel jump to the
newest bubble rather than glide to it. That is the only user-visible behaviour this PR
takes away, and it is contained inside one 384px box.

Blast radius is one component on one route. No shared component, no design token, no
`packages/core` file, no data model, no route config is touched. `ZantaraChat` is imported
only by the KBLI surface, so nothing outside `/kbli` can move.

The container ref is a new binding. If it were ever detached from that div, the effect
would silently do nothing and the panel would stop following new messages — which is why
the five-message table above exists rather than a claim that it works.

## Implication

One unrelated document-scroll path was found while verifying this, and is **not** fixed
here because it is outside what this PR was chartered to change:

`ZantaraChat.tsx:110` (`:103` at `cf50aae962`, unchanged by this PR) calls
`inputRef.current?.focus()` in the `finally` block of `sendMessage`, with no
`preventScroll` option. The instrumented trace caught it directly:

```
t=5680ms  focus  TEXTAREA#  (no options)  y=0
t=5705ms  scroll y=2420
```

Twenty-five milliseconds after that focus, the document jumped to 2420, while the message
list had not changed and the messages container had zero overflow — so this is the focus
call, not the effect this PR touches. It fires only after a send completes, never on load,
so it does not affect a first-time visitor landing on `/kbli` and it is not the bug this PR
closes. It is pre-existing on `origin/main` and deserves its own PR: the fix is
`focus({ preventScroll: true })`, the same option `KBLISearch` already passes.

# Recommendation

Merge. Twelve added lines in one file, one route affected, and the symptom it removes puts
every first-time `/kbli` visitor below the fold of the page they asked for.

Local gates, run on this branch, reported as-is:

- `npm run build -w apps/mouth` → RC 0; `/kbli` still listed as `ƒ` (dynamic).
- `npm run lint -w apps/mouth` → RC 0; 183 warnings, 0 errors — identical to the pre-existing baseline, none from this file.
- `npx prettier --check apps/mouth/src/components/kbli/ZantaraChat.tsx` → RC 0.
- pre-commit hook ran `tsc --noEmit` across `apps/mouth` → passed.

`apps/mouth/public/llms-full.txt` was regenerated by the build and restored before staging;
the commit is the one file.

CI is the real gate and nothing above should be read as a CI result. Nothing here has been
observed in production — the production hash was not re-measured in this session, and the
`2557` / `2613` figures are the earlier repro's, not a current production reading.

# Next Action

1. Open a follow-up for the `sendMessage` `finally` focus described under Implication —
   `inputRef.current?.focus({ preventScroll: true })` at `ZantaraChat.tsx:110`, so a
   completed send stops moving the document.
2. After this deploys, re-run the load probe against production `/kbli` and confirm
   `window.scrollY` is 0 at 1s and 3s, since every number above is from a local build.
3. Consider whether the panel should ease rather than jump — `box.scrollTo({ top:
   box.scrollHeight, behavior: "smooth" })` restores the animation without touching the
   document. Not done here because it was not diagnosed and not asked for.
