### PR TITLE
fix(hooks): context_window_guard deny message names its own escape routes

### DIFF
--- a/docs/runbooks/agent-worktree-broker.md
+++ b/docs/runbooks/agent-worktree-broker.md
@@ -264,6 +264,25 @@ SUBAGENT EXEMPTION note). The contract that closes both gaps:
    never as done — same discipline as `final-gate-discipline`: re-run the
    check yourself before trusting the claim.
 
+## Context-window guard self-cure (2026-09-09)
+
+`infra/claude-hooks/context_window_guard.py` (PreToolUse `*`) can also
+hard-block a lane's tool calls once its estimated context crosses the
+role's percent-of-window threshold — same shape as `orchestrate_gate.py`
+above, different trigger. On 2026-09-09 a Pro session got denied at 85K
+tokens because `~/.claude/settings.json`'s `env` block lacked
+`CONTEXT_WINDOW_TOKENS=1000000` on that seat, and the cure (editing that
+file) was itself a denied tool call. The deny message now states its own
+evidence (model seen, window assumed and why) and three routes in order:
+
+1. `/resume` in a brand-new window; 2. if the WINDOW is wrong on that
+   machine, a `! python3 -c "..."` one-liner typed at the prompt bar — a
+   `!`-prefixed line runs in the session's own shell, not through PreToolUse
+   hooks, so it is not itself denied — which backs up and patches
+   `~/.claude/settings.json`'s env block; 3. `CONTEXT_GUARD_OFF=1` as last
+   resort. See the module docstring's SELF-CURE section for the exact
+   one-liner and rationale.
+
 ## Broker-aware spawn convention (W62 ANTIBODY #4)
 
 Il TTL da solo non basta: nessun consumer lo applicava. La hygiene è ora a 3 livelli, in ordine di affidabilità decrescente:

--- a/infra/claude-hooks/context_window_guard.py
+++ b/infra/claude-hooks/context_window_guard.py
@@ -68,7 +68,9 @@ ALLOW-LIST once at/above threshold (the only things a hand-off needs):
   - `SendMessage`, `TaskStop` (delegate to a peer / end the turn cleanly)
 Everything else — including a bare `Bash`/`Write`/`Edit`/`Agent` that is not
 one of the above — is DENIED (exit 2), in Italian, naming the exact percent,
-threshold, handoff path and the `claude --model ... ` + `/resume` sequence.
+threshold, handoff path, the evidence for the window it computed, and the
+three SELF-CURE routes below (`/resume`, the `! python3` env fix, the kill
+switch).
 
 Fail-open (exit 0), same discipline as every sibling gate in this
 directory: unparseable payload, unreadable transcript, missing/unreadable
@@ -78,6 +80,26 @@ paralyze the harness (cicatrix scar #2, Esiste!=Armato, cuts both ways: a
 gate that blocks everything when it is itself broken teaches the kill
 switch, same lesson `orchestrate_gate.py`'s DISARM AUDIBILITY note already
 draws).
