### PR TITLE
fix(deps): bump httpx2 2.10.0 → 2.12.0 — CVE-2026-84379/84380/84382 (pip-audit red on main)

### DIFF
--- a/apps/backend-rag/requirements-prod.lock.txt
+++ b/apps/backend-rag/requirements-prod.lock.txt
@@ -1265,9 +1265,9 @@ httpcore==1.0.9 \
     --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
     --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
     # via httpx
-httpcore2==2.10.0 \
-    --hash=sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc \
-    --hash=sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01
+httpcore2==2.12.0 \
+    --hash=sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb \
+    --hash=sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648
     # via httpx2
 httplib2==0.32.0 \
     --hash=sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025 \
@@ -1334,15 +1334,16 @@ httpx==0.28.1 \
     #   -r requirements-prod.txt
     #   anthropic
     #   google-genai
+    #   langchain-core
     #   langfuse
     #   langgraph-sdk
     #   langsmith
     #   openai
     #   qdrant-client
     #   weasel
-httpx2==2.10.0 \
-    --hash=sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18 \
-    --hash=sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338
+httpx2==2.12.0 \
+    --hash=sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf \
+    --hash=sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36
     # via mcp
 hyperframe==6.1.0 \
     --hash=sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5 \

--- a/apps/backend-rag/requirements.lock.txt
+++ b/apps/backend-rag/requirements.lock.txt
@@ -1667,9 +1667,9 @@ httpcore==1.0.9 \
     --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
     --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
     # via httpx
-httpcore2==2.10.0 \
-    --hash=sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc \
-    --hash=sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01
+httpcore2==2.12.0 \
+    --hash=sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb \
+    --hash=sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648
     # via httpx2
 httplib2==0.32.0 \
     --hash=sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025 \
@@ -1738,6 +1738,7 @@ httpx==0.28.1 \
     #   datasets
     #   google-genai
     #   huggingface-hub
+    #   langchain-core
     #   langfuse
     #   langgraph-sdk
     #   langsmith
@@ -1745,9 +1746,9 @@ httpx==0.28.1 \
     #   openai
     #   qdrant-client
     #   weasel
-httpx2==2.10.0 \
-    --hash=sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18 \
-    --hash=sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338
+httpx2==2.12.0 \
+    --hash=sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf \
+    --hash=sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36
     # via mcp
 huggingface-hub==1.27.0 \
     --hash=sha256:7df6827c2f956c60fbaa64646e979e566db76f619dd0a9729dfb8c5a3eb4f68d \


### PR DESCRIPTION
## Why

`Backend Static (Python)` — a REQUIRED context on `main` — has been red since 2026-09-08: `pip-audit` on `apps/backend-rag/requirements-prod.lock.txt` reports httpx2 2.10.0 with CVE-2026-84379, CVE-2026-84380 (fixed 2.11.0) and CVE-2026-84382 (fixed 2.12.0). Every PR against main inherits the red (`Backend Tests (Python)` fails on "backend-static concluded 'failure'", `Test Summary` fails), so the merge queue is stalled: #5962, #5969 and every hourly mouth promotion sit BLOCKED. Observed on run 34296972584 (job 102295848086).

## What

Bump `httpx2` 2.10.0 → 2.12.0 and its paired `httpcore2` 2.10.0 → 2.12.0 in both lock files (`requirements.lock.txt`, `requirements-prod.lock.txt`), hashes regenerated. Nothing else moves. Gear 1 (floor): dependency pin only, no code.

## Verification (lane session nuzantara-89, M5)

- local `pip-audit` on the bumped lock: clean
- backend suite: 91 tests green

## Bites

Consumer: the `Backend Static (Python)` required check on this PR's own head, then on `main`'s head after merge. Observation: `pip-audit` step exits 0 with no `httpx2` row; `Test Summary` shows `"Backend (Python)":"success"`; the BLOCKED armed PRs (#5962, #5969, mouth hourlies) become MERGEABLE without a rerun. Deploy: merging `apps/backend-rag/**` IS the deploy — `fly-deploy` run + backend `/health` verified by the shipping session after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuXDJZAcTXJX8jSgvfcseE
