### PR TITLE
chore(regulatory): promote 2026-09-04 delta — no new regs, hukumonline 403

### DIFF
--- a/research/regulatory/2026-09-04-delta.json
+++ b/research/regulatory/2026-09-04-delta.json
@@ -1,0 +1,100 @@
+{
+  "run_at": "2026-09-04T07:15:00+08:00",
+  "today": "2026-09-04",
+  "yesterday_seen_count": 24,
+  "yesterday_file_used": "2026-09-03-delta.json",
+  "new_today_count": 0,
+  "partial": false,
+  "unreachable_sources": [
+    {
+      "url": "https://www.hukumonline.com/berita/",
+      "reason": "http_403",
+      "note": "WAF/Cloudflare challenge (HTTP 403), persisted after 1 retry with Mozilla UA"
+    },
+    {
+      "url": "https://ortax.org/news",
+      "reason": "empty_shell",
+      "note": "HTTP 200 but body is soft-404 'Artikel tidak ditemukan'"
+    },
+    {
+      "url": "https://ikpi.or.id/berita/",
+      "reason": "empty_shell",
+      "note": "HTTP 200 client-side SPA shell ('Memuat artikel perpajakan...'), no static entries"
+    },
+    {
+      "url": "https://jdih.kemenkeu.go.id/peraturan",
+      "reason": "empty_shell",
+      "note": "Next.js client-side SPA shell, no pre-rendered regulation entries in static HTML"
+    },
+    {
+      "url": "https://jdih.kemenkumham.go.id",
+      "reason": "timeout",
+      "note": "Domain unreachable / DNS resolution failed"
+    }
+  ],
+  "sources_checked_no_delta": [
+    {
+      "url": "https://news.ddtc.co.id/",
+      "reason": "checked_no_new",
+      "note": "Newest regulatory articles cover PMK 55/2026 (already in seen_citations) and general tax news"
+    },
+    {
+      "url": "https://muc.co.id/article",
+      "reason": "checked_no_new",
+      "note": "Newest article on macro RAPBN 2027 discussion, no new regulation citations in 48h window"
+    },
+    {
+      "url": "https://peraturan.go.id",
+      "reason": "outside_window",
+      "note": "Newest entries predate 48h window"
+    },
+    {
+      "url": "https://peraturan.bpk.go.id/Search?type=PerundangUndangan&jenis=PMK&tahun=2026",
+      "reason": "checked_no_new",
+      "note": "Search returned zero new PMK entries in 48h window"
+    },
+    {
+      "url": "https://www.imigrasi.go.id",
+      "reason": "checked_no_new",
+      "note": "Newest items are general immigration info/releases, no new visa regulation in 48h window"
+    },
+    {
+      "url": "https://www.pajak.go.id/peraturan",
+      "reason": "outside_window",
+      "note": "Newest filtered entry PER-8/PJ/2026 predates 48h window"
+    },
+    {
+      "url": "https://jdih.kemnaker.go.id/peraturan",
+      "reason": "checked_no_new",
+      "note": "Newest visible entry UU Nomor 2 Tahun 2026; no Permenaker in 48h window"
+    }
+  ],
+  "nb_query_errors": [],
+  "deltas": [],
+  "seen_citations": [
+    "PMK Nomor 28 Tahun 2026",
+    "PMK Nomor 40 Tahun 2026",
+    "PMK Nomor 41 Tahun 2026",
+    "PMK Nomor 42 Tahun 2026",
+    "PMK Nomor 43 Tahun 2026",
+    "PMK Nomor 44 Tahun 2026",
+    "PMK Nomor 55 Tahun 2026",
+    "PMK Nomor 57 Tahun 2026",
+    "PMK Nomor 61 Tahun 2026",
+    "PP Nomor 20 Tahun 2026",
+    "PP Nomor 24 Tahun 2026",
+    "Peraturan Direktur Jenderal Pajak Nomor PER-8/PJ/2026",
+    "Peraturan Menteri Hukum Nomor 13 Tahun 2026",
+    "Permen PMK/Badan PMI Nomor 5 Tahun 2026",
+    "Permenaker No. 12 Tahun 2026; BN 2026 (598)",
+    "Permenaker Nomor 7 Tahun 2026",
+    "Permenaker Nomor 8 Tahun 2026",
+    "Permenaker Nomor 9 Tahun 2026",
+    "Permenkes Nomor 6 Tahun 2026",
+    "Perpres Nomor 26 Tahun 2026",
+    "Perpres Nomor 27 Tahun 2026",
+    "Perpres Nomor 3 Tahun 2026",
+    "UU Nomor 4 Tahun 2026",
+    "UU Nomor 5 Tahun 2026"
+  ]
+}


### PR DESCRIPTION
## Summary
- Promotes the stranded `research/regulatory/2026-09-04-delta.json` that the regulatory-watcher wrote on Pro on 2026-09-04 but never committed. Content: 0 new regulations, 24 seen the day before, hukumonline unreachable (HTTP 403 Cloudflare challenge). 09-05, 09-06, 09-07 and 09-08 are already on main; 09-04 was the only gap.
- Byte-identical copy of the file on Pro's main checkout; no edits.

**Bites:** the proprioception `regulatory_promotion` probe on Pro, which today reports "3 not committed" — after this merge and the pending Pro main realign (see #5925), the 09-04 line disappears from that probe's output. The 09-07/09-08 local copies were superseded by #5877/#5916 and are being removed locally, not promoted.

## Test plan
- [x] `python3 -c 'import json; json.load(open("research/regulatory/2026-09-04-delta.json"))'` on the committed file — valid JSON.
- [x] Pre-commit hooks passed in the broker worktree.

## Adversarial review
- Is a 4-day-old "no new regs" delta worth landing? Yes: the daily delta chain is read by the watcher as `yesterday_file_used`, and a missing day is a gap the next reader has to explain. Nothing downstream is changed by its content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)