### PR TITLE
fix(visa-oracle): stop holding on diaspora answers the pack already decides

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
@@ -169,27 +169,25 @@ const WALKS: readonly WalkCase[] = [
     flags: ["ACTIVITY_BOUNDARY"],
   },
   {
-    // NAME CORRECTED 2026-09-08. This row used to read "HELD:
-    // CATEGORY_TO_PURPOSE emits no purpose for it", and that rationale is now
-    // FALSE: #5855 — merged into this very branch — added `diaspora: "FAMILY"`
-    // to CATEGORY_TO_PURPOSE (fact-mapper.ts), and the spec's own
-    // justification for keeping this clause ("diaspora unmapped", i.e. the
-    // path was unreachable so the flag was harmless) died with it.
+    // NAME CORRECTED 2026-09-08, RELEASED SAME DAY. This row used to read
+    // "HELD: CATEGORY_TO_PURPOSE emits no purpose for it", and that rationale
+    // died when #5855 — merged into this very branch — added
+    // `diaspora: "FAMILY"` to CATEGORY_TO_PURPOSE (fact-mapper.ts): the path
+    // was no longer unreachable, so the flag was no longer harmless.
     //
     // MEASURED against production 2026-09-07, `disclosed_review_flags=[]`: all
     // 15 diaspora walks of the corpus return SUPPORTED_CANDIDATES with real
-    // candidates (C1 + E31A/E31C/E31F/E31G by relation). So the hold this row
-    // asserts now DELETES proven candidates for 100% of diaspora traffic —
-    // the exact pathology this file's own docstring names.
+    // candidates (C1 + E31A/E31C/E31F/E31G by relation). Holding on the mere
+    // presence of `diaspora_connection`/`diaspora_documents` was deleting
+    // proven candidates for 100% of diaspora traffic — the exact pathology
+    // this file's own docstring names. The owner ruled: automatic. This walk
+    // (`former_wni`) is now FREED — the pack decides it on its own.
     //
-    // The clause is kept anyway, and NOT because nobody looked: a former-WNI
-    // claim is the one branch that can surface an Indonesian dual-nationality
-    // question, which the owner listed as a legitimate human-review case.
-    // Whether that justifies holding EVERY diaspora answer is a business and
-    // legal call, not this seat's, and it is raised to the owner rather than
-    // decided here. What is fixed here is the lie: the row now says what it
-    // actually asserts and why.
-    name: "diaspora — HELD by the blanket category clause, NOT by a missing purpose",
+    // `dual` (Indonesian dual citizenship) stays HELD, deliberately: it is the
+    // one diaspora status the owner named as a legitimate human-review case,
+    // and no corpus walk exercises it — see the second row below, which
+    // certifies the exception on the same live branch.
+    name: "diaspora · former_wni — FREED: the pack decides it on its own",
     category: "diaspora",
     tripScope: "single",
     branch: [
@@ -198,6 +196,23 @@ const WALKS: readonly WalkCase[] = [
       // #5855 turned the single dead-end diaspora walk into a full family
       // branch — the sponsor is now interviewed properly instead of the
       // interview stopping. Re-anchored to that live sequence.
+      ["sponsor_category", "FAMILY"],
+      ["family_relation", "SPOUSE"],
+      ["marital_status", "MARRIED"],
+      ["family_sponsor_nationalities", "ID"],
+      ["family_marriage_registered", "yes"],
+      ["family_sponsor_confirmed", "yes"],
+      ["stay_days", "365"],
+    ],
+    flags: [],
+  },
+  {
+    name: "diaspora · dual — HELD: Indonesian dual citizenship, no corpus walk exercises it",
+    category: "diaspora",
+    tripScope: "single",
+    branch: [
+      ["diaspora_connection", "dual"],
+      ["diaspora_documents", "yes"],
       ["sponsor_category", "FAMILY"],
       ["family_relation", "SPOUSE"],
       ["marital_status", "MARRIED"],
@@ -325,10 +340,12 @@ describe("ACTIVITY_BOUNDARY — the decision table itself", () => {
     expect(mapDisclosedReviewFlags({ remote_income: "above" })).toEqual([]);
   });
 
-  it("still holds the whole diaspora category, answers or not", () => {
-    expect(mapDisclosedReviewFlags({ category: "diaspora" })).toEqual([
-      "ACTIVITY_BOUNDARY",
-    ]);
+  it("no longer holds on the bare category — released 2026-09-08, per-answer table governs now", () => {
+    // The blanket `facts.category === "diaspora"` clause is gone: a diaspora
+    // walk with no `diaspora_connection`/`diaspora_documents` answer yet
+    // raises nothing, exactly like every other category — the table above,
+    // not the category label, decides.
+    expect(mapDisclosedReviewFlags({ category: "diaspora" })).toEqual([]);
     expect(mapDisclosedReviewFlags({ category: "business" })).toEqual([]);
   });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -214,10 +214,12 @@ describe("question registry -> wire coverage", () => {
     // below rather than being deleted — the assertion changed sides, it did
     // not disappear. Measured live the same day: `offshore/business` returns
     // NO_SUPPORTED_PATH with `BUSINESS_LOCAL_COMPENSATION_NOT_ALLOWED`.
-    for (const [id, value] of [
-      ["other_purpose", "medical"],
-      ["diaspora_connection", "former_wni"],
-    ] as const) {
+    //
+    // `diaspora_connection`/`diaspora_documents` released 2026-09-08 for the
+    // SAME reason (measured 2026-09-07: all 15 corpus diaspora walks reach
+    // SUPPORTED_CANDIDATES with `disclosed_review_flags=[]`) — moved out of
+    // this list to the must-NOT-flag table below, `former_wni` included.
+    for (const [id, value] of [["other_purpose", "medical"]] as const) {
       expect(mapFacts({ [id]: value }).disclosed_review_flags).toContain(
         "ACTIVITY_BOUNDARY",
       );
@@ -253,6 +255,12 @@ describe("question registry -> wire coverage", () => {
     // Engine-inert: no rule reads a work role (owner ruling, decision 6).
     // All five options are swept in `activity-boundary.test.ts`.
     ["work_role", "specialist"],
+    // Released 2026-09-08 — see the "innocence" test above for the measurement.
+    ["diaspora_connection", "former_wni"],
+    ["diaspora_connection", "descendant"],
+    ["diaspora_connection", "family"],
+    ["diaspora_documents", "yes"],
+    ["diaspora_documents", "no"],
   ])(
     "leaves a decidable answer (%s=%s) unflagged — it must not veto a proven candidate",
     (id, value) => {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -445,14 +445,27 @@ const REVIEW_FLAG_MAP: Readonly<
  * owner ruling of 2026-09-06 decision 6; `tourism_duration`/`remote_income`,
  * question ids that exist nowhere in `tree.ts`): research/visa/
  * 2026-09-06-visa-oracle-decisiveness-investigation.md §4 PR-4 and §6 R3.
+ * `diaspora_connection`/`diaspora_documents` decided 2026-09-07: measured in
+ * production with `disclosed_review_flags=[]`, all 15 corpus diaspora walks
+ * resolved to `SUPPORTED_CANDIDATES` with real candidates (C1, plus
+ * E31A/E31C/E31F/E31G per the declared link) — the pack already decides
+ * `former_wni`/`descendant`/`family` and both document answers on its own, so
+ * holding on their mere presence was discarding a proven answer, the same
+ * defect this table exists to cure for the other questions. `dual` (Indonesian
+ * dual citizenship) and `other` stay undecidable on purpose: `dual` is the
+ * legally most sensitive diaspora status the owner named as a legitimate
+ * human-review case, and no corpus walk exercises it — releasing it would
+ * open a branch never tested on the point that matters most; `other` is
+ * fail-closed by construction, it names no specific status the pack can
+ * reason about.
  * Guilt, innocence and the per-walk census: `activity-boundary.test.ts`.
  */
 export const ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS = {
   business_activity: ["meetings", "negotiation", "conference"],
   investment_vehicle: ["pt_pma"],
   retirement_basis: ["bank_deposit", "passive_income"],
-  diaspora_connection: [],
-  diaspora_documents: [],
+  diaspora_connection: ["former_wni", "descendant", "family"],
+  diaspora_documents: ["yes", "no"],
   other_purpose: [],
   other_paid_activity: [],
 } as const satisfies Readonly<Record<string, readonly string[]>>;
@@ -487,7 +500,7 @@ export function mapDisclosedReviewFlags(
   // Human-context answers the signed vocabulary cannot decide may only lower
   // the result to review. An answer it CAN decide must not: this flag is a
   // hold that deletes candidates, never a label (see the table above).
-  if (facts.category === "diaspora" || hasUndecidableActivityAnswer(facts)) {
+  if (hasUndecidableActivityAnswer(facts)) {
     flags.add("ACTIVITY_BOUNDARY");
   }
   if (


### PR DESCRIPTION
## Summary

`ACTIVITY_BOUNDARY` was raised for the mere PRESENCE of a `diaspora_connection`/`diaspora_documents` answer, and any disclosed flag is terminal backend-side (`evaluate_path.py::_apply_disclosed_review_flags` rewrites the decision to `HUMAN_REVIEW_REQUIRED` with `candidates=()`). Measured in production 2026-09-07 with `disclosed_review_flags=[]`: all 15 diaspora walks of the corpus resolve to `SUPPORTED_CANDIDATES` with real candidates (C1, plus E31A/E31C/E31F/E31G by relation). So today's blanket hold deletes proven candidates for 100% of diaspora traffic.

- Release `former_wni` / `descendant` / `family` (`diaspora_connection`) and `yes`/`no` (`diaspora_documents`) into `ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS` — the pack already decides these on its own.
- Remove the now-redundant `facts.category === "diaspora"` clause it replaces (confirmed present in `mapDisclosedReviewFlags`; removing only the table entries would have had no effect without also removing this clause).
- `dual` (Indonesian dual citizenship) and `other` stay HELD, deliberately: `dual` is the one diaspora status the owner named as a legitimate human-review case and no corpus walk exercises it; `other` is fail-closed by construction.

## Test plan

- [x] `former_wni`/`descendant`/`family` and both `diaspora_documents` answers do NOT raise `ACTIVITY_BOUNDARY` (guilt/innocence pairs in `fact-mapper.test.ts` + a real `flowReducer`-driven walk in `activity-boundary.test.ts`)
- [x] `dual` and `other` still DO raise it (same test files, incl. a new real-walk row for `dual`)
- [x] `npx vitest run "src/app/(visa-oracle)/visa-oracle/"` — 619/619 passing (one pre-existing, unrelated file `walk-corpus-determinism.test.ts` fails to even collect on `origin/main` already — missing `prettier`/`recharts` in a stale local `node_modules`, fixed locally for typecheck via `npm install`, not part of this diff)
- [x] `evidence_pack_lint.py --print-floor` = 1 (< 2 threshold) — no evidence pack required

## Bites

Consumer: the Visa Oracle frontend's disclosed-flags POST body (`mapOracleFactsToApplicantFacts` → `/api/visa-oracle/evaluate`). Observation: the two new must-NOT-flag rows in `fact-mapper.test.ts` assert `disclosed_review_flags` is `[]` for `diaspora_connection=former_wni/descendant/family` and `diaspora_documents=yes/no`, and the new `activity-boundary.test.ts` walk drives the real `flowReducer` through a full diaspora→family interview and asserts the wire-level flags array is empty — proving the release reaches the actual request body sent to the backend, not just the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K49cJhM7o89sKffgK8pU1Y