### PR TITLE
feat(conductor): W2 reviewer-independence validator

### DIFF
--- a/scripts/conductor/review_eligibility.py
+++ b/scripts/conductor/review_eligibility.py
@@ -1,0 +1,130 @@
+"""Pure reviewer-independence validator for the "dual-consul army" mission.
+
+No installed check today rejects a contributor acting as its own grader:
+`evidence_pack_lint.py` enforces build-lane FAMILY diversity and nothing
+about reviewer independence, and this module does not touch that concern —
+family membership is informational here, never a rejection basis. This is
+the missing check: a contributor (A17) must not be its own reviewer, and a
+review of a since-changed artifact (A18) is stale.
+
+`evaluate` is pure, deterministic, and stdlib-only: no I/O, no clock, no
+randomness, no mutation of its input. Rank confers no exemption — a reviewer
+named "opus" or "sol" is judged by the exact same rule as any other name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+try:
+    from scripts.conductor.contracts import Decision
+except ImportError:  # pragma: no cover - exercised when imported standalone
+    class Decision(StrEnum):
+        """An outcome of pure planning, including a visible abstention."""
+
+        ALLOW = "allow"
+        DELEGATE_REQUIRED = "delegate_required"
+        BLOCK = "block"
+        DEGRADED = "degraded"
+        ABSTAIN = "abstain"
+
+
+SCHEMA_VERSION = "review-eligibility/1"
+
+
+@dataclass(frozen=True)
+class ReviewRecord:
+    """The typed shape of one review event: an artifact, its contributors,
+
+    and the reviewer who judged it.
+    """
+
+    artifact_hash: str
+    contributors: tuple[str, ...]
+    reviewer: str
+    reviewed_hash: str
+    reviewer_family: str
+    contributor_families: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of `evaluate`: a decision plus stable, sorted reason codes."""
+
+    decision: Decision
+    reason_codes: tuple[str, ...]
+
+
+def _is_missing(value: object) -> bool:
+    """True when a required field is absent, None, or an empty string."""
+    return value is None or value == ""
+
+
+def _block(reason_codes: set[str]) -> ValidationResult:
+    return ValidationResult(decision=Decision.BLOCK, reason_codes=tuple(sorted(reason_codes)))
+
+
+def _normalize(name: str) -> str:
+    """Case-fold and strip surrounding whitespace for identity comparison."""
+    return name.strip().casefold()
+
+
+def evaluate(record: dict) -> ValidationResult:
+    """Validate that `reviewer` is independent of `contributors` for one review.
+
+    Pure and deterministic: the same `record` always yields an equal
+    `ValidationResult`, with `reason_codes` sorted so ordering never depends
+    on set iteration order. `record` is never mutated.
+    """
+    if not isinstance(record, dict):
+        return _block({"missing_required_field"})
+
+    reason_codes: set[str] = set()
+
+    schema_version = record.get("schema_version")
+    if schema_version != SCHEMA_VERSION:
+        reason_codes.add("unknown_schema_version")
+
+    artifact_hash = record.get("artifact_hash")
+    reviewer = record.get("reviewer")
+    reviewed_hash = record.get("reviewed_hash")
+    reviewer_family = record.get("reviewer_family")
+    raw_contributors = record.get("contributors")
+    raw_contributor_families = record.get("contributor_families")
+
+    for value in (artifact_hash, reviewer, reviewed_hash, reviewer_family):
+        if _is_missing(value):
+            reason_codes.add("missing_required_field")
+
+    if raw_contributors is None or not isinstance(raw_contributors, (list, tuple)):
+        reason_codes.add("missing_required_field")
+        contributors: tuple[object, ...] = ()
+    else:
+        contributors = tuple(raw_contributors)
+        if len(contributors) == 0:
+            reason_codes.add("no_contributor_recorded")
+
+    if raw_contributor_families is None or not isinstance(raw_contributor_families, (list, tuple)):
+        reason_codes.add("missing_required_field")
+
+    # Rank confers no exemption (A17): the SAME normalized-identity comparison
+    # applies to a reviewer named "opus" or "sol" as to any other name — no
+    # branch here treats any name specially. An exact match survives
+    # strip+casefold trivially, so one comparison covers both table rows
+    # ("appears in contributors" and "matches after case/whitespace folding").
+    if isinstance(reviewer, str) and contributors:
+        normalized_reviewer = _normalize(reviewer)
+        for contributor in contributors:
+            if isinstance(contributor, str) and _normalize(contributor) == normalized_reviewer:
+                reason_codes.add("reviewer_is_contributor")
+                break
+
+    if not _is_missing(artifact_hash) and not _is_missing(reviewed_hash):
+        if reviewed_hash != artifact_hash:
+            reason_codes.add("stale_review_hash")
+
+    if reason_codes:
+        return _block(reason_codes)
+
+    return ValidationResult(decision=Decision.ALLOW, reason_codes=())

