### PR TITLE
fix(visa-oracle): give the interview an age dimension for retirement walks

### DIFF
--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_bank_deposit_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_bank_deposit_age64.json
@@ -1,0 +1,142 @@
+{
+  "label": "offshore/retirement/bank_deposit/age64",
+  "asked": [
+    "in_indonesia",
+    "holds_stay_permit",
+    "overstay_days",
+    "nationalities",
+    "birth_date",
+    "category",
+    "trip_scope",
+    "sponsor_category",
+    "retirement_basis",
+    "secondhome_deposit_usd",
+    "secondhome_state_bank",
+    "secondhome_own_name",
+    "secondhome_passive_income_usd",
+    "stay_days",
+    "review_gate"
+  ],
+  "overrides": {
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
+    "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
+    "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
+      "status": "KNOWN",
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.last_entry_date": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
+    "immigration.violation_history": { "status": "KNOWN", "value": [] },
+    "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.stay_days": { "status": "KNOWN", "value": 121 },
+    "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.requested_product_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_country_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_is_indonesian_entity": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.serves_indonesian_clients": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesia_source_compensation": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesian_work_sponsor_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.pt_pma_committed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.investment_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.paid_up_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.proposed_role": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.relation_to_sponsor": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_nationalities": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_status_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.marriage_registered": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_marriage_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_birth_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_permit_basis": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "KNOWN",
+      "value": true
+    },
+    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "KNOWN",
+      "value": 1000000000
+    },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.service_fee_budget_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.wants_quote": { "status": "UNKNOWN", "reason": "NOT_ASKED" }
+  }
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_family_sponsor_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_family_sponsor_age64.json
@@ -1,0 +1,146 @@
+{
+  "label": "offshore/retirement/family_sponsor/age64",
+  "asked": [
+    "in_indonesia",
+    "holds_stay_permit",
+    "overstay_days",
+    "nationalities",
+    "birth_date",
+    "category",
+    "trip_scope",
+    "sponsor_category",
+    "retirement_basis",
+    "secondhome_passive_income_usd",
+    "family_sponsor_confirmed",
+    "stay_days",
+    "review_gate"
+  ],
+  "overrides": {
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
+    "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
+    "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
+      "status": "KNOWN",
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.last_entry_date": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
+    "immigration.violation_history": { "status": "KNOWN", "value": [] },
+    "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.stay_days": { "status": "KNOWN", "value": 121 },
+    "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.requested_product_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_country_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_is_indonesian_entity": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.serves_indonesian_clients": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesia_source_compensation": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesian_work_sponsor_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.pt_pma_committed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.investment_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.paid_up_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.proposed_role": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.relation_to_sponsor": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_nationalities": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_status_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.marriage_registered": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_marriage_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_birth_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_permit_basis": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "KNOWN",
+      "value": 1000000000
+    },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.service_fee_budget_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.wants_quote": { "status": "UNKNOWN", "reason": "NOT_ASKED" }
+  }
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_passive_income_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_passive_income_age64.json
@@ -1,0 +1,146 @@
+{
+  "label": "offshore/retirement/passive_income/age64",
+  "asked": [
+    "in_indonesia",
+    "holds_stay_permit",
+    "overstay_days",
+    "nationalities",
+    "birth_date",
+    "category",
+    "trip_scope",
+    "sponsor_category",
+    "retirement_basis",
+    "secondhome_passive_income_usd",
+    "family_sponsor_confirmed",
+    "stay_days",
+    "review_gate"
+  ],
+  "overrides": {
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
+    "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
+    "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
+      "status": "KNOWN",
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.last_entry_date": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
+    "immigration.violation_history": { "status": "KNOWN", "value": [] },
+    "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.stay_days": { "status": "KNOWN", "value": 121 },
+    "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.requested_product_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_country_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_is_indonesian_entity": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.serves_indonesian_clients": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesia_source_compensation": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesian_work_sponsor_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.pt_pma_committed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.investment_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.paid_up_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.proposed_role": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.relation_to_sponsor": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_nationalities": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_status_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.marriage_registered": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_marriage_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_birth_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_permit_basis": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "KNOWN",
+      "value": 1000000000
+    },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.service_fee_budget_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.wants_quote": { "status": "UNKNOWN", "reason": "NOT_ASKED" }
+  }
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64.json
@@ -1,0 +1,145 @@
+{
+  "label": "offshore/retirement/property/age64",
+  "asked": [
+    "in_indonesia",
+    "holds_stay_permit",
+    "overstay_days",
+    "nationalities",
+    "birth_date",
+    "category",
+    "trip_scope",
+    "sponsor_category",
+    "retirement_basis",
+    "secondhome_property_value_usd",
+    "stay_days",
+    "review_gate"
+  ],
+  "overrides": {
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
+    "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
+    "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
+      "status": "KNOWN",
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.last_entry_date": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
+    "immigration.violation_history": { "status": "KNOWN", "value": [] },
+    "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.stay_days": { "status": "KNOWN", "value": 121 },
+    "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.requested_product_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_country_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_is_indonesian_entity": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.serves_indonesian_clients": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesia_source_compensation": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesian_work_sponsor_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.pt_pma_committed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.investment_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.paid_up_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.proposed_role": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.relation_to_sponsor": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_nationalities": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_status_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.marriage_registered": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_marriage_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_birth_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_permit_basis": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "KNOWN",
+      "value": 1000000000
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.service_fee_budget_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.wants_quote": { "status": "UNKNOWN", "reason": "NOT_ASKED" }
+  }
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64.json
@@ -1,0 +1,144 @@
+{
+  "label": "offshore/retirement/undecided/age64",
+  "asked": [
+    "in_indonesia",
+    "holds_stay_permit",
+    "overstay_days",
+    "nationalities",
+    "birth_date",
+    "category",
+    "trip_scope",
+    "sponsor_category",
+    "retirement_basis",
+    "stay_days",
+    "review_gate"
+  ],
+  "overrides": {
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
+    "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
+    "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
+      "status": "KNOWN",
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.last_entry_date": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
+    "immigration.violation_history": { "status": "KNOWN", "value": [] },
+    "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.stay_days": { "status": "KNOWN", "value": 121 },
+    "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.requested_product_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_country_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_is_indonesian_entity": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.serves_indonesian_clients": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesia_source_compensation": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesian_work_sponsor_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.pt_pma_committed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.investment_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.paid_up_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.proposed_role": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.relation_to_sponsor": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_nationalities": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_status_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.marriage_registered": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_marriage_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_birth_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_permit_basis": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.service_fee_budget_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.wants_quote": { "status": "UNKNOWN", "reason": "NOT_ASKED" }
+  }
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_retirement_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_retirement_age64.json
@@ -1,0 +1,137 @@
+{
+  "label": "onshore/retirement/age64",
+  "asked": [
+    "in_indonesia",
+    "permit_expiry",
+    "holds_stay_permit",
+    "current_status_code",
+    "overstay_days",
+    "wants_onshore_conversion",
+    "application_channel",
+    "nationalities",
+    "birth_date",
+    "category",
+    "trip_scope",
+    "sponsor_category",
+    "retirement_basis",
+    "secondhome_deposit_usd",
+    "secondhome_state_bank",
+    "secondhome_own_name",
+    "secondhome_passive_income_usd",
+    "stay_days",
+    "review_gate"
+  ],
+  "overrides": {
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
+    "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
+    "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": true },
+    "immigration.current_status_code": { "status": "KNOWN", "value": "A1" },
+    "immigration.current_status_expiry": {
+      "status": "KNOWN",
+      "value": "2026-12-31"
+    },
+    "immigration.last_entry_date": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
+    "immigration.violation_history": { "status": "KNOWN", "value": [] },
+    "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.stay_days": { "status": "KNOWN", "value": 121 },
+    "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.requested_product_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_country_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.employer_is_indonesian_entity": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.serves_indonesian_clients": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesia_source_compensation": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "work.indonesian_work_sponsor_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.pt_pma_committed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.investment_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.paid_up_capital_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "investment.proposed_role": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.relation_to_sponsor": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_nationalities": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_status_code": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.marriage_registered": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_marriage_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.stepchild_birth_certificate_confirmed": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_permit_basis": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "KNOWN",
+      "value": true
+    },
+    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "KNOWN",
+      "value": 1000000000
+    },
+    "process.application_channel": { "status": "KNOWN", "value": "OFFSHORE" },
+    "process.wants_onshore_conversion": { "status": "KNOWN", "value": true },
+    "commercial.service_fee_budget_idr": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "commercial.wants_quote": { "status": "UNKNOWN", "reason": "NOT_ASKED" }
+  }
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
@@ -2,21 +2,23 @@
 
 ``test_gold_coverage_floor.py`` proves the pack can support a product when
 every fact arrives. This file proves the opposite half, and it is the half
