### PR TITLE
feat(hooks): per-call hook diet — consolidate 3 inline Bash loggers into one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Agent sessions MUST run under `.worktrees/<lane>-<task-id>/` via `scripts/agent_
 ## Strumenti
 
 MCP: `.mcp.json` untracked (per macchina); tool MCP differiti (`ENABLE_TOOL_SEARCH=true`, settings globale), ~0 tok finché non usati. Prezzi/KBLI/visa/legal: `curl https://nuzantara-rag.fly.dev/...` (`apps/nuzantara-mcp/nuzantara_mcp/server_knowledge.py`). GitHub/Fly/PG: `gh`/`fly`/`scripts/pg.sh`. Browser: `claude --chrome`. Drive: connector claude.ai (`operator[gui]`).
+Repomap on-demand: `cat ~/.nuzantara-repomap.txt` (non più auto-iniettato a SessionStart).
 
 ## 3. Memory (MOS)
 

--- a/evidence/2026-09/agent-nuzantara-infra-per-call-hook-diet-e778d920/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-infra-per-call-hook-diet-e778d920/brief.yml
@@ -1,0 +1,97 @@
+task_id: per-call-hook-diet
+gear: 2
+l_level: L1
+gate_class: opus
+objective: >-
+  Every Bash tool call on Pro fired 14 PreToolUse+PostToolUse hooks (matcher "",
+  "*", or containing "Bash"), three of them separate inline PostToolUse loggers
+  doing overlapping I/O -- one appending ~/.claude/command-history.log, one
+  building a {cmd,cwd} JSON piped into ~/.claude/scripts/hotfix-notify.sh, one
+  rewriting ~/.claude/live-status.json on every tool call -- plus a SessionStart
+  inline that cats ~20KB of ~/.nuzantara-repomap.txt into every session.
+
+  infra/claude-hooks/bash_call_log.sh does all three jobs in one process.
+  Command text written to command-history.log is redacted with the same
+  earliest-anchor-cut pattern as .claude/hooks/codex-spalla-trigger.sh
+  (superscar #4, a live leak from an unredacted per-call Bash logger), ported
+  into infra/claude-hooks/redact_secrets.py. The hotfix-notify.sh pipe is
+  DELIBERATELY left unredacted, byte-identical to the inline it replaces:
+  that script's own DROP/ALTER/fly-secrets classifier needs the raw command,
+  and redacting from the earliest anchor would cut a real hotfix command in
+  half on exactly the case it exists to catch (e.g. `PGPASSWORD=... psql -c
+  'DROP TABLE ...'`). infra/claude-hooks/install_hook_diet.py is the idempotent
+  installer: removes the 3 inline loggers + the SessionStart repomap inline,
+  registers bash_call_log.sh once on PostToolUse matcher=Bash, copies both
+  hook files into ~/.claude/hooks/ at mode 0700, prints a before/after count.
+
+  Gear is 2 via the SIZE term alone (783 net lines: 386 implementation incl.
+  the ported redaction module and its doctrine, 384 guilt+innocence tests, 13
+  declared-pairs/CLAUDE.md wiring). No hot-zone path is touched -- confirmed
+  by running compute_floor()/compute_floor_source() on this diff's own
+  numstat before writing this brief: floor=2, source="size" (the roles-strict
+  lesson: compute the floor WITH the numstat supplied, not without it).
+constraints:
+  - >-
+    Does not touch orchestrate_gate.py, worktree_isolation.py,
+    context_window_guard.py, or any other registered hook -- those are other
+    lanes' PENDING-ARMS today. Only the 3 named inline loggers and the
+    SessionStart repomap inline are removed.
+  - >-
+    Byte-compatible formats for every consumer found by grep (log-rotate.sh,
+    generate-baseline.sh read command-history.log; tmux-briefing.sh and
+    session_marker.py read/write live-status.json; AUTONOMOUS_OPS.md and
+    scripts/claude-hotfix-notify.sh describe the hotfix-notify.sh contract).
+    The only intentional format change is chmod 0600 on the two files this
+    script writes directly (command-history.log, live-status.json), per the
+    task's explicit "log files must be 0600".
+  - >-
+    Never modifies the live ~/.claude/settings.json on the authoring machine
+    -- per the owner's ruling today (2026-09-09), the owner-session applies
+    the installer after merge. All installer runs during authoring were
+    against a disposable COPY of the real settings.json (verified: the copy
+    path, never $HOME/.claude/settings.json, was passed via --settings).
+  - >-
+    Fail-open throughout bash_call_log.sh: a missing python3, a missing
+    hotfix-notify.sh, or a redaction error must never block or crash the
+    Bash call it followed -- proven by a dedicated guilt case
+    (test_hook_exits_0_even_when_hotfix-notify.sh_is_missing).
+acceptance:
+  - >-
+    WHEN install_hook_diet.py runs (real, not --dry-run) against a copy of
+    Pro's live settings.json, THEN it removes exactly the 3 inline
+    PostToolUse loggers and the SessionStart repomap inline, adds ONE
+    PostToolUse matcher=Bash registration, and prints the true before/after
+    hook-per-Bash-call count. probe: test_apply_removes_loggers_and_registers_one
+    (scripts/tests/test_install_hook_diet.py); live 2026-09-09 on a disposable
+    copy of the real ~/.claude/settings.json on Pro -- printed
+    "hooks firing per Bash call: 14 -> 12".
+  - >-
+    WHEN install_hook_diet.py runs a second time on the same (already
+    migrated) settings.json, THEN it reports "(no-op -- already installed)",
+    writes no new backup, and leaves the file byte-identical to the first
+    run's output. probe: test_second_run_is_a_noop; live 2026-09-09 on the
+    same Pro settings.json copy -- second run printed
+    "hooks firing per Bash call: 12 -> 12" and created no second
+    .bak-hookdiet-* file.
+  - >-
+    WHEN --dry-run is passed, THEN the plan and the before/after count print
+    but settings.json, any backup, and the hooks dir are all untouched.
+    probe: test_dry_run_writes_nothing.
+  - >-
+    WHEN bash_call_log.sh runs on a Bash tool call, THEN command-history.log
+    gets one `[YYYY-MM-DD HH:MM:SS] <cmd>` line at mode 0600, live-status.json
+    gets {ts,tool:"Bash",cwd,git_branch} at mode 0600, and the hotfix pipe
+    receives {cmd,cwd} with the RAW (unredacted) command. probe: the first
+    5 assertions in scripts/tests/test_bash_call_log.sh (10/10 pass).
+  - >-
+    WHEN the command contains a credential-shaped fake token
+    (AWS_SECRET_TOKEN=AKIAFAKEEXAMPLE...), THEN command-history.log carries
+    <REDACTED> and never the raw token, WHILE the hotfix pipe still receives
+    the token in full (its classifier is not blinded). probe:
+    the redaction guilt+innocence pair in test_bash_call_log.sh -- live run
+    2026-09-09 confirms both directions.
+  - >-
+    WHEN ~/.claude/scripts/hotfix-notify.sh is missing, THEN bash_call_log.sh
+    still exits 0 and still writes command-history.log. probe: the fail-open
+    case in test_bash_call_log.sh.
+pii_scan: clean

--- a/infra/claude-hooks/bash_call_log.sh
+++ b/infra/claude-hooks/bash_call_log.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# bash_call_log.sh — one PostToolUse process replacing three separate inline
+# Bash loggers that used to fire on every Bash tool call (per-call-hook-diet,
+# 2026-09-09). Writes, in this single bash process:
+#
+#   1. ~/.claude/command-history.log — human-readable command trail, one
+#      line per call. Command text is REDACTED before it is written (see
+#      below) — this is the ONE artifact this script writes the command
+#      text into directly.
+#   2. the {cmd,cwd} JSON that used to be piped inline to
+#      ~/.claude/scripts/hotfix-notify.sh — SAME script, SAME unredacted
+#      payload, SAME byte format as before. Deliberately NOT redacted: that
+#      script's own DROP/ALTER/fly-secrets classifier needs the raw command
+#      (e.g. `PGPASSWORD=... psql -c 'DROP TABLE ...'` — redacting from the
+#      earliest anchor would cut the PGPASSWORD assignment AND everything
+#      after it, including the DROP, on exactly the command this exists to
+#      catch). hotfix-notify.sh decides for itself whether to append
+#      shared/hotfix_audit.jsonl + notify Telegram; this script only builds
+#      its input, exactly like the inline command it replaces did.
+#   3. ~/.claude/live-status.json — last-tool-call marker read by
+#      tmux-briefing.sh. Never carried command text before or now.
+#
+# Command-text redaction uses infra/claude-hooks/redact_secrets.py (the same
+# earliest-anchor-cut pattern as .claude/hooks/codex-spalla-trigger.sh,
+# added after a live leak — cicatrix superscar #4). The installer
+# (install_hook_diet.py) copies both files into ~/.claude/hooks/ together,
+# so this script's own directory always has redact_secrets.py beside it.
+#
+# Input: Claude Code's PostToolUse hook convention for a Bash matcher — the
+# legacy $TOOL_CALL env var (what the inline hooks this replaces relied on)
+# with a stdin-JSON fallback for forward compatibility, same dual-input
+# convention documented in infra/claude-hooks/mos_capture_post_tool.py.
+#
+# Fail-open throughout: a broken/missing dependency must never surface as a
+# blocked tool call. Every write is best-effort (`|| true`).
+
+set -u
+umask 077
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REDACT_PY="$HOOK_DIR/redact_secrets.py"
+
+PAYLOAD="${TOOL_CALL:-}"
+if [ -z "$PAYLOAD" ] && [ ! -t 0 ]; then
+    PAYLOAD="$(cat 2>/dev/null || true)"
+fi
+
+CMD="$(printf '%s' "$PAYLOAD" | /usr/bin/jq -r '.tool_input.command // "unknown"' 2>/dev/null)"
+[ -z "$CMD" ] && CMD="unknown"
+
+# --- 1. command-history.log (redacted) --------------------------------
+HIST_FILE="$HOME/.claude/command-history.log"
+mkdir -p "$(dirname "$HIST_FILE")" 2>/dev/null || true
+LOGGED_CMD=""
+if command -v python3 >/dev/null 2>&1 && [ -f "$REDACT_PY" ]; then
+    LOGGED_CMD="$(printf '%s' "$CMD" | python3 "$REDACT_PY" 2>/dev/null)"
+fi
+[ -z "$LOGGED_CMD" ] && LOGGED_CMD="$CMD"
+printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$LOGGED_CMD" >> "$HIST_FILE" 2>/dev/null || true
+chmod 0600 "$HIST_FILE" 2>/dev/null || true
+
+# --- 2. hotfix jsonl / Telegram, delegated UNCHANGED -------------------
+if [ -x "$HOME/.claude/scripts/hotfix-notify.sh" ] || [ -f "$HOME/.claude/scripts/hotfix-notify.sh" ]; then
+    /usr/bin/jq -nc --arg cmd "$CMD" --arg cwd "$PWD" '{cmd:$cmd, cwd:$cwd}' 2>/dev/null \
+        | bash "$HOME/.claude/scripts/hotfix-notify.sh" 2>/dev/null || true
+fi
+
+# --- 3. live-status.json ------------------------------------------------
+STATUS_FILE="$HOME/.claude/live-status.json"
+STATUS_TMP="${STATUS_FILE}.tmp.$$"
+BRANCH="$(git branch --show-current 2>/dev/null || echo n/a)"
+if printf '{"ts":"%s","tool":"%s","cwd":"%s","git_branch":"%s"}' \
+    "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "Bash" "$PWD" "$BRANCH" > "$STATUS_TMP" 2>/dev/null; then
+    mv -f "$STATUS_TMP" "$STATUS_FILE" 2>/dev/null || rm -f "$STATUS_TMP" 2>/dev/null
+fi
+chmod 0600 "$STATUS_FILE" 2>/dev/null || true
+
+exit 0

--- a/infra/claude-hooks/install_hook_diet.py
+++ b/infra/claude-hooks/install_hook_diet.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""install_hook_diet.py — idempotent installer for the per-call hook diet.
+
+PROBLEM (measured 2026-09-09, Pro): every Bash tool call fired a double-digit
+number of PreToolUse+PostToolUse hook processes, three of them separate
+inline PostToolUse Bash/'' loggers doing overlapping I/O — one appending
+~/.claude/command-history.log, one building a {cmd,cwd} JSON piped into
+~/.claude/scripts/hotfix-notify.sh, one rewriting ~/.claude/live-status.json
+on every tool call — plus a SessionStart inline that cats ~20KB of
+~/.nuzantara-repomap.txt into every session regardless of whether the
+session needs it.
+
+This installer, run once per machine (`python3 infra/claude-hooks/install_hook_diet.py`):
+
+  1. Backs up ~/.claude/settings.json to `<name>.bak-hookdiet-<ts>`.
+  2. Removes the three inline PostToolUse loggers and registers ONE
+     `bash ~/.claude/hooks/bash_call_log.sh` on PostToolUse matcher "Bash"
+     instead — that script does all three jobs in one process (see its own
+     header for exactly what changes and what stays byte-identical).
+  3. Removes the SessionStart "repomap-inject" inline. No replacement is
+     registered: the repomap stays on disk at ~/.nuzantara-repomap.txt,
+     read on demand (`cat ~/.nuzantara-repomap.txt`) instead of injected
+     into every session.
+  4. Copies bash_call_log.sh + redact_secrets.py into ~/.claude/hooks/
+     (mode 0700).
+  5. Prints a before/after count of hooks that fire per Bash tool call:
+     every PreToolUse+PostToolUse group whose matcher is "", "*", or
+     contains "Bash".
+
+Idempotent: step 2/3's marker search finds nothing left to remove on a
+second run, step 2's registration check finds the new command already
+present, so a second run reports "already installed" and does not touch
+settings.json again (no new backup, no rewrite). The hook-file copy step
+always re-runs (copying an identical file is a no-op in effect).
+
+Usage:
+    python3 infra/claude-hooks/install_hook_diet.py [--dry-run]
+    python3 infra/claude-hooks/install_hook_diet.py --settings PATH --hooks-dir DIR   # testing
+
+--dry-run prints the plan and the before/after count without writing
+anything (no backup, no settings.json edit, no file copy).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import time
+from pathlib import Path
+
+DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.json"
+DEFAULT_HOOKS_DIR = Path.home() / ".claude" / "hooks"
+_THIS_DIR = Path(__file__).resolve().parent
+SCRIPT_SRC = _THIS_DIR / "bash_call_log.sh"
+REDACT_SRC = _THIS_DIR / "redact_secrets.py"
+REPOMAP_PATH = Path.home() / ".nuzantara-repomap.txt"
+
+NEW_COMMAND = "bash ~/.claude/hooks/bash_call_log.sh"
+
+COMMAND_HISTORY_MARKER = "command-history.log"
+HOTFIX_MARKER = "hotfix-notify.sh"
+LIVE_STATUS_MARKER = "live-status.json"
+REPOMAP_MARKER = "repomap-inject"
+
+
+def _matches_bash(matcher: str | None) -> bool:
+    matcher = matcher or ""
+    return matcher == "" or matcher == "*" or "Bash" in matcher
+
+
+def count_bash_hooks(hooks: dict) -> int:
+    """Hooks that fire per Bash tool call: PreToolUse+PostToolUse groups
+    whose matcher is '', '*', or contains 'Bash' (substring, e.g.
+    'Bash|Edit|Write')."""
+    total = 0
+    for event in ("PreToolUse", "PostToolUse"):
+        for group in hooks.get(event, []):
+            if _matches_bash(group.get("matcher")):
+                total += len(group.get("hooks", []))
+    return total
+
+
+def _already_installed(hooks: dict) -> bool:
+    for group in hooks.get("PostToolUse", []):
+        if group.get("matcher") == "Bash":
+            for h in group.get("hooks", []):
+                if NEW_COMMAND in h.get("command", ""):
+                    return True
+    return False
+
+
+def strip_inline_loggers(hooks: dict) -> list[str]:
+    """Remove the 3 inline PostToolUse loggers; drop any group left empty.
+
+    Returns the labels of what was actually removed (empty on a no-op run).
+    """
+    removed: list[str] = []
+    kept_groups = []
+    for group in hooks.get("PostToolUse", []):
+        kept_hooks = []
+        for h in group.get("hooks", []):
+            cmd = h.get("command", "")
+            if COMMAND_HISTORY_MARKER in cmd and ">>" in cmd:
+                removed.append("command-history-logger")
+                continue
+            if HOTFIX_MARKER in cmd:
+                removed.append("hotfix-jsonl-builder")
+                continue
+            if LIVE_STATUS_MARKER in cmd and "printf" in cmd:
+                removed.append("live-status-logger")
+                continue
+            kept_hooks.append(h)
+        if kept_hooks:
+            new_group = dict(group)
+            new_group["hooks"] = kept_hooks
+            kept_groups.append(new_group)
+    hooks["PostToolUse"] = kept_groups
+    return removed
+
+
+def strip_repomap_inline(hooks: dict) -> bool:
+    """Remove the SessionStart repomap-inject inline. Returns True if found."""
+    removed = False
+    for group in hooks.get("SessionStart", []):
+        kept_hooks = []
+        for h in group.get("hooks", []):
+            if REPOMAP_MARKER in h.get("command", ""):
+                removed = True
+                continue
+            kept_hooks.append(h)
+        group["hooks"] = kept_hooks
+    return removed
+
+
+def register_bash_call_log(hooks: dict) -> bool:
+    """Append the single consolidated registration. Returns True if added."""
+    if _already_installed(hooks):
+        return False
+    hooks.setdefault("PostToolUse", []).append(
+        {"matcher": "Bash", "hooks": [{"type": "command", "command": NEW_COMMAND}]}
+    )
+    return True
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="print the plan, write nothing")
+    ap.add_argument("--settings", type=Path, default=DEFAULT_SETTINGS)
+    ap.add_argument("--hooks-dir", type=Path, default=DEFAULT_HOOKS_DIR)
+    args = ap.parse_args()
+
+    settings_path: Path = args.settings
+    if not settings_path.exists():
+        print(f"ERROR: settings file not found: {settings_path}")
+        raise SystemExit(1)
+
+    data = json.loads(settings_path.read_text())
+    hooks = data.setdefault("hooks", {})
+
+    before_count = count_bash_hooks(hooks)
+
+    removed = strip_inline_loggers(hooks)
+    repomap_removed = strip_repomap_inline(hooks)
+    added = register_bash_call_log(hooks)
+
+    after_count = count_bash_hooks(hooks)
+    already_clean = not removed and not repomap_removed and not added
+
+    print("== per-call hook diet ==")
+    if removed:
+        print(f"  - remove inline PostToolUse loggers: {', '.join(sorted(set(removed)))}")
+    if repomap_removed:
+        print("  - remove SessionStart repomap-inject")
+    if added:
+        print(f"  - register PostToolUse matcher=Bash -> {NEW_COMMAND}")
+    if already_clean:
+        print("  - (no-op — already installed)")
+    print(f"  hooks firing per Bash call: {before_count} -> {after_count}")
+    print(f"  repomap on demand: cat {REPOMAP_PATH}  (no longer auto-injected at SessionStart)")
+
+    if args.dry_run:
+        print("  (dry-run: no files written)")
+        return
+
+    if not already_clean:
+        ts = time.strftime("%Y%m%d-%H%M%S")
+        backup_path = settings_path.with_name(settings_path.name + f".bak-hookdiet-{ts}")
+        shutil.copy2(settings_path, backup_path)
+        settings_path.write_text(json.dumps(data, indent=2) + "\n")
+        print(f"  backup: {backup_path}")
+    else:
+        print("  settings.json unchanged (already installed)")
+
+    args.hooks_dir.mkdir(parents=True, exist_ok=True)
+    for src in (SCRIPT_SRC, REDACT_SRC):
+        dst = args.hooks_dir / src.name
+        shutil.copy2(src, dst)
+        dst.chmod(0o700)
+        print(f"  installed {dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/claude-hooks/redact_secrets.py
+++ b/infra/claude-hooks/redact_secrets.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""redact_secrets.py — shared secret redaction for Claude Code hook loggers.
+
+Ports the earliest-anchor-cut design from `.claude/hooks/codex-spalla-trigger.sh`
+(added there 2026-08-21 after a live leak — cicatrix superscar #4: an
+unredacted per-call Bash logger printed real tokens to disk) into an
+importable/CLI-usable function, so a new per-call logger does not have to
+re-derive the same regex from a blank page. See that file's header for the
+full derivation history (five leak-and-cure rounds); this module carries
+only the shipped, functional shape.
+
+Design: given a string, find the EARLIEST position matched by any
+credential-shaped anchor (known token prefixes, a PEM private-key header,
+URL userinfo, `Authorization: Basic <b64>`, bare `Bearer <token>`, or a
+`NAME=value` / `NAME: value` assignment where NAME looks like a credential)
+and replace everything from that position to the end of the string with
+`<REDACTED>`. Nothing is rewritten in place and nothing is consumed twice —
+each anchor is searched independently against the ORIGINAL string, so nothing
+after the earliest anchor ever reaches disk. Accepted cost: a command whose
+credential sits early loses the diagnostic tail that follows it. This is a
+telemetry log, not a replayable transcript.
+
+Declared residuals (inherited from the ported pattern, not re-litigated
+here): a handful of narrow shapes still leak — see codex-spalla-trigger.sh's
+own comment block for the exhaustive, measured list (KEY names outside a
+bounded prefix vocabulary, single-segment attribute assignment, positional
+secrets with no name, etc.). This module accepts the same trade the ported
+pattern already made: over-redact a non-secret before under-redacting a
+real one.
+"""
+from __future__ import annotations
+
+import re
+
+WIDE = r"(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL)"
+PRE = (
+    r"(?:API|AUTH|ACCESS|APP|CLIENT|PRIVATE|MASTER|ROOT|ADMIN|USER|SESSION"
+    r"|REFRESH|OAUTH|BEARER|MY|ID|TOKEN|SECRET|PASSWORD|PASSWD"
+    r"|CREDENTIAL)"
+)
+TAIL = r"S?[0-9]{0,8}(?:[_-][A-Za-z0-9]{1,64}){0,16}"
+TAIL_ND = r"S?(?:[_-][A-Za-z0-9]{1,64}){0,16}"
+NAME = (
+    r"(?<![A-Za-z0-9.])(?:"
+    + r"[A-Za-z0-9]*" + WIDE + TAIL  # a. any prefix + a wide credential word
+    + r"|" + PRE + r"KEY" + TAIL  # b. vocabulary-prefixed KEY
+    + r"|KEY" + TAIL_ND  # b. bare KEY, no digit-only suffix
+    + r"|(?:PASS|PWD|AUTH)"  # c. bare generic name
+    + r")"
+)
+VALUE = r"(?:\"[^\"]*\"|'[^']*'|[^\s\"']+)"
+
+ANCHORS = (
+    # Known credential shapes, by their own prefixes.
+    r"sk-ant-[A-Za-z0-9_-]{8,}",
+    r"gh[pousr]_[A-Za-z0-9]{8,}",
+    r"github_pat_[A-Za-z0-9_]{8,}",
+    r"xox[baprs]-[A-Za-z0-9-]{10,}",
+    # A PEM private-key block.
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z ]*-----",
+    # URL userinfo: scheme://user:<secret>@host (including empty user, the
+    # Redis form). Bounded runs keep this linear on long credential-free
+    # input; the port-vs-password discriminator keeps a genuine host:port
+    # followed later by an unrelated @ from anchoring.
+    r"://[^\s:/@]{0,2048}:(?!\d+(?:/@|[/?#][^\s@]{0,2048}/))[^\s@]{1,2048}@",
+    # Authorization: Basic <base64>, requiring a digit or +/= so ordinary
+    # prose ("Basic auth support") stays innocent.
+    r"(?i)Authorization:\s*Basic\s+(?=[A-Za-z0-9+/=]{16,})[A-Za-z0-9+/=]*[0-9+/=][A-Za-z0-9+/=]*",
+    # Bearer <token>, which carries no keyword in a NAME at all.
+    r"(?i)\b(?:Bearer)\s+[A-Za-z0-9._~+/=-]{8,}",
+    # Anything ASSIGNED to a credential-ish NAME (env-style, JSON body, or
+    # `NAME: value`). The \* before the optional quote covers a JSON body
+    # reaching this hook through nested shell quoting (`\"api_key\": <v>`).
+    r"(?i)" + NAME + r"\\*[\"']?\s*[=:]\s*" + VALUE,
+)
+_COMPILED = tuple(re.compile(p) for p in ANCHORS)
+
+
+def redact(text: str) -> str:
+    """Return `text` with everything from the earliest credential anchor cut.
+
+    Never raises — a regex engine error (should not happen with these fixed
+    patterns) falls back to returning the input unchanged rather than
+    crashing a fail-open logging hook.
+    """
+    if not text:
+        return text
+    try:
+        starts = [m.start() for m in (p.search(text) for p in _COMPILED) if m]
+    except Exception:
+        return text
+    if starts:
+        return text[: min(starts)] + "<REDACTED>"
+    return text
+
+
+def main() -> None:
+    import sys
+
+    data = sys.stdin.read()
+    sys.stdout.write(redact(data))
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -518,6 +518,24 @@
           "symbols": {},
           "tests": ["infra/claude-hooks/test_context_window_guard.py"],
           "note": "PreToolUse hard-gate (Zero mandate 2026-09-09): enforces a short-window rule per role by importing the S1 tokenaudit estimator (~/.tokenaudit/hooks/context_hygiene.py) and the PreCompact handoff generator (~/.claude/hooks/precompact-mnemos.py) rather than reimplementing either. Denies every tool call above threshold except a mem-save Bash command, a write to the session's own handoff file, or SendMessage/TaskStop delegation. Not yet registered in ~/.claude/settings.json (see PENDING-ARMS.md) — fail-open on any cannot-verify condition, same discipline as orchestrate_gate.py/model_routing_gate.py."
+        },
+        "infra/claude-hooks/bash_call_log.sh": {
+          "scar": [
+            "superscar-4-secret-in-the-clear",
+            "superscar-2-esiste-non-armato"
+          ],
+          "symbols": {},
+          "tests": [
+            "scripts/tests/test_bash_call_log.sh",
+            "scripts/tests/test_install_hook_diet.py"
+          ],
+          "note": "Per-call hook diet (2026-09-09): replaces 3 separate inline PostToolUse Bash loggers (a command-history.log append, a {cmd,cwd}->hotfix-notify.sh pipe, a live-status.json rewrite) that used to fire on every Bash tool call with ONE registered command hook doing all three jobs in one process. Command text written to command-history.log is redacted with the same earliest-anchor-cut pattern as codex-spalla-trigger.sh above (superscar #4) via the redact_secrets.py sidecar registered below — the hotfix-notify.sh pipe is deliberately left unredacted/byte-identical to the inline it replaces, since that script's own DROP/ALTER/fly-secrets classifier needs the raw command. Installed into ~/.claude/hooks/ by infra/claude-hooks/install_hook_diet.py, which test_install_hook_diet.py exercises end to end (dry-run, apply, idempotent second run) against a fixture settings.json; test_bash_call_log.sh exercises the hook binary itself, including a fake-credential guilt case proving the redaction fires."
+        },
+        "infra/claude-hooks/redact_secrets.py": {
+          "scar": ["superscar-4-secret-in-the-clear"],
+          "symbols": {},
+          "tests": ["scripts/tests/test_bash_call_log.sh"],
+          "note": "Sidecar of bash_call_log.sh above: an importable port of codex-spalla-trigger.sh's earliest-anchor-cut secret-redaction regex (superscar #4), so a new per-call logger does not have to re-derive it from a blank page. Installed alongside bash_call_log.sh by install_hook_diet.py. Exercised indirectly by test_bash_call_log.sh's fake-credential guilt case (command-history.log redacts, the unrelated hotfix-notify.sh pipe does not) rather than a standalone unit test, since its only caller today is bash_call_log.sh."
         }
       },
       "exempt": {

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -948,6 +948,18 @@
       "repo": "infra/launchagents/com.nuzantara.kb-probe-history.6h.plist",
       "machines": ["pro"],
       "_note": "The plist twin of the pair above; installed on Pro only."
+    },
+    {
+      "live": "~/.claude/hooks/bash_call_log.sh",
+      "repo": "infra/claude-hooks/bash_call_log.sh",
+      "machines": ["all"],
+      "_note": "Per-call hook diet (2026-09-09): infra/claude-hooks/install_hook_diet.py copies this into ~/.claude/hooks/ on install, replacing three separate inline PostToolUse Bash loggers in settings.json with one registration. Declared so a future fix landing in the repo does not go silently unsynced on a machine that already ran the installer once (superscar #1)."
+    },
+    {
+      "live": "~/.claude/hooks/redact_secrets.py",
+      "repo": "infra/claude-hooks/redact_secrets.py",
+      "machines": ["all"],
+      "_note": "Sidecar of bash_call_log.sh above, installed alongside it by the same installer — the earliest-anchor secret-redaction pattern applied to command-history.log (superscar #4 lineage, ported from .claude/hooks/codex-spalla-trigger.sh)."
     }
   ],
   "allow": [

--- a/scripts/tests/test_bash_call_log.sh
+++ b/scripts/tests/test_bash_call_log.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# test_bash_call_log.sh — guilt+innocence corpus for
+# infra/claude-hooks/bash_call_log.sh (per-call-hook-diet, 2026-09-09).
+#
+# Runs the REAL script against a fake HOME, a stub hotfix-notify.sh (so we
+# never touch the real Telegram/jsonl side-effects), and a controlled
+# TOOL_CALL payload. Proves the three artifacts land in the expected format
+# AND that a fake credential in the command is redacted in
+# command-history.log while the (separate, unchanged) hotfix pipe still
+# gets the raw command.
+#
+# Run:  sh scripts/tests/test_bash_call_log.sh
+# Exit: 0 all pass, 1 any failure.
+
+fail=0
+pass=0
+note_pass() { pass=$((pass + 1)); echo "PASS - $1"; }
+note_fail() { fail=$((fail + 1)); echo "FAIL - $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET="$REPO_ROOT/infra/claude-hooks/bash_call_log.sh"
+
+if [ ! -f "$TARGET" ]; then
+    echo "FATAL: $TARGET not found"
+    exit 1
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/test-bash-call-log.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+setup_world() {
+    rm -rf "${WORK:?}/home"
+    mkdir -p "$WORK/home/.claude/scripts"
+    # Stub hotfix-notify.sh: records whatever JSON it receives on stdin,
+    # never touches the network. This is what the ported pipe is graded
+    # against — the real hotfix-notify.sh has its own test surface.
+    cat > "$WORK/home/.claude/scripts/hotfix-notify.sh" <<'EOF'
+#!/usr/bin/env bash
+cat > "$HOME/.claude/hotfix-stub-received.json"
+EOF
+    chmod +x "$WORK/home/.claude/scripts/hotfix-notify.sh"
+}
+
+run_hook() {
+    # $1 = command text to embed in TOOL_CALL
+    payload="$(printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")"
+    HOME="$WORK/home" TOOL_CALL="$payload" PWD="$WORK/home" bash "$TARGET"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: plain command — all three artifacts land, in the expected shapes.
+# ---------------------------------------------------------------------------
+setup_world
+run_hook "echo hello world" >/dev/null 2>&1
+
+HIST="$WORK/home/.claude/command-history.log"
+if [ -f "$HIST" ] && grep -q "echo hello world" "$HIST"; then
+    note_pass "command-history.log carries the plain command"
+else
+    note_fail "command-history.log missing or wrong content"
+fi
+
+if [ -f "$HIST" ]; then
+    if head -1 "$HIST" | grep -qE '^\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\] '; then
+        note_pass "command-history.log line format matches [YYYY-MM-DD HH:MM:SS] <cmd>"
+    else
+        note_fail "command-history.log line format wrong: $(head -1 "$HIST")"
+    fi
+    mode="$(stat -f '%Lp' "$HIST" 2>/dev/null || stat -c '%a' "$HIST" 2>/dev/null)"
+    if [ "$mode" = "600" ]; then
+        note_pass "command-history.log is mode 0600"
+    else
+        note_fail "command-history.log mode is $mode, expected 600"
+    fi
+fi
+
+STATUS="$WORK/home/.claude/live-status.json"
+if [ -f "$STATUS" ] && python3 -c "
+import json
+d = json.load(open('$STATUS'))
+assert d['tool'] == 'Bash', d
+assert 'ts' in d and 'cwd' in d and 'git_branch' in d, d
+"; then
+    note_pass "live-status.json has ts/tool/cwd/git_branch with tool=Bash"
+else
+    note_fail "live-status.json missing or malformed: $(cat "$STATUS" 2>/dev/null)"
+fi
+
+RECEIVED="$WORK/home/.claude/hotfix-stub-received.json"
+if [ -f "$RECEIVED" ] && python3 -c "
+import json
+d = json.load(open('$RECEIVED'))
+assert d['cmd'] == 'echo hello world', d
+assert 'cwd' in d, d
+"; then
+    note_pass "hotfix pipe receives {cmd,cwd} JSON with the raw command"
+else
+    note_fail "hotfix stub did not receive expected JSON: $(cat "$RECEIVED" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: a fake credential — redacted in command-history.log, but the
+# hotfix pipe (unchanged, unredacted by design) still sees it raw so its
+# own DROP/ALTER classifier is not blinded.
+# ---------------------------------------------------------------------------
+setup_world
+FAKE_TOKEN="AKIAFAKEEXAMPLE1234567890"
+run_hook "export AWS_SECRET_TOKEN=${FAKE_TOKEN} && aws s3 ls" >/dev/null 2>&1
+
+if [ -f "$HIST" ] && ! grep -q "$FAKE_TOKEN" "$HIST"; then
+    note_pass "command-history.log redacts the fake credential"
+else
+    note_fail "command-history.log LEAKED the fake credential: $(cat "$HIST" 2>/dev/null)"
+fi
+
+if [ -f "$HIST" ] && grep -q "REDACTED" "$HIST"; then
+    note_pass "command-history.log carries the <REDACTED> marker"
+else
+    note_fail "command-history.log missing the <REDACTED> marker"
+fi
+
+if [ -f "$RECEIVED" ] && grep -q "$FAKE_TOKEN" "$RECEIVED"; then
+    note_pass "hotfix pipe still receives the raw command (classifier not blinded)"
+else
+    note_fail "hotfix pipe payload was unexpectedly redacted/missing: $(cat "$RECEIVED" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: missing hotfix-notify.sh must not crash the hook (fail-open).
+# ---------------------------------------------------------------------------
+setup_world
+rm -f "$WORK/home/.claude/scripts/hotfix-notify.sh"
+if run_hook "echo still fine" >/dev/null 2>&1; then
+    note_pass "hook exits 0 even when hotfix-notify.sh is missing"
+else
+    note_fail "hook exited non-zero when hotfix-notify.sh is missing"
+fi
+if [ -f "$HIST" ] && grep -q "echo still fine" "$HIST"; then
+    note_pass "command-history.log still written when hotfix-notify.sh is missing"
+else
+    note_fail "command-history.log not written when hotfix-notify.sh is missing"
+fi
+
+echo ""
+echo "== $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]

--- a/scripts/tests/test_install_hook_diet.py
+++ b/scripts/tests/test_install_hook_diet.py
@@ -1,0 +1,237 @@
+"""Tests for infra/claude-hooks/install_hook_diet.py (per-call hook diet).
+
+Coverage:
+- dry-run on a fixture settings.json removes nothing on disk and reports the
+  right before/after hook-per-Bash-call count
+- a real (non-dry-run) run removes exactly the 3 inline PostToolUse loggers
+  + the SessionStart repomap-inject inline, and adds ONE PostToolUse
+  matcher=Bash registration; backs up the original file first; copies
+  bash_call_log.sh + redact_secrets.py into --hooks-dir at mode 0700
+- a second run is a no-op: no new backup, settings.json byte-identical,
+  hook count unchanged
+
+Never touches the real ~/.claude/settings.json — everything runs against a
+fixture file under tmp_path, via --settings/--hooks-dir.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "infra" / "claude-hooks" / "install_hook_diet.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("install_hook_diet", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def install_hook_diet():
+    return _load_module()
+
+
+def _fixture_settings() -> dict:
+    """A minimal settings.json shaped like the real one on the field it
+    matters for: the 3 inline PostToolUse loggers, one unrelated PostToolUse
+    '' hook (mailbox_inject.py-shaped, must survive), one unrelated
+    Edit|Write hook, two PreToolUse hooks that DO count toward the
+    per-Bash-call total, and a SessionStart '' group with the repomap inline
+    plus one unrelated hook that must survive."""
+    return {
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "Bash|Edit", "hooks": [{"type": "command", "command": "echo pre1"}]},
+                {"matcher": "*", "hooks": [{"type": "command", "command": "echo pre2"}]},
+            ],
+            "PostToolUse": [
+                {"matcher": "Edit|Write", "hooks": [{"type": "command", "command": "ruff check"}]},
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": (
+                                "echo \"[$(date '+%Y-%m-%d %H:%M:%S')] "
+                                "$(echo \"$TOOL_CALL\" | /usr/bin/jq -r "
+                                "'.tool_input.command' 2>/dev/null || echo "
+                                "'unknown')\" >> ~/.claude/command-history.log"
+                            ),
+                        },
+                        {
+                            "type": "command",
+                            "command": (
+                                "CMD=$(echo \"$TOOL_CALL\" | /usr/bin/jq -r "
+                                "'.tool_input.command' 2>/dev/null); /usr/bin/jq -nc "
+                                "--arg cmd \"$CMD\" --arg cwd \"$PWD\" '{cmd:$cmd, "
+                                "cwd:$cwd}' | bash ~/.claude/scripts/hotfix-notify.sh "
+                                "2>/dev/null || true"
+                            ),
+                        },
+                    ],
+                },
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": (
+                                "printf '{\"ts\":\"%s\",\"tool\":\"%s\",\"cwd\":\"%s\","
+                                "\"git_branch\":\"%s\"}' \"$(date -u '+%Y-%m-%dT%H:%M:%SZ')\" "
+                                "\"$(echo \"$TOOL_CALL\" | /usr/bin/jq -r '.name // "
+                                "\"unknown\"')\" \"$PWD\" \"$(git branch --show-current "
+                                "2>/dev/null || echo n/a)\" > ~/.claude/live-status.json "
+                                "2>/dev/null || true"
+                            ),
+                        }
+                    ],
+                },
+                {"matcher": "", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/mailbox_inject.py"}]},
+            ],
+            "SessionStart": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {"type": "command", "command": "bash ~/.claude/scripts/log-rotate.sh"},
+                        {
+                            "type": "command",
+                            "command": (
+                                "# repomap-inject SOTA L4 2026-05-24\n"
+                                "if [[ -f ~/.nuzantara-repomap.txt ]]; then cat "
+                                "~/.nuzantara-repomap.txt; fi"
+                            ),
+                        },
+                    ],
+                }
+            ],
+        }
+    }
+
+
+@pytest.fixture()
+def fixture_paths(tmp_path):
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps(_fixture_settings(), indent=2))
+    hooks_dir = tmp_path / "hooks"
+    return settings, hooks_dir
+
+
+# Expected count per the fixture above (matcher '' / '*' / contains 'Bash'):
+#   PreToolUse: "Bash|Edit" (1) + "*" (1) = 2
+#   PostToolUse: "Bash" (2) + "" live-status (1) + "" mailbox (1) = 4
+#   BEFORE = 6
+# After: the "Bash" group (both hooks removed) and the live-status "" group
+# (its only hook removed) are dropped entirely; mailbox "" group survives;
+# one new "Bash" group with 1 hook is added.
+#   AFTER = mailbox(1) + new-Bash(1) + PreToolUse(2) = 4
+EXPECTED_BEFORE = 6
+EXPECTED_AFTER = 4
+
+
+def test_dry_run_writes_nothing(install_hook_diet, fixture_paths, capsys):
+    settings, hooks_dir = fixture_paths
+    original_bytes = settings.read_bytes()
+
+    import sys as _sys
+
+    argv = _sys.argv
+    _sys.argv = ["install_hook_diet.py", "--dry-run", "--settings", str(settings), "--hooks-dir", str(hooks_dir)]
+    try:
+        install_hook_diet.main()
+    finally:
+        _sys.argv = argv
+
+    out = capsys.readouterr().out
+    assert f"{EXPECTED_BEFORE} -> {EXPECTED_AFTER}" in out
+    assert "dry-run" in out
+    assert settings.read_bytes() == original_bytes, "dry-run must not touch the settings file"
+    assert not hooks_dir.exists(), "dry-run must not create the hooks dir"
+    assert not list(settings.parent.glob("*.bak-hookdiet-*")), "dry-run must not create a backup"
+
+
+def test_apply_removes_loggers_and_registers_one(install_hook_diet, fixture_paths, capsys):
+    settings, hooks_dir = fixture_paths
+
+    import sys as _sys
+
+    argv = _sys.argv
+    _sys.argv = ["install_hook_diet.py", "--settings", str(settings), "--hooks-dir", str(hooks_dir)]
+    try:
+        install_hook_diet.main()
+    finally:
+        _sys.argv = argv
+
+    out = capsys.readouterr().out
+    assert f"{EXPECTED_BEFORE} -> {EXPECTED_AFTER}" in out
+
+    data = json.loads(settings.read_text())
+    hooks = data["hooks"]
+
+    all_post_commands = [
+        h.get("command", "") for g in hooks["PostToolUse"] for h in g.get("hooks", [])
+    ]
+    assert not any("command-history.log" in c and ">>" in c for c in all_post_commands)
+    assert not any("hotfix-notify.sh" in c for c in all_post_commands)
+    assert not any("live-status.json" in c and "printf" in c for c in all_post_commands)
+    # survivors
+    assert any("mailbox_inject.py" in c for c in all_post_commands)
+    assert any(c.strip() == "bash ~/.claude/hooks/bash_call_log.sh" for c in all_post_commands)
+    # the new registration is its own matcher=Bash group
+    new_groups = [g for g in hooks["PostToolUse"] if g.get("matcher") == "Bash"]
+    assert len(new_groups) == 1
+    assert len(new_groups[0]["hooks"]) == 1
+
+    all_session_commands = [
+        h.get("command", "") for g in hooks["SessionStart"] for h in g.get("hooks", [])
+    ]
+    assert not any("repomap-inject" in c for c in all_session_commands)
+    assert any("log-rotate.sh" in c for c in all_session_commands)
+
+    # backup created with the ORIGINAL content
+    backups = list(settings.parent.glob("*.bak-hookdiet-*"))
+    assert len(backups) == 1
+    backup_data = json.loads(backups[0].read_text())
+    assert any(
+        "command-history.log" in h.get("command", "")
+        for g in backup_data["hooks"]["PostToolUse"]
+        for h in g.get("hooks", [])
+    ), "backup must carry the PRE-install content"
+
+    # hook files installed at 0700
+    for name in ("bash_call_log.sh", "redact_secrets.py"):
+        dst = hooks_dir / name
+        assert dst.exists(), f"{name} not installed"
+        mode = stat.S_IMODE(dst.stat().st_mode)
+        assert mode == 0o700, f"{name} mode {oct(mode)} != 0700"
+
+
+def test_second_run_is_a_noop(install_hook_diet, fixture_paths, capsys):
+    settings, hooks_dir = fixture_paths
+
+    import sys as _sys
+
+    argv = _sys.argv
+    _sys.argv = ["install_hook_diet.py", "--settings", str(settings), "--hooks-dir", str(hooks_dir)]
+    try:
+        install_hook_diet.main()
+        capsys.readouterr()  # drain first-run output
+        after_first = settings.read_bytes()
+
+        install_hook_diet.main()
+    finally:
+        _sys.argv = argv
+
+    out = capsys.readouterr().out
+    assert "no-op" in out
+    assert f"{EXPECTED_AFTER} -> {EXPECTED_AFTER}" in out
+    assert settings.read_bytes() == after_first, "second run must not rewrite settings.json"
+
+    backups = list(settings.parent.glob("*.bak-hookdiet-*"))
+    assert len(backups) == 1, "second run must not create a second backup"


