### PR TITLE
feat(evidence): enforce reviewer independence in the release consumer

### DIFF
--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -761,6 +761,24 @@
             "test_lanes_gear3_opus5_sonnet5_flip_behavior"
           ]
         },
+        "check_reviewer_independence": {
+          "scar": ["W2", "A17"],
+          "guilt": [
+            "test_reviewer_independence_guilt_reviewer_is_contributor_rejected_post_flip",
+            "test_reviewer_independence_guilt_rank_confers_no_exemption_opus_too",
+            "test_reviewer_independence_guilt_case_and_whitespace_folded_match",
+            "test_reviewer_independence_guilt_multiple_review_lanes_each_judged"
+          ],
+          "innocence": [
+            "test_reviewer_independence_innocence_eligible_independent_reviewer_passes",
+            "test_reviewer_independence_innocence_no_review_lane_skipped",
+            "test_reviewer_independence_innocence_no_build_lane_skipped",
+            "test_reviewer_independence_innocence_gear1_exempt",
+            "test_reviewer_independence_innocence_pre_flip_notice_not_fail",
+            "test_reviewer_independence_innocence_seat_override_reports_not_fails",
+            "test_reviewer_independence_innocence_all_real_packs_pass_today"
+          ]
+        },
         "check_ground_truth_lane": {
           "scar": ["E3-R8"],
           "guilt": [

--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -422,6 +422,24 @@ from typing import Any
 
 import yaml
 
+# W2 reviewer-independence integration (2026-09-07): the ONE implementation of
+# the "reviewer is not a contributor" rule lives in
+# scripts/conductor/review_eligibility.py — this file calls into it rather
+# than re-deriving the comparison (implementation-plan.md §2: "migrate the
+# actual policy consumer... no copied eligibility list"). `sys.path` is
+# defensive, not required for the real invocation shapes measured (direct
+# `python3 scripts/evidence_pack_lint.py` from repo root, and
+# council_journal.py's dynamic load — both already put this file's own
+# directory on `sys.path[0]`, which is all `conductor.review_eligibility`
+# needs since `scripts/conductor/__init__.py` exists) — kept anyway so an
+# unanticipated third loader does not silently lose this import.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from conductor.review_eligibility import (  # noqa: E402
+    Decision as _ReviewerDecision,
+    SCHEMA_VERSION as _REVIEWER_SCHEMA_VERSION,
+    evaluate as _evaluate_reviewer_eligibility,
+)
+
 # ---------------------------------------------------------------------------
 # Hot-zone floor (rule 6) — DELIBERATE, DECLARED duplication of the case-block
 # in .github/workflows/hot-zone-pr-gate.yml. Keep the two lists in sync by
@@ -2175,6 +2193,164 @@ def check_lanes_build_seat_diversity(
 
 
 # ---------------------------------------------------------------------------
+# Reviewer independence (W2, dual-consul army mission, 2026-09-07). RULED
+# 2026-09-06 (see docs/rules/RULINGS.md): "the required release verdict comes
+# from a qualified verifier who is independent of the artifact's authors and
+# material implementation contributors" — and "rank confers no exemption":
+# a pack naming `opus` or `sol` as reviewer is judged the SAME as any other
+# name. Doctrine existed and a standalone validator (review_eligibility.py)
+# existed, but nothing installed called it — this is that call.
+#
+# THE GAP THIS DOES NOT CLOSE, stated rather than hidden: review_eligibility's
+# `evaluate()` also judges artifact/reviewed-hash STALENESS (A18) and carries
+# required `*_family` fields. No field in this pack format tracks a
+# reviewed-vs-current artifact hash today (grepped: no `artifact_hash`,
+# `reviewed_hash`, `commit_sha`, or `head_sha` key anywhere in this module or
+# `lint()`'s own parameters) — the smallest addition that would close it is a
+# `reviewed_diff_sha`/`artifact_sha` pack field, not invented here. Rather
+# than fabricate a hash this consumer cannot actually observe, both hash
+# arguments below are the SAME literal sentinel (`"unattested"`), which makes
+# `evaluate()`'s staleness comparison neutral BY CONSTRUCTION (equal inputs
+# never trigger `stale_review_hash`) instead of asserting a freshness fact
+# nobody measured. `*_family` is real but coarse — this file's own
+# `_is_anthropic_seat` already tokenizes a seat as "everything before its
+# first `-`"; `_reviewer_family` reuses that exact tokenization. Both
+# `evaluate()`'s own docstring and its test corpus already establish that
+# family is validated for presence only and never drives its verdict, so this
+# coarseness cannot affect the one property that matters here.
+#
+# WHAT DOES NOT NEED INVENTING: contributor and reviewer IDENTITY. The
+# `lanes:` list already names both — a `role: build` lane's `seat` is who
+# materially implemented the artifact; a `role: review` lane's `seat` is who
+# reviewed it. No new pack field is required for the actual A17 comparison.
+REVIEWER_INDEPENDENCE_ENFORCEMENT_DATE = datetime.date(2026, 9, 21)
+
+
+def _reviewer_family(seat: str) -> str:
+    """Coarse vendor/family token for a seat string: everything before its
+    FIRST `-`, lowercased — the same tokenization `_is_anthropic_seat` already
+    uses. Never empty for a non-empty `seat` (callers only pass validated,
+    stripped, non-empty strings)."""
+    return seat.strip().lower().split("-", 1)[0]
+
+
+def check_reviewer_independence(
+    pack: dict[str, Any],
+    gear: int | None = None,
+    today: datetime.date | None = None,
+) -> tuple[list[str], str | None]:
+    """W2: a declared reviewer must be independent of the pack's declared
+    contributors, per `scripts/conductor/review_eligibility.py` (the ONE
+    implementation of this rule — see the module comment above for why this
+    calls it rather than re-deriving the comparison).
+
+    SCOPE, deliberately narrow: this fires only when the pack names BOTH a
+    reviewer (>=1 `role: review` lane with a non-empty `seat`) AND a
+    contributor (>=1 `role: build` lane with a non-empty `seat`) — comparing
+    "is this specific reviewer also this specific contributor" needs both
+    sides present. A pack naming a reviewer with NO declared build lane at
+    all is not this rule's concern (a separate, larger policy question this
+    increment does not decide); D3/rule-8 already requires `lanes:` at all on
+    Gear >= 2, and a shape gap there is D3's finding, not duplicated here.
+    Gear < 2 (or ungraded) is exempt outright, mirroring D3's own gear gate.
+
+    MULTIPLE review lanes are each judged independently against the SAME
+    contributor set — every one that fails produces its own message naming
+    that seat, mirroring how R10 collects every offending seat rather than
+    stopping at the first.
+
+    KNOWN, DOCUMENTED LIMITATION: comparison is exact-normalized-string
+    match (via review_eligibility's own case/whitespace folding) on
+    whatever the pack author typed into `seat:`. Several real packs use
+    free-form prose there (e.g. "claude opus-5 xhigh (this orchestrator) --
+    final on-disk gate, empirical") rather than a clean seat token — the
+    SAME real seat described differently between a build and a review lane
+    will NOT be caught. Fixing that would need NLP-level fuzzy matching,
+    which risks its own over/under-match failure (cicatrix family #3) and is
+    not attempted here.
+
+    GUILT/NOTICE: a reviewer seat that normalizes to the same identity as a
+    contributor seat -> phased violation naming the offending seat. INNOCENCE:
+    no review lane, no build lane, gear < 2, or every reviewer is independent
+    of every contributor -> clean. `seat_override: <reason>` clears it exactly
+    like the other seat rules, always reported."""
+    if gear is None or gear < 2:
+        return [], None
+
+    lanes = pack.get("lanes")
+    if not isinstance(lanes, list):
+        lanes = []
+
+    build_seats: list[str] = []
+    review_seats: list[str] = []
+    for entry in lanes:
+        if not isinstance(entry, dict):
+            continue
+        role = str(entry.get("role", "")).strip().lower()
+        seat = entry.get("seat")
+        if not isinstance(seat, str) or not seat.strip():
+            continue
+        if role == "build":
+            build_seats.append(seat.strip())
+        elif role == "review":
+            review_seats.append(seat.strip())
+
+    if not build_seats or not review_seats:
+        return [], None
+
+    contributors = tuple(dict.fromkeys(build_seats))  # de-dup, order-preserving
+    contributor_families = tuple(_reviewer_family(s) for s in contributors)
+
+    offending: list[str] = []
+    for reviewer in dict.fromkeys(review_seats):
+        record = {
+            "schema_version": _REVIEWER_SCHEMA_VERSION,
+            "artifact_hash": "unattested",
+            "reviewed_hash": "unattested",
+            "reviewer": reviewer,
+            "reviewer_family": _reviewer_family(reviewer),
+            "contributors": contributors,
+            "contributor_families": contributor_families,
+        }
+        result = _evaluate_reviewer_eligibility(record)
+        if result.decision is _ReviewerDecision.BLOCK and "reviewer_is_contributor" in result.reason_codes:
+            offending.append(reviewer)
+
+    if not offending:
+        return [], None
+
+    message = (
+        f"reviewer_independence: reviewer seat(s) {offending} also declared "
+        f"on a build lane in the same pack — rank confers no exemption, this "
+        f"applies identically whatever the seat is named "
+        f"(RULED 2026-09-06, docs/rules/RULINGS.md)"
+    )
+    return _reviewer_independence_verdict(message, pack, today)
+
+
+def _reviewer_independence_verdict(
+    message: str,
+    pack: dict[str, Any],
+    today: datetime.date | None,
+) -> tuple[list[str], str | None]:
+    """Own phasing clock, deliberately NOT `_seat_rule_verdict` (already
+    hard-flipped at SEAT_RULES_ENFORCEMENT_DATE, 2026-08-31 — reusing it
+    would make this rule violate on day one) — same reasoning `_r9_r11_verdict`
+    documents for why R9/R11 got their own clock instead of borrowing D3's:
+    this program has never fired before, so its own enforcement date is the
+    honest one. `seat_override: <reason>` wins outright, always reported,
+    exactly like every other seat rule's escape hatch."""
+    override = pack.get("seat_override")
+    if isinstance(override, str) and override.strip():
+        return [], f"{message} (overridden) — {override.strip()}"
+    if today is None:
+        today = datetime.datetime.now(datetime.timezone.utc).date()
+    if today < REVIEWER_INDEPENDENCE_ENFORCEMENT_DATE:
+        return [], message
+    return [message], None
+
+
+# ---------------------------------------------------------------------------
 # Seat rules by path class (E3/R8-R11 — 2026-08-26 seat-rules program, spec
 # §8 in 2026-08-26-PIANO-SPEC-receptor-live.md). Two rules ship here (R8
 # ground-truth, R10 PII-local); two more (R11 cheap-seat floor, R9 Gear-3
@@ -2911,6 +3087,11 @@ def lint(
     violations += lane_violations
     if lane_notice:
         print(f"evidence_pack_lint: NOTICE — {lane_notice}", file=sys.stderr)
+
+    reviewer_violations, reviewer_notice = check_reviewer_independence(pack, gear)
+    violations += reviewer_violations
+    if reviewer_notice:
+        print(f"evidence_pack_lint: NOTICE — {reviewer_notice}", file=sys.stderr)
 
     # E3/R8-R11 seat rules (2026-08-26 program) — one call site. R8/R10
     # land here; R11 (seat_floor) and R9 (council_run) join this same

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -32,6 +32,7 @@ from evidence_pack_lint import (  # noqa: E402
     FLOOR_SOURCE_SIZE,
     LANES_NON_ANTHROPIC_ENFORCEMENT_DATE,
     R9_R11_ENFORCEMENT_DATE,
+    REVIEWER_INDEPENDENCE_ENFORCEMENT_DATE,
     SEAT_RULES_ENFORCEMENT_DATE,
     SIZE_GEAR2_THRESHOLD,
     SIZE_GEAR3_THRESHOLD,
@@ -54,6 +55,7 @@ from evidence_pack_lint import (  # noqa: E402
     check_pii_local_seat,
     check_pii_scan_clean,
     check_receipts_have_provenance,
+    check_reviewer_independence,
     check_size_budget,
     compute_ceiling,
     compute_floor,
@@ -1527,6 +1529,163 @@ def test_lanes_gear3_opus5_sonnet5_flip_behavior():
     )
     assert violations
     assert notice is None
+
+
+# --------------------------------------------------------- check_reviewer_independence (W2)
+#
+# Shared today= pins for this rule's own flip date — never fired before, so
+# it gets its own clock rather than borrowing D3's or the seat-rules
+# program's (same reasoning _r9_r11_verdict's own module comment gives for
+# why R9/R11 did not reuse SEAT_RULES_ENFORCEMENT_DATE).
+_REVIEWER_PRE_FLIP = REVIEWER_INDEPENDENCE_ENFORCEMENT_DATE - datetime.timedelta(days=1)
+_REVIEWER_POST_FLIP = REVIEWER_INDEPENDENCE_ENFORCEMENT_DATE
+
+
+def test_reviewer_independence_guilt_reviewer_is_contributor_rejected_post_flip():
+    """GUILT: a pack whose reviewer is ALSO a contributor fails — the exact
+    property both W1 and W2 pin (A17, rank confers no exemption)."""
+    pack = _lane_pack(
+        {"lane": "B1", "role": "build", "seat": "sol"},
+        {"lane": "R1", "role": "review", "seat": "sol"},
+    )
+    violations, notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_POST_FLIP)
+    assert violations and "reviewer_independence" in violations[0]
+    assert "sol" in violations[0]
+    assert notice is None
+
+
+def test_reviewer_independence_guilt_rank_confers_no_exemption_opus_too():
+    """GUILT, same shape, named `opus` instead of `sol` — the rule must not
+    special-case either name (RULED 2026-09-06)."""
+    pack = _lane_pack(
+        {"lane": "B1", "role": "build", "seat": "opus"},
+        {"lane": "R1", "role": "review", "seat": "opus"},
+    )
+    violations, notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_POST_FLIP)
+    assert violations and "opus" in violations[0]
+
+
+def test_reviewer_independence_innocence_eligible_independent_reviewer_passes():
+    """INNOCENCE: a pack with an eligible independent reviewer (distinct
+    from every contributor) passes cleanly."""
+    pack = _lane_pack(
+        {"lane": "B1", "role": "build", "seat": "opus"},
+        {"lane": "R1", "role": "review", "seat": "sol"},
+    )
+    violations, notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_POST_FLIP)
+    assert violations == [] and notice is None
+
+
+def test_reviewer_independence_innocence_no_review_lane_skipped():
+    """INNOCENCE: a pack that declares contributors but no review lane at
+    all is not this rule's concern — a separate, larger "must a reviewer
+    exist" policy question this increment does not decide. D3/rule-8
+    already requires `lanes:` shape on Gear>=2; a gap there is D3's finding."""
+    pack = _lane_pack({"lane": "B1", "role": "build", "seat": "opus"})
+    violations, notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_POST_FLIP)
+    assert violations == [] and notice is None
+
+
+def test_reviewer_independence_innocence_no_build_lane_skipped():
+    """INNOCENCE, the mirror case: a review lane with zero declared build
+    lanes has nothing to compare against — skipped, not a fabricated
+    'no contributor recorded' finding this consumer did not ask for."""
+    pack = _lane_pack({"lane": "R1", "role": "review", "seat": "sol"})
+    violations, notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_POST_FLIP)
+    assert violations == [] and notice is None
+
+
+def test_reviewer_independence_innocence_gear1_exempt():
+    """INNOCENCE: Gear 1 is exempt outright, mirroring D3's own gear gate —
+    the same guilty shape at Gear 1 must not fire."""
+    pack = _lane_pack(
+        {"lane": "B1", "role": "build", "seat": "sol"},
+        {"lane": "R1", "role": "review", "seat": "sol"},
+    )
+    violations, notice = check_reviewer_independence(pack, gear=1, today=_REVIEWER_POST_FLIP)
+    assert violations == [] and notice is None
+    violations, notice = check_reviewer_independence(pack, gear=None, today=_REVIEWER_POST_FLIP)
+    assert violations == [] and notice is None
+
+
+def test_reviewer_independence_innocence_pre_flip_notice_not_fail():
+    """INNOCENCE: the same guilty shape only NOTICEs before the flip — this
+    is what keeps the one real pack this rule found (measured 2026-09-07:
+    evidence/2026-08/.../pack.yml with `claude (session, pro)` on both a
+    build and a review lane) passing today rather than turning it red on a
+    PR that never touched it."""
+    pack = _lane_pack(
+        {"lane": "B1", "role": "build", "seat": "sol"},
+        {"lane": "R1", "role": "review", "seat": "sol"},
+    )
+    violations, notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_PRE_FLIP)
+    assert violations == []
+    assert notice is not None and "reviewer_independence" in notice
+
+
+def test_reviewer_independence_innocence_seat_override_reports_not_fails():
+    """INNOCENCE: `seat_override` clears the violation and is reported,
+    exactly like every other seat rule's human-call escape hatch."""
+    pack = _lane_pack(
+        {"lane": "B1", "role": "build", "seat": "sol"},
+        {"lane": "R1", "role": "review", "seat": "sol"},
+    )
+    pack["seat_override"] = "manual exception, reviewed by Zero"
+    violations, notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_POST_FLIP)
+    assert violations == []
+    assert notice is not None and "(overridden)" in notice
+
+
+def test_reviewer_independence_guilt_case_and_whitespace_folded_match():
+    """GUILT: the same identity written with different case/whitespace on
+    each lane is still caught — review_eligibility's own normalization,
+    exercised through this consumer rather than re-derived here."""
+    pack = _lane_pack(
+        {"lane": "B1", "role": "build", "seat": "  Sol  "},
+        {"lane": "R1", "role": "review", "seat": "SOL"},
+    )
+    violations, notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_POST_FLIP)
+    assert violations and "reviewer_independence" in violations[0]
+
+
+def test_reviewer_independence_guilt_multiple_review_lanes_each_judged():
+    """GUILT: with two review lanes, only the offending one is named — each
+    reviewer is judged independently against the same contributor set."""
+    pack = _lane_pack(
+        {"lane": "B1", "role": "build", "seat": "opus"},
+        {"lane": "R1", "role": "review", "seat": "opus"},
+        {"lane": "R2", "role": "review", "seat": "sol"},
+    )
+    violations, notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_POST_FLIP)
+    assert len(violations) == 1
+    assert "opus" in violations[0] and "sol" not in violations[0]
+
+
+@pytest.mark.parametrize(
+    "existing_pack_path",
+    sorted(str(p) for p in Path("evidence").glob("**/pack.yml")),
+)
+def test_reviewer_independence_innocence_all_real_packs_pass_today(existing_pack_path):
+    """INNOCENCE, the non-optional one: every real evidence pack in this
+    tree, run through this rule PRE-FLIP, must never produce a HARD
+    violation — forcing gear=2 on every pack (the worst case: D3 already
+    exempts Gear-1, but a pack's REAL gear is not re-derived here) so this
+    proves the phasing itself, not that most packs happen to be Gear-1. A
+    check that fails everything would satisfy the guilt tests above just as
+    well; this is the one that proves it does not.
+
+    `today` is pinned to `_REVIEWER_PRE_FLIP`, NOT the real wall clock: the
+    property under test is "the phasing protects real packs before the
+    flip", which is true by construction of REVIEWER_INDEPENDENCE_ENFORCEMENT_DATE
+    regardless of which day this suite happens to run — pinning it means
+    this test does not itself start failing the moment the calendar crosses
+    2026-09-21, which would prove nothing about the rule and everything
+    about not having re-run it that day."""
+    pack = yaml.safe_load(Path(existing_pack_path).read_text(encoding="utf-8"))
+    if not isinstance(pack, dict):
+        pytest.skip(f"{existing_pack_path} did not parse to a mapping")
+    violations, _notice = check_reviewer_independence(pack, gear=2, today=_REVIEWER_PRE_FLIP)
+    assert violations == [], (existing_pack_path, violations)
 
 
 # --------------------------------------------------------- seat rules by path class (E3/R8-R11)


