### PR TITLE
feat(conductor): W1 assignment-parent graph validator

### DIFF
--- a/scripts/conductor/army_assignment.py
+++ b/scripts/conductor/army_assignment.py
@@ -1,0 +1,288 @@
+"""Pure validator for the "dual-consul army" assignment-parent graph.
+
+This module is a SIBLING vocabulary to `scripts.conductor.contracts`, not an
+extension of it: `Role`/`Decision` there describe a session-local endpoint
+plan, while `ArmyRole` here describes a mission-scoped command hierarchy
+(imperator -> general -> specialist/builder/support). The two enums are
+deliberately different names for different concepts and must never be
+conflated.
+
+`validate_plan` is pure, deterministic, and stdlib-only: no I/O, no clock, no
+randomness, no mutation of its input. It answers exactly one question — is
+this assignment-parent graph (plus its optional appointment block) internally
+consistent — and returns a `ValidationResult` carrying a `Decision` from
+`contracts.py` (`ALLOW` or `BLOCK` only; the other `Decision` members describe
+outcomes this validator never produces) plus sorted, stable reason codes and
+offending ids.
+
+Explicit non-goals: no scheduler, no ledger, no persistence, no network, no
+file I/O, no dispatch, no grant. This module decides validity only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+try:
+    from scripts.conductor.contracts import Decision
+except ImportError:  # pragma: no cover - exercised when imported standalone
+    class Decision(StrEnum):
+        """An outcome of pure planning, including a visible abstention."""
+
+        ALLOW = "allow"
+        DELEGATE_REQUIRED = "delegate_required"
+        BLOCK = "block"
+        DEGRADED = "degraded"
+        ABSTAIN = "abstain"
+
+
+SCHEMA_VERSION = "army-assignment/1"
+
+_VALID_DUX_CANDIDATES = frozenset({"opus", "sol"})
+_REQUIRED_IMPERATORS = frozenset({"fable", "astra"})
+
+
+class ArmyRole(StrEnum):
+    """A role in the army command hierarchy (mission-scoped, not session-local)."""
+
+    IMPERATOR = "imperator"
+    GENERAL = "general"
+    SPECIALIST = "specialist"
+    BUILDER = "builder"
+    SUPPORT = "support"
+
+
+_ROLES_REQUIRING_PARENT = frozenset({ArmyRole.SPECIALIST, ArmyRole.BUILDER, ArmyRole.SUPPORT})
+
+
+@dataclass(frozen=True)
+class Assignment:
+    """One node in the assignment-parent graph."""
+
+    assignment_id: str
+    mission_id: str
+    role: ArmyRole
+    parent_id: str | None
+    generation: int
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of `validate_plan`: a decision plus stable, sorted evidence."""
+
+    decision: Decision
+    reason_codes: tuple[str, ...]
+    offending_ids: tuple[str, ...]
+
+
+def _is_missing(value: object) -> bool:
+    """True when a required field is absent, None, or an empty string."""
+    return value is None or value == ""
+
+
+def _block(reason_codes: set[str], offending_ids: set[str]) -> ValidationResult:
+    return ValidationResult(
+        decision=Decision.BLOCK,
+        reason_codes=tuple(sorted(reason_codes)),
+        offending_ids=tuple(sorted(offending_ids)),
+    )
+
+
+def _validate_appointment(
+    appointment: object,
+    reason_codes: set[str],
+    offending_ids: set[str],
+    payload_self_supplied: bool,
+) -> None:
+    """Validate the optional `appointment` block, mutating the two accumulators.
+
+    `mission_uuid` is treated as an OPAQUE externally-supplied value: this
+    function never generates, completes, or normalises it. It only checks
+    that one was supplied by the caller and that the caller did not mark it
+    self-supplied.
+    """
+    if not isinstance(appointment, dict):
+        reason_codes.add("missing_required_field")
+        offending_ids.add("appointment")
+        return
+
+    dux = appointment.get("dux")
+    if dux not in _VALID_DUX_CANDIDATES:
+        reason_codes.add("invalid_dux_candidate")
+        offending_ids.add("appointment")
+
+    approvals = appointment.get("approvals")
+    if not isinstance(approvals, list):
+        approvals = []
+    hashes_by_imperator: dict[str, list[str | None]] = {}
+    for approval in approvals:
+        if not isinstance(approval, dict):
+            continue
+        imperator = approval.get("imperator")
+        packet_hash = approval.get("packet_hash")
+        if imperator in _REQUIRED_IMPERATORS:
+            hashes_by_imperator.setdefault(imperator, []).append(packet_hash)
+
+    # "Each imperator exactly once": zero OR more than one approval from the
+    # same imperator both mean that imperator's single required approval is
+    # absent — a repeat is not a stronger approval, it is a missing one.
+    approved_once = {name for name, hashes in hashes_by_imperator.items() if len(hashes) == 1}
+    missing_imperators = _REQUIRED_IMPERATORS - approved_once
+    if missing_imperators:
+        reason_codes.add("missing_imperator_approval")
+        offending_ids.add("appointment")
+
+    # Hash agreement is judged only across the imperators who approved exactly
+    # once; a duplicate's hash(es) never feed this comparison, so a repeated
+    # approval cannot accidentally cause (or hide) a packet_hash_mismatch.
+    packet_hashes = {hashes_by_imperator[name][0] for name in approved_once}
+    if len(packet_hashes) > 1:
+        reason_codes.add("packet_hash_mismatch")
+        offending_ids.add("appointment")
+
+    mission_uuid = appointment.get("mission_uuid")
+    uuid_self_supplied = payload_self_supplied or bool(appointment.get("uuid_self_supplied"))
+    if _is_missing(mission_uuid) or not isinstance(mission_uuid, str) or uuid_self_supplied:
+        reason_codes.add("self_supplied_uuid")
+        offending_ids.add("appointment")
+
+
+def validate_plan(payload: dict) -> ValidationResult:
+    """Validate an assignment-parent graph plus its optional appointment block.
+
+    Pure and deterministic: the same `payload` always yields an equal
+    `ValidationResult`, with `reason_codes` and `offending_ids` sorted so
+    ordering never depends on dict/set iteration order. `payload` is never
+    mutated. A `"messages"` list, if present, is TRAFFIC and is ignored
+    entirely for cycle detection.
+    """
+    if not isinstance(payload, dict):
+        return _block({"missing_required_field"}, set())
+
+    reason_codes: set[str] = set()
+    offending_ids: set[str] = set()
+
+    schema_version = payload.get("schema_version")
+    if schema_version != SCHEMA_VERSION:
+        reason_codes.add("unknown_schema_version")
+
+    raw_assignments = payload.get("assignments")
+    if not isinstance(raw_assignments, list):
+        raw_assignments = []
+
+    # by_id maps to the FIRST occurrence only; later duplicate ids are recorded
+    # separately so the caller still sees every offending id.
+    by_id: dict[str, Assignment] = {}
+    duplicate_ids: set[str] = set()
+    conflicting_parent_ids: set[str] = set()
+
+    for raw in raw_assignments:
+        if not isinstance(raw, dict):
+            reason_codes.add("missing_required_field")
+            continue
+
+        assignment_id = raw.get("assignment_id")
+        mission_id = raw.get("mission_id")
+        role_raw = raw.get("role")
+        parent_id = raw.get("parent_id")
+        generation = raw.get("generation")
+
+        if _is_missing(assignment_id) or _is_missing(mission_id) or _is_missing(role_raw):
+            reason_codes.add("missing_required_field")
+            if not _is_missing(assignment_id):
+                offending_ids.add(assignment_id)
+            continue
+
+        try:
+            role = ArmyRole(role_raw)
+        except ValueError:
+            reason_codes.add("missing_required_field")
+            offending_ids.add(assignment_id)
+            continue
+
+        if not (isinstance(generation, int) and not isinstance(generation, bool) and generation >= 0):
+            reason_codes.add("invalid_generation")
+            offending_ids.add(assignment_id)
+
+        if parent_id is not None and (not isinstance(parent_id, str) or parent_id == ""):
+            reason_codes.add("missing_required_field")
+            offending_ids.add(assignment_id)
+            continue
+
+        assignment = Assignment(
+            assignment_id=assignment_id,
+            mission_id=mission_id,
+            role=role,
+            parent_id=parent_id,
+            generation=generation if isinstance(generation, int) else 0,
+        )
+
+        if assignment_id in by_id:
+            duplicate_ids.add(assignment_id)
+            if by_id[assignment_id].parent_id != assignment.parent_id:
+                conflicting_parent_ids.add(assignment_id)
+            continue
+
+        by_id[assignment_id] = assignment
+
+    if duplicate_ids:
+        reason_codes.add("duplicate_assignment_id")
+        offending_ids |= duplicate_ids
+
+    if conflicting_parent_ids:
+        reason_codes.add("two_operational_parents")
+        offending_ids |= conflicting_parent_ids
+
+    for assignment in by_id.values():
+        if assignment.parent_id is None:
+            if assignment.role in _ROLES_REQUIRING_PARENT:
+                reason_codes.add("unassigned_parent")
+                offending_ids.add(assignment.assignment_id)
+            continue
+
+        parent = by_id.get(assignment.parent_id)
+        if parent is None:
+            reason_codes.add("dangling_parent")
+            offending_ids.add(assignment.assignment_id)
+            continue
+
+        if parent.mission_id != assignment.mission_id:
+            reason_codes.add("cross_mission_edge")
+            offending_ids.add(assignment.assignment_id)
+
+    # Cycle detection over the parent-only graph (never "messages"). A
+    # self-parent is a cycle of length 1 and is caught by this same walk.
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color: dict[str, int] = {node_id: WHITE for node_id in by_id}
+    cyclic_ids: set[str] = set()
+
+    def visit(node_id: str, stack: list[str]) -> None:
+        color[node_id] = GRAY
+        stack.append(node_id)
+        parent_id = by_id[node_id].parent_id
+        if parent_id is not None and parent_id in by_id:
+            if color[parent_id] == GRAY:
+                cycle_start = stack.index(parent_id)
+                cyclic_ids.update(stack[cycle_start:])
+            elif color[parent_id] == WHITE:
+                visit(parent_id, stack)
+        stack.pop()
+        color[node_id] = BLACK
+
+    for node_id in sorted(by_id):
+        if color[node_id] == WHITE:
+            visit(node_id, [])
+
+    if cyclic_ids:
+        reason_codes.add("parent_cycle")
+        offending_ids |= cyclic_ids
+
+    if "appointment" in payload:
+        payload_self_supplied = bool(payload.get("uuid_self_supplied"))
+        _validate_appointment(payload["appointment"], reason_codes, offending_ids, payload_self_supplied)
+
+    if reason_codes:
+        return _block(reason_codes, offending_ids)
+
+    return ValidationResult(decision=Decision.ALLOW, reason_codes=(), offending_ids=())

