### PR TITLE
feat(healer): receptor 8 — a required check red on main is a curable defect

### DIFF
--- a/evidence/2026-09/agent-air-m5-infra-main-red-receptor-7cb74ab0/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-main-red-receptor-7cb74ab0/brief.yml
@@ -1,0 +1,67 @@
+task_id: main-red-receptor
+gear: 2
+l_level: L1
+gate_class: opus
+objective: >-
+  Give the healer a receptor for a REQUIRED status check red on main (Ruling Zero
+  2026-09-09: nothing in the system waits for Zero for a fix). Since 2026-09-08 a
+  required context (Backend Tests (Python), red through Backend Static (Python)'s
+  pip-audit on httpx2 2.10.0) stalled the merge queue and no receptor sensed it:
+  the seven existing receptors watch organs, ledgers, hooks and sessions, never the
+  branch every PR must pass.
+
+  scripts/healer_receptor_main_red.py walks main from HEAD back to each required
+  context's newest non-skipped conclusion (measured before writing: HEAD was a
+  docs-only merge where the context read `skipped`; the failure sat two commits
+  back — a HEAD-only reader says GREEN). For each red it collects the run URL,
+  every failed job of the run with its failed steps and the log window around the
+  root-cause job's last ##[error]; appends ONE HIGH line per (context, sha) to
+  shared/escalations_pro.jsonl with a cure_lane; dedupes by sha in
+  ~/.organism/healer/main_red_state.json; appends a resolved line when the context
+  turns green; never reruns. Wired as receptor 8 in infra/healer/healer-run.sh.
+
+  Gear is 2 via the SIZE term alone (601 net lines: 330 receptor incl. doctrine
+  docstring, 200 guilt+innocence tests, wiring). No hot-zone path is touched.
+constraints:
+  - >-
+    Never `gh run rerun`: a blind rerun replays a stale merge ref (Builder Contract
+    §1). Asserted by test on the module AST and on the fake gh call log.
+  - >-
+    Healer perimeter unchanged: `.github/workflows/**` and `apps/**` stay OUT. The
+    escalation names `cure_lane.owner: session` so the first Claude session that
+    reads the board (SessionStart injects HIGH first) owns the cure; the healer
+    session only triages.
+  - >-
+    Fail-visible, not fail-open: gh or branch protection unreadable = exit 2 BLIND,
+    which healer-run.sh treats as ACTIONABLE (same contract as receptor 4). Kill
+    switch HEALER_MAIN_RED_OFF=1.
+  - >-
+    No PII: the board line carries CI job names, step names and a capped, ANSI- and
+    timestamp-stripped log window of a public-runner job.
+acceptance:
+  - >-
+    WHEN main HEAD reads `skipped` for a required context and the newest non-skipped
+    conclusion two commits back is `failure`, THEN the receptor exits 1, names the
+    context, the sha at depth 2, the failed jobs of that run and the root-cause log
+    window. probe: test_red_two_commits_back_is_red_and_escalates_high; live 2026-09-09
+    10:40 WITA on M5 — `red Backend Tests (Python) @ac9538af70 depth=2`, failed_jobs
+    [Backend Static (Python) [pip-audit], ...], log tail with the httpx2 CVE rows.
+  - >-
+    WHEN the same (context, sha) is still red on the next tick, THEN no second board
+    line is written. probe: test_same_red_second_tick_is_deduped; live second run
+    `+0 escalated`.
+  - >-
+    WHEN the context turns green on a newer sha, THEN a `status: resolved` line for the
+    same job is appended and the receptor exits 0. probe:
+    test_new_sha_still_red_escalates_again_and_green_resolves; live 2026-09-09 11:09
+    WITA after #5971 merged — `board: +0 escalated, 1 resolved`, exit 0, SessionStart
+    receptor back to mute.
+  - >-
+    WHEN a non-required check fails, or a required one is in_progress on HEAD, or
+    HEALER_MAIN_RED_OFF=1, THEN the receptor stays green / pending / disabled and
+    writes nothing. probe: test_non_required_failure_is_ignored,
+    test_in_progress_on_head_is_pending_not_red, test_kill_switch.
+  - >-
+    WHEN branch protection is unreadable, THEN exit 2 and no board write.
+    probe: test_blind_when_protection_unreadable.
+pii_scan: clean

--- a/infra/healer/HEALER-MANDATE.md
+++ b/infra/healer/HEALER-MANDATE.md
@@ -31,6 +31,17 @@ Skill `modus` governa (di norma Gear 1-2; mai Gear 3 senza operatore).
    del cron, non la durata della sessione — e la regola 6 qui sotto ti dà ~40 min a tick.
    Un tick che lavora 11 minuti ed esce 0 è CORRETTO. Non allarmare su quelle righe.
    Una sessione morta comunque non si resuscita: al massimo si riporta.
