### PR TITLE
fix(a11y): raise seven sub-44px controls on /kbli-explorer to 44px

### DIFF
--- a/apps/mouth/src/app/kbli-explorer/page.tsx
+++ b/apps/mouth/src/app/kbli-explorer/page.tsx
@@ -780,7 +780,7 @@ const InspectorChoreographed = ({
           <div className="flex items-center gap-1">
             <button
               onClick={handleCopy}
-              className="p-2 rounded hover:bg-white/5 text-[#666] hover:text-accent-sand transition-colors"
+              className="p-2 rounded hover:bg-white/5 text-[#666] hover:text-accent-sand transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
               title="Copy details"
               aria-label="Copy details"
             >
@@ -944,7 +944,7 @@ const InspectorChoreographed = ({
               <button
                 key={idx}
                 onClick={() => onInspect?.(rel)}
-                className="px-4 py-2 rounded-full bg-surface-deep text-xs text-[#888] border border-white/5 hover:border-accent-sand/30 hover:text-accent-sand cursor-pointer transition-all"
+                className="px-4 py-2 min-h-[44px] inline-flex items-center rounded-full bg-surface-deep text-xs text-[#888] border border-white/5 hover:border-accent-sand/30 hover:text-accent-sand cursor-pointer transition-all"
               >
                 {rel}
               </button>
@@ -1171,7 +1171,7 @@ export default function KBLIExplorerPage() {
           </div>
           <button
             onClick={() => setSidebarOpen(false)}
-            className="md:hidden p-2 rounded text-[#888] hover:text-white"
+            className="md:hidden p-2 rounded text-[#888] hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
           >
             <X size={18} />
           </button>
@@ -1264,7 +1264,7 @@ export default function KBLIExplorerPage() {
             {/* Mobile hamburger */}
             <button
               onClick={() => setSidebarOpen(true)}
-              className="md:hidden absolute -left-1 top-1/2 -translate-y-1/2 p-2 rounded text-[#888] hover:text-white z-10"
+              className="md:hidden absolute -left-1 top-1/2 -translate-y-1/2 p-2 rounded text-[#888] hover:text-white z-10 min-h-[44px] min-w-[44px] flex items-center justify-center"
             >
               <Menu size={20} />
             </button>
@@ -1301,7 +1301,7 @@ export default function KBLIExplorerPage() {
                       setCompareMode((prev) => !prev);
                       if (compareMode) setCompareSelection([]);
                     }}
-                    className={`p-2 rounded-md transition-colors min-h-[36px] min-w-[36px] flex items-center justify-center ${
+                    className={`p-2 rounded-md transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center ${
                       compareMode
                         ? "bg-accent-sand/15 text-accent-sand"
                         : "hover:bg-surface-editorial-elevated text-[#555] hover:text-[#888]"
@@ -1316,7 +1316,7 @@ export default function KBLIExplorerPage() {
                   <button
                     type="button"
                     onClick={handleClearConversation}
-                    className="p-2 rounded-md hover:bg-surface-editorial-elevated text-[#555] hover:text-[#888] transition-colors min-h-[36px] min-w-[36px] flex items-center justify-center"
+                    className="p-2 rounded-md hover:bg-surface-editorial-elevated text-[#555] hover:text-[#888] transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
                     title="Clear conversation"
                     aria-label="Clear conversation"
                   >
@@ -1455,7 +1455,7 @@ export default function KBLIExplorerPage() {
                 </span>
                 <button
                   onClick={() => setCompareOpen(true)}
-                  className="px-4 py-2 rounded-lg bg-accent-sand text-[#050507] text-sm font-medium hover:bg-[#C4A473] transition-colors"
+                  className="px-4 py-2 min-h-[44px] inline-flex items-center rounded-lg bg-accent-sand text-[#050507] text-sm font-medium hover:bg-[#C4A473] transition-colors"
                 >
                   Compare {compareSelection.length} codes &rarr;
                 </button>


### PR DESCRIPTION
Seven interactive controls on /kbli-explorer sit below the 44px minimum touch target, in a file that already applies `min-h-[44px]` nine times elsewhere.

# Insight
This is not a missing convention — it is an intra-file inconsistency with a rule the file already states. `apps/mouth/src/app/kbli-explorer/page.tsx` applies `min-h-[44px]` at nine call sites (:375, :511, :590, :620, :1220, :1229, :1277, :1329, :1361) and omits it at nine others. The fix invents no convention, adds no dependency, and changes no colour, copy, or data.

Two of those nine were measured and then deliberately dropped — see Risk.

# Studio

## Source / Reference
WCAG 2.5.5 Target Size (Enhanced), 44x44 CSS px. Measured on `origin/main` = 15751bd070, 2026-09-09.

## Methodology
Layer 2 only. Pattern `<button|role="button"|<Link` with six lines of trailing context, scoped by positive pathspec to `apps/mouth/src/app/kbli`, `apps/mouth/src/app/kbli-explorer` and `apps/mouth/src/components/kbli`; all three pathspecs confirmed non-empty via `git ls-tree` first, because a non-existent pathspec returns a silent zero. Every candidate whose `className` was a variable or helper was resolved by opening the wrapper, not by reading the call site.

## Raw Observations
49 candidate control lines across 18 files. 23 real sub-44px targets across 10 files. Nine of the 23 are in this file:

- `:346`, `:476` — `text-[10px]`, no padding, approx. 14px — **excluded, see Risk**
- `:781`, `:1172`, `:1265` — `p-2` plus a 14-20px icon, approx. 30-36px
- `:944`, `:1456` — `px-4 py-2`, approx. 32-36px
- `:1298`, `:1316` — explicit `min-h-[36px] min-w-[36px]`

Excluded and not counted: nine inline prose links, and `:193`, an inline glossary term (`cursor-help`, `border-b border-dashed`, `role="button"`) — WCAG 2.5.5 exempts targets inline in a sentence. `:503` looked non-compliant in a six-line window but `:511` carries `p-4 min-h-[44px]`; reclassified as passing.

`min-h-[44px]` line count in this file: **9 before, 16 after**. The two `min-h-[36px]` lines are converted rather than added, so they move between counts rather than into the 44px count from nothing.

## Reasoning Path
Resolving wrappers changed the answer twice, in both directions, so neither the positives nor the negatives here are grep artefacts. Scope was held to one file deliberately: the other 14 controls live in nine other files and are a separate problem. Merging them would make one PR touch ten files.

The icon buttons follow the idiom already at `:1329` in this same file (`p-2 ... min-h-[44px] min-w-[44px] flex items-center justify-center`); the `px-4 py-2` pills follow `:590`/`:620` (`min-h-[44px]` plus flex centring). Nothing here is a new convention.

## Risk / Implication
`:346` and `:476` are text-only affordances with no padding. They were changed, measured in a local browser, and then reverted. Measured in the page's own CSS: both go from 15px to 44px high with width unchanged (161.6px and 40.2px), so `min-h-[44px]` does enlarge the hit area rather than stretch the flex row — but the parent card grows 128px to 157px, leaving visible dead space under the CTA. That is a real layout shift, so they are out of this PR and remain exactly as on main. They need a padding/spacing decision, not a minimum-height one.

The seven that shipped either already centre their content or are icon buttons whose box was already close to 44px, so their delta is 8-14px and absorbed by existing padding.

Not measurable locally, stated rather than softened: vitest cannot resolve the `@/` alias in this repo, so zero tests were collected; Playwright is not run locally. Any e2e assertion touching these controls first executes in CI, and that is the likeliest thing to go red.

Verified locally: `npm run build -w apps/mouth` rc=0, 1766 static pages, `PUBLIC_LOGIN_BUNDLE_OK`; `npm run lint -w apps/mouth` 183 warnings, 0 errors — identical to the main baseline, nothing added. `apps/mouth/public/llms-full.txt` is regenerated by the build and was restored before staging.

# Recommendation
Merge as an atomic accessibility fix. It carries no new convention and no cross-file coupling.

# Next Action
The remaining 14 sub-44px controls across nine files, plus the `:346`/`:476` spacing decision, are recorded in Todoist and follow as separate PRs. The parallel badge system in `app/kbli-explorer/**` and the dead-clone question around `KBLIInspector.tsx` are tracked separately and are not accessibility work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iZEycXKRwKRJPjso8PPaN