--- a/scripts/tests/test_army_assignment.py
+++ b/scripts/tests/test_army_assignment.py
@@ -1,0 +1,486 @@
+"""Guilt+innocence corpus for scripts/conductor/army_assignment.py.
+
+One test per reason code (W1 army-assignment validator), plus the positive
+controls from the acceptance spec (A01/A03/A04): a valid multi-level plan,
+equal-rank dux acceptance, message-traffic exclusion from cycle detection,
+and determinism across repeated calls.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from scripts.conductor.army_assignment import SCHEMA_VERSION, validate_plan
+from scripts.conductor.contracts import Decision
+
+
+def _valid_appointment(dux: str = "opus") -> dict:
+    return {
+        "dux": dux,
+        "approvals": [
+            {"imperator": "fable", "packet_hash": "hash-1"},
+            {"imperator": "astra", "packet_hash": "hash-1"},
+        ],
+        "mission_uuid": "mission-uuid-0001",
+    }
+
+
+def _base_plan(mission_id: str = "m1") -> dict:
+    """A valid multi-level plan: general -> specialist -> builder -> support."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "G1",
+                "mission_id": mission_id,
+                "role": "general",
+                "parent_id": None,
+                "generation": 0,
+            },
+            {
+                "assignment_id": "SP1",
+                "mission_id": mission_id,
+                "role": "specialist",
+                "parent_id": "G1",
+                "generation": 1,
+            },
+            {
+                "assignment_id": "B1",
+                "mission_id": mission_id,
+                "role": "builder",
+                "parent_id": "SP1",
+                "generation": 2,
+            },
+            {
+                "assignment_id": "SU1",
+                "mission_id": mission_id,
+                "role": "support",
+                "parent_id": "B1",
+                "generation": 3,
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Positive controls
+# ---------------------------------------------------------------------------
+
+
+def test_valid_multi_level_plan_allows_with_no_reasons():
+    result = validate_plan(_base_plan())
+    assert result.decision is Decision.ALLOW
+    assert result.reason_codes == ()
+
+
+def test_equal_rank_dux_opus_and_sol_both_allow():
+    plan_opus = _base_plan()
+    plan_opus["appointment"] = _valid_appointment(dux="opus")
+    plan_sol = _base_plan()
+    plan_sol["appointment"] = _valid_appointment(dux="sol")
+
+    result_opus = validate_plan(plan_opus)
+    result_sol = validate_plan(plan_sol)
+
+    assert result_opus.decision is Decision.ALLOW
+    assert result_sol.decision is Decision.ALLOW
+
+
+def test_message_loop_between_two_nodes_does_not_produce_parent_cycle():
+    plan = _base_plan()
+    plan["messages"] = [
+        {"from": "G1", "to": "SP1"},
+        {"from": "SP1", "to": "G1"},
+    ]
+    result = validate_plan(plan)
+    assert result.decision is Decision.ALLOW
+    assert "parent_cycle" not in result.reason_codes
+
+
+def test_validate_plan_is_deterministic_across_repeated_calls():
+    plan = _base_plan()
+    plan["assignments"].append(
+        {
+            "assignment_id": "SU1",  # duplicate id, differing parent -> multi-code BLOCK
+            "mission_id": "m1",
+            "role": "support",
+            "parent_id": "G1",
+            "generation": 3,
+        }
+    )
+    frozen_plan = copy.deepcopy(plan)
+
+    first = validate_plan(plan)
+    second = validate_plan(plan)
+
+    assert first == second
+    assert plan == frozen_plan  # validator must never mutate its input
+
+
+# ---------------------------------------------------------------------------
+# Rejection rules — one isolated test per reason code
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_schema_version_missing():
+    plan = {"assignments": []}
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "unknown_schema_version" in result.reason_codes
+
+
+def test_unknown_schema_version_wrong_value():
+    plan = _base_plan()
+    plan["schema_version"] = "army-assignment/0"
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "unknown_schema_version" in result.reason_codes
+
+
+def test_missing_required_field_when_role_absent():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "G1",
+                "mission_id": "m1",
+                "parent_id": None,
+                "generation": 0,
+            }
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "missing_required_field" in result.reason_codes
+
+
+def test_missing_required_field_when_mission_id_empty_string():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "G1",
+                "mission_id": "",
+                "role": "general",
+                "parent_id": None,
+                "generation": 0,
+            }
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "missing_required_field" in result.reason_codes
+
+
+def test_duplicate_assignment_id():
+    plan = _base_plan()
+    plan["assignments"].append(
+        {
+            "assignment_id": "G1",  # duplicate, SAME parent -> isolate from two_operational_parents
+            "mission_id": "m1",
+            "role": "general",
+            "parent_id": None,
+            "generation": 0,
+        }
+    )
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "duplicate_assignment_id" in result.reason_codes
+    assert "G1" in result.offending_ids
+
+
+def test_dangling_parent():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "SP1",
+                "mission_id": "m1",
+                "role": "specialist",
+                "parent_id": "GHOST",
+                "generation": 0,
+            }
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "dangling_parent" in result.reason_codes
+    assert "SP1" in result.offending_ids
+
+
+def test_cross_mission_edge():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "G1",
+                "mission_id": "m1",
+                "role": "general",
+                "parent_id": None,
+                "generation": 0,
+            },
+            {
+                "assignment_id": "G2",
+                "mission_id": "m2",
+                "role": "general",
+                "parent_id": None,
+                "generation": 0,
+            },
+            {
+                "assignment_id": "SP1",
+                "mission_id": "m1",
+                "role": "specialist",
+                "parent_id": "G2",  # parent lives in mission m2
+                "generation": 1,
+            },
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "cross_mission_edge" in result.reason_codes
+    assert "SP1" in result.offending_ids
+
+
+def test_parent_cycle_two_node_loop():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "A",
+                "mission_id": "m1",
+                "role": "specialist",
+                "parent_id": "B",
+                "generation": 0,
+            },
+            {
+                "assignment_id": "B",
+                "mission_id": "m1",
+                "role": "specialist",
+                "parent_id": "A",
+                "generation": 0,
+            },
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "parent_cycle" in result.reason_codes
+    assert {"A", "B"} <= set(result.offending_ids)
+
+
+def test_parent_cycle_self_parent():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "X",
+                "mission_id": "m1",
+                "role": "specialist",
+                "parent_id": "X",
+                "generation": 0,
+            }
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "parent_cycle" in result.reason_codes
+    assert "X" in result.offending_ids
+
+
+def test_unassigned_parent():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "SP1",
+                "mission_id": "m1",
+                "role": "specialist",
+                "parent_id": None,
+                "generation": 0,
+            }
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "unassigned_parent" in result.reason_codes
+    assert "SP1" in result.offending_ids
+
+
+def test_two_operational_parents():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "G1",
+                "mission_id": "m1",
+                "role": "general",
+                "parent_id": None,
+                "generation": 0,
+            },
+            {
+                "assignment_id": "G2",
+                "mission_id": "m1",
+                "role": "general",
+                "parent_id": None,
+                "generation": 0,
+            },
+            {
+                "assignment_id": "SP1",
+                "mission_id": "m1",
+                "role": "specialist",
+                "parent_id": "G1",
+                "generation": 1,
+            },
+            {
+                "assignment_id": "SP1",  # same id, DIFFERENT parent
+                "mission_id": "m1",
+                "role": "specialist",
+                "parent_id": "G2",
+                "generation": 1,
+            },
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "two_operational_parents" in result.reason_codes
+    assert "SP1" in result.offending_ids
+
+
+def test_invalid_generation():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "G1",
+                "mission_id": "m1",
+                "role": "general",
+                "parent_id": None,
+                "generation": -1,
+            }
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "invalid_generation" in result.reason_codes
+    assert "G1" in result.offending_ids
+
+
+def test_invalid_generation_non_int():
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "assignments": [
+            {
+                "assignment_id": "G1",
+                "mission_id": "m1",
+                "role": "general",
+                "parent_id": None,
+                "generation": "zero",
+            }
+        ],
+    }
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "invalid_generation" in result.reason_codes
+
+
+def test_invalid_dux_candidate():
+    plan = _base_plan()
+    appointment = _valid_appointment()
+    appointment["dux"] = "caesar"
+    plan["appointment"] = appointment
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "invalid_dux_candidate" in result.reason_codes
+
+
+def test_missing_imperator_approval():
+    plan = _base_plan()
+    appointment = _valid_appointment()
+    appointment["approvals"] = [{"imperator": "fable", "packet_hash": "hash-1"}]
+    plan["appointment"] = appointment
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "missing_imperator_approval" in result.reason_codes
+
+
+def test_packet_hash_mismatch():
+    plan = _base_plan()
+    appointment = _valid_appointment()
+    appointment["approvals"] = [
+        {"imperator": "fable", "packet_hash": "hash-1"},
+        {"imperator": "astra", "packet_hash": "hash-2"},
+    ]
+    plan["appointment"] = appointment
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "packet_hash_mismatch" in result.reason_codes
+
+
+def test_self_supplied_uuid_when_mission_uuid_absent():
+    plan = _base_plan()
+    appointment = _valid_appointment()
+    del appointment["mission_uuid"]
+    plan["appointment"] = appointment
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "self_supplied_uuid" in result.reason_codes
+
+
+def test_self_supplied_uuid_when_flagged_truthy():
+    plan = _base_plan()
+    appointment = _valid_appointment()
+    appointment["uuid_self_supplied"] = True
+    plan["appointment"] = appointment
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "self_supplied_uuid" in result.reason_codes
+
+
+def test_missing_imperator_approval_on_repeated_imperator_same_hash():
+    """Each imperator approves exactly once; a repeat is not a stronger
+
+    approval, it is a missing one — "fable" approving twice, even with
+    identical hashes, leaves "fable"'s single required approval absent.
+    """
+    plan = _base_plan()
+    appointment = _valid_appointment(dux="sol")
+    appointment["mission_uuid"] = "ext-uuid-1"
+    appointment["approvals"] = [
+        {"imperator": "fable", "packet_hash": "h1"},
+        {"imperator": "fable", "packet_hash": "h1"},
+        {"imperator": "astra", "packet_hash": "h1"},
+    ]
+    plan["appointment"] = appointment
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "missing_imperator_approval" in result.reason_codes
+    assert "packet_hash_mismatch" not in result.reason_codes
+
+
+def test_missing_imperator_approval_on_repeated_imperator_clashing_hash():
+    """Pinned behaviour: a repeated imperator is `missing_imperator_approval`
+
+    regardless of whether its duplicate hashes agree or clash — the clashing
+    duplicate must not surface as `packet_hash_mismatch` instead, since that
+    would make the earlier last-wins overwrite bug's symptom look intentional.
+    """
+    plan = _base_plan()
+    appointment = _valid_appointment(dux="sol")
+    appointment["mission_uuid"] = "ext-uuid-1"
+    appointment["approvals"] = [
+        {"imperator": "fable", "packet_hash": "h1"},
+        {"imperator": "fable", "packet_hash": "h2"},
+        {"imperator": "astra", "packet_hash": "h1"},
+    ]
+    plan["appointment"] = appointment
+    result = validate_plan(plan)
+    assert result.decision is Decision.BLOCK
+    assert "missing_imperator_approval" in result.reason_codes
+    assert "packet_hash_mismatch" not in result.reason_codes
+
+
+def test_non_dict_payload_returns_structured_block():
+    result = validate_plan(["not", "a", "dict"])
+    assert result.decision is Decision.BLOCK
+    assert "missing_required_field" in result.reason_codes


