### PR TITLE
chore(regulatory): daily delta 2026-09-08 — no new regs

### DIFF
--- a/research/regulatory/2026-09-08-delta.json
+++ b/research/regulatory/2026-09-08-delta.json
@@ -1,0 +1,121 @@
+{
+  "run_at": "2026-09-08T07:06:06+08:00",
+  "today": "2026-09-08",
+  "yesterday_seen_count": 24,
+  "yesterday_file_used": "2026-09-07-delta.json",
+  "new_today_count": 0,
+  "partial": false,
+  "unreachable_sources": [
+    {
+      "url": "https://www.hukumonline.com/berita/",
+      "reason": "http_403",
+      "note": "WAF/Cloudflare challenge (HTTP 403), persisted after 1 retry with Mozilla UA"
+    },
+    {
+      "url": "https://muc.co.id/article",
+      "reason": "http_403",
+      "note": "HTTP 403, persisted after 1 retry with Mozilla UA"
+    },
+    {
+      "url": "https://ikpi.or.id/berita/",
+      "reason": "empty_shell",
+      "note": "301 redirect to /articles, HTTP 200 client-side SPA shell (\"Memuat\"), no static entries"
+    },
+    {
+      "url": "https://ortax.org/news",
+      "reason": "empty_shell",
+      "note": "HTTP 200 but body is soft-404 \"Artikel tidak ditemukan\""
+    },
+    {
+      "url": "https://jdih.kemenkeu.go.id/peraturan",
+      "reason": "timeout",
+      "note": "Connection timed out after 30s, persisted after 1 retry"
+    },
+    {
+      "url": "https://peraturan.bpk.go.id/Search?type=PerundangUndangan&jenis=PMK&tahun=2026",
+      "reason": "empty_shell",
+      "note": "HTTP 200 but static HTML is only search facets/filters, zero PMK result rows rendered (AJAX-driven results)"
+    },
+    {
+      "url": "https://www.pajak.go.id/peraturan",
+      "reason": "empty_shell",
+      "note": "HTTP 200 but static HTML is only nav/filter menu, zero regulation entries rendered"
+    }
+  ],
+  "sources_checked_no_delta": [
+    {
+      "url": "https://news.ddtc.co.id/",
+      "reason": "checked_no_new",
+      "note": "Dated entries through 07 Sep 2026; all reference PMK 55/2026 (already seen) or non-regulatory topics; no new verbatim citation"
+    },
+    {
+      "url": "https://ortax.org/berita/",
+      "reason": "outside_window",
+      "note": "Newest entry 04 September 2026, predates 48h window"
+    },
+    {
+      "url": "https://peraturan.go.id",
+      "reason": "outside_window",
+      "note": "Newest ministerial entries dated 28-31 Aug 2026 (Permenkop 5-6/2026, Permen PMI 9/2026, Permenaker 12/2026 already seen); predate 48h window"
+    },
+    {
+      "url": "https://www.imigrasi.go.id",
+      "reason": "outside_window",
+      "note": "Newest Siaran Pers dated 1 Sep 2026, no new visa regulation, predates 48h window"
+    },
+    {
+      "url": "https://jdih.kemnaker.go.id/peraturan",
+      "reason": "outside_window",
+      "note": "Newest visible entry UU Nomor 2 Tahun 2026 (30 Apr 2026); no Permenaker in 48h window"
+    }
+  ],
+  "nb_query_errors": [
+    {
+      "nb": "NB-INTEL-Regulation — Daily Regulatory Intelligence",
+      "reason": "auth_expired",
+      "note": "nlm auth expired (needs manual nlm login) — persists since 2026-09-06"
+    },
+    {
+      "nb": "NB-INTEL-Press — Daily Press Intelligence",
+      "reason": "auth_expired",
+      "note": "nlm auth expired (needs manual nlm login) — persists since 2026-09-06"
+    },
+    {
+      "nb": "NB-INTEL-Immigration — Daily Immigration Intelligence",
+      "reason": "auth_expired",
+      "note": "nlm auth expired (needs manual nlm login) — persists since 2026-09-06"
+    },
+    {
+      "nb": "NB-INTEL-Tax — Daily Tax/Fiscal Intelligence",
+      "reason": "auth_expired",
+      "note": "nlm auth expired (needs manual nlm login) — persists since 2026-09-06"
+    }
+  ],
+  "deltas": [],
+  "seen_citations": [
+    "PMK Nomor 28 Tahun 2026",
+    "PMK Nomor 40 Tahun 2026",
+    "PMK Nomor 41 Tahun 2026",
+    "PMK Nomor 42 Tahun 2026",
+    "PMK Nomor 43 Tahun 2026",
+    "PMK Nomor 44 Tahun 2026",
+    "PMK Nomor 55 Tahun 2026",
+    "PMK Nomor 57 Tahun 2026",
+    "PMK Nomor 61 Tahun 2026",
+    "PP Nomor 20 Tahun 2026",
+    "PP Nomor 24 Tahun 2026",
+    "Peraturan Direktur Jenderal Pajak Nomor PER-8/PJ/2026",
+    "Peraturan Menteri Hukum Nomor 13 Tahun 2026",
+    "Permen PMK/Badan PMI Nomor 5 Tahun 2026",
+    "Permenaker No. 12 Tahun 2026; BN 2026 (598)",
+    "Permenaker Nomor 7 Tahun 2026",
+    "Permenaker Nomor 8 Tahun 2026",
+    "Permenaker Nomor 9 Tahun 2026",
+    "Permenkes Nomor 6 Tahun 2026",
+    "Perpres Nomor 26 Tahun 2026",
+    "Perpres Nomor 27 Tahun 2026",
+    "Perpres Nomor 3 Tahun 2026",
+    "UU Nomor 4 Tahun 2026",
+    "UU Nomor 5 Tahun 2026"
+  ]
+}


### PR DESCRIPTION
Daily regulatory-watcher run for 2026-09-08 WITA.

**Bites:** consumer is the next daily run of regulatory-watcher (2026-09-09), which reads `seen_citations` from this file for dedup, and Antonello if he manually opens the file. Observation proving it's in force: `research/regulatory/2026-09-08-delta.json` exists with `new_today_count: 0`, `deltas: []`, and `seen_citations` carrying forward all 24 entries from 2026-09-07 unchanged (idempotent, no drift).

- NB-INTEL: all 4 notebooks failed `auth_expired` (persists since 2026-09-06, needs manual `nlm login`).
- Web: 11 sources checked, 0 new verbatim citations found. 7 unreachable (2 http_403, 1 timeout, 4 empty_shell), 5 checked with content but outside the 48h freshness window.
- No Telegram alert sent (new_today_count=0, per spec — Antonello does not want empty pings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)