--- a/scripts/tests/test_review_eligibility.py
+++ b/scripts/tests/test_review_eligibility.py
@@ -1,0 +1,175 @@
+"""Guilt+innocence corpus for scripts/conductor/review_eligibility.py.
+
+One test per reason code, plus the positive controls from the acceptance
+spec: a distinct-reviewer ALLOW, the A17 "rank confers no exemption" four-way
+matrix (opus/sol, in/out of contributors), and a same-family-but-not-a-
+contributor ALLOW proving family membership alone never disqualifies.
+"""
+
+from __future__ import annotations
+
+from scripts.conductor.contracts import Decision
+from scripts.conductor.review_eligibility import SCHEMA_VERSION, evaluate
+
+
+def _valid_record(**overrides) -> dict:
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_hash": "sha256:abc123",
+        "contributors": ("alice", "bob"),
+        "reviewer": "charlie",
+        "reviewed_hash": "sha256:abc123",
+        "reviewer_family": "fam-charlie",
+        "contributor_families": ("fam-alice", "fam-bob"),
+    }
+    record.update(overrides)
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Positive controls
+# ---------------------------------------------------------------------------
+
+
+def test_distinct_reviewer_with_matching_hashes_allows_with_no_reasons():
+    result = evaluate(_valid_record())
+    assert result.decision is Decision.ALLOW
+    assert result.reason_codes == ()
+
+
+def test_rank_confers_no_exemption_opus_in_contributors_blocks():
+    record = _valid_record(reviewer="opus", contributors=("opus", "bob"))
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "reviewer_is_contributor" in result.reason_codes
+
+
+def test_rank_confers_no_exemption_opus_not_in_contributors_allows():
+    record = _valid_record(reviewer="opus", contributors=("alice", "bob"))
+    result = evaluate(record)
+    assert result.decision is Decision.ALLOW
+    assert result.reason_codes == ()
+
+
+def test_rank_confers_no_exemption_sol_in_contributors_blocks():
+    record = _valid_record(reviewer="sol", contributors=("sol", "bob"))
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "reviewer_is_contributor" in result.reason_codes
+
+
+def test_rank_confers_no_exemption_sol_not_in_contributors_allows():
+    record = _valid_record(reviewer="sol", contributors=("alice", "bob"))
+    result = evaluate(record)
+    assert result.decision is Decision.ALLOW
+    assert result.reason_codes == ()
+
+
+def test_same_family_non_contributor_reviewer_is_allowed():
+    """Family membership alone is never disqualifying — only actual
+
+    contribution is. `charlie` shares `fam-alice` with contributor `alice`
+    but never contributed, so this must ALLOW. Family diversity is a separate
+    existing build-lane concern (`evidence_pack_lint.py`) and is not
+    re-implemented here.
+    """
+    record = _valid_record(
+        reviewer="charlie",
+        reviewer_family="fam-alice",
+        contributors=("alice", "bob"),
+        contributor_families=("fam-alice", "fam-bob"),
+    )
+    result = evaluate(record)
+    assert result.decision is Decision.ALLOW
+    assert result.reason_codes == ()
+
+
+# ---------------------------------------------------------------------------
+# Rejection rules — one isolated test per reason code
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_schema_version_missing():
+    record = _valid_record()
+    del record["schema_version"]
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "unknown_schema_version" in result.reason_codes
+
+
+def test_unknown_schema_version_wrong_value():
+    record = _valid_record(schema_version="review-eligibility/0")
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "unknown_schema_version" in result.reason_codes
+
+
+def test_missing_required_field_when_reviewer_absent():
+    record = _valid_record()
+    del record["reviewer"]
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "missing_required_field" in result.reason_codes
+
+
+def test_missing_required_field_when_artifact_hash_empty_string():
+    record = _valid_record(artifact_hash="")
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "missing_required_field" in result.reason_codes
+
+
+def test_missing_required_field_when_reviewer_family_none():
+    record = _valid_record(reviewer_family=None)
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "missing_required_field" in result.reason_codes
+
+
+def test_missing_required_field_when_contributor_families_absent():
+    record = _valid_record()
+    del record["contributor_families"]
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "missing_required_field" in result.reason_codes
+
+
+def test_reviewer_is_contributor_exact_match():
+    record = _valid_record(reviewer="alice", contributors=("alice", "bob"))
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "reviewer_is_contributor" in result.reason_codes
+
+
+def test_reviewer_is_contributor_case_and_whitespace_folded_match():
+    record = _valid_record(reviewer="  Alice  ", contributors=("alice", "bob"))
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "reviewer_is_contributor" in result.reason_codes
+
+
+def test_stale_review_hash():
+    record = _valid_record(reviewed_hash="sha256:different")
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "stale_review_hash" in result.reason_codes
+
+
+def test_no_contributor_recorded():
+    record = _valid_record(contributors=())
+    result = evaluate(record)
+    assert result.decision is Decision.BLOCK
+    assert "no_contributor_recorded" in result.reason_codes
+
+
+def test_non_dict_record_returns_structured_block():
+    result = evaluate(["not", "a", "dict"])
+    assert result.decision is Decision.BLOCK
+    assert "missing_required_field" in result.reason_codes
+
+
+def test_evaluate_is_deterministic_across_repeated_calls():
+    record = _valid_record(reviewer="alice", contributors=("alice", "bob"))
+    first = evaluate(record)
+    second = evaluate(record)
+    assert first == second


### PR DESCRIPTION
## Why
W2 doctrine requires that a reviewer named on a plan's review lane must not also appear on that same plan's build lane — rank confers no exemption.

## What
`scripts/conductor/review_eligibility.py` (130 lines) + `scripts/tests/test_review_eligibility.py` (175 lines). `opus`, `sol`, `kimi` are treated identically; matching is exact-normalized-string per cicatrix #3 (a substring match would over-match).

This is PR-B2 of the B1/B2 split (companion `army_assignment.py` W1 validator is PR-B1, #5942).

## Source commit (agent/air-m5/ops/army-w1-assignment)
- `22000bebe0` feat(conductor): W2 reviewer-independence validator — rank confers no exemption

## Verification
`.venv/bin/python -m pytest scripts/tests/test_review_eligibility.py -q` → 18 passed, this turn.

Fixture level F: no consumer calls `evaluate()` yet.

## Bites
Consumer: `scripts/tests/test_review_eligibility.py` (explicit, fixture-level). The release-consumer integration (`scripts/evidence_pack_lint.py`'s `check_reviewer_independence()`, which calls this module's `evaluate()`) lands in a separate follow-up PR once this one is merged — see PR-C in this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qifh5c48sJpBQocpXKABc6