### PR TITLE
docs(army-map): the workshop v1 steps are Subhi's pilot, not harness doctrine

### DIFF
--- a/docs/architecture/dual-consul/army-map.md
+++ b/docs/architecture/dual-consul/army-map.md
@@ -155,9 +155,10 @@ Codex task):**
 > obtain independent review, pass the Claude final on-disk gate, hand the evidence package to the
 > authorized Claude release owner, prove live, close the ledger with a read-back. Escalate strategic
 > questions to the imperators; business questions to Zero/Subhi with question, options,
-> recommendation, blocked part. _Pilot procedure v1 (workshop 2026-09-08, pending Zero's written
-> ratification): also obtain a PRE-review of the plan and an explicit human scope decision before
-> the first edit; under modus alone these two steps are the conductor's judgment, not a gate._
+> recommendation, blocked part. _Subhi's pilot only (contract v1; Zero 2026-09-09: "lascia questa dottrina per
+> Subhi"): PRE-review of the plan and an explicit human scope decision before the first edit, four
+> PRs per day, Todoist ledger. Not harness doctrine: under modus these are the conductor's judgment,
+> not a gate._
 
 **Builder:** the file set you own, the proof criteria, the worktree path, `model:` pinned, report to
 `<general|specialist>`; never touch outside your ownership; never merge.


### PR DESCRIPTION
## Why
Zero, 2026-09-09: leave the 2026-09-08 workshop contract to Subhi's pilot; the harness takes from it only what does not slow it down and is valid (reviewer independence, escalation format, closure by evidence — all already in force).

## What
`docs/architecture/dual-consul/army-map.md` §6, Dux bootstrap prompt: the sentence that carried PRE-review + human scope decision as "pending Zero's written ratification" now names them, with the 4-PR/day ceiling and the Todoist ledger, as Subhi's pilot only. Companion of the RULINGS sentence in #5962. Docs-only, 4 lines.

Bites: consumer = the imperator/Dux window that reads `army-map.md` §6; observation = the prompt text on `origin/main` after merge (docs-only, no runtime claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qifh5c48sJpBQocpXKABc6