### PR DESCRIPTION
## Why
The W1 assignment doctrine needs a standalone validator: every conductor plan's assignment graph must resolve to a valid parent chain, with no cycles and no orphaned assignments.

## What
`scripts/conductor/army_assignment.py` (278 lines) + `scripts/tests/test_army_assignment.py` (496 lines, includes the later exactly-once imperator approval and non-dict-payload guard tests).

Net 774 lines — over the usual ~400 target. Split from the original combined W1+W2 batch per plan (this is PR-B1 of B1/B2); tests dominate the count (496 of 774 lines), which is the accepted tradeoff for a validator that ships both guilt and innocence fixtures per cicatrix #3.

## Source commits (squashed, agent/air-m5/ops/army-w1-assignment)
- `7015f08ddf` feat(conductor): W1 assignment-parent graph validator with negative-case tests
- `46e1faf8cf` fix(conductor): enforce exactly-once imperator approval; guard non-dict payload

## Verification
`.venv/bin/python -m pytest scripts/tests/test_army_assignment.py -q` → 25 passed, this turn.

Fixture level F: no consumer executes these plans yet. That is stated honestly in the source commits and repeated here — not claimed as integrated.

## Bites
Consumer: `scripts/tests/test_army_assignment.py` (explicit, fixture-level — this is a standalone validator PR). The release-consumer integration lands in a separate follow-up PR once `scripts/conductor/review_eligibility.py` (companion W2 validator, PR-B2 in this batch) is also merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qifh5c48sJpBQocpXKABc6