### PR DESCRIPTION
## Why
W2 had doctrine (RULINGS.md) and a standalone validator (`scripts/conductor/review_eligibility.py`, this batch's companion PR #5943) — and nothing that consumed either. This closes the gap.

## What
`check_reviewer_independence()` in `scripts/evidence_pack_lint.py` calls into `review_eligibility.evaluate()` rather than re-deriving the comparison, so the rule has ONE implementation. A pack whose `role: review` lane names a seat that also appears on a `role: build` lane is flagged — rank confers no exemption, `opus`/`sol`/`kimi` treated identically.

Phasing follows the module's own convention: `REVIEWER_INDEPENDENCE_ENFORCEMENT_DATE = 2026-09-21`. Until then it emits a NOTICE, not a FAIL. `seat_override:` clears it and is always reported.

Registers `check_reviewer_independence` in `infra/guard-conformance/registry.json` (scar W2/A17) with both guilt and innocence fixtures.

## Stacking — IMPORTANT
This PR's base is `agent/air-m5/ops/conductor-w2-review-eligibility` (#5943), NOT `main`, because `check_reviewer_independence()` calls `review_eligibility.evaluate()` directly. Merge #5943 first; this one should be retargeted to `main` (or merge normally once #5943 lands, since GitHub will re-diff against the new base after #5943 merges).

## Source commit (agent/air-m5/ops/army-w1-assignment)
- `5373c5aea5` feat(evidence): enforce reviewer independence in the release consumer

## Verification
- `.venv/bin/python -m pytest scripts/tests/test_evidence_pack_lint.py -q` → 552 passed, this turn
- `python3 infra/guard-conformance/check_guard_conformance.py` → 0 violations, this turn (10 bridge guards, 19 hook entries, 18 evidence-pack-lint checks including the new one, all armed in CI)
- confirmed `infra/guard-conformance/registry.json` has NOT diverged on `main` since the W1 branch's base — the checked-out file is safe to take wholesale

## Bites
Consumer: `scripts/evidence_pack_lint.py` `main()`, same call site that already runs D3 and the seat rules. CI: `.github/workflows/guard-conformance.yml` step "Evidence Pack lint guilt+innocence (evidence_pack_lint.py)" runs `pytest scripts/tests/test_evidence_pack_lint.py -q` and `evidence_pack_lint.py --selftest` on every PR touching this path. Observation: `test_reviewer_independence_guilt_reviewer_is_contributor_rejected_post_flip` asserts a contributor-as-reviewer pack FAILS lint post-flip, passing in this turn.

Evidence level C. The rule is not armed: NOTICE-only until 2026-09-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qifh5c48sJpBQocpXKABc6