+   `python3 scripts/healer_receptor_main_red.py --no-escalate` (receptor 8 — un check
+   OBBLIGATORIO rosso su `main`: la coda di merge è ferma e ogni PR armata eredita il
+   rosso). Legge lo stato EFFETTIVO per contesto camminando gli sha di main all'indietro
+   fino all'ultima conclusione non-skipped (l'HEAD di un merge docs-only dice «skipped»
+   mentre il rosso vero sta due commit sotto). Il wrapper ha già scritto la riga HIGH sul
+   board (una per contesto+sha, con job/step falliti, coda del log e `cure_lane`): tu la
+   LEGGI e triaggi. Curabile solo se la causa sta sotto `scripts/`, `infra/`, `docs/`;
+   `.github/workflows/**` e `apps/**` sono FUORI perimetro → la riga HIGH resta sul board
+   per la prima sessione Claude che la legge (SessionStart la inietta HIGH-first). MAI
+   `gh run rerun` a cieco: prima i job/step falliti e la coda del log. Exit 2 = il
+   receptor è CIECO (gh o branch protection illeggibili) → codice tuo, curalo.
    `python3 scripts/session_declaration.py scan` (receptor 7 — il rilevatore VERO di
    «un run autonomo è morto e nessuno se n'è accorto», quello che sostituisce le righe
    informative qui sopra). Non misura la DURATA: misura se chi ha lanciato è TORNATO.

--- a/infra/healer/healer-run.sh
+++ b/infra/healer/healer-run.sh
@@ -249,6 +249,28 @@ elif [ "$REG_EXIT" -eq 2 ]; then
     ACTIONABLE=1; REASONS="${REASONS}registry-receptor-broken "
 fi
 
