### PR TITLE
fix(seo): add BreadcrumbList JSON-LD to four /kbli routes

### DIFF
--- a/apps/mouth/src/app/kbli/builder/page.tsx
+++ b/apps/mouth/src/app/kbli/builder/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { KBLIBuilderCTA } from "./_components/KBLIBuilderCTA";
+import { KBLIBreadcrumbJsonLd } from "@/components/kbli/KBLIStructuredData";
 
 export const metadata: Metadata = {
   title: "KBLI Builder — Susun Struktur Kode KBLI untuk PT PMA Anda",
@@ -27,6 +28,12 @@ export default function KBLIBuilderPage() {
         minHeight: "100vh",
       }}
     >
+      <KBLIBreadcrumbJsonLd
+        items={[
+          { name: "KBLI Navigator", url: "https://balizero.com/kbli" },
+          { name: "KBLI Builder", url: "https://balizero.com/kbli/builder" },
+        ]}
+      />
       <KBLIBuilderCTA />
     </main>
   );

--- a/apps/mouth/src/app/kbli/decoder/page.tsx
+++ b/apps/mouth/src/app/kbli/decoder/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { KBLIDecoderCTA } from "./_components/KBLIDecoderCTA";
+import { KBLIBreadcrumbJsonLd } from "@/components/kbli/KBLIStructuredData";
 
 export const metadata: Metadata = {
   title: "KBLI Decoder — Temukan Kode Klasifikasi Bisnis Anda",
@@ -27,6 +28,12 @@ export default function KBLIDecoderPage() {
         minHeight: "100vh",
       }}
     >
+      <KBLIBreadcrumbJsonLd
+        items={[
+          { name: "KBLI Navigator", url: "https://balizero.com/kbli" },
+          { name: "KBLI Decoder", url: "https://balizero.com/kbli/decoder" },
+        ]}
+      />
       <KBLIDecoderCTA />
     </main>
   );

--- a/apps/mouth/src/app/kbli/sectors/[id]/page.tsx
+++ b/apps/mouth/src/app/kbli/sectors/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/kbli-data";
 import { KBLIBreadcrumb } from "@/components/kbli/KBLIBreadcrumb";
 import { KBLICard } from "@/components/kbli/KBLICard";
+import { KBLIBreadcrumbJsonLd } from "@/components/kbli/KBLIStructuredData";
 
 export async function generateStaticParams() {
   return getSections()
@@ -51,6 +52,16 @@ export default async function SectorDetailPage({
 
   return (
     <div className="space-y-8">
+      <KBLIBreadcrumbJsonLd
+        items={[
+          { name: "KBLI Navigator", url: "https://balizero.com/kbli" },
+          { name: "Sectors", url: "https://balizero.com/kbli/sectors" },
+          {
+            name: `Section ${id.toUpperCase()}`,
+            url: `https://balizero.com/kbli/sectors/${id.toUpperCase()}`,
+          },
+        ]}
+      />
       <KBLIBreadcrumb
         items={[
           { label: "KBLI Navigator", href: "/kbli" },

--- a/apps/mouth/src/app/kbli/sectors/page.tsx
+++ b/apps/mouth/src/app/kbli/sectors/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getSections } from "@/lib/kbli-data";
 import { KBLIBreadcrumb } from "@/components/kbli/KBLIBreadcrumb";
 import { KBLISectorBrowser } from "@/components/kbli/KBLISectorBrowser";
+import { KBLIBreadcrumbJsonLd } from "@/components/kbli/KBLIStructuredData";
 
 export const metadata: Metadata = {
   title: "KBLI 2025 Sectors — Browse All Business Categories",
@@ -17,6 +18,12 @@ export default function SectorsPage() {
 
   return (
     <div className="space-y-8">
+      <KBLIBreadcrumbJsonLd
+        items={[
+          { name: "KBLI Navigator", url: "https://balizero.com/kbli" },
+          { name: "Sectors", url: "https://balizero.com/kbli/sectors" },
+        ]}
+      />
       <KBLIBreadcrumb
         items={[
           { label: "KBLI Navigator", href: "/kbli" },


### PR DESCRIPTION
Four /kbli routes render a breadcrumb or sit two levels deep but emit no BreadcrumbList JSON-LD.

# Insight
`KBLIBreadcrumbJsonLd` already exists and was used by exactly one route, `/kbli/[code]`. Two sector
routes already render a visual breadcrumb, with the labels and hrefs in hand, but emit nothing
machine-readable. Two CTA routes sit two levels deep with canonical and OpenGraph metadata and no
breadcrumb at all. This adds the existing component at four call sites. The component is unchanged.

# Studio

## Source / Reference
- `apps/mouth/src/components/kbli/KBLIStructuredData.tsx:226` — `KBLIBreadcrumbJsonLd`, existing, untouched
- `apps/mouth/src/app/kbli/[code]/page.tsx:171` — the only prior caller; this PR copies its item shape
- Measured on origin/main `8d0a49d506`

## Methodology
1. Enumerated every `page.tsx` under `apps/mouth/src/app/**kbli**` — 7 files
2. Measured which routes *emit* a BreadcrumbList by grepping the call sites for `<KBLIBreadcrumbJsonLd`
   and `<BreadcrumbJsonLd`, not for the word "breadcrumb": the string `BreadcrumbList` lives inside the
   component, so grepping route files for it returns a false zero
3. Cross-checked against `<KBLIBreadcrumb`, the visual component, to find routes that show a trail to
   users but not to crawlers
4. Applied the change, re-ran the same probes, then ran build and lint

## Raw Observations
`<KBLIBreadcrumbJsonLd` call sites under `app/**kbli**`: 1 before, 5 after.

| route | visual breadcrumb | BreadcrumbList before | after |
|---|---|---|---|
| /kbli/[code] | yes | yes | yes, unchanged |
| /kbli/sectors | yes | no | yes |
| /kbli/sectors/[id] | yes | no | yes |
| /kbli/builder | no | no | yes |
| /kbli/decoder | no | no | yes |

- Diff: 4 files, +32 / -0
- Build rc=0
- Lint: 183 problems, 0 errors. Identical to origin/main at the same commit; this PR adds no warnings.
- `kbli-explorer/layout.tsx` emits `WebApplication`, not `BreadcrumbList` — measured, not assumed

## Reasoning Path
Deliberately excluded: `/kbli` and `/kbli-explorer`. Both are depth-1, so their BreadcrumbList would
carry a single item. That is a judgement, not a measurement — single-item breadcrumbs add markup without
adding a trail. Cheap to add later if the call is wrong.

Item shape copies `/kbli/[code]` exactly: absolute `https://balizero.com/...` URLs, trail starting at
"KBLI Navigator" rather than a Home node, final item carrying its own URL. No new convention introduced.

## Risk / Implication
- Zone VERDE. Four files under `apps/mouth/src/app/kbli/**`; `packages/core` untouched.
- Not the KBLI data model: no schema, no entries, no attribute definitions, no `/api/kbli/*`, no backend
  validation. JSON-LD is page metadata.
- Only call sites are added; nothing existing changes shape.
- NOT MEASURED: what Search Console reports for these URLs before or after. Layer 3 was not run. This PR
  is layer 2 only, and no claim is made about served pages.

# Recommendation
Merge. The visual-versus-markup mismatch on the two sector routes is the part worth fixing; the two CTA
routes come along because they are the same one-line change.

# Next Action
After promote, confirm with Rich Results Test or Search Console that the four URLs report a breadcrumb
trail. That verification is not part of this PR and has not been done.