+
+SELF-CURE (Zero, 2026-09-09 — the bug this section documents): a session
+denied at 85K tokens because `~/.claude/settings.json` env lacked
+`CONTEXT_WINDOW_TOKENS=1000000` could not cure it — editing that file is
+itself a tool call, and the guard denies tool calls. The deny message
+below now states its own evidence (model string seen, window assumed and
+WHY, threshold role) and three routes, IN ORDER:
+  1. `/resume` in a brand-new window (`claude --model <model>` then
+     `/resume`) — the intended, cheap fix.
+  2. If the WINDOW ITSELF is wrong on this machine (this bug's actual
+     cause): the owner types the fix in the Claude Code PROMPT BAR with a
+     `!` prefix (`! python3 -c "..."`, see `ESCAPE_ONE_LINER` below) — a
+     `!`-prefixed line runs in the session's own shell and does NOT pass
+     through PreToolUse hooks, so it is not itself denied. It rewrites
+     `~/.claude/settings.json`'s `env` block (backing up to `.json.bak`
+     first) and the harness hot-reloads it — verified live 2026-09-09.
+  3. `CONTEXT_GUARD_OFF=1` — last resort, same kill switch as always.
+Route 2 is the fix for a WRONG window, not a substitute for route 1: a
+session whose window is already correct and is simply over threshold
+should still open a fresh window.
 """
 from __future__ import annotations
 
@@ -109,6 +131,22 @@ TAIL_BYTES = 400_000  # same tail size context_hygiene.py's own estimator reads
 ALLOWED_TOOLS_UNCONDITIONAL = {"SendMessage", "TaskStop"}
 
 ASSISTANT_TYPE_RE = re.compile(r'"type"\s*:\s*"assistant"')
+
+# The self-cure one-liner printed verbatim in the deny message (see module
+# docstring's SELF-CURE section, route 2): typed with a `!` prefix at the
+# Claude Code prompt bar, it runs in the session's own shell — NOT through
+# PreToolUse hooks — so it is not itself denied by this same guard. It backs
+# up ~/.claude/settings.json to .json.bak before writing, then sets
+# CONTEXT_WINDOW_TOKENS=1000000 in the env block; the harness hot-reloads
+# that file (verified live on M5, 2026-09-09).
+ESCAPE_ONE_LINER = (
+    'python3 -c "import json,pathlib as p;'
+    "h=p.Path.home()/'.claude/settings.json';"
+    "h.with_suffix('.json.bak').write_text(h.read_text());"
+    "d=json.load(open(h));"
+    "d.setdefault('env',{})['CONTEXT_WINDOW_TOKENS']='1000000';"
+    "json.dump(d,open(h,'w'),indent=2)\""
+)
 
 
 def _home() -> Path:
@@ -226,6 +264,22 @@ def _window_size(tail_text: str, tokens: int | None = None) -> int:
     if tokens is not None and tokens > DEFAULT_WINDOW:
         return LARGE_WINDOW
     return DEFAULT_WINDOW
+
+
+def _window_reason(tail_text: str, tokens: int | None) -> str:
+    """Human-readable WHY for the window `_window_size()` computed — mirrors
+    that function's branch order exactly but never feeds back into the
+    decision (display-only, read-only): the window inference logic itself is
+    untouched (see module docstring's SELF-CURE note)."""
+    if os.environ.get("CONTEXT_WINDOW_TOKENS"):
+        return "env override"
+    model = os.environ.get("CONTEXT_GUARD_MODEL") or _last_assistant_model(tail_text) or ""
+    model_l = model.lower()
+    if model_l.endswith("[1m]") or "1m" in model_l:
+        return "modello [1m]"
+    if tokens is not None and tokens > DEFAULT_WINDOW:
+        return ">200K evidenza"
+    return "default"
 
 
 def _role_and_threshold():
@@ -381,11 +435,17 @@ def main() -> int:
     pct_i = int(round(pct * 100))
     threshold_i = int(round(threshold * 100))
     tokens_k = tokens // 1000
+    window_k = window // 1000
+    reason = _window_reason(tail_text, tokens)
+    handoff_str = str(handoff_path) if handoff_path.exists() else "NON scritto (errore)"
     msg = (
         f"[context_window_guard] Contesto ≈{tokens_k}K token = {pct_i}% della finestra "
-        f"(soglia {role} {threshold_i}%). Handoff scritto in {handoff_path if handoff_path.exists() else 'NON scritto (errore)'}. "
-        f"Apri una finestra nuova: claude --model {model} e scrivi /resume. "
-        "Kill switch: CONTEXT_GUARD_OFF=1."
+        f"(soglia {role} {threshold_i}%). Modello: {model}; finestra assunta {window_k}K ({reason}). "
+        f"Handoff: {handoff_str}.\n"
+        f"1) Finestra nuova: claude --model {model} poi /resume.\n"
+        f"2) Finestra sbagliata su QUESTA macchina? Dal prompt bar (bypassa i tool-hook): "
+        f"! {ESCAPE_ONE_LINER}\n"
+        "3) Ultima risorsa: CONTEXT_GUARD_OFF=1."
     )
     print(msg, file=sys.stderr)
     _gc_record("context_window_guard", "deny", payload)

--- a/infra/claude-hooks/test_context_window_guard.py
+++ b/infra/claude-hooks/test_context_window_guard.py
@@ -255,6 +255,41 @@ def test_above_threshold_denies_bash():
     assert "context_window_guard" in err
 
 
+def test_deny_message_has_evidence_line_and_self_cure_route():
+    # Zero, 2026-09-09: a session denied at 85K could not cure the guard
+    # because the fix (editing settings.json) is itself a tool call. The
+    # deny message must now state its own evidence (model/window/why) and
+    # the `! python3 ...` escape route that runs OUTSIDE PreToolUse hooks.
+    rc, _, err, _ = run_gate("Bash", {"command": "rm -rf /tmp/x"}, tokens=150_000, model="claude-sonnet-5")
+    assert rc == 2
+    assert "finestra assunta" in err, f"evidence line (assumed window + why) missing: {err!r}"
+    assert "claude-sonnet-5" in err, f"model string missing from evidence line: {err!r}"
+    assert "finestra assunta 200K (default)" in err, f"window reason missing: {err!r}"
+    assert "! python3 -c" in err, f"the `! python3` self-cure route must be printed verbatim: {err!r}"
+    assert "CONTEXT_WINDOW_TOKENS" in err, f"self-cure one-liner must name the env var it sets: {err!r}"
+    assert "CONTEXT_GUARD_OFF=1" in err, "kill switch route must still be last resort"
+
+
+def test_deny_message_evidence_reflects_1m_and_evidence_rule_reasons():
+    # The evidence line's WHY must match whichever branch _window_size()
+    # actually took: [1m] label vs >200K-implies-1M vs env override.
+    rc_1m, _, err_1m, _ = run_gate("Bash", {"command": "ls"}, tokens=150_000, model="claude-opus-5[1m]")
+    assert rc_1m == 0, "150K/1M is below the 40% default threshold, must allow"
+    rc_evidence, _, err_evidence, _ = run_gate(
+        "Bash", {"command": "ls"}, tokens=458_000, model="claude-fable-5-1",
+    )
+    assert rc_evidence == 2
+    assert "modello [1m]" not in err_evidence
+    assert ">200K evidenza" in err_evidence, f"evidence-rule reason missing: {err_evidence!r}"
+
+    rc_env, _, err_env, _ = run_gate(
+        "Bash", {"command": "ls"}, tokens=300_000, model="claude-sonnet-5",
+        env_extra={"CONTEXT_WINDOW_TOKENS": "50000"},
+    )
+    assert rc_env == 2, "300K/50K forced by env override must deny (600%)"
+    assert "finestra assunta 50K (env override)" in err_env, f"env-override reason missing: {err_env!r}"
+
+
 def test_above_threshold_allows_mem_save():
     rc, _, err, _ = run_gate(
         "Bash", {"command": "~/.claude/scripts/mem save discovery 'x' 7"}, tokens=150_000,


### PR DESCRIPTION
## Summary

A session denied by `context_window_guard.py` at 85K tokens on Pro could not cure the guard because the fix — editing `~/.claude/settings.json`'s `env` block to set `CONTEXT_WINDOW_TOKENS=1000000` — is itself a tool call, and the guard denies every tool call once over threshold. The old deny message only said "Apri una finestra nuova ... Kill switch: CONTEXT_GUARD_OFF=1" — no way out if the *window itself* was wrong.

The deny message now:
- states the evidence for the window it computed: model string seen, window assumed (200K/1M), and WHY (`env override` / `modello [1m]` / `>200K evidenza` / `default`), plus the role's threshold
- prints three routes, **in order**:
  1. `/resume` in a new window (existing behavior)
  2. if the window is wrong on *this* machine: a `! python3 -c "..."` one-liner, run from the Claude Code prompt bar — a `!`-prefixed line runs in the session's own shell, **not** through PreToolUse hooks, so it isn't itself denied — which backs up `~/.claude/settings.json` to `.json.bak` and sets `CONTEXT_WINDOW_TOKENS=1000000` in its `env` block
  3. `CONTEXT_GUARD_OFF=1` as last resort (unchanged)

Same guidance was added to the module docstring under a new **SELF-CURE** heading, and to `docs/runbooks/agent-worktree-broker.md` (no dedicated hooks runbook exists — grepped `docs/` for `context_window_guard`, only `docs/architecture/dual-consul/army-map.md` mentions it in passing, so this adds a short section to the nearest runbook that already documents a PreToolUse gate hard-blocking a lane).

**No change to thresholds, roles, or the window-inference logic** — `_window_size()` is untouched; a new read-only `_window_reason()` mirrors its branches purely for the message text.

## Bites

Consumer: the next session on Pro/M5/Mini that trips this guard, once the live `~/.claude/hooks/context_window_guard.py` copy is refreshed from this PR (HOME-fork pair, same as #5969/#5974).

Observation — synthetic 500K-token deny, run against the patched file in this branch:

```
$ python3 -c "
import sys; sys.path.insert(0, 'infra/claude-hooks')
import importlib.util
spec = importlib.util.spec_from_file_location('t', 'infra/claude-hooks/test_context_window_guard.py')
t = importlib.util.module_from_spec(spec); spec.loader.exec_module(t)
rc, out, err, tmp = t.run_gate('Bash', {'command': 'rm -rf /tmp/x'}, tokens=500_000, model='claude-sonnet-5')
print('RC=', rc); print(err)
"
```

stderr (rc=2) contains the evidence line and the escape route verbatim:

```
[context_window_guard] Contesto ≈500K token = 50% della finestra (soglia default 40%). Modello: claude-sonnet-5; finestra assunta 1000K (>200K evidenza). Handoff: .../precompact-handoff-testsess.json.
1) Finestra nuova: claude --model claude-sonnet-5 poi /resume.
2) Finestra sbagliata su QUESTA macchina? Dal prompt bar (bypassa i tool-hook): ! python3 -c "import json,pathlib as p;h=p.Path.home()/'.claude/settings.json';h.with_suffix('.json.bak').write_text(h.read_text());d=json.load(open(h));d.setdefault('env',{})['CONTEXT_WINDOW_TOKENS']='1000000';json.dump(d,open(h,'w'),indent=2)"
3) Ultima risorsa: CONTEXT_GUARD_OFF=1.
```

## Test plan

- [x] `python3 infra/claude-hooks/test_context_window_guard.py` — all 16 tests pass (14 pre-existing + 2 new: `test_deny_message_has_evidence_line_and_self_cure_route`, `test_deny_message_evidence_reflects_1m_and_evidence_rule_reasons`)
- [x] Deny message measured at 701 chars for the worst-case (500K tokens, long temp handoff path) — within the ~700-char budget for a real (shorter) handoff path
- [x] No pytest available on this machine; ran via the file's documented direct-execution fallback (`_run_all()`)

Not done: could not run the full CI Backend Tests suite locally (path-aware pre-push allowlist skips it for `infra/claude-hooks/**` + `docs/**`-only diffs) — CI will run it on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)