-the user lives in: replay the **61 real interview walks** — every distinct
+the user lives in: replay the **67 real interview walks** — every distinct
 path through ``flow.ts``'s two-arm spine and ``getCategoryQuestionIds``'
 eleven categories, each answered through the real ``fact-mapper.ts`` —
 against the highest signed PRODUCTION pack, and pin the outcome census.
 
 Measured 2026-09-07 on ``rulepack-prod-020.signed.json``, with PR-3's
-interview on top: **0 NEEDS_INPUT / 10 NO_SUPPORTED_PATH / 51
-SUPPORTED_CANDIDATES — at ENGINE level, with no disclosure flags supplied.**
-That qualifier is load-bearing and is spelled out under "WHAT THIS CENSUS
-DOES NOT SEE" below; 51 is not the number of applicants who see a
-recommendation without human review. No walk asks the applicant for a fact
-the interview has no question for any more
+interview on top and PR-5's age dimension on top of that: **2 NEEDS_INPUT /
+10 NO_SUPPORTED_PATH / 55 SUPPORTED_CANDIDATES — at ENGINE level, with no
+disclosure flags supplied.** That qualifier is load-bearing and is spelled
+out under "WHAT THIS CENSUS DOES NOT SEE" below; 55 is not the number of
+applicants who see a recommendation without human review. Almost no walk
+asks the applicant for a fact the interview has no question for any more —
+the two exceptions are PR-5's own, and the module carries their allowlist
+rows below
 (research/visa/2026-09-06-visa-oracle-decisiveness-investigation.md §1-§2).
 
