### PR TITLE
fix(hooks): worktree_isolation allows read-only git verbs in the main checkout

### DIFF
--- a/infra/claude-hooks/test_block_regex.py
+++ b/infra/claude-hooks/test_block_regex.py
@@ -38,6 +38,12 @@ CASES = {
     "git checkout main": True,
     "git stash": True,
     "git reset --hard": True,
+    # 7th over-match (2026-09-09): `merge` lacked stash's trailing-hyphen
+    # guard, so `git merge-base`/`merge-file`/`merge-tree` — distinct,
+    # read-only-or-informational subcommands — were judged as `git merge`
+    # on a shared prefix. `git merge` itself must keep blocking.
+    "git merge origin/main": True,
+    "git merge --no-ff feature": True,
     # W117 class-audit (2026-08-10): `clean` and `restore` were never in this
     # enumeration, so five shapes of the SAME damage passed in the main checkout
     # while reset/checkout/stash blocked. Both letter tests read the flag CLUSTER,
@@ -68,6 +74,11 @@ CASES = {
     "git log --oneline": False,
     "git diff HEAD": False,
     "git push origin feature": False,
+    # the exact false-positive reported 2026-09-09: `git diff $(git merge-base ...)`
+    "git merge-base origin/main HEAD": False,
+    "git diff $(git merge-base origin/main HEAD) HEAD -- file.py": False,
+    "git merge-file a b c": False,
+    "git merge-tree base a b": False,
 }
 
 

--- a/infra/claude-hooks/test_hook_innocence.py
+++ b/infra/claude-hooks/test_hook_innocence.py
@@ -114,6 +114,38 @@ CASES: dict[str, list[tuple[dict, str, str]]] = {
         (bash(f"git -C {WT} checkout main"), "ALLOW", "git mutate inside worktree via -C"),
         (bash("grep -rn 'cp ' infra/ | head"), "ALLOW", "the word cp inside a grep pattern"),
         (bash("echo 'use tee to split output' "), "ALLOW", "the word tee inside a quoted string"),
+        # 7th over-match (2026-09-09): the EXACT command reported blocked in
+        # the main checkout — `git diff $(git merge-base ...)` — plus the
+        # rest of the read-only-verb allowlist this PR opens explicitly.
+        (bash("h40=$(gh pr view 5740 --json headRefOid --jq .headRefOid); "
+              "git diff $(git merge-base origin/main $h40) $h40 -- infra/claude-hooks/worktree_isolation.py"),
+         "ALLOW", "the exact reported false-positive: git diff + git merge-base"),
+        (bash("git merge-base origin/main HEAD"), "ALLOW", "merge-base alone is not git merge"),
+        (bash("git show HEAD~1:apps/mouth/README.md"), "ALLOW", "read-only show"),
+        (bash("git rev-parse --show-toplevel"), "ALLOW", "read-only rev-parse"),
+        (bash("git cat-file -p HEAD"), "ALLOW", "read-only cat-file"),
+        (bash("git ls-files apps/mouth"), "ALLOW", "read-only ls-files"),
+        (bash("git ls-tree HEAD"), "ALLOW", "read-only ls-tree"),
+        (bash("git blame apps/mouth/README.md"), "ALLOW", "read-only blame"),
+        (bash("git describe --tags"), "ALLOW", "read-only describe"),
+        (bash("git rev-list --count HEAD"), "ALLOW", "read-only rev-list"),
+        (bash("git name-rev HEAD"), "ALLOW", "read-only name-rev"),
+        (bash("git branch --list"), "ALLOW", "read-only branch --list"),
+        (bash("git branch -a"), "ALLOW", "read-only branch -a"),
+        (bash("git branch --show-current"), "ALLOW", "read-only branch --show-current"),
+        (bash("git remote -v"), "ALLOW", "read-only remote -v"),
+        (bash("git tag"), "ALLOW", "read-only bare tag listing"),
+        (bash("git tag -l 'v1.*'"), "ALLOW", "read-only tag -l with a glob pattern"),
+        (bash("git shortlog -sn"), "ALLOW", "read-only shortlog"),
+        (bash("git for-each-ref"), "ALLOW", "read-only for-each-ref"),
+        (bash("git config --get user.name"), "ALLOW", "read-only config --get"),
+        (bash("git config --list"), "ALLOW", "read-only config --list"),
+        (bash("git fetch origin"), "ALLOW", "read-only fetch (never touches the working tree)"),
+        (bash("git stash list"), "ALLOW", "read-only stash list"),
+        (bash("git reflog"), "ALLOW", "read-only reflog listing"),
+        (bash("git diff -- infra/claude-hooks/worktree_isolation.py"), "ALLOW", "plain diff, no --output"),
+        (bash("git log --oneline | git diff --stat $(git merge-base main HEAD)"),
+         "ALLOW", "compound command with ONLY read-only gits"),
         # W80 arm-before-remove — INNOCENCE tripwires (no git state needed; these
         # resolve to non-dirty / out-of-scope targets so the guard must stay silent).
         (bash("rm -rf /tmp/scratch-dir"), "ALLOW", "rm -rf outside .worktrees → not a worktree removal"),
@@ -128,6 +160,18 @@ CASES: dict[str, list[tuple[dict, str, str]]] = {
         (bash("git stash"), "BLOCK", "git stash in main (sibling-orphan creator)"),
         (bash("echo poison > infra/claude-hooks/orchestrate_gate.py"), "BLOCK", "shell write into main checkout file"),
         (bash("sed -i 's/a/b/' apps/backend-rag/backend/app/main.py"), "BLOCK", "sed -i on main checkout file"),
+        # 7th over-match PR (2026-09-09): writing siblings of the newly-opened
+        # read-only verbs — previously NOT in BLOCKED_SUBCMD_RE at all, so
+        # before this PR both their read AND write forms were silently allowed.
+        (bash("git branch -d old-feature"), "BLOCK", "git branch -d deletes a ref"),
+        (bash("git branch -D old-feature"), "BLOCK", "git branch -D force-deletes a ref"),
+        (bash("git branch -m old new"), "BLOCK", "git branch -m renames a ref"),
+        (bash("git tag v1.2.3"), "BLOCK", "git tag <name> creates a ref"),
+        (bash("git tag -d v1.2.3"), "BLOCK", "git tag -d deletes a ref"),
+        (bash("git config user.email x@balizero.com"), "BLOCK", "git config <key> <value> writes .git/config"),
+        (bash("git diff --output=/tmp/x.patch HEAD"), "BLOCK", "git diff --output writes a file"),
+        (bash("git diff HEAD --output=/tmp/x.patch"), "BLOCK", "git diff --output writes a file (flag last)"),
+        (bash("git log --oneline && git branch -d stale"), "BLOCK", "compound: read-only git chained with a write git still blocks"),
     ],
     # ---- worktree_file_write_check.py (Edit/Write/MultiEdit)
     "worktree_file_write_check.py": [

--- a/infra/claude-hooks/test_readonly_git_verbs.py
+++ b/infra/claude-hooks/test_readonly_git_verbs.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Regression test for the 7th over-match of worktree_isolation.py (2026-09-09).
+
+TRAUMA: an agent's read-only `git diff $(git merge-base origin/main $h) ...`
+was blocked in the main checkout with "WORKTREE ISOLATION VIOLATION (Bash git
+op in main)". MECHANISM: BLOCKED_SUBCMD_RE's `merge` alternative had no
+trailing-hyphen guard (the sibling `stash` alternative already carries one,
+W85) — `\\bmerge\\b` is satisfied by the word-to-punctuation transition into
+"-base"/"-file"/"-tree", so those distinct, read-only-or-informational git
+subcommands were judged as `git merge` on a shared prefix alone (superscar
+#3: guard-over-match). Read-only git verbs cannot race with another agent, so
+blocking them forced a worktree just to READ.
+
+CURE, widened in the same PR (Zero ruling 2026-09-09): an explicit read-only
+allowlist for diff/log/show/status/rev-parse/merge-base/cat-file/ls-files/
+ls-tree/blame/describe/rev-list/name-rev/branch(read forms)/remote -v/tag
+(listing)/shortlog/grep/for-each-ref/config --get|--list/fetch/worktree list/
+stash list/reflog — none of which were ever in BLOCKED_SUBCMD_RE, so BOTH
+their read and write forms were silently allowed before this PR. Opening the
+read forms without giving each verb's WRITE form its own block would have
+widened a hole while documenting it as a feature: BRANCH_WRITE_RE,
+TAG_INVOCATION_RE + `_tag_is_write`, CONFIG_SET_RE and DIFF_OUTPUT_RE (all in
+worktree_isolation.py) close that, folded into `_git_verb_verdict`'s existing
+`blocked_matches` list via `_extra_write_verdicts` — no new decision path.
+
+This file unit-tests the PURE functions directly (fast, no subprocess); the
+full hook-as-subprocess contract for the same shapes is also pinned in
+test_hook_innocence.py (CASES["worktree_isolation.py"]) and the regex-only
+view in test_block_regex.py (BLOCKED_SUBCMD_RE). guard_fuzz_harness.py's
+445-case corpus is unaffected by this change (0 unexplained mismatches,
+verified before this PR shipped).
+
+Run:  python3 infra/claude-hooks/test_readonly_git_verbs.py
+      pytest infra/claude-hooks/test_readonly_git_verbs.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def _load_wi():
+    spec = importlib.util.spec_from_file_location(
+        "wi_readonly_test", str(HERE / "worktree_isolation.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    mod.REPO_ROOT = "/synthetic-main"  # never resolved on disk in these cases
+    return mod
+
+
+MOD = _load_wi()
+
+
+# ---------------------------------------------------------------------------
+# _git_verb_verdict: the exact reported command + the read-only allowlist.
+# Every case here resolves the effective target to REPO_ROOT itself (no -C,
+# no cd), so "no_blocked_verb" IS the innocence signal and "block" IS guilt.
+# ---------------------------------------------------------------------------
+INNOCENCE_VERDICT_CASES = {
+    # the exact command reported blocked 2026-09-09
+    "git diff $(git merge-base origin/main HEAD) HEAD -- infra/claude-hooks/worktree_isolation.py": True,
+    "git merge-base origin/main HEAD": True,
+    "git merge-file a b c": True,
+    "git merge-tree base a b": True,
+    "git diff HEAD": True,
+    "git log --oneline -5": True,
+    "git show HEAD~1": True,
+    "git status": True,
+    "git rev-parse --show-toplevel": True,
+    "git cat-file -p HEAD": True,
+    "git ls-files": True,
+    "git ls-tree HEAD": True,
+    "git blame README.md": True,
+    "git describe --tags": True,
+    "git rev-list --count HEAD": True,
+    "git name-rev HEAD": True,
+    "git branch --list": True,
+    "git branch": True,
+    "git branch -a": True,
+    "git branch -r": True,
+    "git branch --show-current": True,
+    "git remote -v": True,
+    "git tag": True,
+    "git tag -l": True,
+    "git tag -l 'v1.*'": True,
+    "git shortlog -sn": True,
+    "git grep TODO": True,
+    "git for-each-ref": True,
+    "git config --get user.name": True,
+    "git config --list": True,
+    "git config -l": True,
+    "git fetch origin": True,
+    "git worktree list": True,
+    "git stash list": True,
+    "git stash show": True,
+    "git reflog": True,
+    # compound: only read-only gits anywhere in the command → allowed
+    "git log --oneline; git diff --stat $(git merge-base main HEAD)": True,
+}
+
+GUILT_VERDICT_CASES = {
+    # pre-existing blocked verbs must be untouched by this PR
+    "git merge origin/main": False,
+    "git merge --no-ff feature": False,
+    "git checkout main": False,
+    "git reset --hard": False,
+    "git stash": False,
+    # newly-blocked writing siblings of the newly-opened read verbs
+    "git branch -d old-feature": False,
+    "git branch -D old-feature": False,
+    "git branch -m old new": False,
+    "git branch -M old new": False,
+    "git branch --delete old-feature": False,
+    "git branch --move old new": False,
+    "git tag v1.2.3": False,
+    "git tag -d v1.2.3": False,
+    "git config user.email x@balizero.com": False,
+    "git config --unset user.email": False,
+    "git diff --output=/tmp/x.patch HEAD": False,
+    "git diff HEAD --output=/tmp/x.patch": False,
+    "git diff --output /tmp/x.patch HEAD": False,
+    # compound: a read-only git chained with a blocked one still blocks
+    "git log --oneline && git branch -d stale": False,
+    "git status; git tag v9.9.9": False,
+    "git diff HEAD && git config user.email x@balizero.com": False,
+}
+
+
+def _run_verdict_cases(cases: dict[str, bool], expect_allow: bool) -> list[str]:
+    failures = []
+    for cmd, _ in cases.items():
+        v = MOD._git_verb_verdict(cmd, MOD.REPO_ROOT)
+        allowed = v.decision != "block"
+        if allowed != expect_allow:
+            failures.append(
+                f"expected {'ALLOW' if expect_allow else 'BLOCK'}, "
+                f"got decision={v.decision!r} for: {cmd}"
+            )
+    return failures
+
+
+def test_readonly_verbs_are_allowed_including_the_reported_command():
+    failures = _run_verdict_cases(INNOCENCE_VERDICT_CASES, expect_allow=True)
+    assert not failures, "\n".join(failures)
+
+
+def test_writing_siblings_and_preexisting_verbs_still_block():
+    failures = _run_verdict_cases(GUILT_VERDICT_CASES, expect_allow=False)
+    assert not failures, "\n".join(failures)
+
+
+# ---------------------------------------------------------------------------
+# _tag_is_write: the stateful helper CONFIG_SET_RE/BRANCH_WRITE_RE don't need
+# (tag's -l/--list takes a glob-PATTERN positional that looks identical to a
+# create-target positional — a plain regex can't tell them apart).
+# ---------------------------------------------------------------------------
+def test_tag_is_write_distinguishes_listing_from_create_and_delete():
+    assert MOD._tag_is_write("") is False                      # bare `git tag`
+    assert MOD._tag_is_write(" -l") is False                   # `-l` alone
+    assert MOD._tag_is_write(" -l ''") is False                # `-l` + stripped glob pattern
+    assert MOD._tag_is_write(" --list") is False
+    assert MOD._tag_is_write(" v1.2.3") is True                 # create
+    assert MOD._tag_is_write(" -d v1.2.3") is True              # delete
+    assert MOD._tag_is_write(" --delete v1.2.3") is True
+
+
+if __name__ == "__main__":
+    fails = []
+    fails += _run_verdict_cases(INNOCENCE_VERDICT_CASES, expect_allow=True)
+    fails += _run_verdict_cases(GUILT_VERDICT_CASES, expect_allow=False)
+    try:
+        test_tag_is_write_distinguishes_listing_from_create_and_delete()
+    except AssertionError as e:
+        fails.append(f"_tag_is_write: {e}")
+    total = len(INNOCENCE_VERDICT_CASES) + len(GUILT_VERDICT_CASES) + 1
+    if fails:
+        print(f"=== {len(fails)}/{total} FAIL ===")
+        for f in fails:
+            print("  [FAIL] " + f)
+        sys.exit(1)
+    print(f"=== ALL {total} PASS ===")
+    sys.exit(0)

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -59,12 +59,44 @@ preserved: `foo | ssh mini git pull` and
 `scp -q file pro:/tmp/x && ssh pro git pull` still exempt (the mutating
 segment IS the ssh one in both).
 
+7th over-match (2026-09-09, found by an agent whose read-only `git diff
+$(git merge-base origin/main $h) ...` was blocked in the main checkout):
+BLOCKED_SUBCMD_RE's `merge` alternative had no boundary check against a
+TRAILING HYPHEN — `\bmerge\b` is satisfied by the transition from "merge" to
+"-" in `merge-base`, so `git merge-base`/`merge-file`/`merge-tree` (real,
+read-only-or-informational subcommands, not `git merge` with arguments) were
+judged guilty of the entity `git merge` names, on nothing but a shared
+prefix. Fixed the same way W85's `stash` gained its lookahead: `merge(?!-)`.
+Read-only git verbs forced a worktree just to run — the L1 brake exists for
+races on WRITES, and a read cannot race.
+
+Widened the same PR to an explicit read-only allowlist for `diff / log / show
+/ status / rev-parse / merge-base / cat-file / ls-files / ls-tree / blame /
+describe / rev-list / name-rev / branch --list|-a|-r|--show-current|(no args)
+/ remote -v / tag (listing) / shortlog / grep / for-each-ref / config
+--get|--list / fetch / worktree list / stash list / reflog` — none of those
+were ever in BLOCKED_SUBCMD_RE, so before this PR their WRITING siblings
+(`branch -d/-D/-m`, `tag <name>` create/delete, `config <key> <value>` set,
+`git diff --output=<file>`) were ALSO silently allowed: opening the read
+forms without a peer block on their write forms would have widened a hole,
+not closed one. BRANCH_WRITE_RE / TAG_CREATE_OR_DELETE_RE / CONFIG_SET_RE /
+DIFF_OUTPUT_RE below give each of those its own guilt+innocence pair, folded
+into the SAME `blocked_matches` list `_git_verb_verdict` already threads
+through remote-dispatch / worktree-target / ff-only-pull logic — no new
+decision path, no new parser.
+
 Blocked (only when effective target resolves INTO main checkout, NOT a worktree):
 - git checkout / switch / stash / reset / merge / rebase / pull / commit -a / add -A / add .
+- git branch -d/-D/-m/-M/--delete/--move ; git tag <name> create/delete ; git
+  config <key> <value> set ; git diff --output=<file> [7th over-match PR]
 - shell writes: `> file`, `>> file`, `tee file`, `sed -i ... file`, `cp/mv ... dest`, `dd of=`
 
 Allow (defense conservative — a global L1 hook on 3 machines must NOT false-positive):
 - git read-only; git -C <worktree>; git add <file>; git commit -m; git push
+- git diff / log / show / status / rev-parse / merge-base / cat-file / ls-files
+  / ls-tree / blame / describe / rev-list / name-rev / branch (read forms) /
+  remote -v / tag (listing) / shortlog / grep / for-each-ref / config
+  --get|--list / fetch / worktree list / stash list / reflog [7th over-match PR]
 - ANY write whose target is a worktree, /tmp, $HOME outside the repo, or unclassifiable
 - a git op carried by a remote ssh/scp/rsync dispatch IN ITS OWN SEGMENT (runs on another host) [W83, segment-scoped]
 - a shell WRITE carried by a remote ssh/scp/rsync dispatch IN ITS OWN SEGMENT (same reasoning) [W92, segment-scoped]
@@ -136,7 +168,12 @@ REPO_ROOT = _derive_repo_root()
 BLOCKED_SUBCMD_RE = re.compile(
     r"\bgit[ \t]+(?:-c[ \t]+\S+[ \t]+)*"  # optional -c key=val flags
     r"(?:-C[ \t]+\S+[ \t]+)?"  # optional -C path
-    r"(checkout|switch|stash(?!\s+(?:list|show)\b)|reset|merge|rebase|pull)\b"
+    # 7th over-match (2026-09-09): `merge` needs the SAME trailing-hyphen guard
+    # `stash` already has for `list|show` — `\bmerge\b` is satisfied by the
+    # word-to-punctuation transition into "-base"/"-file"/"-tree", so those
+    # distinct, read-only-or-informational git subcommands were judged as
+    # `git merge` on a shared prefix alone (family #3).
+    r"(checkout|switch|stash(?!\s+(?:list|show)\b)|reset|merge(?!-)|rebase|pull)\b"
     r"|\bgit\s+commit\s+(?:[^\s]+\s+)*(?:-[A-Za-z]*a|--all\b)"  # commit -a / -am / -a -m / --all
     r"|\bgit\s+add\s+(?:-A|-a|--all|\.)"  # add -A / add -a / add --all / add .
     # W117 class-audit (2026-08-10): the enumeration above never included `clean`
@@ -160,6 +197,65 @@ BLOCKED_SUBCMD_RE = re.compile(
     r"[^;&|\n]*(?:--force\b|\s-[A-Za-z]*f)"  # --force, or -f anywhere in a cluster
     r"|\bgit[ \t]+(?:-c[ \t]+\S+[ \t]+)*(?:-C[ \t]+\S+[ \t]+)?restore\b"  # discards the worktree copy
 )
+
+# --- 7th over-match PR (2026-09-09): writing siblings of the newly-recognized
+# read-only verbs (branch/tag/config/diff) --------------------------------
+# BLOCKED_SUBCMD_RE never mentioned branch/tag/config at all, so BOTH their
+# read and write forms were silently allowed before this PR. Opening the read
+# forms explicitly (branch --list/-a/-r/--show-current, tag listing, config
+# --get/--list) without giving each verb's WRITE form its own block would
+# have widened a hole while documenting it as a feature. These live as
+# separate regexes/helper (not folded into BLOCKED_SUBCMD_RE's single
+# alternation) because `tag` needs stateful token inspection — `-l`/`--list`
+# takes a glob-PATTERN positional argument that looks identical to a
+# create-target positional argument, so a single regex cannot tell
+# `git tag -l 'v1.*'` (read) from `git tag v1.2.3` (write) without also
+# checking for the list flag. Matches feed into the SAME `blocked_matches`
+# list `_git_verb_verdict` builds from BLOCKED_SUBCMD_RE, so every downstream
+# rule (remote-dispatch segment-scoping, worktree-target allow, ff-only-pull
+# exception) applies to these exactly as it does to the pre-existing verbs.
+BRANCH_WRITE_RE = re.compile(
+    r"\bgit[ \t]+(?:-c[ \t]+\S+[ \t]+)*(?:-C[ \t]+\S+[ \t]+)?branch\b"
+    r"[^;&|\n]*(?:--delete\b|--move\b|\s-[A-Za-z]*[dDmM]\b)"
+)
+CONFIG_SET_RE = re.compile(
+    r"\bgit[ \t]+(?:-c[ \t]+\S+[ \t]+)*(?:-C[ \t]+\S+[ \t]+)?config\b[ \t]+"
+    r"(?!--get\b|--get-all\b|--list\b|-l\b)\S+[ \t]+\S+"
+)
+DIFF_OUTPUT_RE = re.compile(
+    r"\bgit[ \t]+(?:-c[ \t]+\S+[ \t]+)*(?:-C[ \t]+\S+[ \t]+)?diff\b"
+    r"[^;&|\n]*--output(?:=|[ \t]+)\S+"
+)
+TAG_INVOCATION_RE = re.compile(
+    r"\bgit[ \t]+(?:-c[ \t]+\S+[ \t]+)*(?:-C[ \t]+\S+[ \t]+)?tag\b(?P<rest>[^;&|\n]*)"
+)
+
+
+def _tag_is_write(rest: str) -> bool:
+    """True if a `git tag<rest>` invocation mutates (creates or deletes a
+    tag) rather than listing. `-d`/`--delete` always writes. Otherwise, any
+    non-flag positional token names a tag to CREATE — unless `-l`/`--list` is
+    present, in which case a positional token is a glob PATTERN for the
+    listing (`git tag -l 'v1.*'`), not a name to create."""
+    tokens = rest.split()
+    if any(t in ("-d", "--delete") for t in tokens):
+        return True
+    if any(t in ("-l", "--list") for t in tokens):
+        return False
+    return any(t and not t.startswith("-") for t in tokens)
+
+
+def _extra_write_verdicts(cmd_scan: str) -> list[re.Match]:
+    """Additional writing-git matches, appended to BLOCKED_SUBCMD_RE's own
+    matches by `_git_verb_verdict` — see the block comment above."""
+    out = list(BRANCH_WRITE_RE.finditer(cmd_scan))
+    out += list(CONFIG_SET_RE.finditer(cmd_scan))
+    out += list(DIFF_OUTPUT_RE.finditer(cmd_scan))
+    for m in TAG_INVOCATION_RE.finditer(cmd_scan):
+        if _tag_is_write(m.group("rest")):
+            out.append(m)
+    return out
+
 
 # Extract `git -C <path>` target.
 # W119c (2026-08-31): every `\s+` here is SAME-LINE (`[ \t]+`). A bash Tool call is
@@ -965,6 +1061,12 @@ def _only_ffonly_pull(cmd_scan: str) -> bool:
     # group(1) is None for the commit -a / add -A alternation branches → not a pull.
     if not verbs or any(v != "pull" for v in verbs):
         return False
+    # 7th over-match PR (2026-09-09): a compound command can carry a pull PLUS
+    # a branch/tag/config write that BLOCKED_SUBCMD_RE itself never sees (those
+    # live in _extra_write_verdicts) — the exception must not fire just because
+    # THIS regex's own view of the command happens to be pull-only.
+    if _extra_write_verdicts(cmd_scan):
+        return False
     if not FFONLY_PULL_SEGMENT_RE.search(cmd_scan) or "--rebase" in cmd_scan:
         return False
     return True
@@ -1253,7 +1355,12 @@ def _git_verb_verdict(cmd: str, cwd: str) -> GitVerbVerdict:
     # real command. The git scan + target resolution all run on the stripped form.
     cmd_scan = _strip_noise(cmd)
 
-    blocked_matches = list(BLOCKED_SUBCMD_RE.finditer(cmd_scan))
+    # 7th over-match PR (2026-09-09): the writing siblings of the newly-opened
+    # read-only verbs (branch -d/-D/-m, tag create/delete, config set, diff
+    # --output) fold into the SAME match list so every downstream rule below
+    # (remote-dispatch segment-scoping, worktree-target allow, ff-only-pull)
+    # applies to them exactly as it does to the pre-existing blocked verbs.
+    blocked_matches = list(BLOCKED_SUBCMD_RE.finditer(cmd_scan)) + _extra_write_verdicts(cmd_scan)
     if not blocked_matches:
         return GitVerbVerdict("no_blocked_verb", pathlib.Path(REPO_ROOT))
 

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -299,15 +299,17 @@
             "W92",
             "segment-scoping-6th",
             "W105",
-            "W117"
+            "W117",
+            "readonly-verb-widening-7th-overmatch-2026-09-09"
           ],
           "symbols": {
             "BLOCKED_SUBCMD_RE": {
               "tests": [
                 "infra/claude-hooks/test_block_regex.py",
-                "infra/claude-hooks/test_w85_stash_readonly.py"
+                "infra/claude-hooks/test_w85_stash_readonly.py",
+                "infra/claude-hooks/test_readonly_git_verbs.py"
               ],
-              "note": "W85 stash over-match FIXED 2026-07-06 (negative lookahead: read-only `stash list|show` pass, bare/mutating stash still blocked) — test_w85_stash_readonly.py converted from tripwire-pin to plain guilt+innocence per the pin's own instructions"
+              "note": "W85 stash over-match FIXED 2026-07-06 (negative lookahead: read-only `stash list|show` pass, bare/mutating stash still blocked) — test_w85_stash_readonly.py converted from tripwire-pin to plain guilt+innocence per the pin's own instructions. 7th over-match (2026-09-09): `merge` needed the SAME trailing-hyphen guard `stash` already had — `\\bmerge\\b` matched inside `merge-base`/`merge-file`/`merge-tree` (real, mostly read-only subcommands, not `git merge` with arguments), blocking a read-only `git diff $(git merge-base ...)` in the main checkout. Fixed with `merge(?!-)`; test_readonly_git_verbs.py pins both the fix and that `git merge` itself still blocks."
             },
             "_is_remote_dispatch": {
               "tests": ["infra/claude-hooks/test_w83_remote_dispatch.py"],
@@ -320,9 +322,10 @@
             "_git_verb_verdict": {
               "tests": [
                 "infra/claude-hooks/test_segment_scoped_dispatch.py",
-                "infra/claude-hooks/guard_fuzz_harness.py"
+                "infra/claude-hooks/guard_fuzz_harness.py",
+                "infra/claude-hooks/test_readonly_git_verbs.py"
               ],
-              "note": "Pure decision function extracted from main() during the 6th-over-match fix (2026-07-11) SPECIFICALLY so guard_fuzz_harness.py can call the REAL logic instead of re-implementing it. The harness's ORIGINAL run_corpus() had hand-copied the git-verb decision path inline — that copy used the pre-fix whole-command `_is_remote_dispatch` check and drifted from `main()` the same day it was written, producing 24 false mismatches against cases the real guard already handled correctly. A fuzz harness testing its own stale reimplementation instead of the guard is the exact failure this tool exists to prevent; extracting a single callable source-of-truth closes that structurally, not just for today's drift."
+              "note": "Pure decision function extracted from main() during the 6th-over-match fix (2026-07-11) SPECIFICALLY so guard_fuzz_harness.py can call the REAL logic instead of re-implementing it. The harness's ORIGINAL run_corpus() had hand-copied the git-verb decision path inline — that copy used the pre-fix whole-command `_is_remote_dispatch` check and drifted from `main()` the same day it was written, producing 24 false mismatches against cases the real guard already handled correctly. A fuzz harness testing its own stale reimplementation instead of the guard is the exact failure this tool exists to prevent; extracting a single callable source-of-truth closes that structurally, not just for today's drift. 7th over-match PR (2026-09-09): `blocked_matches` now also folds in `_extra_write_verdicts()` (branch/tag/config/diff-output writes) so every downstream rule here (remote-dispatch segment-scoping, worktree-target allow, ff-only-pull) applies to them identically; test_readonly_git_verbs.py calls this function directly against the exact reported false-positive plus the full read-only-verb allowlist and its writing siblings, and guard_fuzz_harness.py's 445-case corpus was re-run green (0 unexplained mismatches) before this fix shipped."
             },
             "_strip_noise": {
               "tests": [
@@ -345,7 +348,31 @@
             },
             "_only_ffonly_pull": {
               "tests": ["infra/claude-hooks/test_ffonly_pull_exception.py"],
-              "note": "ff-only pull exception (2026-07-06, Zero directive). W91 fixed same day: the first version did a bare substring check and a shell COMMENT mentioning --ff-only opened the exception for a bare pull (4th over-match of this guard) — now FFONLY_PULL_SEGMENT_RE anchors the flag to the pull segment. 15 guilt + 7 innocence + 4 probe cases."
+              "note": "ff-only pull exception (2026-07-06, Zero directive). W91 fixed same day: the first version did a bare substring check and a shell COMMENT mentioning --ff-only opened the exception for a bare pull (4th over-match of this guard) — now FFONLY_PULL_SEGMENT_RE anchors the flag to the pull segment. 15 guilt + 7 innocence + 4 probe cases. 7th over-match PR (2026-09-09): now also disqualifies when `_extra_write_verdicts()` finds a branch/tag/config/diff-output write elsewhere in the command — BLOCKED_SUBCMD_RE's own view of the command could otherwise look pull-only while a write it cannot see (those live in a separate regex family) sat in a later segment."
+            },
+            "BRANCH_WRITE_RE": {
+              "tests": ["infra/claude-hooks/test_readonly_git_verbs.py"],
+              "note": "7th over-match PR (2026-09-09): `branch` was never in BLOCKED_SUBCMD_RE, so before this PR BOTH `git branch --list` (read) and `git branch -d/-D/-m/-M` (write) were silently allowed. Opening the read forms explicitly required blocking the write forms by INTENT (a `d`/`m`/`D`/`M` flag cluster or `--delete`/`--move`), not by bare verb — `git branch -a`/`--show-current`/(no args) carry neither and stay allowed."
+            },
+            "CONFIG_SET_RE": {
+              "tests": ["infra/claude-hooks/test_readonly_git_verbs.py"],
+              "note": "7th over-match PR (2026-09-09): blocks `git config <key> <value>` (two positional tokens) while a negative lookahead spares `--get`/`--get-all`/`--list`/`-l` — a single positional token (`git config user.name`, a GET) is also spared since the two-token shape never matches."
+            },
+            "DIFF_OUTPUT_RE": {
+              "tests": ["infra/claude-hooks/test_readonly_git_verbs.py"],
+              "note": "7th over-match PR (2026-09-09): `git diff --output=<file>` (or `--output <file>`) writes a file directly, bypassing the shell-redirect write-target channel entirely (`_write_hits_main` never sees it — there is no `>`). Plain `git diff` without `--output` is unaffected."
+            },
+            "TAG_INVOCATION_RE": {
+              "tests": ["infra/claude-hooks/test_readonly_git_verbs.py"],
+              "note": "7th over-match PR (2026-09-09): captures the full `git tag<rest>` tail for `_tag_is_write` to classify — see that symbol for why a plain regex alternative cannot do this alone."
+            },
+            "_tag_is_write": {
+              "tests": ["infra/claude-hooks/test_readonly_git_verbs.py"],
+              "note": "7th over-match PR (2026-09-09): `-l`/`--list` takes a glob-PATTERN positional (`git tag -l 'v1.*'`) that is syntactically identical to a create-target positional (`git tag v1.2.3`) — only the presence of the list flag tells them apart, which a single regex alternation (unlike BLOCKED_SUBCMD_RE's other members) cannot express. `-d`/`--delete` always writes regardless of any other flag."
+            },
+            "_extra_write_verdicts": {
+              "tests": ["infra/claude-hooks/test_readonly_git_verbs.py"],
+              "note": "7th over-match PR (2026-09-09): folds BRANCH_WRITE_RE/CONFIG_SET_RE/DIFF_OUTPUT_RE/TAG_INVOCATION_RE matches into the SAME `blocked_matches` list `_git_verb_verdict` builds from BLOCKED_SUBCMD_RE — no second decision path, so remote-dispatch segment-scoping and worktree-target resolution apply to these verbs identically. guard_fuzz_harness.py's existing 445-case corpus re-ran green with 0 unexplained mismatches after this symbol was wired in, proving it introduced no new over/under-match in the pre-existing corpus even though the corpus itself was not extended to name it."
             },
             "_main_tree_tracked_clean": {
               "tests": [


### PR DESCRIPTION
## Summary
- `BLOCKED_SUBCMD_RE`'s `merge` alternative had no trailing-hyphen guard (unlike the sibling `stash` alternative, W85), so `git merge-base`/`merge-file`/`merge-tree` over-matched as `git merge` and blocked a read-only `git diff $(git merge-base origin/main $h) ...` in the main checkout today (superscar #3: guard-over-match). Fixed with `merge(?!-)`.
- Widened to an explicit read-only allowlist in the same PR: `diff/log/show/status/rev-parse/merge-base/cat-file/ls-files/ls-tree/blame/describe/rev-list/name-rev/branch(read forms)/remote -v/tag(listing)/shortlog/grep/for-each-ref/config --get|--list/fetch/worktree list/stash list/reflog` — none of those were ever in `BLOCKED_SUBCMD_RE`, so before this PR their WRITING siblings (`branch -d/-D/-m`, `tag <name>` create/delete, `config <key> <value>` set, `git diff --output=<file>`) were ALSO silently allowed. New `BRANCH_WRITE_RE`/`CONFIG_SET_RE`/`DIFF_OUTPUT_RE`/`TAG_INVOCATION_RE`(+`_tag_is_write`) close that, folded into `_git_verb_verdict`'s existing `blocked_matches` list via `_extra_write_verdicts` — no new decision path, no new parser. Compound commands stay per-invocation: a chained read+write git still blocks; an all-read-only compound is allowed.
- `_only_ffonly_pull` now also disqualifies on an extra write it would otherwise not see (a compound with `pull --ff-only` plus a branch/tag/config write elsewhere).

## Bites
Every Claude session's Bash calls in the main checkout on Pro/M5/Mini after the live copy is refreshed via `install_worktree_hooks.sh` — observed: the exact reported command `h40=$(gh pr view 5740 --json headRefOid --jq .headRefOid); git diff $(git merge-base origin/main $h40) $h40 -- <file>` now returns exit 0 from the hook, while `git reset --hard` still exits 2 (guilt preserved).

## Test plan
- [x] `python3 infra/claude-hooks/test_block_regex.py` — 39 PASS (added merge/merge-base cases)
- [x] `python3 infra/claude-hooks/test_hook_innocence.py` — 69 OK (added the exact reported command, the full read-only allowlist, and the new writing-sibling guilt cases)
- [x] `python3 infra/claude-hooks/test_readonly_git_verbs.py` — 59 PASS (new file, direct `_git_verb_verdict` unit tests)
- [x] `python3 infra/claude-hooks/guard_fuzz_harness.py` — 445 PASS, 0 unexplained mismatches (pre-existing corpus, re-verified against this change)
- [x] `python3 infra/claude-hooks/test_ffonly_pull_exception.py`, `test_w85_stash_readonly.py`, `test_arm_keep_hook.py` — all green
- [x] `python3 infra/guard-conformance/check_guard_conformance.py` — 0 violations (registry.json updated with new symbols + scar id)
- Net: +384/-8 across 5 files (4 modified, 1 new test file)
- NOT armed for auto-merge / NOT merged per instruction — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)