### PR TITLE
fix(usage): seat usage collector — streaming usage, provenance labels, dedup identity policy

### DIFF
--- a/evidence/2026-09/agent-air-m5-ops-usage-collector-fix-v2-b9d74db4/brief.yml
+++ b/evidence/2026-09/agent-air-m5-ops-usage-collector-fix-v2-b9d74db4/brief.yml
@@ -1,0 +1,35 @@
+task_id: usage-collector-fix-v2
+gear: 2
+objective: >-
+  Land the seat usage collector repair (scripts/usage/seat_usage_collector.py) that was
+  built and accepted at fixture level on agent/air-m5/ops/sol-usage-collector but never
+  shipped as a PR. Real bug measured 2026-09-07: streaming Claude responses re-write the
+  same message with growing cumulative token snapshots, and the collector was either
+  summing every snapshot (double-counting) or taking the first (undercounting) —
+  852 reported output tokens vs 14,931 actual on a completed Sonnet builder transcript.
+  This PR carries the code as-is from the source branch, squashing five commits.
+
+  Gear 2 by SIZE, deterministically: net churn is 635 lines (196 net in the collector,
+  439 in the test file), over the 400-line non-hot-zone threshold.
+constraints:
+  - >-
+    This is a landing PR, not new design: the collector's fix logic is unchanged from
+    what was reviewed and accepted at fixture level on the source branch.
+  - >-
+    The collector is not yet armed as a live cron: scripts/usage/com.nuzantara.seat-usage.plist.template
+    is still marked "non armare finché seat_usage_collector.py non è testato sui log reali" —
+    this PR does not flip that switch, it only lands the tested code.
+  - >-
+    Guilt AND innocence fixtures both ship: the streaming-dedup regression test pins the
+    exact defect shape measured live, not a hypothetical.
+acceptance:
+  - text: >-
+      The collector reports the FINAL cumulative snapshot per (message_id, request_id)
+      group, summed across distinct groups — not the sum of all snapshots and not the
+      first snapshot.
+    probe: pytest scripts/usage/test_seat_usage_collector.py -k streaming_last_snapshot_wins -q
+  - text: >-
+      The full collector test suite passes, including the incomplete-identity dedup
+      policy and provenance-label tests.
+    probe: pytest scripts/usage/test_seat_usage_collector.py -q
+pii_scan: clean

--- a/scripts/usage/seat_usage_collector.py
+++ b/scripts/usage/seat_usage_collector.py
@@ -10,7 +10,14 @@ Sorgenti (tutte best-effort, stdlib only):
   - Claude Code: $CLAUDE_PROFILE_DIRS (colon-sep; default ~/.claude) →
     projects/**/*.jsonl → entries con message.usage {input_tokens, output_tokens,
     cache_read_input_tokens, cache_creation_input_tokens} + model + timestamp.
-    Dedupe su (message.id, requestId) — stesso approccio di ccusage.
+    Grouping on (message.id, requestId) with LAST-WINS: under streaming the
+    same response group is rewritten several times with growing CUMULATIVE
+    snapshots — the latest snapshot counts, never the first, never their
+    sum. Latest is by the record's own timestamp, not file order (tie on
+    equal timestamps: the record encountered later in the scan wins), and
+    counters merge per field: a counter omitted by the latest snapshot keeps
+    the value of its latest report in the group — "unknown" means no record
+    of the group ever reported it.
   - Codex CLI: $CODEX_HOMES (colon-sep; default ~/.codex:~/.codex-o2) →
     sessions/**/*.jsonl → oggetti con token count (campi tollerati:
     input_tokens/output_tokens | prompt_tokens/completion_tokens).
@@ -29,7 +36,11 @@ Sorgenti (tutte best-effort, stdlib only):
     status "unknown", mai un numero inventato da una dir non verificata.
 
 Output: JSON snapshot (default ~/.agent/cost-ledger/seat_usage_snapshot.json)
-con schema {generated_at, seats:[{id, source, status, days:{...}, metrics}]}.
+con schema {generated_at, seats:[{id, source, status, days:{...}, metrics,
+provenance?}]}. `provenance` esiste SOLO sui seat Claude: metadato additivo
+(superficie JSONL locale, ultimo snapshot per gruppo, osservato/provvisorio)
+— le chiavi in/out/cache_r/cache_w restano invariate per nome, tipo e
+semantica di status (matrice collector-provenance/2, righe P3/C2).
 Con --inject <dashboard.html> riscrive il blocco window.__SNAPSHOT__.seats.
 
 Uso:
@@ -41,6 +52,7 @@ template da editare: quale profilo cswap corrisponde ad A1/A2/A3/AZ, ecc.)
 from __future__ import annotations
 import argparse, glob, json, os, sys, time
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -81,13 +93,87 @@ def _day(ts: str) -> str | None:
         return None
 
 
