### PR TITLE
fix(services): drop the response-time promise the data does not support

### DIFF
--- a/apps/mouth/src/app/(blog)/services/page.tsx
+++ b/apps/mouth/src/app/(blog)/services/page.tsx
@@ -352,7 +352,7 @@ export default function ServicesPage() {
               {
                 n: "01",
                 title: "Scope it",
-                body: "WhatsApp or Visa Check for a first read — free, under 15 min.",
+                body: "WhatsApp or Visa Check for a first read — free.",
                 accent: "#c8102e",
               },
               {


### PR DESCRIPTION
## 1. Insight
A response-time promise that the measured data contradicts was still being 
served on /services. Removing it costs nothing: the offer is free either 
way.

## 2. Measured
Layer 2, origin/main 6c6f25a96:
`apps/mouth/src/app/(blog)/services/page.tsx:355` — `body: "WhatsApp or 
Visa Check for a first read — free, under 15 min."` — 1 line.
Positive control, separate call: `grep -c 'export'` on the same file 
returns non-zero.

Layer 3, https://balizero.com/services, 2026-09-07 ~13:55 WITA:
`x-vercel-cache: HIT`, `age: 33138`. `<title>Services | Bali Zero` — real 
route, not a soft 404 from `(blog)/[category]`. `grep -c 'under 15 min'` 
on the served body returns 1.
The read is a stale HIT, so it does not prove origin state now. It only 
misleads in one direction — showing a claim already removed — and nothing 
was removed: the line still stands in main, and production `1bdadc5f28` is 
an ancestor of main. Both readings agree, so the claim is served.

Response-time data, 189 inbound-outbound pairs, `meta_inbox_messages`, 3 
Jun – 30 Jul: mean 548.8 min, median 4.9 min, p90 411.2 min, answered 
within 2 min 24.3%. The median clears 15 minutes; the mean and p90 do not.

## 3. Change
One line. `"... — free, under 15 min."` becomes `"... — free."` The 
promise is removed, not softened, and no new number replaces it.

## 4. Studio
`packages/core/components/TrustBand.tsx:8` already carries the history in 
a code comment: the same claim first read `~15 min` there and was called 
"a response-time promise nobody had". It was pulled from that surface and 
this one was never swept. That comment is left untouched — it is the 
record of why.

## 5. Risk
Text only. Rollback is `gh pr revert`. No token, no layout, no component 
API touched. `apps/mouth/**` — VERDE.

## 6. Not in scope
This closes ONE instance. The class is open, measured, and tracked 
separately: three response-time promises live in 
`apps/mouth/src/i18n/locales/it.json` at lines 89, 129 and 215, in the 
directory the `response-time-claim` guard does not walk. Those are a 
different shape — `entro 24 ore` is not contradicted by the data above — 
and they need a decision, not a fix. The sweep pattern used here catches 
only `under|entro|kurang dari|less than`; it is blind to `within 24 
hours`, `24-hour`, `dalam 24 jam`, `24h`, so four is a floor, not a count. 
Nothing in this PR should be read as the class being closed.
