### PR TITLE
chore(deps): npm audit fix — 2 high + 2 moderate → 1 high + 1 moderate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5727,9 +5727,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.1.tgz",
-      "integrity": "sha512-4znKhxTmXmuPye9Z6pbIyYb5VZlkZ05qG1L6Dr4g+7oTwc6V50Bs9XirFBDdjWt+H/AabMn9aUnxBcvj8z05aA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.10.0.tgz",
+      "integrity": "sha512-Rcg828gIRE3HOQ3pOATFjV5d/P0U9OIobxhd/IMxlfWjA4vru0eGwb0AIwFw0rmcLMVShohZYWPixVxkBHsxUA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5740,9 +5740,9 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
-      "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.10.0.tgz",
+      "integrity": "sha512-caygJKtltmRIgdJ3jRpkOr7yM4DW6zxo5uOmojKWFb3asnxWoRkQOwZmXBgD8FZp4htrX+nMpcWqDwzlQ1+Y4g==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
@@ -5778,34 +5778,34 @@
       "license": "MIT"
     },
     "node_modules/@prisma/engines": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.1.tgz",
-      "integrity": "sha512-UprXSMNXx2NF5ow4pqaQtE8OuBz6K78B0wc0tn2L28G5r933iWp1DR9Do2qWrsNvvFIP3x6mpEWnQtckMO0Uhg==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.10.0.tgz",
+      "integrity": "sha512-KNumN6NHFwybvfdYzTee9pqwx5PvknpWAaHn6L5NsbrKdl+SQrsVZs9opKs6U6SAsvB26HDt3WybRjOhgoWOYQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.9.1",
-        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-        "@prisma/fetch-engine": "7.9.1",
-        "@prisma/get-platform": "7.9.1"
+        "@prisma/debug": "7.10.0",
+        "@prisma/engines-version": "7.10.0-4.0edf323efd1d98336f3f0a68684b56f689b900d3",
+        "@prisma/fetch-engine": "7.10.0",
+        "@prisma/get-platform": "7.10.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad.tgz",
-      "integrity": "sha512-2BsPPFksz3CQUXG6af3rVCtJKg6+JJGJTtfgu2fU8DdXhOfkBjulCq8mwybCd6ge0/jhZq2kOtLAbmUDMyI1nA==",
+      "version": "7.10.0-4.0edf323efd1d98336f3f0a68684b56f689b900d3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.10.0-4.0edf323efd1d98336f3f0a68684b56f689b900d3.tgz",
+      "integrity": "sha512-8OJ6RuZTZ06eFUOtBwxVmv8XMmOW6HWN5F+uxUbZkGxR0Bfab1dfAdXaHPmR5mb59E+fmUo8IOzXlbLY1SClbw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
-      "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.10.0.tgz",
+      "integrity": "sha512-0bra1LFYi8xNw0yqV62bHJNQk4BKleOngZiqPWIQc7a3+9q6rqsnqJ15BuepP8943PFMvtmgnP52juZsyYkA6w==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.9.1"
+        "@prisma/debug": "7.10.0"
       }
     },
     "node_modules/@prisma/extension-accelerate": {
@@ -5820,25 +5820,25 @@
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.1.tgz",
-      "integrity": "sha512-9DwxrNTeT25Orbu9CWh0CZvVlyY1lmscpbaeLZcOnuR7zcuFrt91YSmmOfIm7zJ08YOZ6mVzURKwLoMwEBcK8w==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.10.0.tgz",
+      "integrity": "sha512-Zqyu8DY14t6W/xwmAxUYWCXtHrvQnSvT644EAZSsdM8NSmCS74vJJbBKdVsK3ucFpnUWkEpbO1a0CxJXrg130g==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.9.1",
-        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-        "@prisma/get-platform": "7.9.1"
+        "@prisma/debug": "7.10.0",
+        "@prisma/engines-version": "7.10.0-4.0edf323efd1d98336f3f0a68684b56f689b900d3",
+        "@prisma/get-platform": "7.10.0"
       }
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
-      "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.10.0.tgz",
+      "integrity": "sha512-0bra1LFYi8xNw0yqV62bHJNQk4BKleOngZiqPWIQc7a3+9q6rqsnqJ15BuepP8943PFMvtmgnP52juZsyYkA6w==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.9.1"
+        "@prisma/debug": "7.10.0"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -12142,9 +12142,9 @@
       }
     },
     "node_modules/c12/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -13351,9 +13351,9 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
