### PR TITLE
chore(lint): exclude apps/mouth/coverage from the ESLint scan

### DIFF
--- a/apps/mouth/eslint.config.mjs
+++ b/apps/mouth/eslint.config.mjs
@@ -7,6 +7,7 @@ const config = [
       'node_modules/',
       '.next/',
       'out/',
+      'coverage/',
       'playwright-report/',
       'test-results/',
       'scripts/',


### PR DESCRIPTION
Stop ESLint scanning the gitignored coverage output; 183 -> 177 warnings, no rule changes.

# Insight
ESLint flat config does not read .gitignore. `apps/mouth/coverage/` is ignored by git
(.gitignore:306) but was still linted, so six of the warnings on main came from Istanbul's
generated report scripts rather than from application code.

# Studio

## Source / Reference
- `apps/mouth/eslint.config.mjs` — `ignores` array, 15 entries, no coverage entry
- `.gitignore:306` — `apps/mouth/coverage/`
- Measured on origin/main `8d0a49d506`, 2026-09-09, 12:00 WITA

## Methodology
1. `npm run lint -w apps/mouth` on origin/main; warnings read from the ESLint summary line
2. Added `'coverage/'` to `ignores`, adjacent to the other build-output entries
3. Re-ran the same command, same machine, same session
4. `npm run build -w apps/mouth` to confirm the config still loads

## Raw Observations
- Before: `183 problems (0 errors, 183 warnings)`, 19 fixable with --fix
- After: `177 problems (0 errors, 177 warnings)`, 13 fixable with --fix
- Delta -6, all six from `apps/mouth/coverage/**`, each `Unused eslint-disable directive`:
  `coverage/block-navigation.js:1`, `coverage/prettify.js:1`, `coverage/sorter.js:1`,
  `coverage/lcov-report/block-navigation.js:1`, `coverage/lcov-report/prettify.js:1`,
  `coverage/lcov-report/sorter.js:1`
- Build: rc=0, 1766 static pages, `PUBLIC_LOGIN_BUNDLE_OK`
- Diff: 1 file changed, 1 insertion(+)
- `prettier --check` is not applicable here: the root `lint:check` glob is
  `**/*.{ts,js,json,md,yml,yaml}`, which excludes `.mjs`, and no prettier config resolves
  in this repo (`prettier --find-config-path` errors). Tracked separately.

## Reasoning Path
All six warnings are `Unused eslint-disable directive` on Istanbul's own report scripts.
They cannot be fixed in source, because the files are regenerated by every coverage run,
and they cannot be silenced per-file for the same reason. Ignoring the directory is the
only fix that survives the next run, and it matches how `.next/` and `out/` are already
handled in the same array.

## Risk / Implication
- No rule is changed, disabled or downgraded. Application-code warnings are untouched: 177 remain.
- If coverage output were ever expected to be linted, this hides it. It is gitignored, so it is not reviewed code.
- Not measured: whether CI's ESLint invocation differs from `npm run lint -w apps/mouth`.

# Recommendation
Merge as-is. One line, reversible with `gh pr revert`.

# Next Action
The remaining 177 warnings are application-code findings and are not addressed here. Four
rules dominate them: `no-html-link-for-pages`, `react-hooks/exhaustive-deps`,
`no-img-element`, `react/no-unescaped-entities`. Triage belongs in a separate per-rule sequence.