+def _ts_epoch(ts: str) -> float:
+    """Record timestamp as epoch seconds, for ordering a group's snapshots.
+    A naive ISO timestamp is assumed UTC; a missing/unparseable one maps to
+    -inf, so any timestamped record outranks it and two untimestamped
+    records fall through to the encounter-order tie-break (see
+    collect_claude's docstring)."""
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except Exception:
+        return float("-inf")
+
+
+def _tok_or_none(usage: dict, key: str) -> int | None:
+    """Value of a token counter: int if reported, None if ABSENT.
+    0 and 'not reported' are different facts — never collapse None into 0."""
+    v = usage.get(key)
+    return v if isinstance(v, int) and not isinstance(v, bool) else None
+
+
+def _acc_tok(acc: int | str, val: int | None) -> int | str:
+    """Accumulate a counter that may be 'unknown'. If ANY contribution is
+    None (not reported) the aggregate stays 'unknown': summing only the
+    known values would be an underestimate passed off as a total."""
+    if not isinstance(acc, int) or val is None:
+        return "unknown"
+    return acc + val
+
+
 def collect_claude(profile_dir: str, since: datetime) -> dict:
-    """Parse dei transcript JSONL di Claude Code per un profilo/account."""
+    """Parse Claude Code JSONL transcripts for one profile/account.
+
+    Real bug (2026-09-07, "output 852 vs 14931" on a Sonnet builder
+    transcript): under streaming the same response group (message.id,
+    requestId) is written MULTIPLE times into the transcript, each line a
+    CUMULATIVE snapshot of that group's counters growing as the stream
+    advances. The old dedupe kept the FIRST snapshot seen (first-wins on a
+    `seen` set) and dropped every update — it published the partial
+    beginning-of-stream count. Correct semantics: per group the LATEST
+    snapshot wins (last-wins); NEVER sum a group's snapshots (they are
+    cumulative: summing double-counts, the same defect class as the Codex
+    2026-08-20 bug).
+
+    "Latest" is decided by the record's own `timestamp`, NOT by file order
+    (records can arrive out of order: replays, merged logs, concurrent
+    writers). Ordering key is (timestamp, encounter_seq). Tie-break,
+    explicit: records of a group with EQUAL timestamps resolve to the one
+    encountered LATER in the scan — deterministic, and right for streaming
+    (a same-timestamp rewrite is the more advanced snapshot). A record with
+    a missing/unparseable timestamp sorts lowest (-inf): any timestamped
+    record outranks it; two untimestamped records fall back to the
+    encounter-order tie-break.
+
+    Counters merge PER FIELD across the group's records: a counter omitted
+    by the winning record keeps the latest value any record of the group
+    reported (same ordering). A counter surfaces as "unknown" ONLY when no
+    record of the group ever reported it — "missing from the last snapshot"
+    is not unknown, and 0 and "not reported" are different facts.
+
+    cache_* stay counters SEPARATE from in/out (they can overlap): never add
+    them together. Day and model come from the group's latest record.
+
+    Incomplete identity: the pair (message.id, requestId) groups records ONLY
+    when BOTH ids are present. A record missing either id receives a fresh
+    unique group key (a singleton group): partial identity cannot prove
+    sameness, so it must never merge two records on the strength of the one
+    id they happen to share — see the INCOMPLETE-IDENTITY POLICY comment in
+    the code below.
+    """
     out = {"status": "ok", "days": defaultdict(lambda: defaultdict(int)), "models": defaultdict(int)}
     root = Path(profile_dir) / "projects"
     if not root.is_dir():
         return {"status": "absent", "note": f"{root} non esiste"}
-    seen: set[tuple] = set()
+    # (message.id, requestId) -> per-group state: "order" is the (timestamp,
+    # seq) key of the latest record overall (source of day/model); each
+    # counter is None or the (timestamp, seq, value) of its latest REPORT.
+    groups: dict[tuple, dict] = {}
+    anon = 0
+    seq = 0
     files = glob.glob(str(root / "**" / "*.jsonl"), recursive=True)
     if not files:
         return {"status": "empty"}
@@ -106,20 +192,59 @@ def collect_claude(profile_dir: str, since: datetime) -> dict:
                     if not usage:
                         continue
                     key = (msg.get("id"), j.get("requestId"))
