### PR TITLE
test(trust): close DECLARED GAP #1 — first-read reply promise removed in #5893

### DIFF
--- a/apps/mouth/src/components/trust/response-time-claim.test.ts
+++ b/apps/mouth/src/components/trust/response-time-claim.test.ts
@@ -124,6 +124,11 @@ const CLAIMS: RegExp[] = [
   /\busually\s+(?:within|under)\s+\d+\s*(?:min|hour|hr)[a-z]*\b/i,
   /\b(response|repl(?:y|ies))[_\s-]*minutes\b/i,
   /\b(?:we|we'll|we will|our\s+team|balizero)\b[^.\n]{0,20}?\bpick\s+up\s+(?:in|within)\s+(?:under\s+|less\s+than\s+)?\d/i,
+  // Pattern 11 — the claim declared above and ruled a reply promise by the
+  // owner on 2026-09-09, removed in #5893. "first read" carries no reply word
+  // and no first-person subject, so Patterns 1-10 never reached it; the
+  // duration is what makes it a promise, so the duration is what it requires.
+  /\bfirst\s+read\b[^.\n]{0,20}?\b(?:in|within|under|less\s+than)\s+\d+\s*(?:min|hour|hr)[a-z]*\b/i,
 ];
 
 /**
@@ -196,12 +201,13 @@ function sweep(messages: unknown, patterns: RegExp[]): string[] {
 // down rather than left silent, because an undeclared residue is the next
 // leak:
 //
-//   1. `app/(blog)/services/page.tsx:353` — "WhatsApp or Visa Check for a
-//      first read — free, under 15 min." Whether "first read" is a reply-time
-//      promise or a scope promise is an OWNER call that has not been made.
-//      It is not removed and no pattern is aimed at it. If the owner rules it
-//      a claim, the pattern belongs beside Pattern 10, not in a widened
-//      Pattern 1.
+//   1. RESOLVED 2026-09-09. The owner ruled "free, under 15 min." on
+//      `app/(blog)/services/page.tsx` a reply-time promise, not a scope
+//      promise: readers take it as time-to-answer, and median 4.9 min passes
+//      while p90 411 min does not. Removed in #5893 — the line now reads
+//      "WhatsApp or Visa Check for a first read — free." — with no new number
+//      put in its place. Per this note's own instruction the pattern sits
+//      beside Pattern 10 below, not in a widened Pattern 1.
 //   2. `fr.json` / `ru.json` get no per-language ruleset. The measurement that
 //      stood here EXPIRED, and it is worth naming how: it read "2026-08-24:
 //      188 string leaves each … neither carries `secondHome.cta.note` at all,
@@ -261,6 +267,9 @@ describe("no page claims a response time nobody measured", () => {
       '      "note": "Prima risposta su WhatsApp in genere entro 5 ore."',
       '      "note": "Balasan pertama di WhatsApp biasanya kurang dari 5 jam."',
       '        description="Fixed fee, processed in ~14 days. Start on WhatsApp — we\'ll pick up in under 5 hours."',
+      // removed 2026-09-09 (#5893) — the owner ruled it a reply promise.
+      // Pattern 11's positive control.
+      "WhatsApp or Visa Check for a first read — free, under 15 min.",
       // caught by the first version, must not regress
       "  <p>We reply within 5 minutes</p>",
       "  <p>Our team responds in 2 minutes</p>",
@@ -324,6 +333,10 @@ describe("no page claims a response time nobody measured", () => {
       "We can pick up your documents in 2 days.",
       "Our team will pick up the file from the notary.",
       "Pick up the conversation where you left it.",
+      // Pattern 11's neighbours. The scope promise that replaced the removed
+      // claim, and a "first read" whose number is not a duration at all.
+      "WhatsApp or Visa Check for a first read — free.",
+      "Book a first read of your documents in 3 languages.",
     ]) {
       const fired = [...CLAIMS, ...CLAIMS_IT, ...CLAIMS_ID].filter((re) =>
         re.test(innocent),


### PR DESCRIPTION
## 1. What this changes

One file: `apps/mouth/src/components/trust/response-time-claim.test.ts`.

- Rewrites item **1.** of the `── DECLARED GAP (2026-08-24) ──` comment block from an
  open owner question into a RESOLVED note.
- Adds **Pattern 11** to the `CLAIMS` array, immediately after Pattern 10.
- Adds one positive control to the GUILTY corpus and two negative controls to the
  INNOCENT corpus.

No production copy is touched. No locale JSON is touched.

## 2. Why now — the decision is the owner's, not this PR's

The DECLARED GAP block, written 2026-08-24, said in its own words that whether
`"WhatsApp or Visa Check for a first read — free, under 15 min."` was a reply-time
promise or a scope promise was *"an OWNER call that has not been made"*, and that if
the owner ruled it a claim, *"the pattern belongs beside Pattern 10, not in a widened
Pattern 1."*

The owner (Antonello) made that call on **2026-09-09**: readers take "under 15 min" as
time-to-answer, so it is a reply-time promise. This PR does not decide anything — it
records a decision that was already made and executes the instruction the block itself
left behind.

## 3. The measurement the owner ruled on

The same Meta-inbox measurement quoted in this file's header (189 inbound/outbound
pairs, 2026-06-03 → 2026-07-30):

- **median 4.9 min** — passes a 15-minute promise
- **p90 411.2 min** — does not

A promise that half of readers see honoured and a tenth see missed by nearly seven
hours is not a promise this repo can keep. The line was removed, and **no new number
was put in its place** — consistent with the header's standing rule that a response-time
claim comes back only in a module carrying its own `MEASURED_ON`.

## 4. What already shipped, and where

The string itself was removed by **#5893** (merged 2026-09-09T07:51:56Z, merge commit
`31efad9be3c0c11ce956c29d9b8a8573c0b55e19`). That PR changed one line in
`apps/mouth/src/app/(blog)/services/page.tsx`:

```
- WhatsApp or Visa Check for a first read — free, under 15 min.
+ WhatsApp or Visa Check for a first read — free.
```

This branch is cut from `origin/main` at `31efad9be3` — i.e. on top of that merge.
This PR adds only the guard and the note; it ships no copy change of its own.

## 5. Pattern 11

```js
/\bfirst\s+read\b[^.\n]{0,20}?\b(?:in|within|under|less\s+than)\s+\d+\s*(?:min|hour|hr)[a-z]*\b/i,
```

`"first read"` carries no reply word and no first-person subject, which is exactly why
Patterns 1–10 never reached it — the same structural miss as Pattern 10's `"pick up"`
(diction, not scope; the file was always inside the walk). The **duration** is what
turns "first read" into a promise, so the duration is what the pattern requires: a
bare "first read" with no time unit attached does not fire.

## 6. Positive control — measured

Added to the GUILTY corpus, the historical offender verbatim:

```
"WhatsApp or Visa Check for a first read — free, under 15 min."
```

Measured on this branch, isolating the patterns:

- Patterns 1–10 firing on it: **none** (empty list) — the pattern is necessary, not decorative.
- Pattern 11 firing on it: **true** — it is armed and it fires.

This is the file's own standing rule: a pattern that looks armed but cannot fire is the
disease this guard exists to prevent.

## 7. Negative controls — measured

Added to the INNOCENT corpus:

```
"WhatsApp or Visa Check for a first read — free."          → Pattern 11: false
"Book a first read of your documents in 3 languages."      → Pattern 11: false
```

The first is the replacement copy now live on `/services` — the guard must never fire on
the fix. The second is the near-miss the `{0,20}` window makes reachable: the gap between
`read` and `in` is 19 characters, so the window *is* crossed, and what stops the match is
the required time unit — `3 languages` is a number that is not a duration.

Neither required narrowing the regex. Had either fired, the instruction was to narrow
Pattern 11, not to drop the test.

## 8. Gates run

| Gate | Result |
|---|---|
| `npx vitest run apps/mouth/src/components/trust/response-time-claim.test.ts` | **PASS** — 10/10 tests in the root copy of the file (the path filter also matched stale `.worktrees/` copies; the root copy is confirmed green by name in the verbose reporter) |
| `npm run lint -w apps/mouth` | **0 errors**, 183 warnings — byte-identical to the baseline measured with this file stashed (183 warnings, 0 errors). Zero lint messages in the changed file. |
| `git diff --stat` | exactly 1 file, 19 insertions / 6 deletions |
| pre-commit hooks | allowed to run, all passed (typecheck, lint, secrets, off-limits). No `--no-verify`. |

## 9. Deliberately NOT touched

- The `"entro 24 ore"` class in `it.json` — **still parked**, untouched.
- DECLARED GAP item **2.** (`fr.json` / `ru.json` having no per-language ruleset) —
  **still open**, untouched, still filed rather than fixed.
- `SCANNED`, the walk, the i18n imports, and Patterns 1–10 — all unchanged.
- The production page `app/(blog)/services/page.tsx` — unchanged here; #5893 owns it.

## 10. Not measured

Stated as-is, not softened:

- **Whether Pattern 11 fires on any file currently in the walk beyond the corpus is not
  independently measured.** The `no file promises a reply speed` test is green, which
  proves zero offenders across the walked tree, but no per-pattern hit count was taken
  the way round four took one for Pattern 10 (1 hit, zero others).
- **Whether "first read" appears in `fr.json` / `ru.json` with a duration is not
  measured** — those locales have no ruleset and are not imported here.
- **Whether the live `/services` page is serving the new copy is not measured** in this
  PR. #5893 is merged; a deploy of that merge was not observed from this branch.
- **The 4.9 / 411 minute figures were not re-measured today.** They are the figures
  already recorded in this file's header from the 2026-07-30 window, and they are what
  the owner ruled on — not a fresh reading.

## Bites

**Consumer:** the vitest suite in CI, which runs this file on every PR touching
`apps/mouth`.

**Observation proving it is in force:** the positive control
`"WhatsApp or Visa Check for a first read — free, under 15 min."` is now inside the
GUILTY corpus of the `guilt: it catches every shape that was actually served` test, and
that test asserts `.toBe(true)`. Measured on this branch: Patterns 1–10 return an empty
firing list for that string, so with Pattern 11 removed the suite goes RED. The guard
and its consumer ship in this same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDARNEaaQhpPUeY5qbXNSZ
