### PR TITLE
fix(a11y): make the /kbli search focus ring and muted text meet AA

### DIFF
--- a/apps/mouth/src/components/kbli/KBLISearch.tsx
+++ b/apps/mouth/src/components/kbli/KBLISearch.tsx
@@ -167,7 +167,7 @@ export function KBLISearch({
   return (
     <div ref={containerRef} className={cn("relative w-full", className)}>
       <div className="relative group">
-        <div className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 group-focus-within:text-zinc-300 transition-colors">
+        <div className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400 group-focus-within:text-zinc-300 transition-colors">
           {isLoading ? (
             <Loader2 className="w-5 h-5 animate-spin" />
           ) : (
@@ -184,9 +184,9 @@ export function KBLISearch({
           placeholder={placeholder}
           aria-label={placeholder || "Search KBLI"}
           className={cn(
-            "w-full pl-12 pr-10 py-4 bg-white/[0.04] backdrop-blur-xl border border-white/[0.08] rounded-2xl text-white placeholder-zinc-500",
+            "w-full pl-12 pr-10 py-4 bg-white/[0.04] backdrop-blur-xl border border-white/[0.08] rounded-2xl text-white placeholder-zinc-400",
             "shadow-[0_4px_20px_rgba(0,0,0,0.3),inset_0_1px_0_rgba(255,255,255,0.04)]",
-            "focus:outline-none focus:ring-2 focus:ring-[#dc2626]/20 focus:border-white/[0.15] transition-all text-lg",
+            "focus:outline-none focus:ring-2 focus:ring-[#dc2626] focus:border-white/[0.15] transition-all text-lg",
           )}
         />
         {query && (
@@ -278,14 +278,14 @@ export function KBLISearch({
                 </div>
                 <ChevronRight
                   className={cn(
-                    "w-4 h-4 self-center text-zinc-600",
+                    "w-4 h-4 self-center text-zinc-400",
                     index === activeIndex && "text-[#dc2626] animate-pulse",
                   )}
                 />
               </button>
             ))}
           </div>
-          <div className="p-3 bg-white/[0.02] border-t border-white/[0.06] flex justify-between items-center text-[10px] text-zinc-500 uppercase tracking-widest font-bold">
+          <div className="p-3 bg-white/[0.02] border-t border-white/[0.06] flex justify-between items-center text-[10px] text-zinc-400 uppercase tracking-widest font-bold">
             <span>{results.length} KBLI codes found</span>
             <span className="flex items-center gap-1">
               Press{" "}


### PR DESCRIPTION
fix(a11y): make the /kbli search focus ring and muted text meet AA

# Insight
The keyboard focus ring on the /kbli search input is a 20%-alpha red that
composites to 1.07:1 against the input background — WCAG 1.4.11 asks for 3.0:1.
A keyboard user has no visible focus indicator on the primary control of the page.

# Studio
## Source / Reference
apps/mouth/src/components/kbli/KBLISearch.tsx at origin/main 2d3eaf62b.
WCAG 2.x contrast formula; alpha composited onto the real underlying surface.

## Methodology
Every ratio computed from the hex values in the file, not sampled from a screenshot.
Positive control white/black = 21.00, negative control #141416/#141416 = 1.00.
Tailwind v4 hex used: zinc-400 #a1a1aa, zinc-500 #71717b, zinc-600 #52525c.

## Raw Observations
- :189 ring-[#dc2626]/20 over #141416 -> #3c1819, vs input bg #1d1d1f = 1.07:1 (need 3.0) FAIL
- :187 placeholder-zinc-500 on #1d1d1f = 3.49:1 (need 4.5) FAIL
- :170 text-zinc-500 icon on #1d1d1f = 3.49:1 FAIL as text
- :288 text-zinc-500 10px on #1c1c1f = 3.52:1 (need 4.5) FAIL
- :281 text-zinc-600 chevron on #1c1c1f = 2.20:1 (need 3.0) FAIL
- :185 the input already carries aria-label — programmatic labelling PASSES, unchanged

## Reasoning Path
zinc-500 -> zinc-400 is one existing step on a scale already in use in this file
(:221, :260, :292 use zinc-400), so it is not an invented value and it keeps the
visual hierarchy. The focus ring cannot be fixed by a scale step: alpha is the
defect, so the alpha is removed.

## Risk / Implication
Muted text becomes lighter on two surfaces. No layout, no font-size, no token,
no brand colour changes. The red badge at :253 (3.30:1) is knowingly left alone —
fixing it means changing a brand red, which is an open question, not a PR.

# Recommendation
Merge after CI. The remaining /kbli contrast failures live in page.tsx and are
held back deliberately: that file is being changed by the --kbli-ink token PR.

# Next Action
Follow-up PR for apps/mouth/src/app/kbli/page.tsx :125 and :223 (text-zinc-500 on
#141416 = 3.81:1) once the token PR has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrazjyFAUU7H6Dorbkb5ZK