-                    if key in seen and key != (None, None):
-                        continue
-                    seen.add(key)
-                    day = _day(j.get("timestamp", "")) or "??"
-                    model = msg.get("model", "?")
-                    d = out["days"][day]
-                    d["in"] += usage.get("input_tokens", 0) or 0
-                    d["out"] += usage.get("output_tokens", 0) or 0
-                    d["cache_r"] += usage.get("cache_read_input_tokens", 0) or 0
-                    d["cache_w"] += usage.get("cache_creation_input_tokens", 0) or 0
-                    out["models"][model] += (usage.get("output_tokens", 0) or 0)
-        except Exception as e:  # una sorgente rotta non ferma il giro
+                    if key[0] is None or key[1] is None:
+                        # INCOMPLETE-IDENTITY POLICY (explicit, never implicit):
+                        # the group key answers "are these the same record?"
+                        # and a tuple with a hole cannot answer yes — a hole
+                        # is not a value.
+                        #   - BOTH ids present → dedupe on the pair
+                        #     (last-wins per group, per the docstring);
+                        #   - EITHER id missing → identity is incomplete: the
+                        #     record must NOT merge with another record on the
+                        #     strength of the half that is present. Two
+                        #     genuinely independent records can share a
+                        #     requestId while both lack message.id (or vice
+                        #     versa); collapsing them is the W1 exactly-once
+                        #     defect shape — a key that silently merges what
+                        #     it should distinguish;
+                        #   - both missing → the anonymous path (unchanged).
+                        # Mechanism: ANY incomplete-identity record gets a
+                        # FRESH unique key, i.e. a singleton group of one —
+                        # records merge only when both ids are present and
+                        # equal, the only shape in which sameness is provable.
+                        anon += 1
+                        key = ("__incomplete_id__", anon)
+                    seq += 1
+                    order = (_ts_epoch(j.get("timestamp", "")), seq)
+                    g = groups.setdefault(
+                        key,
+                        {"order": None, "day": "??", "model": "?",
+                         "in": None, "out": None, "cache_r": None, "cache_w": None},
+                    )
+                    if g["order"] is None or order >= g["order"]:
+                        # day/model follow the group's latest record
+                        g["order"] = order
+                        g["day"] = _day(j.get("timestamp", "")) or "??"
+                        g["model"] = msg.get("model", "?")
+                    for field, usage_key in (("in", "input_tokens"),
+                                             ("out", "output_tokens"),
+                                             ("cache_r", "cache_read_input_tokens"),
+                                             ("cache_w", "cache_creation_input_tokens")):
+                        v = _tok_or_none(usage, usage_key)
+                        if v is None:
+                            continue  # absent here: keep any earlier report
+                        cur = g[field]
+                        if cur is None or order >= (cur[0], cur[1]):
+                            g[field] = (order[0], order[1], v)
+        except Exception as e:  # a broken source does not stop the run
             out["status"] = "partial"
             out.setdefault("errors", []).append(f"{fp}: {e}")
+    for g in groups.values():
+        d = out["days"][g["day"]]
+        for k in ("in", "out", "cache_r", "cache_w"):
+            d[k] = _acc_tok(d[k], g[k][2] if g[k] is not None else None)
+        group_out = g["out"][2] if g["out"] is not None else None
+        out["models"][g["model"]] = _acc_tok(out["models"][g["model"]], group_out)
     out["days"] = {k: dict(v) for k, v in out["days"].items()}
     out["models"] = dict(out["models"])
     return out
@@ -270,12 +395,51 @@ def collect_api_mirror(export_dir: str, since: datetime) -> dict:
     return {"status": "ok", "usd_by_provider": dict(tot)} if tot else {"status": "empty"}
 
 
-def fmt_metrics(days: dict) -> str:
+def _fmt_tok(v: int | str) -> str:
+    return f"{v:,}" if isinstance(v, int) else "unknown"
+
+
+def _sum_tok(values: Iterable[int | str]) -> int | str:
+    """Sum only if EVERY contribution is known: a single 'unknown' makes the
+    total 'unknown' (a partial sum would be an underestimate)."""
+    total = 0
+    for v in values:
+        if not isinstance(v, int):
+            return "unknown"
+        total += v
+    return total
+
+
+# Provenance label for the figures collect_claude publishes (acceptance
+# matrix collector-provenance/2, rows P1/P5/C1). Three DIFFERENT surfaces
+# produce token figures and must never read as one: SDK per-step counters
+# (which may be documented placeholders), cumulative SSE deltas, and THIS
+# collector's source — the local Claude Code JSONL transcripts, read as
+# latest-observed snapshot per response group. The label names the third.
+# Claude seats ONLY: the provenance of Codex/agy/Kimi/TP1 figures is not
+# established here, so their metrics strings stay byte-unchanged (row C3) —
+# stamping this label on them would manufacture a claim, not state a fact.
+CLAUDE_LOCAL_JSONL_PROVENANCE = (
+    "fonte: JSONL locali, ultimo snapshot per gruppo — "
+    "osservato/provvisorio, non provider-final"
+)
+
+
+def fmt_metrics(days: dict, provenance: str | None = None) -> str:
+    """Render the per-seat metrics line. `provenance=None` (the default)
+    keeps the rendering BYTE-IDENTICAL to the pre-provenance format — the
+    Codex path depends on that (row C3); only the Claude path passes the
+    label, so the provenance claim travels with the string a dashboard
+    reader copies (row C1), not just with the JSON payload."""
     today = NOW.strftime("%d/%m")
     t = days.get(today, {})
