### PR TITLE
fix(kbli): render kewenangan arrays with a separator on /kbli/[code]

### DIFF
--- a/apps/mouth/src/components/kbli/KBLIDivergence.test.tsx
+++ b/apps/mouth/src/components/kbli/KBLIDivergence.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { KBLIDivergence, authorityLabel } from "./KBLIDivergence";
+
+describe("authorityLabel helper", () => {
+  it("returns null for undefined", () => {
+    expect(authorityLabel(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string ''", () => {
+    expect(authorityLabel("")).toBeNull();
+  });
+
+  it("returns trimmed string for single non-empty string 'OSS'", () => {
+    expect(authorityLabel("OSS")).toBe("OSS");
+  });
+
+  it("returns null for empty array []", () => {
+    expect(authorityLabel([])).toBeNull();
+  });
+
+  it("returns single element string for array ['Gubernur']", () => {
+    expect(authorityLabel(["Gubernur"])).toBe("Gubernur");
+  });
+
+  it("joins multiple array elements with comma-space", () => {
+    expect(authorityLabel(["Bupati/Walikota", "Menteri", "Gubernur"])).toBe(
+      "Bupati/Walikota, Menteri, Gubernur",
+    );
+  });
+
+  it("filters out empty and whitespace-only elements inside array", () => {
+    expect(authorityLabel(["", "   "])).toBeNull();
+    expect(authorityLabel(["Gubernur", "", "  ", "Menteri"])).toBe(
+      "Gubernur, Menteri",
+    );
+  });
+});
+
+describe("KBLIDivergence component rendering", () => {
+  const baseProvenance = {
+    state: "not_classifiable" as const,
+    definition: { locator: null, assembly: null },
+    licensing: {
+      status: "detached" as const,
+      locator: null,
+      vintage: null,
+      noOssScope: false,
+      contentInheritedFrom: null,
+    },
+    pma: {
+      source: null,
+      vintage: null,
+      status: "declared_gap" as const,
+      locator: null,
+    },
+    dataNote: "Test correction note",
+  };
+
+  it("does not render Authority line when kewenangan is empty array []", () => {
+    const provenance = {
+      ...baseProvenance,
+      disputed: {
+        key: "per_skala_disputed_pp28_test",
+        rows: [
+          {
+            skala_usaha: ["Mikro" as const],
+            kategori_risiko: "Rendah",
+            kewenangan: [],
+          },
+        ],
+      },
+    };
+
+    render(<KBLIDivergence code="12345" provenance={provenance} />);
+    expect(screen.queryByText(/Authority:/)).toBeNull();
+  });
+
+  it("renders joined Authority line when kewenangan is an array of strings", () => {
+    const provenance = {
+      ...baseProvenance,
+      disputed: {
+        key: "per_skala_disputed_pp28_test",
+        rows: [
+          {
+            skala_usaha: ["Mikro" as const],
+            kategori_risiko: "Rendah",
+            kewenangan: ["Bupati/Walikota", "Menteri", "Gubernur"],
+          },
+        ],
+      },
+    };
+
+    render(<KBLIDivergence code="12345" provenance={provenance} />);
+    expect(
+      screen.getByText("Authority: Bupati/Walikota, Menteri, Gubernur"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/components/kbli/KBLIDivergence.tsx
+++ b/apps/mouth/src/components/kbli/KBLIDivergence.tsx
@@ -24,6 +24,19 @@ function licenseLabel(perizinan: string | string[] | undefined): string {
   return perizinan;
 }
 
+/** `kewenangan` is a string on legacy rows, an array elsewhere. Returns null if empty. */
+export function authorityLabel(
+  kewenangan: string | string[] | undefined,
+): string | null {
+  if (!kewenangan) return null;
+  if (Array.isArray(kewenangan)) {
+    const filtered = kewenangan.filter((k) => k.trim().length > 0);
+    return filtered.length > 0 ? filtered.join(", ") : null;
+  }
+  const trimmed = kewenangan.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 export function KBLIDivergence({ code, provenance }: KBLIDivergenceProps) {
   const { dataNote, disputed } = provenance;
   if (!dataNote && !disputed) return null;
@@ -120,38 +133,41 @@ export function KBLIDivergence({ code, provenance }: KBLIDivergenceProps) {
               page describes. They are preserved here as the audit trail of the
               divergence.
             </p>
-            {disputed.rows.map((row, i) => (
-              <div
-                key={i}
-                className="rounded-lg border border-[var(--border)] px-4 py-3"
-                style={{ background: "var(--kbli-bg-elevated)" }}
-              >
-                <div className="flex flex-wrap items-center gap-2.5">
-                  {Array.isArray(row.skala_usaha) &&
-                    row.skala_usaha.length > 0 && (
-                      <span className="text-xs font-semibold text-[var(--foreground)]">
-                        {row.skala_usaha.join(", ")}
+            {disputed.rows.map((row, i) => {
+              const authority = authorityLabel(row.kewenangan);
+              return (
+                <div
+                  key={i}
+                  className="rounded-lg border border-[var(--border)] px-4 py-3"
+                  style={{ background: "var(--kbli-bg-elevated)" }}
+                >
+                  <div className="flex flex-wrap items-center gap-2.5">
+                    {Array.isArray(row.skala_usaha) &&
+                      row.skala_usaha.length > 0 && (
+                        <span className="text-xs font-semibold text-[var(--foreground)]">
+                          {row.skala_usaha.join(", ")}
+                        </span>
+                      )}
+                    {row.kategori_risiko && (
+                      <RiskBadge category={row.kategori_risiko} size="sm" />
+                    )}
+                    <span className="text-xs text-[var(--foreground-muted)]">
+                      {licenseLabel(row.perizinan)}
+                    </span>
+                    {authority && (
+                      <span className="ml-auto text-[11px] text-[var(--foreground-muted)]">
+                        Authority: {authority}
                       </span>
                     )}
-                  {row.kategori_risiko && (
-                    <RiskBadge category={row.kategori_risiko} size="sm" />
-                  )}
-                  <span className="text-xs text-[var(--foreground-muted)]">
-                    {licenseLabel(row.perizinan)}
-                  </span>
-                  {row.kewenangan && (
-                    <span className="ml-auto text-[11px] text-[var(--foreground-muted)]">
-                      Authority: {row.kewenangan}
-                    </span>
+                  </div>
+                  {row.scope_uraian && (
+                    <p className="mt-1.5 text-[11px] italic text-[var(--foreground-muted)]">
+                      Source-row scope: {row.scope_uraian}
+                    </p>
                   )}
                 </div>
-                {row.scope_uraian && (
-                  <p className="mt-1.5 text-[11px] italic text-[var(--foreground-muted)]">
-                    Source-row scope: {row.scope_uraian}
-                  </p>
-                )}
-              </div>
-            ))}
+              );
+            })}
           </div>
         </details>
       )}

--- a/apps/mouth/src/lib/kbli-types.ts
+++ b/apps/mouth/src/lib/kbli-types.ts
@@ -55,7 +55,7 @@ export interface KBLIDisputedScaleRow {
   skala_usaha?: KBLIBusinessScale[];
   kategori_risiko?: string;
   perizinan?: string | string[];
-  kewenangan?: string;
+  kewenangan?: string | string[];
   jangka_waktu?: string;
   scope_uraian?: string;
   [key: string]: unknown;


### PR DESCRIPTION
Render `kewenangan` correctly when it arrives as an array instead of a string on /kbli/[code].

# Insight
`KBLIDisputedScaleRow.kewenangan` was typed as `string`. Where the field arrives as an array,
the component rendered it without a separator. Widening the type and joining at the render site
makes both shapes read the same way.

# Studio

## Source / Reference
- `apps/mouth/src/lib/kbli-types.ts` (:58 in this branch) — `kewenangan?: string` becomes `string | string[]`
- `apps/mouth/src/components/kbli/KBLIDivergence.tsx` — render site
- `apps/mouth/src/components/kbli/KBLIDivergence.test.tsx` — new test file
- Commit `bf8cbb68a1`, authored 2026-09-03T14:48:23 +08:00

## Methodology
1. `npm run build -w apps/mouth` in the branch worktree
2. `npm run lint -w apps/mouth` in the same worktree
3. `git diff origin/main...HEAD` read per file to establish the zone

## Raw Observations
- Diff: 3 files, +144 / -29
  - `lib/kbli-types.ts`: one line changed
  - `components/kbli/KBLIDivergence.tsx`: 72 lines changed
  - `components/kbli/KBLIDivergence.test.tsx`: +99, new file
- Build: rc=0
- Lint: 0 errors
- Branch base is 238 commits behind main at the time of opening; the diff above is against the merge base
- NOT MEASURED: the new test assertions. vitest does not run locally in this repo, the `@/` alias
  fails to resolve, so zero tests were collected. CI is the first place these assertions execute,
  and they are the most likely part of this PR to go red.
- NOT MEASURED: whether the backend guarantees a single shape for `kewenangan`.

## Reasoning Path
The type was narrower than the data. Two fixes were available: normalise the shape at the data
boundary, or widen the type and handle both at the render site. This takes the second, because
`KBLIDisputedScaleRow` already carries `[key: string]: unknown` and is treated as a permissive
shape throughout, so a strict boundary normaliser would be the only strict thing in a lenient path.

## Risk / Implication
- Zone VERDE: all three files are under `apps/mouth/**`; `packages/core` is untouched.
- This does not touch the KBLI data model: no schema, no entries, no attribute definitions,
  no `/api/kbli/*`, no backend validation. It changes how the frontend types and renders a field
  the backend already sends.
- If the backend is in fact guaranteed to send a string, this widening hides a contract mismatch
  rather than fixing it. Recorded so review can reject on that ground.

# Recommendation
Review the new test file first. It is the only part of this change that has never executed anywhere.

# Next Action
None from this PR. Remaining `/kbli` layer work continues separately.
