### PR TITLE
fix(a11y): raise the three /kbli sector table sort controls to 44px

### DIFF
--- a/apps/mouth/src/components/kbli/KBLISectorTable.tsx
+++ b/apps/mouth/src/components/kbli/KBLISectorTable.tsx
@@ -36,9 +36,9 @@ export function KBLISectorTable({ sections }: { sections: KBLISection[] }) {
   });
 
   const headCell =
-    "px-3 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-zinc-400";
+    "px-3 py-0 text-[11px] font-semibold uppercase tracking-wider text-zinc-400";
   const sortBtn =
-    "inline-flex items-center gap-1 transition-colors hover:text-accent-warm";
+    "inline-flex min-h-[44px] items-center gap-1 transition-colors hover:text-accent-warm";
 
   return (
     <div className="overflow-x-auto rounded-2xl border border-white/[0.08] bg-white/[0.03] backdrop-blur-xl shadow-[0_4px_24px_rgba(0,0,0,0.3)]">
@@ -78,7 +78,10 @@ export function KBLISectorTable({ sections }: { sections: KBLISection[] }) {
                 Codes <ArrowUpDown size={12} />
               </button>
             </th>
-            <th scope="col" className={`${headCell} hidden sm:table-cell`}>
+            <th
+              scope="col"
+              className={`${headCell} hidden py-2.5 sm:table-cell`}
+            >
               Share
             </th>
           </tr>


### PR DESCRIPTION
The three sort controls in the /kbli sector table are 16.5px tall — under 40% of the 44px minimum — because their shared class carries no padding and no minimum height.

Bites: `KBLISectorBrowser` "Table" tab, rendered on `/kbli` and `/kbli/sectors`. Observed in a browser on the built page: the three `thead` sort buttons measure 44 x 62.58 / 55.73 / 53.59 with the diff applied and 16.5 x same-widths with it stashed, at a fixed 1432px viewport.

# Insight
`sortBtn` is `inline-flex items-center gap-1 transition-colors hover:text-accent-warm`: no padding, no height. The buttons are therefore only as tall as their 11px label and 12px icon. The table's visual padding lives on the surrounding `<th>` via `headCell`, so the cell looks comfortable while the actual target is tiny. This moves the vertical padding onto the button, which both meets the threshold and makes the whole header cell clickable rather than the two words inside it.

# Studio

## Source / Reference
WCAG 2.5.5 Target Size (Enhanced), 44x44 CSS px. Measured against `origin/main` = dfd0245407, 2026-09-09.

## Methodology
File read, then a browser measurement of the rendered header row before and after, on a local dev server, by stashing and restoring the diff at a fixed 1432px viewport. Both class helpers were confirmed file-local first: `headCell` and `sortBtn` have zero references anywhere else in the repo, with the positive control returning exactly this one file. That mattered, because a shared helper would have made this a cross-surface change rather than a local one.

## Raw Observations
Three `<button>` elements in `<thead>`, all `className={sortBtn}`, wrapping an 11px label plus `<ArrowUpDown size={12} />`. A fourth `<th>` uses the same `headCell` but has no button — the "Share" column, hidden below the `sm` breakpoint.

The table renders behind the "Table" tab of `KBLISectorBrowser`, on both `/kbli` and `/kbli/sectors`. It is production-reachable; this is not a dead surface.

Measured at viewport 1432px, `getBoundingClientRect()`:

| | before | after |
|---|---|---|
| `thead tr` height | 37.00 | 44.50 |
| Section button | 16.5 x 62.58 | 44 x 62.58 |
| Sector button | 16.5 x 55.73 | 44 x 55.73 |
| Codes button | 16.5 x 53.59 | 44 x 53.59 |

All three controls clear 44px on both axes after the change. Header row grows by 7.5px. Computed padding after the change: the three button cells are `0px` top/bottom, the "Share" cell is `10px` top/bottom — the explicit `py-2.5` on that cell wins over the helper's `py-0`, verified by reading `getComputedStyle`, not assumed from class order. All four `<th>` share the same `top`, so vertical alignment is unchanged.

Narrow viewport, measured at 517px (below the 640px `sm` breakpoint; Chrome's minimum window width prevented an exact 390px viewport, stated rather than rounded): "Share" is `display: none`, header row 44.50, all three buttons 44px tall.

## Reasoning Path
Two shapes were available. The one-line fix — adding `min-h-[44px]` to `sortBtn` alone — meets the threshold but grows the header row by roughly 26px, because the cell keeps its own `py-2.5` on top of the taller button. Moving the vertical padding from the cell to the button instead cost 7.5px, measured. The buttonless "Share" cell keeps its padding explicitly, so it is unaffected.

The second shape was chosen because of what happened on PR #5997 earlier the same day: `min-h-[44px]` on two text-only affordances produced correct 44px hit areas but grew the parent card from 128px to 157px, and both lines were reverted. The threshold is not the whole problem; the layout delta is.

## Risk / Implication
The header row still grows, by 7.5px. Header cell vertical alignment and the below-`sm` layout, where "Share" is hidden, were both measured and visually checked.

Not measurable locally, stated rather than softened: vitest cannot resolve the `@/` alias in this repo, so zero tests were collected; Playwright is not run locally. Any e2e assertion on these three controls first executes in CI, and that is the likeliest thing to go red.

One gate reports green without reading this file: CI's `prettier --check (changed files)` filters candidates with `grep -E '\.(ts|js|json|md|ya?ml)$'` at `.github/workflows/prettier-changed-files.yml:104`, which excludes `.tsx`. The workflow's own header comment says so. Formatting here was left to the local pre-commit hook, whose file regex does include `.tsx` — and it did reject the first attempt. `npx prettier --check` on the unmodified file from `origin/main` returns rc=0, so this file already conforms to the resolved Prettier defaults; running `--write` on it therefore changed nothing but the new code. Prettier's only reflow was splitting the "Share" `<th>` attributes across lines; it left the long class string literal intact.

Build `rc=0`, 1766 static pages, `PUBLIC_LOGIN_BUNDLE_OK`. Lint 0 errors, 183 warnings — unchanged from the main baseline.

# Recommendation
Merge as an atomic accessibility fix. One file, three class edits plus a Prettier attribute reflow, no new convention, no colour, copy, or data change.

# Next Action
Thirteen sub-44px controls remain across eight files and are recorded in Todoist as separate PRs. `KBLIInspector.tsx:391` is among them and is deliberately excluded: that component is never rendered in production, and fixing a target nobody can reach is not accessibility work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MDGXxpXoNSNY6bvmsyHW9