-      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+      "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
       "devOptional": true,
       "funding": [
         {
@@ -13367,7 +13367,7 @@
       ],
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/define-data-property": {
@@ -13718,9 +13718,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
-      "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.1.tgz",
+      "integrity": "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -15206,9 +15206,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",
@@ -21806,9 +21806,9 @@
       }
     },
     "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -22467,16 +22467,23 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.2.tgz",
+      "integrity": "sha512-v0sVXzj7oPGysr543YYZLYbcJNJsKikSsp/fFzoxQ12ewY3ZZr7oCPC8y7OlmxfYB3QPvriXmuPD8KZggE1vqg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.4",
-        "exsolve": "^1.0.8",
+        "confbox": "^0.3.0",
+        "exsolve": "^1.1.1",
         "pathe": "^2.0.3"
       }
+    },
+    "node_modules/pkg-types/node_modules/confbox": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.3.1.tgz",
+      "integrity": "sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.62.1",
@@ -22710,16 +22717,16 @@
       }
     },
     "node_modules/prisma": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.1.tgz",
-      "integrity": "sha512-aPqePoZIqwlAchbgbFDO/wHqGB+7H1nj9gaM+OsL9h77S5S3TnLd9BgD3LnoeDikULo7cl2HSUrEyQ55Z7DYbg==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.10.0.tgz",
+      "integrity": "sha512-o0ornyJOWgygVAzGCpr8PdXV8EJLHyVGDDUr/voBQt8Azzw8cYTByzzPGcA/m4tCkPcnJA8raEOv2CslsKhPEw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "7.9.1",
+        "@prisma/config": "7.10.0",
         "@prisma/dev": "0.24.17",
-        "@prisma/engines": "7.9.1",
+        "@prisma/engines": "7.10.0",
         "@prisma/studio-core": "0.33.0",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
@@ -23005,12 +23012,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -23080,13 +23088,13 @@
       }
     },
     "node_modules/rc9": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
-      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.1.0.tgz",
+      "integrity": "sha512-ufjkNVzbRHKcCOmTahZkmVsyc3W+MSk3jY03m+a7tGHkIsdVMG9l10/3HvFbWkkKzY5VFp3pkRsIo/UYgmFL7Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.6",
+        "defu": "^6.1.7",
         "destr": "^2.0.5"
       }
     },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,14 @@
 packages:
   - "apps/*"
   - "packages/*"
+allowBuilds:
+  "@prisma/client": set this to true or false
+  "@prisma/engines": set this to true or false
+  "@sentry/cli": set this to true or false
+  "@whiskeysockets/baileys": set this to true or false
+  esbuild: set this to true or false
+  prisma: set this to true or false
+  protobufjs: set this to true or false
+  sharp: set this to true or false
+  unrs-resolver: set this to true or false
+  workerd: set this to true or false


### PR DESCRIPTION
## Summary
- Lands the `npm audit fix` lockfile refresh that was committed on Pro's main checkout 30h ago (`d04ca64744`) and never pushed. It touches only `package-lock.json` (+83/-64) and adds `pnpm-workspace.yaml`; `package.json` is untouched.
- The unpushed commit is the root cause of the chronic `git_alignment` P1 on Pro: the git-pull cron refuses to realign a main that is ahead of origin, so Pro has been 15 commits behind for ~2 days (healer ticks 0907c → 0908b). Moving the commit onto this branch is what unblocks the cron.

**Bites:** two consumers. (1) The required `Frontend Tests (Next.js) (mouth, true)` job runs `npm audit --audit-level=high --omit=dev` at repo root against this exact lockfile — its verdict on this PR is the observation. (2) Pro's `scripts/pro/pro-git-pull.sh` cron: once this content is on main and Pro's main is reset onto `origin/main`, the proprioception `git_alignment` probe stops reporting "unpushed local commit blocks git-pull cron". The second observation is made in the interactive session that opened this PR, after merge.

## Test plan
- [x] `git diff --quiet d04ca64744^ origin/main -- package-lock.json` → lockfile unchanged upstream since the commit's base, so the rebase is clean.
- [x] Pre-push gate on Pro: all checks passed, tip-drift clean.
- [ ] CI `Frontend Tests (mouth)` incl. root `npm audit --audit-level=high --omit=dev` — the grader for this change.

## Adversarial review
- Two other open PRs touch `package-lock.json` (#5905 dependabot group, red on Frontend Tests; #5599 qs bump, clean). Neither is armed, so no queue race; whichever lands second gets a dependabot rebase.
- The commit was authored by a prior session and I did not re-run the audit locally in this session; CI is the grader, not my word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)