-    tot_out_7d = sum(v.get("out", 0) for v in days.values())
-    return (f"oggi: {t.get('in',0):,}in/{t.get('out',0):,}out · "
-            f"7g out: {tot_out_7d:,} tok · cache r/w oggi: {t.get('cache_r',0):,}/{t.get('cache_w',0):,}")
+    tot_out_7d = _sum_tok(v.get("out", 0) for v in days.values())
+    s = (f"oggi: {_fmt_tok(t.get('in', 0))}in/{_fmt_tok(t.get('out', 0))}out · "
+         f"7g out: {_fmt_tok(tot_out_7d)} tok · "
+         f"cache r/w oggi: {_fmt_tok(t.get('cache_r', 0))}/{_fmt_tok(t.get('cache_w', 0))}")
+    if provenance:
+        s += f" · {provenance}"
+    return s
 
 
 def main() -> int:
@@ -294,7 +458,18 @@ def main() -> int:
         r = collect_claude(os.path.expanduser(pdir), since)
         seats.append({"id": seat_id, "source": f"claude:{pdir}", "status": r.get("status"),
                       "days": r.get("days", {}), "models": r.get("models", {}),
-                      "metrics": fmt_metrics(r.get("days", {})) if r.get("days") else None,
+                      "metrics": fmt_metrics(r.get("days", {}),
+                                             provenance=CLAUDE_LOCAL_JSONL_PROVENANCE)
+                      if r.get("days") else None,
+                      # Additive metadata (rows P1/C2): the existing keys
+                      # above keep names, types and status semantics;
+                      # provenance only ADDS, never renames or retypes.
+                      "provenance": {
+                          "surface": "claude_code_local_jsonl_transcripts",
+                          "method": "latest_observed_snapshot_per_response_group",
+                          "reading": "observed/provisional — not provider-final",
+                          "label": CLAUDE_LOCAL_JSONL_PROVENANCE,
+                      },
                       "note": r.get("note")})
 
     for chome, seat_id in (smap.get("codex_homes") or {}).items():

--- a/scripts/usage/test_seat_usage_collector.py
+++ b/scripts/usage/test_seat_usage_collector.py
@@ -285,3 +285,442 @@ def test_collect_invocations_absent_dir_unaffected_by_identity_check(tmp_path):
         entity_glob="log/cli-*.log",
     )
     assert result["status"] == "absent"