-Three hops got here, and this file has been re-derived at each one — never
+Four hops got here, and this file has been re-derived at each one — never
 hand-edited:
 
 1. **seq-19 → seq-20 (the signed fold, #5867): 36/0/7 → 21/0/22.** Fold edit
@@ -61,26 +63,61 @@ hand-edited:
      construction: the corpus carries a walk's wire FACTS, and ``work_role``
      was ``HUMAN_CONTEXT`` — it mapped to no FactPath, only to a disclosure
      flag. Both work walks still answer E23 with the same candidates.
+4. **PR-5, THIS PR — the AGE dimension: 0/10/51 → 2/10/55 over a corpus that
+   grows 61 → 67.** Neither the pack nor the interview tree moved; only the
+   corpus did. ``birth_date`` is a spine question no branch reads, so every
+   walk before this PR answers it with a fixed 25-year-old identity — and
+   every one of the six ``retirement`` walks is excluded by
+   ``hf.e33e.age-below-55`` / ``hf.e33f.age-below-55`` before either
+   product's own eligibility rule is ever exercised. This PR adds 6 walks —
+   the same 5 offshore retirement bases plus the onshore retirement walk,
+   replayed at age 64 (birth date ``1961-11-11``, deliberately outside
+   ``el.e33e.age-55-59-disputed-band``) — so E33E/E33F get exercised on the
+   facts for the first time:
 
-**No walk moved DOWN.** Every one of the 22 seq-20 answers keeps its exact
-candidate list, the 10 NO_SUPPORTED_PATH walks stay NO_SUPPORTED_PATH, and
-the only transition in the census is ``NEEDS_INPUT`` →
-``SUPPORTED_CANDIDATES``.
+   - ``bank_deposit``, ``passive_income`` and ``family_sponsor`` (offshore)
+     and the onshore neutral walk all reach ``SUPPORTED_CANDIDATES`` — four
+     new answers.
+   - ``property`` and ``undecided`` (offshore) end ``NEEDS_INPUT`` on
+     ``family.sponsor_confirmed``: honest dead ends, not a defect. The
+     question exists in the ``retirement`` category (the ``passive_income``
+     and ``family_sponsor`` bases both ask it) but neither the ``property``
+     nor the ``undecided`` branch reaches it — see
+     ``WALK_DEAD_END_ALLOWLIST`` below, which is why the invariant this file
+     arms is no longer unconditional.
+
+**No EXISTING walk moved.** Every one of the 61 pre-PR-5 walks keeps its
+exact state and candidate list — the 6 new walks are the only entries this
+PR adds to the census, and 2 of them are the first ``NEEDS_INPUT`` this file
+has ever pinned.
 
 The invariant this file exists to arm is one sentence:
 
     no walk may end in NEEDS_INPUT on a fact for which the interview has no
     reachable question in that walk's own history.
 
-**It is now UNCONDITIONAL.** ``WALK_DEAD_END_ALLOWLIST`` is empty, so
-``_dead_end_violations`` has no excuse left to find for any NEEDS_INPUT walk;
-the allowlist machinery stays because a future signed pack can raise a new
-``on_unknown: NEEDS_INPUT`` rule on an unaskable fact, and the guilt tests
-below keep every branch of it exercised against a fabricated row.
+**It is CONDITIONAL again, on exactly two named rows.** PR-3 made
+``WALK_DEAD_END_ALLOWLIST`` empty; PR-5 adds back the two rows above,
+each with its own anchor checked against the walk's own ``asked`` history
+(``test_every_allowlisted_dead_end_is_genuinely_unaskable_in_its_own_walk``).
+Curing ``flow.ts`` so ``retirement/property`` and ``retirement/undecided``
+also ask ``family_sponsor_confirmed`` — restoring the unconditional
+invariant — is a second concern and a follow-up, not this PR: it would
+rewrite the *young* ``offshore/retirement/property`` fixture that
+``test_the_retirement_walk_merges_age_below_55_keeping_both_rules_and_both_refs``
+pins. The allowlist machinery otherwise stays because a future signed pack
+can raise a new ``on_unknown: NEEDS_INPUT`` rule on an unaskable fact, and
+the guilt tests below keep every branch of it exercised against a
+fabricated row.
 
 WHAT THIS CENSUS DOES NOT SEE — read the numbers with these two bounds, both
 raised by independent review on 2026-09-06 (codex) and both PRE-EXISTING, not
-introduced by this PR:
+introduced by this PR. Both bounds and the two measurements below them
+(**51**, **10/15/36**, **21/35/5**) were taken on the pre-PR-5, 61-walk
+corpus — PR-5 adds no disclosure-flag interaction of its own to replay, and
+none of its 6 new walks carries a disclosure flag either, so the bound's
+shape is unchanged; only the raw SUPPORTED_CANDIDATES/NEEDS_INPUT counts
+below move, per the invariant section above:
 
 1. **Disclosure flags are not carried, so this file proves LESS than it
    looks like it proves.** A fixture stores a walk's ``facts`` only, so every
@@ -100,9 +137,11 @@ introduced by this PR:
      what ``work_role`` did, and it is why the E23 claim in this PR rests on
      a separate replay rather than on this table.
 
-   What IS sound as stated: "0 NEEDS_INPUT", the allowlist invariant and the
-   candidate lists. A review flag can only LOWER a result to
-   HUMAN_REVIEW_REQUIRED; it cannot create a missing fact.
+   What IS sound as stated: the allowlist invariant (conditional, since
+   PR-5, on the two named rows below — never unconditionally "0
+   NEEDS_INPUT" again) and the candidate lists. A review flag can only
+   LOWER a result to HUMAN_REVIEW_REQUIRED; it cannot create a missing
+   fact.
 
    MEASURED by this seat, 2026-09-07, replaying this same corpus through
    ``evaluator.evaluate`` + ``apply_public_policy_adapters`` with
@@ -196,12 +235,13 @@ class DeadEnd:
     why_unaskable: str
 
 
-#: EMPTY, and that is the whole point of PR-3: the invariant below is now
-#: unconditional. A row here says "this walk may end NEEDS_INPUT on this fact
-#: because the funnel genuinely cannot ask for it"; there is no longer a walk
-#: for which that is true.
+#: Was EMPTY between PR-3 and PR-5: the invariant below was UNCONDITIONAL for
+#: that stretch. A row here says "this walk may end NEEDS_INPUT on this fact
+#: because the funnel genuinely cannot ask for it" — PR-5 is the first PR
+#: since PR-3 for which that is true again, on exactly 2 walks.
 #:
-#: The wave retired every shape by CURING it, never by loosening a count:
+#: History (every shape before PR-5 was retired by CURING it, never by
+#: loosening a count):
 #:
 #: - seq-20's fold: `family.sponsor_status_code` (its eight rules made
 #:   NO_EFFECT) and `intent.requested_product_code` (the four BRIDGING rules
@@ -210,14 +250,41 @@ class DeadEnd:
 #:   `investment.{investment,paid_up}_capital_idr` (2 rows, always paired) and
 #:   `sponsor.type` (1 row) — each raised on behalf of a product that could
 #:   not cover the walk's declared purposes under ANY fact resolution.
-#: - THIS PR: `family.sponsor_confirmed` (9 rows) by adding
+#: - PR-3: `family.sponsor_confirmed` (9 rows) by adding
 #:   `family_sponsor_confirmed` to the `invest` and `other` branches, and
 #:   `intent.purposes` (2 rows) by giving the `diaspora` tile the `FAMILY`
 #:   purpose instead of `unknownFact(NOT_APPLICABLE)`.
+#: - THIS PR (PR-5): `family.sponsor_confirmed` (2 rows) on
+#:   `offshore/retirement/property/age64` and
+#:   `offshore/retirement/undecided/age64` — the age-64 walks are the first
+#:   to clear `hf.e33e.age-below-55` / `hf.e33f.age-below-55` and exercise
+#:   `el.e33e.retirement` / `el.e33f.retirement` on the facts, and neither the
+#:   `property` nor the `undecided` retirement branch (`flow.ts`,
+#:   `getCategoryQuestionIds`) ever asks `family_sponsor_confirmed` — only the
+#:   `passive_income` and `family_sponsor` bases do. Curing that (making
+#:   `property`/`undecided` ask it too) is a follow-up, not this PR: it would
+#:   also rewrite the *young* `offshore/retirement/property` fixture pinned by
+#:   `test_the_retirement_walk_merges_age_below_55_keeping_both_rules_and_both_refs`.
 #:
 #: Never add a row without an anchor showing the fact is genuinely unaskable
-#: in that walk — and prefer curing it, which is what every row above became.
-WALK_DEAD_END_ALLOWLIST: dict[str, tuple[DeadEnd, ...]] = {}
+#: in that walk — and prefer curing it, which is what every row before THIS
+#: PR became.
+WALK_DEAD_END_ALLOWLIST: dict[str, tuple[DeadEnd, ...]] = {
+    "offshore/retirement/property/age64": (
+        DeadEnd(
+            fact="family.sponsor_confirmed",
+            source_question="family_sponsor_confirmed",
+            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
+        ),
+    ),
+    "offshore/retirement/undecided/age64": (
+        DeadEnd(
+            fact="family.sponsor_confirmed",
+            source_question="family_sponsor_confirmed",
+            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
+        ),
+    ),
+}
 
 #: Per-walk outcome pin: state plus the candidate products, in rank order.
 #: Candidates are pinned too — a pack edit that adds or drops a product for a
@@ -263,10 +330,15 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "offshore/other": ("SUPPORTED_CANDIDATES", ("C6",)),
     "offshore/remote": ("NO_SUPPORTED_PATH", ()),
     "offshore/retirement/bank_deposit": ("NO_SUPPORTED_PATH", ()),
+    "offshore/retirement/bank_deposit/age64": ("SUPPORTED_CANDIDATES", ("E33E",)),
     "offshore/retirement/family_sponsor": ("NO_SUPPORTED_PATH", ()),
+    "offshore/retirement/family_sponsor/age64": ("SUPPORTED_CANDIDATES", ("E33F",)),
     "offshore/retirement/passive_income": ("NO_SUPPORTED_PATH", ()),
+    "offshore/retirement/passive_income/age64": ("SUPPORTED_CANDIDATES", ("E33F",)),
     "offshore/retirement/property": ("NO_SUPPORTED_PATH", ()),
+    "offshore/retirement/property/age64": ("NEEDS_INPUT", ()),
     "offshore/retirement/undecided": ("NO_SUPPORTED_PATH", ()),
+    "offshore/retirement/undecided/age64": ("NEEDS_INPUT", ()),
     "offshore/second_home/bank_deposit": ("SUPPORTED_CANDIDATES", ("E33",)),
     "offshore/second_home/property": ("SUPPORTED_CANDIDATES", ("E33",)),
     "offshore/study": ("SUPPORTED_CANDIDATES", ("E30", "E30A")),
@@ -281,6 +353,7 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "onshore/other": ("SUPPORTED_CANDIDATES", ("C6",)),
     "onshore/remote": ("NO_SUPPORTED_PATH", ()),
     "onshore/retirement": ("NO_SUPPORTED_PATH", ()),
+    "onshore/retirement/age64": ("SUPPORTED_CANDIDATES", ("E33E",)),
     "onshore/second_home": ("SUPPORTED_CANDIDATES", ("E33",)),
     "onshore/study": ("SUPPORTED_CANDIDATES", ("E30", "E30A")),
     "onshore/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
@@ -294,11 +367,17 @@ EXPECTED_STATE_CENSUS: dict[str, int] = dict(
     Counter(state for state, _ in EXPECTED_OUTCOME.values())
 )
 
-#: Which fact blocks how many walks — the §2.2 table, now EMPTY. A cure that
-#: moves walks between blocking facts instead of removing the block goes red
-#: here even if the total happens to stay the same, and so does the first fact
-#: that starts blocking again.
-EXPECTED_DEAD_END_FACT_CENSUS: dict[str, int] = {}
+#: Which fact blocks how many walks — the §2.2 table, EMPTY between PR-3 and
+#: PR-5. A cure that moves walks between blocking facts instead of removing
+#: the block goes red here even if the total happens to stay the same, and so
+#: does the first fact that starts blocking again — which is exactly what
+#: THIS PR does: 2 age-64 retirement walks (`property`, `undecided`) block on
+#: `family.sponsor_confirmed`, the same fact PR-3 retired for 9 OTHER walks by
+#: adding the question to the `invest`/`other` branches (see
+#: `WALK_DEAD_END_ALLOWLIST` above) — this pack's rules still ask for it, the
+#: `retirement` branch just doesn't route these two bases to the question
+#: that supplies it.
+EXPECTED_DEAD_END_FACT_CENSUS: dict[str, int] = {"family.sponsor_confirmed": 2}
 
 
 def _load_walks() -> dict[str, dict[str, Any]]:
@@ -474,18 +553,19 @@ def outcomes(walks: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return _evaluate_walks(walks)
 
 
-def test_corpus_is_the_61_real_interview_walks(walks: dict[str, dict[str, Any]]) -> None:
+def test_corpus_is_the_67_real_interview_walks(walks: dict[str, dict[str, Any]]) -> None:
     """An empty or shrunken corpus fails loudly: a census that passes because
     nobody fed it any walks is the green-but-dead shape (cicatrix #2).
 
-    43 before this PR. The 18 new walks are the branches the interview gained:
-    `second_home` × 2 bases offshore + 1 onshore, `STEPCHILD` × 2 sponsor
-    nationalities on the family tile, and the `diaspora` tile crossed like the
-    family one (7 relations × 2 nationalities) now that
-    `getCategoryQuestionIds` serves it the same sequence — 14 walks replacing
-    the single neutral `offshore/diaspora`, which is DELETED, not renamed."""
+    43 before PR-3, 61 before THIS PR. PR-5's 6 new walks are the 5 offshore
+    `retirement` bases plus the onshore neutral `retirement` walk, each
+    replayed with `birth_date` overridden to `RETIREMENT_AGE_64_BIRTH_DATE`
+    (age 64 on `CORPUS_TODAY`) instead of the corpus-wide default 25 — the
+    generator's own age dimension, not a new tree branch. Every OTHER walk in
+    the corpus is unchanged, byte-for-byte, because `birth_date` is a spine
+    question no branch reads."""
 
-    assert len(walks) == 61, f"expected 61 interview walks, found {len(walks)}"
+    assert len(walks) == 67, f"expected 67 interview walks, found {len(walks)}"
     assert sorted(walks) == sorted(EXPECTED_OUTCOME), "corpus and EXPECTED_OUTCOME disagree"
     for label, spec in walks.items():
         assert spec["asked"], f"{label}: walk carries no asked-question history"
@@ -497,7 +577,7 @@ def test_every_walk_ends_in_its_pinned_outcome(outcomes: dict[str, dict[str, Any
     assert not violations, "interview-walk outcomes moved:\n  " + "\n  ".join(violations)
 
 
-def test_walk_state_census_is_0_dead_ends_10_no_paths_and_51_answers(
+def test_walk_state_census_is_2_dead_ends_10_no_paths_and_55_answers(
     outcomes: dict[str, dict[str, Any]],
 ) -> None:
     """The headline number of the decisiveness wave. Every PR that changes it
@@ -505,14 +585,20 @@ def test_walk_state_census_is_0_dead_ends_10_no_paths_and_51_answers(
 
     36/0/7 on seq-19; 21/0/22 once the signed seq-20 bundle's stay-day
     widening landed; 11/10/22 with PR-2's reorder on top; 0/10/51 over a
-    43 → 61 corpus with this PR's interview (module docstring)."""
+    43 → 61 corpus with PR-3's interview; 2/10/55 over a 61 → 67 corpus with
+    THIS PR's age dimension on top (module docstring). The 2 NEEDS_INPUT are
+    new walks, not moved ones: `offshore/retirement/property/age64` and
+    `offshore/retirement/undecided/age64`, both allowlisted above."""
 
     census = dict(Counter(outcome["state"] for outcome in outcomes.values()))
-    assert census == EXPECTED_STATE_CENSUS == {"NO_SUPPORTED_PATH": 10, "SUPPORTED_CANDIDATES": 51}
-    # Stated as an absence, not as a zero count, because `Counter` simply omits
-    # a state nobody reached: the dead end is gone from the census, not merely
-    # rare. The invariant test below says the same thing from the other side.
-    assert "NEEDS_INPUT" not in census
+    assert census == EXPECTED_STATE_CENSUS == {
+        "NEEDS_INPUT": 2,
+        "NO_SUPPORTED_PATH": 10,
+        "SUPPORTED_CANDIDATES": 55,
+    }
+    # No longer stated as an absence: THIS PR is the one that puts NEEDS_INPUT
+    # back in the census, on exactly the 2 walks the allowlist above names.
+    assert census["NEEDS_INPUT"] == 2
     # NOT a claim about production. The corpus carries no disclosure flags, so
     # the review arm of `apply_public_policy_adapters` is unreachable from
     # here by construction: this line says the FIXTURES trigger no review, and
@@ -520,8 +606,8 @@ def test_walk_state_census_is_0_dead_ends_10_no_paths_and_51_answers(
     # the module docstring, with the measurement.
     assert census.get("HUMAN_REVIEW_REQUIRED", 0) == 0
     # The 10 NO_SUPPORTED_PATH walks are PR-2's, unmoved: this PR only ever
-    # supplies facts the interview was already refusing to ask for, and no
-    # supplied fact turned an answer back into a no-path.
+    # adds NEW walks that either answer or dead-end, and no existing walk's
+    # state changed.
     assert census["NO_SUPPORTED_PATH"] == 10
 
 
@@ -627,14 +713,32 @@ def test_no_walk_dead_ends_outside_the_allowlist(outcomes: dict[str, dict[str, A
     assert not violations, "walk-census invariant broken:\n  " + "\n  ".join(violations)
 
 
-def test_allowlist_is_empty_so_the_invariant_is_unconditional() -> None:
-    """The strongest form this table can take, and PR-3's deliverable.
+def test_allowlist_has_exactly_the_two_age64_rows_so_the_invariant_is_conditional_again() -> None:
+    """PR-3's deliverable — ``len(...) == 0``, the strongest form this table
+    can take — held for exactly one wave. THIS PR is the one that reopens it.
 
-    Was ``len(...) == 11`` before this PR. An equality against ``{}`` is not a
-    loosened count: it is the count that admits nothing, and any future row —
-    however well argued — has to move this literal in the PR that adds it."""
+    The invariant is no longer unconditional: it now reads "no walk may end
+    NEEDS_INPUT on a fact for which the interview has no reachable question
+    in that walk's own history, OR the walk is one of these 2 named rows,
+    each checked against its own `asked` history below." That is a WEAKER
+    claim than PR-3 shipped, on purpose — `offshore/retirement/property/age64`
+    and `offshore/retirement/undecided/age64` are the first walks able to
+    clear `hf.e33e.age-below-55` / `hf.e33f.age-below-55` and reach
+    `el.e33e.retirement` / `el.e33f.retirement` on the facts, and neither
+    retirement sub-branch asks `family_sponsor_confirmed`. Curing `flow.ts` so
+    they do would restore `len(...) == 0`, but it is a second concern (see
+    `WALK_DEAD_END_ALLOWLIST`'s module-level comment) and not this PR's.
 
-    assert WALK_DEAD_END_ALLOWLIST == {}
+    An equality against a named 2-row dict is still not a loosened count in
+    the sense PR-3 warned about: it names both rows explicitly, and any
+    THIRD row — however well argued — still has to move this literal in the
+    PR that adds it."""
+
+    assert set(WALK_DEAD_END_ALLOWLIST) == {
+        "offshore/retirement/property/age64",
+        "offshore/retirement/undecided/age64",
+    }
+    assert len(WALK_DEAD_END_ALLOWLIST) == 2
 
 
 def _unaskable_violations(
@@ -793,7 +897,7 @@ def test_guilt_withdrawing_the_newly_asked_fact_restores_the_dead_end(
 def test_guilt_a_walk_that_loses_its_answer_is_caught(
     walks: dict[str, dict[str, Any]],
 ) -> None:
-    """GUILT: ``offshore/work`` is one of the 51 walks that DO answer (E23).
+    """GUILT: ``offshore/work`` is one of the 55 walks that DO answer (E23).
     Take its ``work.indonesian_work_sponsor_confirmed`` away and the outcome
     pin must fire.
 
@@ -834,7 +938,7 @@ def test_guilt_a_dead_end_on_an_unlisted_fact_is_caught() -> None:
     produce — is a violation, and stays one when the allowlist is EMPTY, which
     is no longer a hypothetical: it is the live table this PR ships."""
 
-    # `offshore/work` is one of the 51 ANSWERING walks, so it carries no
+    # `offshore/work` is one of the 55 ANSWERING walks, so it carries no
     # allowlist row — which is exactly the branch under test here.
     fabricated = {
         "offshore/work": {

--- a/apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts
+++ b/apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts
@@ -15,7 +15,11 @@
  * (`invest` × 6 vehicles, `retirement` × 5 bases, `second_home` × 2 bases,
  * and — because `getCategoryQuestionIds` now serves `familyQuestionIds`
  * VERBATIM on both tiles — `family` AND `diaspora`, each × 7 relations × 2
- * sponsor nationalities), plus the three `holds_stay_permit = yes` walks.
+ * sponsor nationalities), plus the three `holds_stay_permit = yes` walks,
+ * plus 6 more `retirement` walks (the 5 offshore bases + the one onshore
+ * neutral walk) re-run at `RETIREMENT_AGE_64_BIRTH_DATE` — every other walk
+ * still applies at `YOUNG_APPLICANT_BIRTH_DATE`, since `birth_date` is a
+ * spine question no branch reads (see `answerFor`).
  *
  * Diaspora is crossed rather than sampled once because its wire facts are
  * NOT a copy of the family arm's: `mapDisclosureFlags` adds
@@ -69,6 +73,25 @@ export const CORPUS_TODAY = new Date("2026-09-06T00:00:00Z");
 /** Fixed synthetic assessment id — the mapper needs one and never emits it. */
 const ASSESSMENT_ID = "x";
 
+/**
+ * The synthetic identity's birth date for every walk except the age-64
+ * retirement variants below: 25 on `CORPUS_TODAY`, comfortably clear of
+ * every age-gated rule in the pack.
+ */
+const YOUNG_APPLICANT_BIRTH_DATE = "2000-11-11";
+
+/**
+ * Birth date for the 6 age-64 retirement walks. `_derive_age_years`
+ * (`fact_registry.py`) is birthday-inclusive against `effective_at`; both
+ * `CORPUS_TODAY` and the highest signed pack's `signed_at` land on
+ * 2026-09-06, so this clears the `hf.e33e.age-below-55` /
+ * `hf.e33f.age-below-55` floor with margin while staying deliberately OUTSIDE
+ * `el.e33e.age-55-59-disputed-band` (55-59) — that band carries its own
+ * reason code and its own legal claim, and deserves a walk of its own rather
+ * than a silent absorption into this one.
+ */
+const RETIREMENT_AGE_64_BIRTH_DATE = "1961-11-11";
+
 /** Runaway guard: no real walk is anywhere near this long. */
 const MAX_STEPS = 200;
 
@@ -99,7 +122,7 @@ export function answerFor(
   const question = QUESTIONS[id];
   if (!question) throw new Error(`unknown question ${id}`);
   if (question.kind === "date") {
-    return id === "birth_date" ? "2000-11-11" : "2026-12-31";
+    return id === "birth_date" ? YOUNG_APPLICANT_BIRTH_DATE : "2026-12-31";
   }
   if (question.kind === "number") {
     if (id === "overstay_days") return "0";
@@ -191,6 +214,21 @@ export function enumerateScenarios(): Scenario[] {
           overrides: { ...base, retirement_basis: basis },
         });
       }
+      // Age dimension (owner mandate, 2026-09-07): the same 5 bases, replayed
+      // at RETIREMENT_AGE_64_BIRTH_DATE. `AGE_BELOW_55` excluded E33E/E33F on
+      // every walk above regardless of basis, so those 5 never exercised
+      // either product's actual eligibility rule — E33E and E33F were never
+      // exercised at an age that clears the hard filter.
+      for (const basis of RETIREMENT_BASES) {
+        scenarios.push({
+          label: `offshore/${category}/${basis}/age64`,
+          overrides: {
+            ...base,
+            retirement_basis: basis,
+            birth_date: RETIREMENT_AGE_64_BIRTH_DATE,
+          },
+        });
+      }
     } else if (category === "second_home") {
       for (const basis of SECOND_HOME_BASES) {
         scenarios.push({
@@ -226,6 +264,20 @@ export function enumerateScenarios(): Scenario[] {
         category,
       },
     });
+    // Age dimension (owner mandate, 2026-09-07): the onshore retirement walk
+    // gets its own age-64 sibling too, same reasoning as the offshore loop
+    // above.
+    if (category === "retirement") {
+      scenarios.push({
+        label: `onshore/${category}/age64`,
+        overrides: {
+          in_indonesia: "yes",
+          holds_stay_permit: "no",
+          category,
+          birth_date: RETIREMENT_AGE_64_BIRTH_DATE,
+        },
+      });
+    }
   }
 
   // The three walks that already hold a stay permit: expired vs current,

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/walk-corpus-determinism.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/walk-corpus-determinism.test.ts
@@ -30,12 +30,16 @@ import {
   writeWalkCorpus,
 } from "../../../../../scripts/visa-oracle/generate-walk-corpus";
 
-/** The corpus size as committed. A PR that adds an interview branch moves it.
+/** The corpus size as committed. A PR that adds an interview branch — or, as
+ * of PR-5, a new DIMENSION replayed over existing branches — moves it.
  * 43 → 61 on 2026-09-06: `second_home` (2 offshore bases + 1 onshore),
  * `STEPCHILD` (×2 sponsor nationalities), and `diaspora` crossed like the
  * family tile now that it serves the same question sequence (14 walks
- * replacing one). */
-const EXPECTED_WALK_COUNT = 61;
+ * replacing one). 61 → 67 on PR-5 (2026-09-07): the 5 offshore `retirement`
+ * bases plus the onshore neutral `retirement` walk, each replayed a second
+ * time at `RETIREMENT_AGE_64_BIRTH_DATE` (age 64) instead of the corpus-wide
+ * default 25 — no new tree branch, the same 6 walks answered twice. */
+const EXPECTED_WALK_COUNT = 67;
 
 function jsonFilesIn(dir: string): string[] {
   return readdirSync(dir)


### PR DESCRIPTION
## Summary
- Every interview-walk-corpus fixture answered `birth_date` with the same 2000-11-11 identity, so all 6 `retirement` walks were excluded by `hf.e33e.age-below-55` / `hf.e33f.age-below-55` before either product's own eligibility rule (`el.e33e.retirement`, `el.e33f.retirement`) was ever exercised on the facts. Measured in production 2026-09-07: 6 of 10 `NO_SUPPORTED_PATH` walks carried `AGE_BELOW_55` as their only reason, and E33E/E33F were never reached by any retirement walk in the corpus.
- `generate-walk-corpus.ts` hoists two named birth-date constants (`YOUNG_APPLICANT_BIRTH_DATE`, `RETIREMENT_AGE_64_BIRTH_DATE`) and adds 6 walks — the 5 offshore retirement bases plus the onshore neutral walk — replayed at age 64 through the existing `overrides` mechanism (`answerFor` already honors `overrides[id]` first, no new plumbing). `1961-11-11` clears the age-55 floor with margin while staying deliberately OUTSIDE `el.e33e.age-55-59-disputed-band`, which carries its own reason code and legal claim and deserves a walk of its own. Corpus 61 → 67.
- 4 of the 6 new walks reach `SUPPORTED_CANDIDATES` (E33E on `bank_deposit`/onshore, E33F on `passive_income`/`family_sponsor`). The other 2 (`property`, `undecided`) end `NEEDS_INPUT` on `family.sponsor_confirmed` — an honest dead end, since neither retirement sub-branch asks that question (only `passive_income`/`family_sponsor` do), not a defect this PR cures. `WALK_DEAD_END_ALLOWLIST` gains exactly those 2 rows, each checked against its own `asked` history; the invariant it arms goes from unconditional back to conditional on these two named facts, stated explicitly in the module docstring. Census: 0/10/51 → 2/10/55.
- All 61 pre-existing walks are byte-identical (`birth_date` is a spine question no branch reads) — `git diff` touches only the generator, the census test, and 6 new fixture files.

## Verification
- `pytest backend/tests/services/visa_engine/test_interview_walk_census.py` — 15/15 green with the new 2/10/55 census.
- `pytest backend/tests/services/visa_engine/` (full visa_engine suite) — same pass/fail set as before this change; the only failures/errors present are pre-existing DB/migration infra issues unrelated to this diff (verified independent of this PR).
- Measured against **production** (`POST https://nuzantara-rag.fly.dev/api/visa-oracle/evaluate?traffic_source=real`) for all 6 new walks: `bank_deposit`/`onshore` → `SUPPORTED_CANDIDATES [E33E]`, `passive_income`/`family_sponsor` → `SUPPORTED_CANDIDATES [E33F]`, `property`/`undecided` → `NEEDS_INPUT` with `missing_facts: ["family.sponsor_confirmed"]`. None carry `AGE_BELOW_55` any more.
- `git diff --stat` against `origin/main`: exactly 8 files (generator, census test, 6 new fixtures) — no other fixture, no pack, no engine file touched.
- Evidence-pack floor: 1 (below the 2 threshold) — no brief/pack required.

## Follow-up (explicitly out of scope for this PR)
Curing `flow.ts` so `retirement/property` and `retirement/undecided` also ask `family_sponsor_confirmed` would restore the unconditional dead-end invariant, but it would also rewrite the *young* `offshore/retirement/property` fixture pinned by `test_the_retirement_walk_merges_age_below_55_keeping_both_rules_and_both_refs`. Left as a named follow-up per the module docstring.

Bites: `test_interview_walk_census.py`'s own census (15/15 green with the new 2/10/55 numbers) and the production evaluate endpoint, which now returns E33E/E33F for these 6 walks instead of AGE_BELOW_55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K49cJhM7o89sKffgK8pU1Y