### PR DESCRIPTION
## Summary

- Every Bash tool call fires a double-digit number of Pre/PostToolUse hooks. Three of them are separate inline PostToolUse Bash/`""` loggers doing overlapping I/O: one appends `~/.claude/command-history.log`, one builds a `{cmd,cwd}` JSON piped into `~/.claude/scripts/hotfix-notify.sh`, one rewrites `~/.claude/live-status.json` on every tool call. A SessionStart inline also `cat`s ~20KB of `~/.nuzantara-repomap.txt` into every session.
- Adds `infra/claude-hooks/bash_call_log.sh` — does all three jobs in one process. Command text written to `command-history.log` is redacted with the same earliest-anchor-cut pattern as `.claude/hooks/codex-spalla-trigger.sh` (superscar #4 — a live leak from an unredacted per-call Bash logger). The `hotfix-notify.sh` pipe stays **unredacted by design**: that script's own DROP/ALTER/fly-secrets classifier needs the raw command, and redacting from the earliest anchor would cut a real hotfix command in half on exactly the case it exists to catch (e.g. `PGPASSWORD=... psql -c 'DROP TABLE ...'`).
- Adds `infra/claude-hooks/install_hook_diet.py` — idempotent installer: backs up `settings.json` to `.bak-hookdiet-<ts>`, removes the 3 inline loggers + the SessionStart repomap inline, registers `bash_call_log.sh` once on `PostToolUse` matcher `Bash`, copies both hook files into `~/.claude/hooks/` at mode 0700, prints a before/after count of hooks firing per Bash call. `--dry-run` prints the plan without writing; a second run is a no-op (verified).
- Declares the new live/repo pair in `infra/home-fork/declared-pairs.json` (superscar #1) and documents the on-demand repomap path in `CLAUDE.md` §Strumenti (Italian, one line).
- Does **not** touch `orchestrate_gate.py`, `worktree_isolation.py`, `context_window_guard.py`, or any other registered hook.

Per owner's ruling today (2026-09-09): this PR does **not** arm auto-merge and does **not** modify the live `~/.claude/settings.json` on this machine — the owner-session applies the installer after merge.

## Bites

Consumer: Bash tool calls on Pro/M5/Mini, once `python3 infra/claude-hooks/install_hook_diet.py` runs there.

Observation (measured against a **copy** of the live `~/.claude/settings.json` on Pro, never the live file itself — dry-run and real-run both printed):
```
hooks firing per Bash call: 14 -> 12
```
A second run against the same copy reported `(no-op — already installed)` and `12 -> 12`, with `settings.json` byte-identical to the first run's output. The three consolidated artifacts (`command-history.log`, the `hotfix-notify.sh` pipe, `live-status.json`) were verified still updating in the correct byte-compatible formats via `scripts/tests/test_bash_call_log.sh` (10/10 pass), including a fake-credential redaction case proving `command-history.log` redacts while the `hotfix-notify.sh` pipe still receives the raw command.

## Test plan

- [x] `apps/backend-rag/.venv/bin/pytest scripts/tests/test_install_hook_diet.py -q` — 3 passed (dry-run no-op, apply removes exactly the 3 loggers + repomap inline and adds 1 registration, second run is a no-op)
- [x] `sh scripts/tests/test_bash_call_log.sh` — 10 passed (format/mode of all 3 artifacts, redaction of a fake token, hotfix pipe unredacted, fail-open when `hotfix-notify.sh` is missing)
- [x] `ruff check` clean on the new Python files; `shellcheck` clean on the new shell files
- [x] Dry-run + real-run + idempotent-second-run verified against a **copy** of the real `~/.claude/settings.json` on Pro (14 -> 12, confirmed no-op on rerun) — the live file itself was never touched
- [x] `scripts/lint_home_fork.py --check` — the two new declared pairs report `not on disk` (expected pre-install, same treatment as other pending pairs already in the file); pre-existing `context_window_guard.py` divergence is unrelated (present on `origin/main` baseline too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)