### PR TITLE
feat(cascade): window jump, headless half — re-invoke the seat on a context-guard trip

### DIFF
--- a/evidence/2026-09/agent-air-m5-infra-window-jump-headless-28841dea/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-window-jump-headless-28841dea/brief.yml
@@ -1,0 +1,74 @@
+task_id: window-jump-headless
+gear: 3
+l_level: L1
+gate_class: opus
+objective: |
+  Ruling Zero 2026-09-09 «tutti i seat»: the window jump (PR #5987, interactive
+  half) must also work where there is no window. In `-p` mode the hook
+  infra/claude-hooks/context_window_guard.py trips exactly as in a Ghostty
+  window: it writes ~/.organism/context-guard/pending-jump-<session>.json with
+  seat=headless and denies every tool, so a cron seat run by
+  infra/launchagents/wrappers/claude-cascade.sh ends its turn early with
+  partial output and nobody re-invokes it — the mandate silently dies at the
+  context ceiling (superscar #2, Esiste≠Armato: the run is "green", the work
+  is not done).
+
+  Fix, in the wrapper only: after a seat returns, if a jump file was raised by
+  THAT run (seat=headless, to_session unset, same cwd, ts >= run start),
+  re-invoke the SAME seat (same bin/token/config dir — zsh dynamic scoping of
+  try_claude's locals) with a fresh session and a short continuation prompt
+  fed through PROMPT_FILE/stdin; context_jump_resume.py (SessionStart, from
+  PR #5987) injects mandate + handoff and stamps to_session, so a file is
+  never consumed twice. Outputs of the hops are concatenated on stdout. Cap
+  JUMP_MAX_HOPS=3 per run (the guard caps the chain too). Kill switch
+  CONTEXT_JUMP_OFF=1, shared with the guard. Ghostty-seat files are ignored.
+
+  Depends on PR #5987 for the guard that WRITES the file; against a main
+  without it the wrapper is inert (no file → zero hops, behaviour identical
+  to before).
+
+  Gear is 3 DETERMINISTICALLY, sourced from PATH: infra/launchagents/* is a
+  hot zone in scripts/evidence_pack_lint.py's HOTZONE_PATTERNS. Reproduced on
+  this branch's merge-base diff (422609311f366c35b1bd0c106c17b8607ce794e0):
+  see receipts.
+
+acceptance:
+  - text: >-
+      WHEN a fake headless seat writes pending-jump-<sid>.json (seat=headless,
+      cwd=$PWD, to_session unset) during its first invocation, the wrapper
+      SHALL invoke the same seat again with a continuation prompt naming the
+      session and hop, and stdout SHALL carry both outputs concatenated.
+    probe: pytest scripts/tests/test_claude_cascade_shell.py -q -k headless_jump_reinvokes
+  - text: >-
+      WHEN every hop raises a new jump file, the wrapper SHALL stop after
+      JUMP_MAX_HOPS=3 re-invocations (4 runs total), never looping further.
+    probe: pytest scripts/tests/test_claude_cascade_shell.py -q -k capped_at_three
+  - text: >-
+      WHEN CONTEXT_JUMP_OFF=1, a raised jump file SHALL NOT trigger any
+      re-invocation (one run, one output).
+    probe: pytest scripts/tests/test_claude_cascade_shell.py -q -k kill_switch_runs_once
+  - text: >-
+      WHEN the jump file carries seat=ghostty (written by an interactive
+      session sharing the machine), the wrapper SHALL ignore it.
+    probe: pytest scripts/tests/test_claude_cascade_shell.py -q -k ignores_a_ghostty_seat
+  - text: >-
+      WHILE the change is in force, the pre-existing cascade shell suite SHALL
+      stay green and the wrapper SHALL parse under zsh -n.
+    probe: pytest scripts/tests/test_claude_cascade_shell.py -q; zsh -n infra/launchagents/wrappers/claude-cascade.sh
+
+assumptions:
+  - text: >-
+      run_bounded reads the prompt from $PROMPT_FILE at invocation time
+      (stdin redirect), so re-pointing PROMPT_FILE before the hop is enough
+      to change the prompt without rebuilding CLAUDE_ARGS.
+    status: verified
+    probe: grep -n 'PROMPT_FILE' infra/launchagents/wrappers/claude-cascade.sh # line 296 redirects "$@" <"$PROMPT_FILE"
+  - text: >-
+      The guard on PR #5987's branch writes seat=headless when TERM_PROGRAM
+      is not ghostty, with cwd and ts fields the wrapper filters on.
+    status: verified
+    probe: grep -n '"seat"\|"cwd"\|"ts"' infra/claude-hooks/context_window_guard.py # PR #5987 branch, same md5 as the live M5 copy
+
+appetite:
+  wall_clock_hours: 3
+  adversarial_rounds: 1

--- a/evidence/2026-09/agent-air-m5-infra-window-jump-headless-28841dea/journal.jsonl
+++ b/evidence/2026-09/agent-air-m5-infra-window-jump-headless-28841dea/journal.jsonl
@@ -1,0 +1,2 @@
+{"seat": "codex-gpt-5.6-sol", "role": "review", "ok": true, "ts": "2026-09-09T05:40:00Z", "verdict": "NO-GO", "findings": 7, "target": "a84bc72715 (first cut)", "note": "codex exec --sandbox read-only on the worktree; read the wrapper, the guard and the tests; 5 BUG + 1 RISCHIO + 1 OK"}
+{"seat": "kimi-code/k3", "role": "review", "ok": true, "ts": "2026-09-09T05:45:00Z", "verdict": "NO-GO", "findings": 10, "target": "a84bc72715 (first cut, diff inline)", "note": "kimi -p with the full diff in the prompt (no file tools in -p); 3 BUG + 4 RISCHIO + 3 OK"}

--- a/evidence/2026-09/agent-air-m5-infra-window-jump-headless-28841dea/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-window-jump-headless-28841dea/pack.yml
@@ -1,0 +1,205 @@
+brief_ref: evidence/brief.yml
+council_run: journal.jsonl
+plan_ref: >-
+  Ruling Zero 2026-09-09 «tutti i seat» (research/operations/2026-09-09-window-jump-
+  automatic-handoff-it.md §4b): the headless half of the window jump lives in
+  the cascade wrapper, the interactive half in PR #5987. This pack covers the
+  wrapper only.
+
+lanes:
+  - lane: build
+    role: build
+    seat: claude-fable-5-1
+  - lane: review-cross-family-codex
+    role: review
+    seat: codex-gpt-5.6-sol
+  - lane: review-cross-family-kimi
+    role: review
+    seat: kimi-code/k3
+
+what_changed: |
+  2 files. infra/launchagents/wrappers/claude-cascade.sh: every claude
+  invocation gets its own --session-id (fresh UUID); after a run the wrapper
+  checks ~/.organism/context-guard/pending-jump-<that id>.json (seat=headless,
+  unclaimed) and, if the guard tripped, re-invokes the SAME seat with a new id,
+  a short continuation prompt on stdin (PROMPT_FILE swap) and
+  NZ_JUMP_FROM=<previous id> in the env; hop outputs accumulate and are emitted
+  only when the chain ends cleanly; every hop passes retryable_failure_detected
+  (quota banner → 98, rotate seat); non-zero/empty hop → 96 (rotate), nothing
+  emitted; cap JUMP_MAX_HOPS=3 with an INCOMPLETE stderr warning when a jump is
+  still pending; kill switch CONTEXT_JUMP_OFF=1. scripts/tests/
+  test_claude_cascade_shell.py: 6 tests (re-invocation with fresh id + env,
+  cap + warning, kill switch, ghostty/sibling files ignored, hop quota banner
+  rotates without partial stdout, hop failure rotates without partial stdout).
+
+proof: |
+  Receipts below. Floor 3 sourced from PATH (infra/launchagents/*) reproduced
+  on the merge-base diff; zsh -n green; the whole cascade shell suite green
+  (70 = 64 pre-existing + 6 new). Two cross-family reviews on the first cut
+  (a84bc72715) both returned NO-GO; every CONFIRMED finding is fixed in
+  f1be599d02 and pinned by a test (see dissent). Live proof needs PR #5987's
+  guard on a headless seat: against today's main the wrapper is inert by
+  construction (no file → zero hops; the 64 pre-existing tests are that
+  proof). Bites: the first Pro/Mini cron run whose seat trips the guard logs
+  `[jump] <seat> — context guard tripped` on stderr and `used: <seat> (hops: N)`.
+
+dissent:
+  - seat: codex-gpt-5.6-sol
+    objection: >-
+      Detection by newest file in the cwd (ts/cwd heuristic, from_session
+      ignored): two wrappers in one checkout (Pro runs many seats from
+      ~/Desktop/nuzantara) can adopt each other's trip; a file without cwd
+      matched any cwd. kimi raised the same (its #5).
+    status: CONFIRMED
+    resolution: >-
+      Every invocation now carries --session-id <fresh UUID> and the wrapper
+      looks only for pending-jump-<that id>.json. Test
+      test_headless_jump_ignores_a_ghostty_seat_file_and_another_sessions_file
+      plants a sibling's headless file in the same cwd and asserts one run.
+  - seat: codex-gpt-5.6-sol
+    objection: >-
+      A hop's result skipped retryable_failure_detected: a quota/auth banner
+      with exit 0 on hop N ended the cascade as success. kimi #1 identical.
+    status: CONFIRMED
+    resolution: >-
+      Each hop runs the same classification as the first run and returns 98
+      (rotate). Test test_headless_jump_hop_quota_banner_rotates_seat_without_partial_stdout.
+  - seat: codex-gpt-5.6-sol
+    objection: >-
+      Partial output was emitted before the hop; a failed hop then returned
+      96 with stdout already contaminated, and the next seat restarted the
+      mandate on top of it. kimi #7 identical.
+    status: CONFIRMED
+    resolution: >-
+      Outputs accumulate in a temp file and are emitted only when the chain
+      ends cleanly; a failed hop emits nothing (the handoff on disk keeps the
+      partial work, path logged). Tests hop_quota_banner / hop_failure assert
+      stdout == the next seat's output only, and the temp dir is empty.
+  - seat: codex-gpt-5.6-sol
+    objection: >-
+      Cap reached with a jump still pending returned 0 as if complete.
+    status: PLAUSIBLE
+    resolution: >-
+      Kept exit 0 (the emitted hops are real work; failing would make the
+      next seat redo the mandate from scratch and burn its quota) but the
+      wrapper now logs `cap 3 reached … mandate may be INCOMPLETE` on stderr;
+      the cap test asserts the warning. The guard caps the chain at 3 too, so
+      in practice the loop ends because no new file is written.
+  - seat: codex-gpt-5.6-sol
+    objection: >-
+      Fresh session not guaranteed: unchanged argv could carry --resume/
+      --continue/--session-id from EXTRA_ARGS.
+    status: CONFIRMED
+    resolution: >-
+      --session-id <fresh UUID> is appended per invocation; no plist passes
+      --resume/--continue (grep infra/launchagents: none). The reinvocation
+      test asserts two distinct 36-char ids.
+  - seat: codex-gpt-5.6-sol
+    objection: >-
+      Test fakes used ${p:0:24} under #!/bin/sh (dash on CI: Bad substitution)
+      and simulated the injector's stamp instead of exercising it.
+    status: CONFIRMED
+    resolution: >-
+      Fakes are POSIX (cut -c1-24); the wrapper no longer depends on the stamp
+      at all (it keys on its own session id), so the simulation is gone. The
+      injector's NZ_JUMP_FROM contract is tested in PR #5987
+      (test_context_jump_resume.py, +2 tests).
+  - seat: codex-gpt-5.6-sol
+    objection: >-
+      At HEAD the guard writes precompact-handoff, never pending-jump, and
+      context_jump_resume.py is absent: the loop waits for an artifact main
+      does not produce.
+    status: CONFIRMED
+    resolution: >-
+      True of main today: the producer is PR #5987 (armed, same ruling). This
+      PR is inert without it and declares the dependency in the brief and the
+      PR body; merge order is #5987 first. Not a defect of the wrapper.
+  - seat: kimi-code/k3
+    objection: >-
+      `${hop:+ (hops: $hop)}` expands for hop=0, so every run logged
+      `(hops: 0)`.
+    status: CONFIRMED
+    resolution: >-
+      Replaced with an explicit -gt 0 test; the reinvocation test asserts
+      `hops: 1`, and the pre-existing suite (which greps `used: <label>`)
+      stays green.
+  - seat: kimi-code/k3
+    objection: >-
+      A failed hop returns 96 (hard fail) instead of 97, skipping the quota
+      fallback mid-chain.
+    status: RETRACTED
+    resolution: >-
+      The caller rotates on ANY non-zero return (`[ $rc -eq 0 ] && exit 0`,
+      claude-cascade.sh main loop); 96/97/98 are labels, not branches. The
+      hop_failure test shows token1 → hop fails → token2 answers.
+  - seat: kimi-code/k3
+    objection: >-
+      The continuation prompt asserts the mandate is injected; if the
+      SessionStart injector is not active in -p, each hop is a task-less
+      session whose output is still accepted.
+    status: PLAUSIBLE
+    resolution: >-
+      Residual, declared: the injector is a HOME-fork pair (declared-pairs.json)
+      armed on M5/Pro/Mini by PR #5987's shipping session and linted by
+      lint_home_fork.py; a missing injector shows as a proprioception
+      divergence, not silently. Not fixable from the wrapper without
+      re-implementing the injector.
+
+receipts:
+  - claim: "deterministic Gear floor is 3, sourced from PATH (infra/launchagents/*)"
+    cmd: "python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file <changed> --numstat-file <numstat>; --print-floor-source (same args); merge-base 422609311f366c35b1bd0c106c17b8607ce794e0"
+    result: "3 / path"
+    exit: 0
+    ts: "2026-09-09T05:25:00Z"
+    seat: claude-fable-5-1
+  - claim: "the wrapper parses under zsh (it is #!/bin/zsh — shellcheck refuses zsh, bash -n is the wrong tool)"
+    cmd: "zsh -n infra/launchagents/wrappers/claude-cascade.sh"
+    result: "ZSH_SYNTAX_OK"
+    exit: 0
+    ts: "2026-09-09T05:27:00Z"
+    seat: claude-fable-5-1
+  - claim: "the whole cascade shell suite is green after the review fixes (64 pre-existing + 6 new)"
+    cmd: "python3 -m pytest scripts/tests/test_claude_cascade_shell.py -q"
+    result: "70 passed in 54.23s"
+    exit: 0
+    ts: "2026-09-09T05:33:00Z"
+    seat: claude-fable-5-1
+  - claim: "the first cut (a84bc72715) was reviewed by two seats outside the author's family, both NO-GO"
+    cmd: "codex exec --sandbox read-only -C <worktree> <review prompt>; kimi -p <review prompt + diff>"
+    result: "codex: 7 findings (5 BUG, 1 RISCHIO, 1 OK), NON MERGE; kimi: 10 findings (3 BUG, 4 RISCHIO, 3 OK), NON MERGE — see dissent"
+    exit: 0
+    ts: "2026-09-09T05:45:00Z"
+    seat: codex-gpt-5.6-sol
+  - claim: "the interactive half's injector honours NZ_JUMP_FROM as this wrapper sends it"
+    cmd: "python3 -m pytest infra/claude-hooks/test_context_jump_resume.py infra/claude-hooks/test_context_window_jump.py -q  # PR #5987 branch, 7feb9809b8"
+    result: "22 passed in 0.66s"
+    exit: 0
+    ts: "2026-09-09T05:48:00Z"
+    seat: claude-fable-5-1
+  - claim: "no plist or wrapper passes --resume/--continue that a fresh --session-id could conflict with"
+    cmd: "grep -n 'session-id\\|--resume\\|--continue' infra/launchagents/wrappers/claude-cascade.sh infra/launchagents/*.plist"
+    result: "one docs mention (army-jules-harvest.plist inbox path), no CLI flag"
+    exit: 0
+    ts: "2026-09-09T05:26:00Z"
+    seat: claude-fable-5-1
+  - claim: "the four acceptance probes of the brief (reinvokes / capped_at_three / kill_switch_runs_once / ignores_a_ghostty_seat) pass"
+    cmd: 'pytest scripts/tests/test_claude_cascade_shell.py -q -k "headless_jump_reinvokes or capped_at_three or kill_switch_runs_once or ignores_a_ghostty_seat"'
+    result: "4 passed, 66 deselected in 1.61s"
+    exit: 0
+    ts: "2026-09-09T05:52:00Z"
+    seat: claude-fable-5-1
+
+pii_scan: clean
+pii_scan_note: >-
+  Diff is a launchd wrapper's control flow, its shell test fixtures (fake
+  seats writing synthetic JSON under a temp HOME) and this pack. No client
+  data, OSINT or credentials; the wrapper's existing credential isolation
+  (ISOLATED_PROVIDER_ENV) is untouched and the fake fleet's LEAK probe stays
+  in every test.
+
+spend:
+  wall_clock_hours: 2.5
+  adversarial_rounds: 1
+
+diff:
+  net_lines: "measured by CI from git numstat at merge-base..HEAD; ~+200 locally (two-dot vs merge ref differ — the CI value governs)"

--- a/infra/launchagents/wrappers/claude-cascade.sh
+++ b/infra/launchagents/wrappers/claude-cascade.sh
@@ -357,54 +357,62 @@ build_claude_args() {
 # context_window_guard.py trips exactly as in a window: it writes
 # ~/.organism/context-guard/pending-jump-<session>.json (seat=headless) and
 # denies every tool, so the session ends its turn early with partial output.
-# Nothing can open a "window" here — the wrapper IS the window: when a jump was
-# raised by the run that just returned (same cwd, unclaimed, newer than the
-# run start), re-invoke the SAME seat with a fresh session and a short
-# continuation prompt; context_jump_resume.py (SessionStart) injects the
-# mandate + handoff and stamps to_session, so the file is not picked twice.
-# Outputs of the hops are concatenated. Cap JUMP_MAX_HOPS per run (the guard
-# caps the chain as well). Kill switch: CONTEXT_JUMP_OFF=1 (same as the guard).
+# Nothing can open a "window" here — the wrapper IS the window: every
+# invocation gets its OWN session id (--session-id, a fresh UUID each time, so
+# a hop can never resume or fork the previous transcript), and after the run
+# the wrapper looks for THAT session's jump file — never "the newest file in
+# this cwd" (Pro runs many seats from one checkout; cross-family review found
+# the heuristic could hand one seat's trip to another). On a trip it
+# re-invokes the SAME seat with a fresh id, a short continuation prompt on
+# stdin and NZ_JUMP_FROM=<previous id> in the env, which context_jump_resume.py
+# (SessionStart) uses to inject exactly that mandate + handoff. Hop outputs are
+# ACCUMULATED and emitted only when the chain ends cleanly: a failed hop emits
+# nothing, so the cascade's next seat starts from a clean stdout (the handoff
+# on disk keeps the partial work). Every hop goes through the same quota/auth
+# classification as the first run. Cap JUMP_MAX_HOPS per run (the guard caps
+# the chain as well). Kill switch: CONTEXT_JUMP_OFF=1 (same as the guard).
 # ---------------------------------------------------------------------------
 JUMP_MAX_HOPS="${JUMP_MAX_HOPS:-3}"
+JUMP_STATE_DIR="${JUMP_STATE_DIR:-$HOME/.organism/context-guard}"
 
-headless_jump_raised_since() {
-    # $1 = epoch the run started. Prints the newest matching jump file, or nothing.
+new_session_id() {
+    REPLY="$(python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null || uuidgen | tr 'A-Z' 'a-z')"
+}
+
+headless_jump_raised_by() {
+    # $1 = session id of the run that just returned. Prints its jump file when
+    # the guard tripped in that run (seat=headless, not yet claimed), else nothing.
     [ "${CONTEXT_JUMP_OFF:-0}" = "1" ] && return 1
-    python3 - "$1" "$PWD" <<'PY' 2>/dev/null
-import glob, json, os, sys
-since, cwd = float(sys.argv[1]), os.path.realpath(sys.argv[2])
-best, best_ts = "", -1.0
-for f in glob.glob(os.path.expanduser("~/.organism/context-guard/pending-jump-*.json")):
-    try:
-        j = json.load(open(f))
-    except Exception:
-        continue
-    if j.get("to_session") or j.get("seat") != "headless":
-        continue
-    try:
-        ts = float(j.get("ts") or 0)
-    except (TypeError, ValueError):
-        continue
-    if ts < since - 1 or (j.get("cwd") and os.path.realpath(str(j["cwd"])) != cwd):
-        continue
-    if ts > best_ts:
-        best, best_ts = f, ts
-print(best)
+    local f="$JUMP_STATE_DIR/pending-jump-$1.json"
+    [ -f "$f" ] || return 1
+    python3 - "$f" <<'PY' 2>/dev/null
+import json, sys
+try:
+    j = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+if not isinstance(j, dict) or j.get("to_session") or j.get("seat") != "headless":
+    sys.exit(1)
+print(sys.argv[1])
 PY
 }
 
 claude_seat_invoke() {
+    # $1 = session id for this invocation; $2 = previous session id (hop) or "".
     # Uses try_claude's own locals (bin, oauth_token, config_dir, label,
-    # tmpout, tmperr) — dynamic scoping — so hops run the SAME seat.
+    # tmpout, tmperr) — zsh dynamic scoping — so hops run the SAME seat.
+    local -a hop_env
+    hop_env=()
+    [ -n "${2:-}" ] && hop_env=(NZ_JUMP_FROM="$2")
     if [ -n "$oauth_token" ]; then
         run_bounded "$tmpout" "$tmperr" "$label" "${ISOLATED_PROVIDER_ENV[@]}" \
             CLAUDE_CONFIG_DIR="$config_dir" \
-            CLAUDE_CODE_OAUTH_TOKEN="$oauth_token" \
-            "$bin" "${CLAUDE_ARGS[@]}"
+            CLAUDE_CODE_OAUTH_TOKEN="$oauth_token" "${hop_env[@]}" \
+            "$bin" "${CLAUDE_ARGS[@]}" --session-id "$1"
     else
         run_bounded "$tmpout" "$tmperr" "$label" "${ISOLATED_PROVIDER_ENV[@]}" \
-            CLAUDE_CONFIG_DIR="$config_dir" \
-            "$bin" "${CLAUDE_ARGS[@]}"
+            CLAUDE_CONFIG_DIR="$config_dir" "${hop_env[@]}" \
+            "$bin" "${CLAUDE_ARGS[@]}" --session-id "$1"
     fi
 }
 
@@ -433,9 +441,9 @@ try_claude() {
     build_isolated_provider_env
 
     echo "  [try] $label ($bin)" >&2
-    local run_started
-    run_started="$(date +%s)"
-    claude_seat_invoke
+    local run_sid
+    new_session_id; run_sid="$REPLY"
+    claude_seat_invoke "$run_sid" ""
     exit_code=$?
 
     # Some Claude CLI auth/quota failures incorrectly return exit 0. Content
@@ -457,34 +465,47 @@ try_claude() {
     fi
 
     # Window jump, headless half: the run tripped the context guard → fresh
-    # session on the same seat, continuation prompt, outputs concatenated.
-    local hop=0 jump_file hop_prompt_file saved_prompt_file
-    while jump_file="$(headless_jump_raised_since "$run_started")" && [ -n "$jump_file" ] \
+    # session on the same seat, continuation prompt, outputs accumulated.
+    local hop=0 jump_file hop_prompt_file saved_prompt_file prev_sid acc
+    new_temp_file; acc="$REPLY"
+    cat "$tmpout" >"$acc"
+    while jump_file="$(headless_jump_raised_by "$run_sid")" && [ -n "$jump_file" ] \
           && [ "$hop" -lt "$JUMP_MAX_HOPS" ]; do
         hop=$((hop + 1))
-        echo "  [jump] $label — context guard tripped ($(basename "$jump_file")): fresh session, hop $hop/$JUMP_MAX_HOPS" >&2
-        cat "$tmpout"
+        prev_sid="$run_sid"
+        new_session_id; run_sid="$REPLY"
+        echo "  [jump] $label — context guard tripped ($(basename "$jump_file")): fresh session $run_sid, hop $hop/$JUMP_MAX_HOPS" >&2
         new_temp_file
         hop_prompt_file="$REPLY"
-        printf '%s' "Sei la sessione successiva di $(basename "$jump_file" .json | sed 's/^pending-jump-//') (salto $hop). Il mandato originale e lo stato raggiunto sono nel contesto iniettato da context_jump_resume: continua da lì, senza chiedere, e non ripetere il lavoro già verificato." >"$hop_prompt_file"
+        printf '%s' "Sei la sessione successiva di $prev_sid (salto $hop). Il mandato originale e lo stato raggiunto sono nel contesto iniettato da context_jump_resume: continua da lì, senza chiedere, e non ripetere il lavoro già verificato." >"$hop_prompt_file"
         saved_prompt_file="$PROMPT_FILE"
         PROMPT_FILE="$hop_prompt_file"
-        run_started="$(date +%s)"
         : >"$tmpout"; : >"$tmperr"
-        claude_seat_invoke
+        claude_seat_invoke "$run_sid" "$prev_sid"
         exit_code=$?
         PROMPT_FILE="$saved_prompt_file"
         rm -f "$hop_prompt_file"
+        # Same classification as the first run: a quota banner with exit 0 on
+        # a hop must cascade to the next seat, not pass as the seat's answer.
+        if retryable_failure_detected "$tmpout" "$tmperr" "$exit_code"; then
+            echo "  [retry] $label hop $hop quota/auth failure (partial work kept in $jump_file)" >&2
+            rm -f "$tmpout" "$tmperr" "$acc"
+            return 98
+        fi
         if [ "$exit_code" -ne 0 ] || [ ! -s "$tmpout" ]; then
-            echo "  [error] $label hop $hop exit=$exit_code (empty=$([ -s "$tmpout" ] && echo no || echo yes))" >&2
-            rm -f "$tmpout" "$tmperr"
+            echo "  [error] $label hop $hop exit=$exit_code (empty=$([ -s "$tmpout" ] && echo no || echo yes)) — nothing emitted, partial work kept in $jump_file" >&2
+            rm -f "$tmpout" "$tmperr" "$acc"
             return 96
         fi
+        cat "$tmpout" >>"$acc"
     done
+    if [ "$hop" -ge "$JUMP_MAX_HOPS" ] && jump_file="$(headless_jump_raised_by "$run_sid")" && [ -n "$jump_file" ]; then
+        echo "  [jump] $label — cap $JUMP_MAX_HOPS reached with a jump still pending ($(basename "$jump_file")): mandate may be INCOMPLETE" >&2
+    fi
 
-    cat "$tmpout"
-    rm -f "$tmpout" "$tmperr"
-    echo "[claude-cascade] used: $label${hop:+ (hops: $hop)}" >&2
+    cat "$acc"
+    rm -f "$tmpout" "$tmperr" "$acc"
+    echo "[claude-cascade] used: $label$([ "$hop" -gt 0 ] && echo " (hops: $hop)")" >&2
     return 0
 }
 

--- a/infra/launchagents/wrappers/claude-cascade.sh
+++ b/infra/launchagents/wrappers/claude-cascade.sh
@@ -350,6 +350,64 @@ build_claude_args() {
     CLAUDE_ARGS+=("${EXTRA_ARGS[@]}")
 }
 
+
+# ---------------------------------------------------------------------------
+# WINDOW JUMP, headless half (Ruling Zero 2026-09-09 «tutti i seat», research/
+# operations/2026-09-09-window-jump-automatic-handoff-it.md §4b). In `-p` mode
+# context_window_guard.py trips exactly as in a window: it writes
+# ~/.organism/context-guard/pending-jump-<session>.json (seat=headless) and
+# denies every tool, so the session ends its turn early with partial output.
+# Nothing can open a "window" here — the wrapper IS the window: when a jump was
+# raised by the run that just returned (same cwd, unclaimed, newer than the
+# run start), re-invoke the SAME seat with a fresh session and a short
+# continuation prompt; context_jump_resume.py (SessionStart) injects the
+# mandate + handoff and stamps to_session, so the file is not picked twice.
+# Outputs of the hops are concatenated. Cap JUMP_MAX_HOPS per run (the guard
+# caps the chain as well). Kill switch: CONTEXT_JUMP_OFF=1 (same as the guard).
+# ---------------------------------------------------------------------------
+JUMP_MAX_HOPS="${JUMP_MAX_HOPS:-3}"
+
+headless_jump_raised_since() {
+    # $1 = epoch the run started. Prints the newest matching jump file, or nothing.
+    [ "${CONTEXT_JUMP_OFF:-0}" = "1" ] && return 1
+    python3 - "$1" "$PWD" <<'PY' 2>/dev/null
+import glob, json, os, sys
+since, cwd = float(sys.argv[1]), os.path.realpath(sys.argv[2])
+best, best_ts = "", -1.0
+for f in glob.glob(os.path.expanduser("~/.organism/context-guard/pending-jump-*.json")):
+    try:
+        j = json.load(open(f))
+    except Exception:
+        continue
+    if j.get("to_session") or j.get("seat") != "headless":
+        continue
+    try:
+        ts = float(j.get("ts") or 0)
+    except (TypeError, ValueError):
+        continue
+    if ts < since - 1 or (j.get("cwd") and os.path.realpath(str(j["cwd"])) != cwd):
+        continue
+    if ts > best_ts:
+        best, best_ts = f, ts
+print(best)
+PY
+}
+
+claude_seat_invoke() {
+    # Uses try_claude's own locals (bin, oauth_token, config_dir, label,
+    # tmpout, tmperr) — dynamic scoping — so hops run the SAME seat.
+    if [ -n "$oauth_token" ]; then
+        run_bounded "$tmpout" "$tmperr" "$label" "${ISOLATED_PROVIDER_ENV[@]}" \
+            CLAUDE_CONFIG_DIR="$config_dir" \
+            CLAUDE_CODE_OAUTH_TOKEN="$oauth_token" \
+            "$bin" "${CLAUDE_ARGS[@]}"
+    else
+        run_bounded "$tmpout" "$tmperr" "$label" "${ISOLATED_PROVIDER_ENV[@]}" \
+            CLAUDE_CONFIG_DIR="$config_dir" \
+            "$bin" "${CLAUDE_ARGS[@]}"
+    fi
+}
+
 try_claude() {
     local bin="$1"
     local label="$2"
@@ -375,18 +433,10 @@ try_claude() {
     build_isolated_provider_env
 
     echo "  [try] $label ($bin)" >&2
-    if [ -n "$oauth_token" ]; then
-        run_bounded "$tmpout" "$tmperr" "$label" "${ISOLATED_PROVIDER_ENV[@]}" \
-            CLAUDE_CONFIG_DIR="$config_dir" \
-            CLAUDE_CODE_OAUTH_TOKEN="$oauth_token" \
-            "$bin" "${CLAUDE_ARGS[@]}"
-        exit_code=$?
-    else
-        run_bounded "$tmpout" "$tmperr" "$label" "${ISOLATED_PROVIDER_ENV[@]}" \
-            CLAUDE_CONFIG_DIR="$config_dir" \
-            "$bin" "${CLAUDE_ARGS[@]}"
-        exit_code=$?
-    fi
+    local run_started
+    run_started="$(date +%s)"
+    claude_seat_invoke
+    exit_code=$?
 
     # Some Claude CLI auth/quota failures incorrectly return exit 0. Content
     # classification therefore precedes the exit-code success check.
@@ -406,9 +456,35 @@ try_claude() {
         return 97
     fi
 
+    # Window jump, headless half: the run tripped the context guard → fresh
+    # session on the same seat, continuation prompt, outputs concatenated.
+    local hop=0 jump_file hop_prompt_file saved_prompt_file
+    while jump_file="$(headless_jump_raised_since "$run_started")" && [ -n "$jump_file" ] \
+          && [ "$hop" -lt "$JUMP_MAX_HOPS" ]; do
+        hop=$((hop + 1))
+        echo "  [jump] $label — context guard tripped ($(basename "$jump_file")): fresh session, hop $hop/$JUMP_MAX_HOPS" >&2
+        cat "$tmpout"
+        new_temp_file
+        hop_prompt_file="$REPLY"
+        printf '%s' "Sei la sessione successiva di $(basename "$jump_file" .json | sed 's/^pending-jump-//') (salto $hop). Il mandato originale e lo stato raggiunto sono nel contesto iniettato da context_jump_resume: continua da lì, senza chiedere, e non ripetere il lavoro già verificato." >"$hop_prompt_file"
+        saved_prompt_file="$PROMPT_FILE"
+        PROMPT_FILE="$hop_prompt_file"
+        run_started="$(date +%s)"
+        : >"$tmpout"; : >"$tmperr"
+        claude_seat_invoke
+        exit_code=$?
+        PROMPT_FILE="$saved_prompt_file"
+        rm -f "$hop_prompt_file"
+        if [ "$exit_code" -ne 0 ] || [ ! -s "$tmpout" ]; then
+            echo "  [error] $label hop $hop exit=$exit_code (empty=$([ -s "$tmpout" ] && echo no || echo yes))" >&2
+            rm -f "$tmpout" "$tmperr"
+            return 96
+        fi
+    done
+
     cat "$tmpout"
     rm -f "$tmpout" "$tmperr"
-    echo "[claude-cascade] used: $label" >&2
+    echo "[claude-cascade] used: $label${hop:+ (hops: $hop)}" >&2
     return 0
 }
 

--- a/scripts/tests/test_claude_cascade_shell.py
+++ b/scripts/tests/test_claude_cascade_shell.py
@@ -1303,3 +1303,79 @@ def test_a_directory_without_auth_json_is_not_a_seat(tmp_path: Path) -> None:
     assert result.stdout == "ollama-answer\n"
     lines = call_log.read_text(encoding="utf-8").splitlines()
     assert not any(l.startswith("codex-") for l in lines), lines
+
+
+# ── window jump, headless half (Ruling Zero 2026-09-09) ──────────────────────
+# The fake seat writes the SAME file context_window_guard.py writes when it
+# trips in `-p` mode, then answers on the next call: the wrapper must re-invoke
+# the same seat with a continuation prompt and concatenate the outputs.
+
+_JUMP_WRITER = (
+    'mkdir -p "$HOME/.organism/context-guard"; '
+    "python3 -c 'import json,os,sys,time; "
+    'json.dump({"from_session":sys.argv[1],"to_session":None,"seat":sys.argv[2],'
+    '"cwd":os.getcwd(),"hops":1,"ts":time.time(),"mandate":"M"},'
+    'open(os.path.expanduser("~/.organism/context-guard/pending-jump-"+sys.argv[1]+".json"),"w"))\' '
+)
+_JUMP_STAMP = (
+    "python3 -c 'import json,os,sys; p=os.path.expanduser(\"~/.organism/context-guard/pending-jump-\"+sys.argv[1]+\".json\"); "
+    'j=json.load(open(p)); j["to_session"]="next"; json.dump(j,open(p,"w"))\' '
+)
+
+
+def _counting_body(first: str, later: str) -> str:
+    return (
+        'n="$HOME/jump-calls"; c=$(cat "$n" 2>/dev/null || echo 0); c=$((c+1)); echo "$c" > "$n"; '
+        'if [ "$c" = 1 ]; then ' + first + "; else " + later + "; fi"
+    )
+
+
+def test_headless_jump_reinvokes_the_same_seat_with_a_continuation_prompt(tmp_path: Path) -> None:
+    bodies = _default_bodies()
+    bodies["token1"] = _counting_body(
+        _JUMP_WRITER + 'h1 headless; printf "first-part\\n"; exit 0',
+        # the hop must READ the continuation prompt on stdin and the injector
+        # (simulated here) stamps the file so it is not picked a third time
+        'p=$(cat); ' + _JUMP_STAMP + 'h1; printf "second-part[%s]\\n" "${p:0:24}"; exit 0',
+    )
+    call_log, temp_dir, env = _fake_fleet(tmp_path, bodies)
+    result = _run_cascade(env, "hermetic prompt", "--claude-only")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "first-part\nsecond-part[Sei la sessione successi]\n"
+    assert _labels(call_log) == ["token1", "token1"]
+    assert "[jump] claude-token-1-env" in result.stderr and "hops: 1" in result.stderr
+    assert list(temp_dir.iterdir()) == []
+
+
+def test_headless_jump_is_capped_at_three_hops(tmp_path: Path) -> None:
+    bodies = _default_bodies()
+    # never stamps: every call raises a fresh jump → 1 run + 3 hops, then stop
+    bodies["token1"] = (
+        'n="$HOME/jump-calls"; c=$(cat "$n" 2>/dev/null || echo 0); c=$((c+1)); echo "$c" > "$n"; '
+        + _JUMP_WRITER + '"s$c" headless; printf "part%s\\n" "$c"; exit 0'
+    )
+    call_log, _, env = _fake_fleet(tmp_path, bodies)
+    result = _run_cascade(env, "hermetic prompt", "--claude-only")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "part1\npart2\npart3\npart4\n"
+    assert _labels(call_log) == ["token1"] * 4
+    assert "hop 3/3" in result.stderr
+
+
+def test_headless_jump_kill_switch_runs_once(tmp_path: Path) -> None:
+    bodies = _default_bodies()
+    bodies["token1"] = _JUMP_WRITER + 'h1 headless; printf "only\\n"; exit 0'
+    call_log, _, env = _fake_fleet(tmp_path, bodies)
+    env["CONTEXT_JUMP_OFF"] = "1"
+    result = _run_cascade(env, "hermetic prompt", "--claude-only")
+    assert result.returncode == 0 and result.stdout == "only\n"
+    assert _labels(call_log) == ["token1"] and "[jump]" not in result.stderr
+
+
+def test_headless_jump_ignores_a_ghostty_seat_file(tmp_path: Path) -> None:
+    bodies = _default_bodies()
+    bodies["token1"] = _JUMP_WRITER + 'g1 ghostty; printf "only\\n"; exit 0'
+    call_log, _, env = _fake_fleet(tmp_path, bodies)
+    result = _run_cascade(env, "hermetic prompt", "--claude-only")
+    assert result.returncode == 0 and result.stdout == "only\n"
+    assert _labels(call_log) == ["token1"]

--- a/scripts/tests/test_claude_cascade_shell.py
+++ b/scripts/tests/test_claude_cascade_shell.py
@@ -1305,22 +1305,27 @@ def test_a_directory_without_auth_json_is_not_a_seat(tmp_path: Path) -> None:
     assert not any(l.startswith("codex-") for l in lines), lines
 
 
+
 # ── window jump, headless half (Ruling Zero 2026-09-09) ──────────────────────
 # The fake seat writes the SAME file context_window_guard.py writes when it
-# trips in `-p` mode, then answers on the next call: the wrapper must re-invoke
-# the same seat with a continuation prompt and concatenate the outputs.
+# trips in `-p` mode — named after the `--session-id` the wrapper hands every
+# invocation — then answers on the next call: the wrapper must re-invoke the
+# same seat with a fresh id, a continuation prompt on stdin and
+# NZ_JUMP_FROM=<previous id>, and emit the accumulated outputs.
+# Fake bodies run under /bin/sh (dash on CI): POSIX only, no ${var:0:n}.
 
-_JUMP_WRITER = (
+_SID_FROM_ARGV = (
+    'sid=""; while [ $# -gt 0 ]; do [ "$1" = --session-id ] && sid="$2"; shift; done; '
+    'echo "$sid" >> "$HOME/jump-sids"; '
+)
+_JUMP_FILE = (
     'mkdir -p "$HOME/.organism/context-guard"; '
     "python3 -c 'import json,os,sys,time; "
     'json.dump({"from_session":sys.argv[1],"to_session":None,"seat":sys.argv[2],'
     '"cwd":os.getcwd(),"hops":1,"ts":time.time(),"mandate":"M"},'
     'open(os.path.expanduser("~/.organism/context-guard/pending-jump-"+sys.argv[1]+".json"),"w"))\' '
 )
-_JUMP_STAMP = (
-    "python3 -c 'import json,os,sys; p=os.path.expanduser(\"~/.organism/context-guard/pending-jump-\"+sys.argv[1]+\".json\"); "
-    'j=json.load(open(p)); j["to_session"]="next"; json.dump(j,open(p,"w"))\' '
-)
+_JUMP_WRITER = _SID_FROM_ARGV + _JUMP_FILE
 
 
 def _counting_body(first: str, later: str) -> str:
@@ -1330,41 +1335,52 @@ def _counting_body(first: str, later: str) -> str:
     )
 
 
-def test_headless_jump_reinvokes_the_same_seat_with_a_continuation_prompt(tmp_path: Path) -> None:
+def _sids(tmp_path: Path) -> list[str]:
+    return (tmp_path / "home" / "jump-sids").read_text().split()
+
+
+def test_headless_jump_reinvokes_the_same_seat_with_a_fresh_id_and_the_previous_one_in_env(
+    tmp_path: Path,
+) -> None:
     bodies = _default_bodies()
     bodies["token1"] = _counting_body(
-        _JUMP_WRITER + 'h1 headless; printf "first-part\\n"; exit 0',
-        # the hop must READ the continuation prompt on stdin and the injector
-        # (simulated here) stamps the file so it is not picked a third time
-        'p=$(cat); ' + _JUMP_STAMP + 'h1; printf "second-part[%s]\\n" "${p:0:24}"; exit 0',
+        _JUMP_WRITER + '"$sid" headless; printf "first-part\\n"; exit 0',
+        # the hop must READ the continuation prompt on stdin and carry the
+        # previous session id in NZ_JUMP_FROM (what context_jump_resume.py keys on)
+        _SID_FROM_ARGV + 'p=$(cat); printf "second-part[%s][from=%s]\\n" '
+        '"$(printf %s "$p" | cut -c1-24)" "${NZ_JUMP_FROM:-unset}"; exit 0',
     )
     call_log, temp_dir, env = _fake_fleet(tmp_path, bodies)
     result = _run_cascade(env, "hermetic prompt", "--claude-only")
     assert result.returncode == 0, result.stderr
-    assert result.stdout == "first-part\nsecond-part[Sei la sessione successi]\n"
+    first, second = _sids(tmp_path)
+    assert first != second and len(first) == 36 and len(second) == 36
+    assert result.stdout == f"first-part\nsecond-part[Sei la sessione successi][from={first}]\n"
     assert _labels(call_log) == ["token1", "token1"]
     assert "[jump] claude-token-1-env" in result.stderr and "hops: 1" in result.stderr
+    assert "INCOMPLETE" not in result.stderr
     assert list(temp_dir.iterdir()) == []
 
 
-def test_headless_jump_is_capped_at_three_hops(tmp_path: Path) -> None:
+def test_headless_jump_is_capped_at_three_hops_and_says_so(tmp_path: Path) -> None:
     bodies = _default_bodies()
-    # never stamps: every call raises a fresh jump → 1 run + 3 hops, then stop
+    # every call raises a fresh jump for ITS OWN id → 1 run + 3 hops, then stop
     bodies["token1"] = (
         'n="$HOME/jump-calls"; c=$(cat "$n" 2>/dev/null || echo 0); c=$((c+1)); echo "$c" > "$n"; '
-        + _JUMP_WRITER + '"s$c" headless; printf "part%s\\n" "$c"; exit 0'
+        + _JUMP_WRITER + '"$sid" headless; printf "part%s\\n" "$c"; exit 0'
     )
     call_log, _, env = _fake_fleet(tmp_path, bodies)
     result = _run_cascade(env, "hermetic prompt", "--claude-only")
     assert result.returncode == 0, result.stderr
     assert result.stdout == "part1\npart2\npart3\npart4\n"
     assert _labels(call_log) == ["token1"] * 4
-    assert "hop 3/3" in result.stderr
+    assert len(set(_sids(tmp_path))) == 4
+    assert "hop 3/3" in result.stderr and "cap 3 reached" in result.stderr and "INCOMPLETE" in result.stderr
 
 
 def test_headless_jump_kill_switch_runs_once(tmp_path: Path) -> None:
     bodies = _default_bodies()
-    bodies["token1"] = _JUMP_WRITER + 'h1 headless; printf "only\\n"; exit 0'
+    bodies["token1"] = _JUMP_WRITER + '"$sid" headless; printf "only\\n"; exit 0'
     call_log, _, env = _fake_fleet(tmp_path, bodies)
     env["CONTEXT_JUMP_OFF"] = "1"
     result = _run_cascade(env, "hermetic prompt", "--claude-only")
@@ -1372,10 +1388,47 @@ def test_headless_jump_kill_switch_runs_once(tmp_path: Path) -> None:
     assert _labels(call_log) == ["token1"] and "[jump]" not in result.stderr
 
 
-def test_headless_jump_ignores_a_ghostty_seat_file(tmp_path: Path) -> None:
+def test_headless_jump_ignores_a_ghostty_seat_file_and_another_sessions_file(tmp_path: Path) -> None:
     bodies = _default_bodies()
-    bodies["token1"] = _JUMP_WRITER + 'g1 ghostty; printf "only\\n"; exit 0'
+    # a ghostty file under this run's id, plus a headless file under SOMEONE
+    # ELSE's id in the same cwd (a sibling seat on Pro): neither is ours
+    bodies["token1"] = (
+        _JUMP_WRITER + '"$sid" ghostty; ' + _JUMP_FILE + '"other-seat" headless; '
+        'printf "only\\n"; exit 0'
+    )
     call_log, _, env = _fake_fleet(tmp_path, bodies)
     result = _run_cascade(env, "hermetic prompt", "--claude-only")
-    assert result.returncode == 0 and result.stdout == "only\n"
+    assert result.returncode == 0 and result.stdout == "only\n", result.stderr
     assert _labels(call_log) == ["token1"]
+
+
+def test_headless_jump_hop_quota_banner_rotates_seat_without_partial_stdout(tmp_path: Path) -> None:
+    bodies = _default_bodies()
+    bodies["token1"] = _counting_body(
+        _JUMP_WRITER + '"$sid" headless; printf "partial-from-one\\n"; exit 0',
+        'printf "weekly limit reached\\n"; exit 0',
+    )
+    bodies["token2"] = 'printf "from-two\\n"; exit 0'
+    call_log, temp_dir, env = _fake_fleet(tmp_path, bodies)
+    result = _run_cascade(env, "hermetic prompt", "--claude-only")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "from-two\n"
+    assert _labels(call_log) == ["token1", "token1", "token2"]
+    assert "[retry] claude-token-1-env hop 1" in result.stderr
+    assert list(temp_dir.iterdir()) == []
+
+
+def test_headless_jump_hop_failure_rotates_seat_without_partial_stdout(tmp_path: Path) -> None:
+    bodies = _default_bodies()
+    bodies["token1"] = _counting_body(
+        _JUMP_WRITER + '"$sid" headless; printf "partial-from-one\\n"; exit 0',
+        'exit 3',
+    )
+    bodies["token2"] = 'printf "from-two\\n"; exit 0'
+    call_log, temp_dir, env = _fake_fleet(tmp_path, bodies)
+    result = _run_cascade(env, "hermetic prompt", "--claude-only")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "from-two\n"
+    assert _labels(call_log) == ["token1", "token1", "token2"]
+    assert "[error] claude-token-1-env hop 1 exit=3" in result.stderr
+    assert list(temp_dir.iterdir()) == []


### PR DESCRIPTION
## What

Ruling Zero 2026-09-09 «tutti i seat»: the window jump (PR #5987, interactive half) also works where there is no window. In `-p` mode the context guard trips exactly as in a Ghostty window and writes `~/.organism/context-guard/pending-jump-<session>.json` (seat=headless); today a cron seat then ends its turn early with partial output and nobody re-invokes it — the mandate dies at the context ceiling while the run looks green (superscar #2).

`infra/launchagents/wrappers/claude-cascade.sh`:
- every `claude` invocation gets its own `--session-id` (fresh UUID);
- after a run, if `pending-jump-<that id>.json` exists unclaimed with seat=headless, re-invoke the SAME seat with a new id, a short continuation prompt on stdin and `NZ_JUMP_FROM=<previous id>` in the env (the injector in #5987 keys on it);
- hop outputs accumulate and are emitted only when the chain ends cleanly; every hop passes the same quota/auth classification as the first run (banner → rotate seat); a failed hop emits nothing;
- cap `JUMP_MAX_HOPS=3` (+ `INCOMPLETE` warning on stderr if a jump is still pending); kill switch `CONTEXT_JUMP_OFF=1`.

Tests: 6 new in `scripts/tests/test_claude_cascade_shell.py` (fake seats write the guard's file under a temp HOME; POSIX bodies for dash on CI). Suite: 70 passed.

## Review

Gear 3 (hot zone `infra/launchagents/*`), evidence pack `evidence/2026-09/agent-air-m5-infra-window-jump-headless-28841dea/`. Two cross-family reviews of the first cut, both NO-GO (codex 7 findings, kimi 10): every CONFIRMED finding is fixed in `f1be599d02` and pinned by a test — session-keyed detection instead of newest-file-in-cwd, hop classification, no partial stdout on a failed hop, `(hops: 0)` log bug, dash-unsafe fakes. Details in `pack.yml` dissent.

## Dependency

Merge after #5987 (it ships the guard that writes the file and the SessionStart injector). Against a main without it this wrapper is inert: no file → zero hops → behaviour identical to before (the 64 pre-existing tests are that proof).

Bites: the cascade wrapper on Pro/Mini (live copy is refreshed from `origin/main` by the launchagent canon). Observation: the first cron run whose seat trips the guard logs `[jump] <seat> — context guard tripped (pending-jump-<id>.json): fresh session <id>, hop 1/3` and `[claude-cascade] used: <seat> (hops: 1)` on stderr, with the hop's output appended to the seat's stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161T9bR15Ecs3SSLfqemT6J