+
+
+# --------------------------------------------------------------- collect_claude
+#
+# Regression pin for the 2026-09-07 "output 852 vs 14931" defect: Claude
+# Code streaming writes the SAME response group (message.id, requestId)
+# several times into the transcript, each line a CUMULATIVE snapshot of
+# that group's counters growing as the stream advances. The old collector
+# deduped on (message.id, requestId) with a first-wins `seen` set, keeping
+# the earliest partial snapshot and dropping every later update (measured
+# on a completed Sonnet builder transcript: 852 reported vs 14,931 from
+# the final snapshots). Correct semantics: last-wins per response group,
+# never a sum of the group's snapshots (they are cumulative — summing
+# double-counts, same defect class as the Codex 2026-08-20 bug), and a
+# missing counter surfaces as "unknown", never 0.
+#
+# All fixtures below are SYNTHETIC: invented ids, numbers and timestamps
+# only — no real transcript content.
+
+
+def _claude_line(msg_id: str | None, req_id: str | None, input_tokens, output_tokens,
+                 cache_read=0, cache_creation=0,
+                 ts: str = "2026-08-19T10:00:00.000Z") -> str:
+    """One assistant-usage line shaped like a Claude Code transcript entry
+    ({message: {id, model, usage}}, requestId, timestamp at top level).
+    None => the counter is omitted from the record entirely; a None msg_id
+    or req_id is serialized as JSON null, i.e. that half of the identity
+    is missing."""
+    usage = {}
+    for k, v in (("input_tokens", input_tokens), ("output_tokens", output_tokens),
+                 ("cache_read_input_tokens", cache_read),
+                 ("cache_creation_input_tokens", cache_creation)):
+        if v is not None:
+            usage[k] = v
+    return json.dumps({
+        "type": "assistant",
+        "timestamp": ts,
+        "requestId": req_id,
+        "message": {"id": msg_id, "model": "claude-test-model", "usage": usage},
+    })
+
+
+def _write_transcript(tmp_path: Path, name: str, lines: list[str]) -> Path:
+    proj = tmp_path / "projects" / "-synthetic-workspace"
+    proj.mkdir(parents=True, exist_ok=True)
+    fp = proj / name
+    fp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return fp
+
+
+def test_collect_claude_streaming_last_snapshot_wins(tmp_path):
+    """Guilt case, synthetic: two response groups, each re-written several
+    times with growing cumulative snapshots (streaming). The collector must
+    report the FINAL snapshot per group, summed across groups — not the
+    first snapshot (the old first-wins defect) and not the sum of all
+    snapshots (double-counting cumulative data)."""
+    lines = [
+        # group A: stream grows 100 -> 400 -> 852 output tokens
+        _claude_line("msg_a", "req_a", 10, 100, cache_read=0, cache_creation=20),
+        _claude_line("msg_a", "req_a", 10, 400, cache_read=0, cache_creation=60),
+        _claude_line("msg_a", "req_a", 10, 852, cache_read=5, cache_creation=120),
+        # group B: stream grows 50 -> 120 output tokens
+        _claude_line("msg_b", "req_b", 7, 50, cache_read=2, cache_creation=9),
+        _claude_line("msg_b", "req_b", 7, 120, cache_read=3, cache_creation=9),
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    assert result["status"] == "ok"
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 852 + 120
+    assert day["in"] == 10 + 7
+    assert day["cache_r"] == 5 + 3
+    assert day["cache_w"] == 120 + 9
+
+    # Document the two wrong readings this pins against:
+    first_wins_out = 100 + 50        # the old defect: earliest partial snapshot
+    naive_sum_out = 100 + 400 + 852 + 50 + 120  # summing cumulative snapshots
+    assert day["out"] != first_wins_out
+    assert day["out"] < naive_sum_out
+
+
+def test_collect_claude_replayed_record_not_double_counted(tmp_path):
+    """A replayed/duplicated line (same group, identical snapshot written
+    twice) must be counted ONCE — last-wins makes the replay idempotent."""
+    replay = _claude_line("msg_r", "req_r", 11, 852, cache_read=5, cache_creation=120)
+    lines = [replay, replay]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 852
+    assert day["in"] == 11
+
+
+def test_collect_claude_distinct_request_ids_both_counted(tmp_path):
+    """Same message.id under two different requestIds are two different
+    response groups: both must contribute (the group key is the pair)."""
+    lines = [
+        _claude_line("msg_x", "req_1", 10, 200),
+        _claude_line("msg_x", "req_2", 30, 300),
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 500
+    assert day["in"] == 40
+
+
+def test_collect_claude_missing_counter_is_unknown_not_zero(tmp_path):
+    """A record that omits a counter must surface 'unknown' for it — 0 and
+    'not reported' are different facts. Counters that ARE reported stay
+    numeric, and one unknown contribution makes the day total unknown."""
+    lines = [
+        _claude_line("msg_m", "req_m", None, 852, cache_read=5, cache_creation=120),
+        _claude_line("msg_k", "req_k", 11, 100, cache_read=2, cache_creation=9),
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["in"] == "unknown"  # one group never reported it
+    assert day["out"] == 952
+    assert day["cache_r"] == 7
+    assert day["cache_w"] == 129
+    assert result["models"]["claude-test-model"] == 952
+
+
+def test_collect_claude_missing_output_does_not_zero_models(tmp_path):
+    """If the final snapshot of a group omits output_tokens, the model
+    breakdown must say 'unknown' rather than silently reporting 0."""
+    lines = [_claude_line("msg_n", "req_n", 10, None)]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == "unknown"
+    assert day["in"] == 10
+    assert result["models"]["claude-test-model"] == "unknown"
+
+
+def test_collect_claude_out_of_order_records_resolved_by_timestamp(tmp_path):
+    """Round-1 blocker: last-wins must follow the record's TIMESTAMP, not
+    file order — replays, merged logs and concurrent writers can deliver an
+    older snapshot AFTER a newer one. Here the file lists the FINAL
+    snapshot (10:02) first and the earlier partial one (10:00) last: a
+    file-order last-wins would keep 100 output tokens, the timestamp-
+    ordered answer is 852. The 10:02 record omits input_tokens, so 'in'
+    must come from its latest report (the 10:00 record) — per-counter
+    merge."""
+    lines = [
+        _claude_line("msg_a", "req_a", None, 852, cache_read=None, cache_creation=None,
+                     ts="2026-08-19T10:02:00.000Z"),
+        _claude_line("msg_a", "req_a", 10, 100, cache_read=None, cache_creation=None,
+                     ts="2026-08-19T10:00:00.000Z"),
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 852
+    assert day["in"] == 10
+    file_order_out = 100  # what the round-1 file-order last-wins would report
+    assert day["out"] != file_order_out
+
+
+def test_collect_claude_equal_timestamps_later_record_wins(tmp_path):
+    """The documented tie-break: two records of one group with EQUAL
+    timestamps resolve to the one encountered LATER in the scan — a
+    same-timestamp streaming rewrite is the more advanced snapshot. Pinned
+    so the rule stays explicit (collect_claude docstring), never implicit
+    in dict-overwrite behavior."""
+    lines = [
+        _claude_line("msg_t", "req_t", 10, 400, ts="2026-08-19T10:00:00.000Z"),
+        _claude_line("msg_t", "req_t", 10, 852, ts="2026-08-19T10:00:00.000Z"),
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 852
+
+
+def test_collect_claude_partial_update_preserves_earlier_counters(tmp_path):
+    """Round-1 blocker 2: snapshot A reports input+output, the NEWER
+    snapshot B reports only output — input must survive (per-counter
+    merge), and a counter NO snapshot of the group ever reported stays
+    'unknown' (never 'missing from the last one')."""
+    lines = [
+        _claude_line("msg_p", "req_p", 10, 100, cache_read=None, cache_creation=20,
+                     ts="2026-08-19T10:00:00.000Z"),
+        _claude_line("msg_p", "req_p", None, 852, cache_read=None, cache_creation=None,
+                     ts="2026-08-19T10:02:00.000Z"),
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["in"] == 10              # survives from snapshot A
+    assert day["out"] == 852            # from the newer snapshot B
+    assert day["cache_w"] == 20         # survives from snapshot A
+    assert day["cache_r"] == "unknown"  # never reported by any snapshot
+    assert result["models"]["claude-test-model"] == 852
+
+
+# ------------------------------------------- incomplete identity (round-2 blocker)
+#
+# The dedup key (message.id, requestId) answers "are these the same
+# record?" — and a tuple with a hole cannot answer yes. The old code
+# treated PARTIAL identity as full identity: (None, "req-1") seen twice
+# collapsed into one group even when the two records were genuinely
+# independent (W1's exactly-once defect shape: a key that silently merges
+# what it should distinguish). Explicit policy, pinned here and stated in
+# collect_claude's code comment: BOTH ids present → dedupe on the pair;
+# EITHER id missing → never merge on the strength of the half present;
+# BOTH missing → the anonymous path (each record its own group).
+
+
+def test_collect_claude_shared_request_id_without_message_id_not_merged(tmp_path):
+    """Regression 1: two records sharing a requestId but BOTH missing
+    message.id are not provably the same record — they must NOT collapse
+    into one group on the strength of the shared requestId."""
+    lines = [
+        _claude_line(None, "req_shared", 10, 100),
+        _claude_line(None, "req_shared", 20, 200),
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 300  # not 200 (buggy partial-identity merge, last-wins)
+    assert day["in"] == 30
+    assert result["models"]["claude-test-model"] == 300
+
+
+def test_collect_claude_shared_message_id_without_request_id_not_merged(tmp_path):
+    """Regression 2: symmetric case — two records sharing a message.id but
+    BOTH missing requestId must NOT collapse either."""
+    lines = [
+        _claude_line("msg_shared", None, 10, 100),
+        _claude_line("msg_shared", None, 20, 200),
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 300
+    assert day["in"] == 30
+
+
+def test_collect_claude_fully_anonymous_records_still_never_collapse(tmp_path):
+    """Regression 3: both ids missing on several records → the pre-existing
+    anonymous behaviour holds: each record is its own group, nothing
+    collapses, every record counts once. Includes one line with the id
+    keys ABSENT ENTIRELY (not just null) — the truly keyless shape."""
+    keyless = json.dumps({
+        "type": "assistant",
+        "timestamp": "2026-08-19T10:00:00.000Z",
+        "message": {"model": "claude-test-model",
+                    "usage": {"input_tokens": 5, "output_tokens": 50}},
+    })
+    lines = [
+        _claude_line(None, None, 10, 100),
+        _claude_line(None, None, 20, 200),
+        keyless,
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 350
+    assert day["in"] == 35
+
+
+def test_collect_claude_full_identity_still_dedupes(tmp_path):
+    """Positive control: two records that genuinely ARE the same response
+    group (BOTH ids present and equal) must still dedupe, last-wins. A fix
+    that simply stopped merging everything would pass regressions 1-3 and
+    be wrong — this is the check that catches it."""
+    lines = [
+        _claude_line("msg_same", "req_same", 10, 100),
+        _claude_line("msg_same", "req_same", 10, 852),  # same ts: later wins
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 852  # not 952 (never summed), not 100 (never first-wins)
+    assert day["in"] == 10
+
+
+def test_collect_claude_partial_identity_does_not_merge_into_full_group(tmp_path):
+    """Boundary case: a record missing one id must not merge INTO a
+    full-identity group that shares the other half — the shared half is
+    not proof of sameness in either direction."""
+    lines = [
+        _claude_line("msg_a", "req_a", 10, 100),  # full-identity group
+        _claude_line(None, "req_a", 20, 200),      # shares requestId only
+        _claude_line("msg_a", None, 30, 300),      # shares message.id only
+    ]
+    _write_transcript(tmp_path, "transcript.jsonl", lines)
+
+    result = suc.collect_claude(str(tmp_path), SINCE)
+    day = next(iter(result["days"].values()))
+    assert day["out"] == 600  # three distinct groups
+    assert day["in"] == 60
+
+
+def test_fmt_metrics_survives_unknown_counters():
+    """A day carrying 'unknown' must format as 'unknown', never crash the
+    {:,} formatter, and the 7-day total must not silently degrade to a
+    partial sum."""
+    days = {
+        "19/08": {"in": 100, "out": "unknown", "cache_r": 5, "cache_w": 9},
+        "20/08": {"in": 50, "out": 200, "cache_r": 1, "cache_w": 2},
+    }
+    text = suc.fmt_metrics(days)
+    assert "unknown" in text
+    # 7g out total must be unknown (one contribution is unknown), not 200
+    assert "7g out: unknown tok" in text
+
+
+# ------------------------------------------- provenance (matrix collector-provenance/2)
+#
+# Rows covered here: P1/C1 (label in the Claude metrics string AND the JSON
+# payload), P2 (no billing/cost/quota vocabulary in the emitted surface,
+# asserted BY NAME below), P3/C2 (existing keys in/out/cache_r/cache_w keep
+# name, type and status semantics — provenance is additive), P4 ('unknown'
+# stays distinct from 0 at the emitted boundary), P5 (the label names WHICH
+# surface produced the figure), C3 (Codex/agy/Kimi/TP1 strings
+# byte-unchanged, no provenance stamp on them).
+#
+# P2's named list. "crediti" is deliberately NOT in it: TP1's pre-existing
+# static note ("crediti Token Plan: endpoint da individuare in PROBE-1") is
+# protected byte-unchanged by row C3 and claims no remaining allowance — it
+# is a probe TODO, not a figure. Test function names in this section avoid
+# every banned substring on purpose: tmp_path embeds the test name and the
+# snapshot carries tmp_path inside seat "source" fields.
+BANNED_SURFACE_VOCABULARY = [
+    "billing", "fattur", "cost", "costo", "spend", "spesa", "price",
+    "prezzo", "quota", "allowance", "remaining", "saldo", "usd", "eur",
+    "$", "€",
+]
+
+
+def test_fmt_metrics_default_rendering_byte_unchanged():
+    """C3, unit level: the Codex path calls fmt_metrics WITHOUT provenance;
+    its rendering must stay byte-identical to the pre-provenance format."""
+    today = suc.NOW.strftime("%d/%m")
+    days = {today: {"in": 17, "out": 952, "cache_r": 5, "cache_w": 120}}
+    assert suc.fmt_metrics(days) == (
+        "oggi: 17in/952out · 7g out: 952 tok · cache r/w oggi: 5/120"
+    )
+
+
+def test_fmt_metrics_claude_provenance_label():
+    """P1/C1/P5, unit level: the Claude rendering carries the provenance
+    label IN the string a dashboard reader copies, the label names which
+    surface produced the figure, and the label itself is vocabulary-clean."""
+    today = suc.NOW.strftime("%d/%m")
+    days = {today: {"in": 17, "out": 952, "cache_r": 5, "cache_w": 120}}
+    text = suc.fmt_metrics(days, provenance=suc.CLAUDE_LOCAL_JSONL_PROVENANCE)
+    assert text.endswith(" · " + suc.CLAUDE_LOCAL_JSONL_PROVENANCE)
+    assert "JSONL locali" in text           # names the surface (P5)
+    assert "osservato/provvisorio" in text  # observed/provisional (P1)
+    for word in BANNED_SURFACE_VOCABULARY:
+        assert word not in text.lower()
+
+
+def test_emitted_snapshot_provenance_end_to_end(tmp_path, monkeypatch):
+    """Boundary round for the whole matrix: run main() against synthetic
+    fixtures (HOME redirected to tmp_path so the agy/Kimi/api-mirror seats
+    resolve to 'absent' deterministically) and assert every row on the REAL
+    emitted snapshot, not on internals."""
+    claude_prof = tmp_path / "claude-prof"
+    _write_transcript(claude_prof, "t.jsonl", [
+        # today (WITA): one complete group + one group that never reports
+        # output_tokens -> day 'out' must be 'unknown'
+        _claude_line("msg_a", "req_a", 10, 852, cache_read=5, cache_creation=120,
+                     ts="2026-08-20T10:00:00.000Z"),
+        _claude_line("msg_b", "req_b", 7, None,
+                     ts="2026-08-20T10:01:00.000Z"),
+        # yesterday: a group that genuinely reports ZERO — 0 is a fact and
+        # must stay distinct from 'unknown' (P4)
+        _claude_line("msg_z", "req_z", 0, 0,
+                     ts="2026-08-19T10:00:00.000Z"),
+    ])
+    codex_home = tmp_path / "codex-home"
+    _write_session(codex_home, "rollout.jsonl", [
+        _token_count_line(total_in=1000, total_out=40, last_in=1000, last_out=40),
+    ])
+    seat_map = tmp_path / "seat_map.json"
+    seat_map.write_text(json.dumps({
+        "claude_profiles": {str(claude_prof): "A1"},
+        "codex_homes": {str(codex_home): "O1"},
+    }))
+    out_json = tmp_path / "snapshot.json"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(suc, "NOW", datetime(2026, 8, 20, 12, 0, tzinfo=suc.WITA))
+    monkeypatch.setattr(sys, "argv", [
+        "seat_usage_collector.py", "--seat-map", str(seat_map), "--out", str(out_json),
+    ])
+
+    assert suc.main() == 0
+    snap = json.loads(out_json.read_text())
+    seats = {s["id"]: s for s in snap["seats"]}
+    claude, codex = seats["A1"], seats["O1"]
+
+    # P3/C2 — old keys, old types, old status semantics; provenance additive
+    assert claude["status"] == "ok" and codex["status"] == "ok"
+    day_today = claude["days"]["20/08"]
+    assert set(day_today) == {"in", "out", "cache_r", "cache_w"}
+    assert isinstance(day_today["in"], int)
+    assert isinstance(claude["days"]["19/08"]["out"], int)
+
+    # P4 — 'unknown' stays distinct from 0 in the EMITTED surface
+    assert day_today["out"] == "unknown"
+    assert claude["days"]["19/08"]["out"] == 0
+    assert "oggi: 17in/unknownout" in claude["metrics"]
+    assert "7g out: unknown tok" in claude["metrics"]
+
+    # P1/C1 — provenance in the human string AND in the JSON payload
+    assert suc.CLAUDE_LOCAL_JSONL_PROVENANCE in claude["metrics"]
+    prov = claude["provenance"]
+    assert prov["surface"] == "claude_code_local_jsonl_transcripts"  # P5
+    assert "observed/provisional" in prov["reading"]
+
+    # C3 — every other seat byte-unchanged, no provenance stamp anywhere
+    assert codex["metrics"] == "oggi: 0in/0out · 7g out: 40 tok · cache r/w oggi: 0/0"
+    assert "provenance" not in codex
+    for seat_id in ("G1", "K1", "TP1"):
+        assert "provenance" not in seats[seat_id]
+        assert suc.CLAUDE_LOCAL_JSONL_PROVENANCE not in json.dumps(seats[seat_id])
+
+    # P2 — no billing/cost/quota vocabulary ANYWHERE in the emitted surface
+    surface = json.dumps(snap, ensure_ascii=False).lower()
+    for word in BANNED_SURFACE_VOCABULARY:
+        assert word not in surface, f"banned vocabulary leaked into emitted surface: {word!r}"


### PR DESCRIPTION
## Why
Streaming Claude responses re-write the same message with growing cumulative token snapshots. The collector was either summing every snapshot (double-counting) or taking the first (undercounting) — measured 2026-09-07 on a completed Sonnet builder transcript: 852 reported output tokens vs 14,931 actual.

## What
`scripts/usage/seat_usage_collector.py` now takes the FINAL snapshot per `(message_id, request_id)` group and sums across distinct groups, with an explicit incomplete-identity dedup policy and provenance labels on the Claude figures. Plus `evidence/2026-09/agent-air-m5-ops-usage-collector-fix-v2-b9d74db4/brief.yml` declaring gear 2.

Supersedes #5944, which Harness floor recompute correctly failed (635 net lines, floor==2 via SIZE alone, no evidence/brief.yml). Reopened fresh from origin/main per Builder Contract §1 rather than pushing a follow-up to the armed branch.

## Source commits (squashed, agent/air-m5/ops/sol-usage-collector)
- `d7b28bd058` wip(usage): collector round-1 output — NOT accepted, five open defects
- `9ed9773875` fix(usage): order collector snapshots by timestamp; merge partial counter updates
- `efe4f67f91` fix(usage): actually revert the unscoped cswap edits (ASTRA-1732)
- `b0586405be` fix(usage): explicit incomplete-identity policy for the collector dedup key
- `5bdf218f95` feat(usage): label the Claude collector figures with their actual provenance

## Verification
- `.venv/bin/python -m pytest scripts/usage/test_seat_usage_collector.py -q` → 27 passed, this turn
- `scripts/evidence_pack_lint.py --print-floor --numstat-file ...` on this exact diff → 2, matching the declared gear
- Regression pin `test_collect_claude_streaming_last_snapshot_wins` run standalone, passing

## Bites
Consumer: `scripts/usage/seat_usage_collector.py`, installed as a launchd cron by `infra/launchagents/install_seat_usage_cron.sh` (template: `scripts/usage/com.nuzantara.seat-usage.plist.template`, currently marked "non armare finché seat_usage_collector.py non è testato sui log reali" — this PR does not flip that switch, it lands the tested code). Observation: the regression-pin test passes on this turn against the exact defect shape measured live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qifh5c48sJpBQocpXKABc6