### PR TITLE
fix(hooks): orchestrate_gate counts delegation as orchestration (SendMessage fix)

### DIFF
--- a/infra/claude-hooks/orchestrate_gate.py
+++ b/infra/claude-hooks/orchestrate_gate.py
@@ -56,6 +56,19 @@ read (`is_subagent_context`, right below `GATED_TOOLS`):
 A main-session transcript with zero dispatches past the threshold keeps
 blocking exactly as before — this exemption is scoped to the two markers
 above, never to "transcript looks quiet."
+
+DELEGATION COUNTS TOO (2026-09-07, W2 hook-canon repair, defect 2). A session
+that delegates to an ALREADY-LIVE agent via `SendMessage` — no new seat, the
+correct move when a peer already exists — was penalised exactly like a
+session that delegates nothing: the counter only recognised NEW dispatches.
+Measured 2026-09-07: three real `SendMessage` delegations to a live agent,
+zero counted, hard-blocked anyway. `SendMessage` is now a DISPATCH_TOOLS
+member for the same reason `Agent` is: it is positive evidence that the
+session is orchestrating rather than doing everything itself. Known
+coarseness, inherited from the pre-existing `Agent` detector and not newly
+introduced here: neither this nor the `Agent` check verifies the delegation
+carried real work — both are "some qualifying tool fired," not a quality
+judgment.
 """
 import json
 import os
@@ -80,14 +93,18 @@ except Exception:
 HARD_BLOCK_THRESHOLD = 800
 RECENT_LINES = 300
 
-# Tool names that mean "a subagent was dispatched". `Agent` is the CURRENT
-# harness tool; `Task`/`TaskCreate` are its predecessors, kept so an older
+# Tool names that count as "this session is orchestrating, not doing
+# everything itself". `Agent` is the CURRENT harness tool for spawning a NEW
+# subagent; `Task`/`TaskCreate` are its predecessors, kept so an older
 # transcript still reads correctly. Measured 2026-08-12 on live M5 transcripts:
 # the quoted forms of Task/TaskCreate score ZERO occurrences ever, while
 # `"name":"Agent"` is what a real dispatch actually writes — this gate spent
 # an unknown stretch of its life with 4 of its 5 keywords pointing at a
-# vocabulary the harness had stopped emitting.
-DISPATCH_TOOLS = ("Agent", "Task", "TaskCreate")
+# vocabulary the harness had stopped emitting. `SendMessage` (2026-09-07,
+# defect 2 of the W2 hook-canon repair) is DELEGATION rather than a new
+# spawn — reusing a live agent instead of spawning a redundant one — and must
+# count identically; see the module docstring's DELEGATION COUNTS TOO note.
+DISPATCH_TOOLS = ("Agent", "Task", "TaskCreate", "SendMessage")
 # JSON spacing is not ours to assume: match `"name":"Agent"` and `"name": "Agent"`.
 DISPATCH_TOOL_RE = re.compile(
     r'"(?:name|tool_name)"\s*:\s*"(?:%s)"' % "|".join(DISPATCH_TOOLS)
@@ -296,7 +313,8 @@ def main():
             f"\n[ORCHESTRATE-GATE] Session {verdict['total_lines']} lines, zero subagent "
             f"dispatch in last {RECENT_LINES} lines. Direct {tool_name} BLOCKED.\n"
             f"Choose: (a) Agent(subagent_type=Explore|backend-verifier|frontend-browser|"
-            f"nb-curator|mcp-health|spalla-review|general-purpose, model=\"sonnet\", ...) "
+            f"nb-curator|mcp-health|spalla-review|general-purpose, model=\"sonnet\", ...), "
+            f"or SendMessage to an already-live agent if one exists (reusing it counts too), "
             f"or (b) `export ORCHESTRATE_GATE_OFF=1` if intentional direct work.\n"
         )
         print(msg, file=sys.stderr)

--- a/infra/claude-hooks/test_orchestrate_gate_vocab.py
+++ b/infra/claude-hooks/test_orchestrate_gate_vocab.py
@@ -110,6 +110,24 @@ def test_innocence_sidechain_marker_counts():
     assert run_gate(_transcript(['{"isSidechain":true,"role":"assistant"}'])) == 0
 
 
+def test_innocence_send_message_to_existing_agent_counts():
+    """W2 hook-canon repair, defect 2 (2026-09-07): delegating to an ALREADY-LIVE
+    agent is legitimate orchestration and must count exactly like a new Agent
+    dispatch — a session that reuses a live subagent instead of spawning a
+    redundant one was previously penalised identically to a session that
+    delegates nothing at all."""
+    text = _transcript(['{"type":"tool_use","name":"SendMessage","input":{"to":"w1-builder"}}'])
+    assert run_gate(text) == 0
+
+
+def test_guilt_send_message_older_than_the_window_still_blocks():
+    """Same recency rule as any other dispatch evidence: a delegation 400
+    lines ago does not license the next 400 lines of direct work."""
+    old = ['{"name":"SendMessage","input":{"to":"w1-builder"}}']
+    text = _transcript(old + [SHAPE] * 400)
+    assert run_gate(text) == 2
+
+
 # ── innocence: the gate must stay out of the way elsewhere ───────────────────
 
 def test_innocence_short_session_never_blocks():


### PR DESCRIPTION
## Why
The orchestrate gate counted spawns, not delegation: a session that handed work to an already-live agent via `SendMessage` — the correct move when a peer already exists, avoiding a redundant seat against the hard four-seat ceiling — was penalised identically to a session that delegated nothing.

## What
`SendMessage` joins `DISPATCH_TOOLS` (alongside `Agent`/`Task`/`TaskCreate`) in `infra/claude-hooks/orchestrate_gate.py`, through the same counting machinery. Adds vocabulary-test coverage in `infra/claude-hooks/test_orchestrate_gate_vocab.py`.

This PR carries the NET of two source commits on `agent/air-m5/ops/army-w1-assignment`:
- `abceb50d5d` added the SendMessage fix bundled with an `ORCHESTRATE_GATE_ROLE` exemption
- `761e3e9279` backed the unqualified role exemption back out (Astra refused to install the bundle) and left the SendMessage fix standing alone

The role exemption is deliberately NOT reintroduced here — it stays deferred per the source history.

## Source commits
- `abceb50d5d` fix(hooks): count delegation as orchestration; add an unspoofable role exemption
- `761e3e9279` fix(hooks): reduce the gate repair to the SendMessage fix alone

## Verification
`.venv/bin/python -m pytest infra/claude-hooks -q` → 131 passed, this turn.

`infra/guard-conformance/registry.json` is untouched here: its new `check_reviewer_independence` entry belongs to the separate evidence-pack PR (source commit `5373c5aea5`), confirmed by inspecting that commit's diff — it is not part of either hook-fix commit. No `guard-conformance` test depends on a `DISPATCH_TOOLS` vocabulary entry (checked `infra/guard-conformance/check_guard_conformance.py`).

## Bites
Consumer: the HOME hook copy at `~/.claude/hooks/orchestrate_gate.py`, realigned from repo canon by the healer after merge (scar #1, HOME-fork drift). Observation possible now: `.venv/bin/python -m pytest infra/claude-hooks/test_orchestrate_gate_vocab.py -q` passes on the exact test encoding the SendMessage case. The live HOME copy itself is realigned by the healer post-merge, not by this PR — stated honestly, not claimed as done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qifh5c48sJpBQocpXKABc6