+# Receptor 8: a REQUIRED check red on main (Zero 2026-09-09: "nulla aspetta
+# Zero per un fix"). Walks main back to each context's newest non-skipped
+# conclusion (HEAD-only reads GREEN on a docs-only merge while every PR is
+# BLOCKED). Writes ONE HIGH line per (context, sha) on the escalations board,
+# resolves it when the context turns green; never reruns. exit 1 = red,
+# exit 2 = BLIND (gh/protection unreadable) — actionable, same as receptor 4.
+# Kill switch: HEALER_MAIN_RED_OFF=1.
+MAIN_RED_OUT=$(python3 scripts/healer_receptor_main_red.py --json --writer mini 2>/dev/null)
+MAIN_RED_EXIT=$?
+if [ "$MAIN_RED_EXIT" -eq 1 ]; then
+    MAIN_RED_CTX=$(printf '%s' "$MAIN_RED_OUT" | python3 -c "
+import json,sys
+try:
+    print(','.join(json.load(sys.stdin).get('red',[])) or '?')
+except Exception:
+    print('?')
+" 2>/dev/null)
+    ACTIONABLE=1; REASONS="${REASONS}main-required-red:${MAIN_RED_CTX:-?} "
+elif [ "$MAIN_RED_EXIT" -eq 2 ]; then
+    ACTIONABLE=1; REASONS="${REASONS}main-red-receptor-blind "
+fi
+
 # Receptor 5: arsenal seats (scripts/arsenal_probe.py) — the quota-cascade can
 # silently thin to 2-deep (codex 401, agy keychain, glm 401/529, deepseek 402).
 # Live-probe at most ~daily (self-throttled by report age — keeps the "healthy

--- a/scripts/healer_receptor_main_red.py
+++ b/scripts/healer_receptor_main_red.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""healer_receptor_main_red.py — receptor 8: a REQUIRED check red on main.
+
+RULING (Zero, 2026-09-09): "tutto ciò che succede nel sistema non deve aspettare
+me per un fix". A required status check that is red on `main` stalls the whole
+merge queue (every armed PR inherits the red and sits BLOCKED) and, until this
+receptor, nothing in the organism *sensed* it: the healer's seven receptors look
+at organs, ledgers, hooks and sessions — never at the branch every PR must pass.
+
+WHAT "RED ON MAIN" MEANS HERE (measured 2026-09-09 before writing this):
+main's HEAD commit was a docs-only merge, so `Backend Static (Python)` was
+`skipped` on it — while the same context was `failure` two commits earlier and
+every PR was BLOCKED on exactly that. A receptor that reads HEAD only would have
+said GREEN. So, per required context, this walks main's history from HEAD back
+(`--depth`, default 20) to the newest check-run whose conclusion is not
+skipped/neutral: that conclusion IS the effective state of the context on main.
+`in_progress` on HEAD is PENDING (neither red nor green, stop walking).
+
+For each red context it collects what a curing session needs to start without a
+blind rerun: the run/job URL, the failed steps of the failing job and the tail
+of that job's log (ANSI/timestamps stripped, capped). It NEVER calls
+`gh run rerun` — "never rerun a red check before you know WHY it is red"
+(Builder Contract §1); the test suite asserts the absence of that call.
+
+ESCALATION + DEDUPE: one HIGH pending line per (context, sha) is appended to
+`shared/escalations_pro.jsonl` (the LIVE board every SessionStart surfaces
+HIGH-first, so ANY Claude session — not only the healer — picks it up). The
+(context, sha) pair is remembered in the state file; a later tick on the same
+red appends nothing. When the context turns green on a newer sha, a
+`status: resolved` line is appended for the same `job` so the board nets it out
+(escalations_alert_sessionstart.sh resolution semantics).
+
+CURE LANE: the healer mandate's curable perimeter excludes `.github/workflows/**`
+and `apps/**`, which is where a required-check red usually lives; the escalation
+therefore names `cure_lane.owner = "session"` (first Claude session that reads
+the board) with a suggested branch `agent/<host>/infra/main-red-<context-slug>`.
+The healer wrapper still goes ACTIONABLE on exit 1 (a healer session triages
+per its mandate: cure if under scripts/infra/docs, otherwise leave the HIGH row
+to the next session — it is already on the board).
+
+Kill switch: `HEALER_MAIN_RED_OFF=1` (exit 0, `{"disabled": true}`).
+
+Exit codes (same contract as healer_receptor_registry.py):
+  0 = no required context red · 1 = red found (actionable) · 2 = receptor BLIND
+  (required contexts or main history unreadable via gh) — actionable too.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ESCALATIONS = REPO_ROOT / "shared" / "escalations_pro.jsonl"
+DEFAULT_STATE = Path("~/.organism/healer/main_red_state.json")
+KILL_SWITCH_ENV = "HEALER_MAIN_RED_OFF"
+JOB_PREFIX = "main-required-red:"
+
+RED = {"failure", "timed_out", "cancelled", "action_required", "startup_failure"}
+NOT_A_VERDICT = {"skipped", "neutral", None, ""}
+LOG_TAIL_LINES = 25
+LOG_TAIL_CHARS = 1500
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T[0-9:.]+Z\s?")
+_JOB_URL_RE = re.compile(r"/actions/runs/(\d+)/job/(\d+)")
+
+GhFn = Callable[[str], object]
+
+
+# --------------------------------------------------------------------------
+# gh transport (swapped for a dict-backed fake in tests)
+# --------------------------------------------------------------------------
+class GhError(RuntimeError):
+    pass
+
+
+def gh_api(path: str) -> object:
+    """`gh api <path>`; raises GhError on non-zero exit or non-JSON output.
+    Job logs (`.../logs`) come back as text and are returned as str."""
+    cmd = ["gh", "api", path]
+    if path.endswith("/logs"):  # raw job log: gh refuses ANSI unless told; we strip it ourselves
+        cmd.append("--allow-escape-sequences")
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise GhError((proc.stderr or proc.stdout).strip()[:300])
+    if path.endswith("/logs"):
+        return proc.stdout
+    try:
+        return json.loads(proc.stdout)
+    except ValueError as exc:
+        raise GhError(f"non-JSON from gh api {path}: {exc}") from exc
+
+
+# --------------------------------------------------------------------------
+# sensing
+# --------------------------------------------------------------------------
+def required_contexts(gh: GhFn, branch: str) -> list[str]:
+    out: list[str] = []
+    prot = gh(f"repos/{{owner}}/{{repo}}/branches/{branch}/protection/required_status_checks")
+    for c in (prot or {}).get("contexts") or []:
+        if c not in out:
+            out.append(c)
+    try:  # rulesets are optional — their absence is not blindness
+        rules = gh(f"repos/{{owner}}/{{repo}}/rules/branches/{branch}")
+    except GhError:
+        rules = []
+    for r in rules or []:
+        if r.get("type") != "required_status_checks":
+            continue
+        for c in (r.get("parameters") or {}).get("required_status_checks") or []:
+            ctx = c.get("context")
+            if ctx and ctx not in out:
+                out.append(ctx)
+    return out
+
+
+def main_shas(gh: GhFn, branch: str, depth: int) -> list[str]:
+    commits = gh(f"repos/{{owner}}/{{repo}}/commits?sha={branch}&per_page={depth}")
+    return [c["sha"] for c in commits or [] if c.get("sha")]
+
+
+def check_runs(gh: GhFn, sha: str) -> list[dict]:
+    data = gh(f"repos/{{owner}}/{{repo}}/commits/{sha}/check-runs?per_page=100")
+    return list((data or {}).get("check_runs") or [])
+
+
+def effective_state(contexts: list[str], shas: list[str], gh: GhFn) -> dict[str, dict]:
+    """Per context: the newest non-skipped conclusion walking main from HEAD."""
+    pending = {c: None for c in contexts}
+    for depth, sha in enumerate(shas):
+        unresolved = [c for c, v in pending.items() if v is None]
+        if not unresolved:
+            break
+        runs = check_runs(gh, sha)
+        for ctx in unresolved:
+            mine = [r for r in runs if r.get("name") == ctx]
+            if not mine:
+                continue
+            if depth == 0 and any(r.get("status") != "completed" for r in mine):
+                pending[ctx] = {"state": "pending", "sha": sha, "depth": 0}
+                continue
+            verdicts = [r for r in mine if r.get("conclusion") not in NOT_A_VERDICT]
+            if not verdicts:
+                continue
+            newest = sorted(verdicts, key=lambda r: r.get("completed_at") or "", reverse=True)[0]
+            concl = newest.get("conclusion")
+            pending[ctx] = {
+                "state": "red" if concl in RED else "green",
+                "conclusion": concl,
+                "sha": sha,
+                "depth": depth,
+                "url": newest.get("html_url") or newest.get("details_url") or "",
+            }
+    return {c: (v or {"state": "unknown", "sha": None, "depth": None}) for c, v in pending.items()}
+
+
+def _clean_log_tail(text: str) -> str:
+    lines = [_TS_RE.sub("", _ANSI_RE.sub("", ln)).rstrip() for ln in text.splitlines()]
+    lines = [ln for ln in lines if ln.strip()]
+    # The raw tail of a GitHub job log is post-job cleanup boilerplate (git
+    # credential scrubbing), never the failure. Window around the LAST
+    # `##[error]` marker instead; fall back to the plain tail without one.
+    errs = [i for i, ln in enumerate(lines) if "##[error]" in ln]
+    if errs:
+        i = errs[-1]
+        window = lines[max(0, i - LOG_TAIL_LINES + 3): i + 3]
+    else:
+        window = lines[-LOG_TAIL_LINES:]
+    return "\n".join(window)[-LOG_TAIL_CHARS:]
+
+
+def enrich(gh: GhFn, url: str) -> dict:
+    """Failed steps + log tail of the failing job named by a check-run URL.
+    Best-effort: any gh failure here degrades to an empty field, never to
+    blindness — the red itself was already sensed."""
+    m = _JOB_URL_RE.search(url or "")
+    empty = {"run_id": None, "job_id": None, "job": None, "failed_steps": [], "failed_jobs": [], "log_tail": ""}
+    if not m:
+        return empty
+    run_id, job_id = m.group(1), m.group(2)
+    # Every failed job of the run, not only the check's own: a required context is
+    # often an AGGREGATOR ("Assert every upstream job succeeded") whose cause sits
+    # in a sibling job that is not itself required (measured 2026-09-09: `Backend
+    # Tests (Python)` red because `Backend Static (Python)` failed on pip-audit).
+    failed_jobs: list[dict] = []
+    try:
+        jobs = (gh(f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}/jobs?per_page=100") or {}).get("jobs") or []
+        for j in jobs:
+            if j.get("conclusion") in RED:
+                failed_jobs.append({"id": str(j.get("id")), "name": j.get("name"),
+                                    "completed_at": j.get("completed_at") or "",
+                                    "steps": [s.get("name") for s in j.get("steps") or []
+                                              if s.get("conclusion") in RED]})
+    except (GhError, AttributeError):
+        pass
+    own = next((j for j in failed_jobs if j["id"] == job_id), None)
+    # log tail from the ROOT cause: the failed job that finished FIRST — a real
+    # failure completes before the aggregators that fail because of it
+    root = min(failed_jobs, key=lambda j: j["completed_at"]) if failed_jobs else None
+    tail = ""
+    if root:
+        try:
+            tail = _clean_log_tail(str(gh(f"repos/{{owner}}/{{repo}}/actions/jobs/{root['id']}/logs")))
+        except GhError:
+            pass
+    return {"run_id": run_id, "job_id": job_id, "job": own["name"] if own else None,
+            "failed_steps": own["steps"] if own else [], "failed_jobs": failed_jobs,
+            "log_job": root["name"] if root else None, "log_tail": tail}
+
+
+# --------------------------------------------------------------------------
+# board + state
+# --------------------------------------------------------------------------
+def _slug(ctx: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", ctx.lower()).strip("-")
+
+
+def _load_state(path: Path) -> dict:
+    try:
+        d = json.loads(path.read_text(encoding="utf-8"))
+        return d if isinstance(d, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _append(path: Path, line: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(line, ensure_ascii=False) + "\n")
+
+
+def reconcile(reds: dict[str, dict], greens: set[str], *, state: dict, escalations: Path,
+              writer: str, host: str, now: float) -> dict:
+    """Append HIGH lines for NEW (context, sha) reds, resolved lines for contexts
+    that were open and are now green. Returns {'escalated': [...], 'resolved': [...]}."""
+    escalated = state.setdefault("escalated", {})
+    open_ctx = state.setdefault("open", {})
+    out = {"escalated": [], "resolved": []}
+    for ctx, info in reds.items():
+        key = f"{ctx}@{info['sha']}"
+        job = JOB_PREFIX + _slug(ctx)
+        if key in escalated:
+            continue
+        line = {
+            "job": job,
+            "type": "main_required_red",
+            "priority": "HIGH",
+            "status": "pending",
+            "error_summary": (
+                f"required check '{ctx}' is {info.get('conclusion')} on main@{info['sha'][:10]} "
+                f"(depth {info.get('depth')}); failed jobs: "
+                + "; ".join(f"{j['name']} [{', '.join(j['steps'])}]" for j in info.get("failed_jobs") or [])
+            ),
+            "context": ctx,
+            "sha": info["sha"],
+            "run_url": info.get("url", ""),
+            "failed_job": info.get("job"),
+            "failed_steps": info.get("failed_steps", []),
+            "failed_jobs": [{"name": j["name"], "steps": j["steps"]} for j in info.get("failed_jobs") or []],
+            "log_job": info.get("log_job"),
+            "log_tail": info.get("log_tail", ""),
+            "cure_lane": {
+                "owner": "session",
+                "branch": f"agent/{host}/infra/main-red-{_slug(ctx)}",
+                "note": "read failed_steps + log_tail first; never rerun blind (Builder Contract §1); "
+                        "healer perimeter excludes .github/workflows/** and apps/**",
+            },
+            "machine": writer,
+            "_writer": writer,
+            "ts": str(now),
+        }
+        _append(escalations, line)
+        escalated[key] = now
+        open_ctx[ctx] = info["sha"]
+        out["escalated"].append(key)
+    for ctx in list(open_ctx):
+        if ctx in greens:
+            job = JOB_PREFIX + _slug(ctx)
+            _append(escalations, {"job": job, "type": "main_required_red", "status": "resolved",
+                                  "resolved_at": str(now), "ts": str(now), "machine": writer,
+                                  "_writer": writer, "context": ctx})
+            del open_ctx[ctx]
+            out["resolved"].append(ctx)
+    return out
+
+
+# --------------------------------------------------------------------------
+def run(*, gh: GhFn = gh_api, branch: str = "main", depth: int = 20, escalate: bool = True,
+        state_path: Path = DEFAULT_STATE, escalations: Path = DEFAULT_ESCALATIONS,
+        writer: str | None = None, now: float | None = None) -> tuple[int, dict]:
+    if os.environ.get(KILL_SWITCH_ENV) == "1":
+        return 0, {"disabled": True, "kill_switch": KILL_SWITCH_ENV}
+    now = time.time() if now is None else now
+    host = socket.gethostname().split(".")[0].lower() or "unknown"
+    writer = writer or host
+    try:
+        contexts = required_contexts(gh, branch)
+        shas = main_shas(gh, branch, depth)
+    except (GhError, KeyError, TypeError) as exc:
+        return 2, {"blind": True, "error": str(exc)[:300], "branch": branch}
+    if not contexts or not shas:
+        return 2, {"blind": True, "error": "no required contexts or no commits readable", "branch": branch}
+    try:
+        states = effective_state(contexts, shas, gh)
+    except (GhError, KeyError, TypeError) as exc:
+        return 2, {"blind": True, "error": f"check-runs unreadable: {str(exc)[:300]}", "branch": branch}
+    reds = {c: dict(v) for c, v in states.items() if v["state"] == "red"}
+    for ctx, info in reds.items():
+        info.update(enrich(gh, info.get("url", "")))
+        states[ctx] = info  # the report carries the enriched view too
+    greens = {c for c, v in states.items() if v["state"] == "green"}
+    report = {"branch": branch, "head": shas[0], "depth_scanned": len(shas),
+              "required": contexts, "states": states, "red": sorted(reds),
+              "board": {"escalated": [], "resolved": []}}
+    if escalate:
+        state = _load_state(Path(state_path).expanduser())
+        report["board"] = reconcile(reds, greens, state=state, escalations=Path(escalations),
+                                    writer=writer, host=host, now=now)
+        _save_state(Path(state_path).expanduser(), state)
+    return (1 if reds else 0), report
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--branch", default="main")
+    ap.add_argument("--depth", type=int, default=20, help="commits walked back from HEAD per context")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--no-escalate", action="store_true", help="sense only: no board line, no state write")
+    ap.add_argument("--state", default=str(DEFAULT_STATE))
+    ap.add_argument("--escalations", default=str(DEFAULT_ESCALATIONS))
+    ap.add_argument("--writer", default=None, help="machine tag for the board line (default: hostname)")
+    a = ap.parse_args(argv)
+    rc, report = run(branch=a.branch, depth=a.depth, escalate=not a.no_escalate,
+                     state_path=Path(a.state), escalations=Path(a.escalations), writer=a.writer)
+    if a.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        if report.get("disabled"):
+            print(f"disabled ({KILL_SWITCH_ENV}=1)")
+        elif report.get("blind"):
+            print(f"BLIND: {report.get('error')}")
+        else:
+            for ctx, v in report["states"].items():
+                print(f"{v['state']:8} {ctx}  @{(v.get('sha') or '')[:10]} depth={v.get('depth')}")
+            print(f"board: +{len(report['board']['escalated'])} escalated, "
+                  f"{len(report['board']['resolved'])} resolved")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_healer_receptor_main_red.py
+++ b/scripts/tests/test_healer_receptor_main_red.py
@@ -1,0 +1,203 @@
+"""Guilt + innocence for healer_receptor_main_red.py (receptor 8).
+
+Fixture = the shape measured on 2026-09-09: main HEAD is a docs-only merge where
+`Backend Static (Python)` is `skipped`, the same context is `failure` on the
+commit two back (pip-audit httpx2 CVE), everything else green. A HEAD-only
+reader says GREEN there; this receptor must say RED, escalate HIGH once, dedupe
+on the next tick, resolve when a newer sha turns green, and NEVER rerun.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_MOD_PATH = Path(__file__).resolve().parents[1] / "healer_receptor_main_red.py"
+_spec = importlib.util.spec_from_file_location("healer_receptor_main_red", _MOD_PATH)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["healer_receptor_main_red"] = mod
+_spec.loader.exec_module(mod)
+
+HEAD, MID, OLD = "a" * 40, "b" * 40, "c" * 40
+STATIC, TESTS, E2E = "Backend Static (Python)", "Backend Tests (Python)", "E2E Tests (Playwright)"
+JOB_URL = "https://github.com/o/r/actions/runs/111/job/222"      # the aggregator job
+STATIC_URL = "https://github.com/o/r/actions/runs/111/job/333"   # the root-cause job
+
+
+def _run(name, conclusion, url="", status="completed", completed="2026-09-09T01:00:00Z"):
+    return {"name": name, "conclusion": conclusion, "status": status,
+            "html_url": url, "completed_at": completed}
+
+
+def fixture(static_on_head="skipped", static_on_mid="failure", head_in_progress=False):
+    head_runs = [_run(STATIC, static_on_head, STATIC_URL), _run(TESTS, "skipped"), _run(E2E, "success")]
+    if head_in_progress:
+        head_runs.append(_run(E2E, None, status="in_progress"))
+    return {
+        "repos/{owner}/{repo}/branches/main/protection/required_status_checks":
+            {"contexts": [STATIC, TESTS, E2E]},
+        "repos/{owner}/{repo}/rules/branches/main": [],
+        "repos/{owner}/{repo}/commits?sha=main&per_page=20":
+            [{"sha": HEAD}, {"sha": MID}, {"sha": OLD}],
+        f"repos/{{owner}}/{{repo}}/commits/{HEAD}/check-runs?per_page=100": {"check_runs": head_runs},
+        f"repos/{{owner}}/{{repo}}/commits/{MID}/check-runs?per_page=100": {"check_runs": [
+            _run(STATIC, static_on_mid, STATIC_URL), _run(TESTS, "failure", JOB_URL),
+            # an older SKIPPED run of the same context on the same sha must not mask the verdict
+            _run(STATIC, "skipped", completed="2026-09-08T00:00:00Z")]},
+        f"repos/{{owner}}/{{repo}}/commits/{OLD}/check-runs?per_page=100": {"check_runs": [
+            _run(STATIC, "success"), _run(TESTS, "success"), _run(E2E, "success")]},
+        # the required context (job 222) is an AGGREGATOR; the root cause is the
+        # sibling job 333 (not required) which finished first
+        "repos/{owner}/{repo}/actions/runs/111/jobs?per_page=100": {"jobs": [
+            {"id": 222, "name": TESTS, "conclusion": "failure", "completed_at": "2026-09-09T01:01:00Z",
+             "steps": [{"name": "Assert every upstream job succeeded", "conclusion": "failure"}]},
+            {"id": 333, "name": STATIC, "conclusion": "failure", "completed_at": "2026-09-09T00:57:00Z",
+             "steps": [{"name": "Install", "conclusion": "success"},
+                       {"name": "pip-audit", "conclusion": "failure"}]},
+            {"id": 444, "name": "MCP Server Tests", "conclusion": "success", "completed_at": "2026-09-09T00:58:00Z",
+             "steps": []}]},
+        "repos/{owner}/{repo}/actions/jobs/333/logs":
+            "2026-09-09T00:57:25.5Z \x1b[36;1mFound 3 known vulnerabilities\x1b[0m\n"
+            "2026-09-09T00:57:25.6Z httpx2 2.10.0  CVE-2026-84382 2.12.0\n"
+            "2026-09-09T00:57:25.7Z ##[error]Process completed with exit code 1.\n",
+    }
+
+
+class FakeGh:
+    def __init__(self, table):
+        self.table, self.calls = table, []
+
+    def __call__(self, path):
+        self.calls.append(path)
+        if path not in self.table:
+            raise mod.GhError(f"unmapped {path}")
+        return self.table[path]
+
+
+def _go(gh, tmp_path, **kw):
+    kw.setdefault("state_path", tmp_path / "state.json")
+    kw.setdefault("escalations", tmp_path / "esc.jsonl")
+    kw.setdefault("writer", "testhost")
+    kw.setdefault("now", 1_000.0)
+    return mod.run(gh=gh, **kw)
+
+
+def _lines(p):
+    return [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+
+
+# ---------------- guilt ----------------
+def test_red_two_commits_back_is_red_and_escalates_high(tmp_path):
+    gh = FakeGh(fixture())
+    rc, rep = _go(gh, tmp_path)
+    assert rc == 1
+    assert rep["red"] == sorted([STATIC, TESTS])
+    assert rep["states"][STATIC] == {**rep["states"][STATIC], "state": "red", "sha": MID, "depth": 1}
+    assert rep["states"][E2E]["state"] == "green"
+    lines = _lines(tmp_path / "esc.jsonl")
+    static = [l for l in lines if l["context"] == STATIC][0]
+    assert static["priority"] == "HIGH" and static["status"] == "pending"
+    assert static["job"] == "main-required-red:backend-static-python"
+    assert static["failed_steps"] == ["pip-audit"]
+    assert [j["name"] for j in static["failed_jobs"]] == [TESTS, STATIC]
+    assert "CVE-2026-84382" in static["log_tail"] and "\x1b" not in static["log_tail"]
+    tests = [l for l in lines if l["context"] == TESTS][0]
+    assert tests["failed_steps"] == ["Assert every upstream job succeeded"]
+    assert tests["log_job"] == STATIC and "pip-audit" in tests["error_summary"]
+    assert "CVE-2026-84382" in tests["log_tail"]  # aggregator line carries the ROOT log
+    assert static["cure_lane"]["owner"] == "session"
+    assert static["cure_lane"]["branch"].endswith("/infra/main-red-backend-static-python")
+    assert rep["board"]["escalated"] == [f"{STATIC}@{MID}", f"{TESTS}@{MID}"]
+
+
+def test_same_red_second_tick_is_deduped(tmp_path):
+    gh = FakeGh(fixture())
+    _go(gh, tmp_path)
+    rc, rep = _go(gh, tmp_path, now=2_000.0)
+    assert rc == 1 and rep["board"]["escalated"] == []
+    assert len([l for l in _lines(tmp_path / "esc.jsonl") if l["status"] == "pending"]) == 2
+
+
+def test_new_sha_still_red_escalates_again_and_green_resolves(tmp_path):
+    gh = FakeGh(fixture())
+    _go(gh, tmp_path)
+    cured = fixture(static_on_head="success")
+    cured[f"repos/{{owner}}/{{repo}}/commits/{HEAD}/check-runs?per_page=100"]["check_runs"][1] = \
+        _run(TESTS, "success")
+    rc, rep = _go(FakeGh(cured), tmp_path, now=3_000.0)
+    assert rc == 0 and sorted(rep["board"]["resolved"]) == sorted([STATIC, TESTS])
+    resolved = [l for l in _lines(tmp_path / "esc.jsonl") if l["status"] == "resolved"]
+    assert {l["job"] for l in resolved} == {"main-required-red:backend-static-python",
+                                            "main-required-red:backend-tests-python"}
+    assert json.loads((tmp_path / "state.json").read_text())["open"] == {}
+
+
+def test_blind_when_protection_unreadable(tmp_path):
+    t = fixture()
+    del t["repos/{owner}/{repo}/branches/main/protection/required_status_checks"]
+    rc, rep = _go(FakeGh(t), tmp_path)
+    assert rc == 2 and rep["blind"]
+    assert not (tmp_path / "esc.jsonl").exists()
+
+
+# ---------------- innocence ----------------
+def test_all_green_is_green_and_writes_nothing(tmp_path):
+    t = fixture(static_on_head="success", static_on_mid="success")
+    t[f"repos/{{owner}}/{{repo}}/commits/{HEAD}/check-runs?per_page=100"]["check_runs"][1] = \
+        _run(TESTS, "success")
+    rc, rep = _go(FakeGh(t), tmp_path)
+    assert rc == 0 and rep["red"] == []
+    assert not (tmp_path / "esc.jsonl").exists()
+
+
+def test_green_on_head_beats_older_red(tmp_path):
+    t = fixture(static_on_head="success")
+    t[f"repos/{{owner}}/{{repo}}/commits/{HEAD}/check-runs?per_page=100"]["check_runs"][1] = \
+        _run(TESTS, "success")
+    rc, rep = _go(FakeGh(t), tmp_path)
+    assert rc == 0 and rep["states"][STATIC]["depth"] == 0
+
+
+def test_non_required_failure_is_ignored(tmp_path):
+    t = fixture(static_on_head="success", static_on_mid="success")
+    runs = t[f"repos/{{owner}}/{{repo}}/commits/{HEAD}/check-runs?per_page=100"]["check_runs"]
+    runs[1] = _run(TESTS, "success")
+    runs.append(_run("npm audit (advisory)", "failure"))
+    rc, rep = _go(FakeGh(t), tmp_path)
+    assert rc == 0 and "npm audit (advisory)" not in rep["states"]
+
+
+def test_in_progress_on_head_is_pending_not_red(tmp_path):
+    t = fixture(static_on_head="success", static_on_mid="success", head_in_progress=True)
+    t[f"repos/{{owner}}/{{repo}}/commits/{HEAD}/check-runs?per_page=100"]["check_runs"][1] = \
+        _run(TESTS, "success")
+    rc, rep = _go(FakeGh(t), tmp_path)
+    assert rc == 0 and rep["states"][E2E]["state"] == "pending"
+
+
+def test_kill_switch(tmp_path, monkeypatch):
+    monkeypatch.setenv(mod.KILL_SWITCH_ENV, "1")
+    gh = FakeGh(fixture())
+    rc, rep = _go(gh, tmp_path)
+    assert rc == 0 and rep["disabled"] and gh.calls == []
+
+
+def test_no_escalate_senses_without_touching_board_or_state(tmp_path):
+    rc, rep = _go(FakeGh(fixture()), tmp_path, escalate=False)
+    assert rc == 1 and rep["red"]
+    assert not (tmp_path / "esc.jsonl").exists() and not (tmp_path / "state.json").exists()
+
+
+def test_never_reruns():
+    tree = ast.parse(_MOD_PATH.read_text(encoding="utf-8"))
+    tree.body = tree.body[1:]  # drop the module docstring, which NAMES the forbidden call
+    code = ast.unparse(tree)
+    assert not re.search(r"run\s+rerun|rerun-failed|actions/runs/\S*/rerun", code)
+    gh = FakeGh(fixture())
+    mod.run(gh=gh, escalate=False)
+    assert not any("rerun" in c for c in gh.calls)


### PR DESCRIPTION
## Why

Ruling Zero 2026-09-09: _"tutto ciò che succede nel sistema non deve aspettare me per un fix"_. Since 2026-09-08 a REQUIRED context (`Backend Tests (Python)`, red because `Backend Static (Python)`'s pip-audit finds httpx2 2.10.0 CVEs) has stalled the merge queue — #5962, #5969 and every hourly mouth promotion BLOCKED — and no receptor in the organism sensed it. The healer's seven receptors watch organs, ledgers, hooks and sessions, never the branch every PR must pass.

## What

`scripts/healer_receptor_main_red.py` — receptor 8.

- **Effective state, not HEAD**: per required context (branch protection contexts + rulesets), walks main from HEAD back (`--depth 20`) to the newest non-skipped conclusion. Measured before writing: main HEAD is a docs-only merge where the context is `skipped`; the `failure` sits two commits back. A HEAD-only reader says GREEN there.
- **What a curing session needs**: run URL, every failed job of the run with its failed steps, and the log window around the root-cause job's last `##[error]` (root = the failed job that finished first — a required context is usually an aggregator, "Assert every upstream job succeeded", whose cause is a sibling job that is not itself required).
- **Board + dedupe**: one HIGH pending line per (context, sha) in `shared/escalations_pro.jsonl` with `cure_lane` (`owner: session`, suggested `agent/<host>/infra/main-red-<slug>` branch, "never rerun blind"); (context, sha) remembered in `~/.organism/healer/main_red_state.json`; a `status: resolved` line is appended when the context turns green so `escalations_alert_sessionstart.sh` nets it out.
- **Never reruns**: no `gh run rerun` anywhere — asserted by test on the AST.
- **Kill switch** `HEALER_MAIN_RED_OFF=1`; exit 0 green / 1 red (ACTIONABLE) / 2 BLIND (gh or protection unreadable — actionable too, same as receptor 4).
- Wired as receptor 8 in `infra/healer/healer-run.sh` (`REASONS=main-required-red:<contexts>` / `main-red-receptor-blind`); `HEALER-MANDATE.md` tells the healer session how to triage it (curable only under `scripts/`, `infra/`, `docs/`; `.github/workflows/**` and `apps/**` stay on the board for the first Claude session that reads it).

Net lines 601 (> the ~400 guideline): 330 receptor incl. doctrine docstring, 200 guilt+innocence tests, the rest is wiring. Splitting the tests from the receptor would ship a guard without its guilt/innocence proof.

## Verification

```
$ .venv/bin/python3 -m pytest scripts/tests/test_healer_receptor_main_red.py -q
11 passed
$ bash -n infra/healer/healer-run.sh   # ok
```

Live probe on M5 against the real red (2026-09-09 10:40 WITA):

```
$ python3 scripts/healer_receptor_main_red.py --writer m5
red      Backend Tests (Python)  @ac9538af70 depth=2
green    ... (12 other required contexts)
board: +1 escalated, 0 resolved      exit=1
```

The HIGH line carries `failed_jobs: [Backend Static (Python) [pip-audit], Backend Tests (Python) [Assert every upstream job succeeded], Test Summary [Create test summary]]`, `log_job: Backend Static (Python)` and a log tail with the three `httpx2 2.10.0 CVE-2026-8437x/84382` rows. Second run: `+0 escalated` (deduped by sha). `bash scripts/hooks/escalations_alert_sessionstart.sh` now injects `1 HIGH-priority open (act first): main-required-red:backend-tests-python`.

## Bites

Consumer: `infra/healer/healer-run.sh` receptor 8 on the Mini healer tick (every 4h) and, through the board line it writes, every SessionStart on every machine (`escalations_alert_sessionstart.sh`, HIGH-first). Observation already made: the board line above is LIVE on M5 and surfaced by the SessionStart receptor. After #5971 (the httpx2 cure) merges, the next receptor run must append `status: resolved` for `main-required-red:backend-tests-python` and exit 0 — the shipping session runs it and reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuXDJZAcTXJX8jSgvfcseE
