### PR TITLE
fix(seo): give /kbli-explorer its own canonical instead of the homepage

### DIFF
--- a/apps/mouth/src/app/kbli-explorer/layout.tsx
+++ b/apps/mouth/src/app/kbli-explorer/layout.tsx
@@ -13,6 +13,9 @@ export const metadata: Metadata = {
       "Describe your business idea in any language — we find the right Indonesian codes, licenses and requirements.",
     url: `${baseUrl}/kbli-explorer`,
   },
+  alternates: {
+    canonical: `${baseUrl}/kbli-explorer`,
+  },
 };
 
 function KBLIExplorerJsonLd() {


### PR DESCRIPTION
`/kbli-explorer` declared the homepage as its canonical URL while sitting in the sitemap,
telling crawlers the page they were asked to index is a duplicate of `/`.

# Insight

The page had `openGraph.url` pointing at itself but no `alternates.canonical`, so Next fell
back to the root layout's canonical and every crawl of `/kbli-explorer` was told the real
address is `https://balizero.com`. That is not a missing tag — it is a present tag carrying
the wrong value, which is worse: a crawler has no reason to doubt it. The page is
simultaneously listed in the sitemap, so the site asks for it to be indexed and then tells
the crawler not to bother. Its neighbours on the same site already do this correctly, which
is what makes the omission a defect rather than a design choice.

```
SCOPE — /kbli-explorer canonical URL

GOAL : /kbli-explorer declares itself as its own canonical instead of the homepage.
NON-GOAL : app/layout.tsx root alternates, (blog)/services, (blog)/contact, (blog)/team, sitemap.ts and the KBLIExplorerJsonLd component in the same file are not touched; no KBLI data model, schema, entry, attribute or /api/kbli/* surface is read or changed.
FILES : apps/mouth/src/app/kbli-explorer/layout.tsx
MEASURED BY : curl for `rel="canonical"` against production for the defect, then against a local production build for the fix, with /kbli, / and three untouched sibling routes as controls in the same run.
ROLLBACK : revert this PR. Three lines in one metadata block, no migration, no data change.
DONE WHEN : state 6 — api/health serves this commit and production /kbli-explorer returns its own canonical.
```

# Studio

Nothing changes for a person looking at the page. `/kbli-explorer` renders exactly as
before — same layout, same texture, same ambient lighting, same explorer. The change is one
line of `<head>`: the `rel="canonical"` tag, which today says `https://balizero.com` and
after this says `https://balizero.com/kbli-explorer`. What changes is who the page claims
to be when a crawler or a link preview asks. Today a search engine indexing the KBLI
explorer is told it is looking at a copy of the homepage, so the explorer's own content
competes for nothing and any ranking signal it earns is credited to `/`. The edit lives in
the route's metadata block at `apps/mouth/src/app/kbli-explorer/layout.tsx:6-16`, adding an
`alternates` property beside the existing `openGraph`, reusing the `baseUrl` constant
already declared at `:4` of the same file. The `KBLIExplorerJsonLd` component below it in
the same file is untouched. Zone VERDE, `apps/mouth/**`.

## Source / Reference

- `apps/mouth/src/app/kbli-explorer/layout.tsx:4` — `baseUrl`, reused rather than duplicated or hard-coded.
- `apps/mouth/src/app/kbli-explorer/layout.tsx:6-16` — the `metadata` block that had `openGraph` but no `alternates`.
- `apps/mouth/src/app/kbli-explorer/layout.tsx:18-54` — `KBLIExplorerJsonLd`, deliberately not touched.
- `apps/mouth/src/app/sitemap.ts:41` — `"/kbli-explorer"` in `staticPaths`, the reason the wrong canonical costs something.

## Methodology

The defect was measured against production with `curl`, reading the served HTML rather than
inferring from the source. `/kbli` was measured in a **separate** call as a positive
control, so that a `rel="canonical"` on the subject page proves the site emits the tag at
all and the wrong value is not an artefact of the request.

The fix was verified against a **local production build** (`npm run build -w apps/mouth`,
then `npx next start -p 3413`), not the dev server. Five routes were read in the same run:
the subject, plus `/kbli`, `/`, `/services`, `/contact` and `/team` as controls, because
the risk of an `alternates` change is that it moves a neighbour, and a fix that also
changes the root canonical would be a regression, not a fix.

All numbers below were produced in this session. Nothing is carried over.

## Raw Observations

Production, 2026-09-07, `api/health` reporting served commit `1bdadc5f2839f2d49d3d4f5d0424ccdaf4937d50`:

```
curl -s https://balizero.com/kbli-explorer | grep -o 'rel="canonical" href="[^"]*"'
  -> rel="canonical" href="https://balizero.com"

curl -s https://balizero.com/kbli | grep -o 'rel="canonical" href="[^"]*"'      # positive control, separate call
  -> rel="canonical" href="https://balizero.com/kbli"
```

The subject points at the homepage. The control points at itself, which proves the tag is
emitted correctly elsewhere on the same deployment and the subject's value is a real defect
rather than a missing feature.

`apps/mouth/src/app/sitemap.ts:41` lists `"/kbli-explorer"` in `staticPaths`, so the page is
submitted for indexing while telling crawlers it is a duplicate of `/`.

Local production build with this change, all six routes read in one run:

| route | `rel="canonical"` | expected |
|---|---|---|
| `/kbli-explorer` | `https://balizero.com/kbli-explorer` | changed — this PR |
| `/kbli` | `https://balizero.com/kbli` | unchanged |
| `/` | `https://balizero.com` | unchanged — root alternates untouched |
| `/services` | `https://balizero.com/services` | unchanged |
| `/contact` | `https://balizero.com/contact` | unchanged |
| `/team` | `https://balizero.com/team` | unchanged |

The subject moved from the homepage to itself. Every control held. `grep -c
'kbli-explorer-jsonld'` on the rendered subject page returns `2`, so the JSON-LD block is
still emitted and was not disturbed.

The build listed `/kbli-explorer` as `○` (static), the same rendering mode as before — this
change adds metadata, it does not move the route.

## Reasoning Path

`alternates.canonical` is the property Next reads for `rel="canonical"`; `openGraph.url` is
a separate signal and does not feed it, which is exactly why the page could look
self-referential in one place and point at `/` in another.

`baseUrl` at `:4` is reused rather than re-declared. A second constant would be a second
thing to keep in step with `NEXT_PUBLIC_PUBLIC_URL`, and hard-coding the domain would break
every non-production deployment silently — the canonical would still render, just pointing
at the wrong host, which is the same class of defect this PR is closing.

The sibling routes `(blog)/services`, `(blog)/contact` and `(blog)/team` were measured and
left alone. They already emit correct canonicals, and folding them into this PR would turn
a one-line fix into a cross-surface refactor with nothing measured to justify it.

`sitemap.ts` was not touched. Whether `/kbli-explorer` belongs in the sitemap is a separate
decision from whether it should lie about its identity while it is there. This PR makes the
page honest; it does not relitigate its presence.

## Risk

The canonical URL is a claim to search engines, so the failure mode of getting it wrong is
invisible locally and slow to surface. It is asserted here against a local production build
across six routes rather than reasoned about, which is the only defence available before
deploy.

Blast radius is one route. Three added lines inside one metadata object, in a layout
imported by nothing else. No shared component, no design token, no `packages/core` file, no
route config, no data model. The root canonical was read after the change and is unchanged.

Re-indexing is not instant. Search engines will keep serving the old signal until they
re-crawl, so the effect of this PR is not observable the moment it deploys, and its absence
in the days after is not evidence the change failed.

## Implication

If crawlers have been consolidating `/kbli-explorer` into `/`, any authority the explorer
earned has been credited to the homepage. Correcting the tag stops the loss but does not
reverse it: the page starts accumulating its own signal from the next crawl, not from its
history. That is an argument for merging sooner rather than a reason to expect a step
change.

This measurement was made on one route because one route was reported. The same defect
shape — `openGraph.url` present, `alternates` absent — is invisible from the source unless
each route's rendered `<head>` is read, and nothing here establishes whether other routes
share it. That is a sweep worth running, not a claim this PR makes.

# Recommendation

Merge. Three added lines in one file, no behaviour change for any human visitor, and it
stops the site from telling crawlers that a page it explicitly submits for indexing is a
duplicate of the homepage.

Local gates, run on this branch, reported as-is:

- `npm run build -w apps/mouth` → RC 0; `/kbli-explorer` still listed as `○` (static).
- `npm run lint -w apps/mouth` → RC 0; 183 warnings, 0 errors — identical to the pre-existing baseline, none from this file.
- `npx prettier --check apps/mouth/src/app/kbli-explorer/layout.tsx` → RC 0.
- pre-commit hook ran `tsc --noEmit` across `apps/mouth` → passed.

`apps/mouth/public/llms-full.txt` was regenerated by the build and restored before staging;
the commit is the one file.

CI is the real gate and nothing above should be read as a CI result. The post-fix canonicals
are from a local build — production still serves the old value, and nothing in this PR has
been observed live.

# Next Action

1. After this deploys, re-run `curl -s https://balizero.com/kbli-explorer | grep -o 'rel="canonical" href="[^"]*"'`
   and confirm it returns `https://balizero.com/kbli-explorer`, since every post-fix number
   above is from a local build.
2. Sweep the remaining routes in `sitemap.ts` for the same shape — rendered `rel="canonical"`
   read per route, not inferred from the source — and open one PR for whatever that finds.
   `/kbli-explorer` was reported individually; nothing here says it is the only one.
