### PR TITLE
feat(hooks): host_boundary_reminder_sessionstart — surface the disarmed guard every session

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/scripts/hooks/memory_recall_sessionstart.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/hooks/host_boundary_reminder_sessionstart.sh"
           }
         ]
       }

--- a/docs/runbooks/agent-worktree-broker.md
+++ b/docs/runbooks/agent-worktree-broker.md
@@ -283,6 +283,13 @@ evidence (model seen, window assumed and why) and three routes in order:
    resort. See the module docstring's SELF-CURE section for the exact
    one-liner and rationale.
 
+A sibling disarmed-guard reminder exists for `host_boundary` (Zero ruling,
+2026-09-09: stays off on Pro/M5/Mini via `HOST_BOUNDARY_OFF=1` until Zero
+decides otherwise): `scripts/hooks/host_boundary_reminder_sessionstart.sh`,
+a SessionStart receptor that prints a short re-arm reminder (same
+`! python3 -c "..."` prompt-bar route, different one-liner) whenever that
+env var is `1`, and stays silent otherwise.
+
 ## Broker-aware spawn convention (W62 ANTIBODY #4)
 
 Il TTL da solo non basta: nessun consumer lo applicava. La hygiene è ora a 3 livelli, in ordine di affidabilità decrescente:

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -563,6 +563,12 @@
           "symbols": {},
           "tests": ["scripts/tests/test_bash_call_log.sh"],
           "note": "Sidecar of bash_call_log.sh above: an importable port of codex-spalla-trigger.sh's earliest-anchor-cut secret-redaction regex (superscar #4), so a new per-call logger does not have to re-derive it from a blank page. Installed alongside bash_call_log.sh by install_hook_diet.py. Exercised indirectly by test_bash_call_log.sh's fake-credential guilt case (command-history.log redacts, the unrelated hotfix-notify.sh pipe does not) rather than a standalone unit test, since its only caller today is bash_call_log.sh."
+        },
+        "scripts/hooks/host_boundary_reminder_sessionstart.sh": {
+          "scar": ["superscar-2-esiste-non-armato"],
+          "symbols": {},
+          "tests": ["scripts/tests/test_host_boundary_reminder.py"],
+          "note": "SessionStart receptor (Zero ruling 2026-09-09): reporting-only, no block/allow decision — host_boundary stays disarmed on Pro/M5/Mini (HOST_BOUNDARY_OFF=1) until Zero decides otherwise, and this receptor is the reminder that it is off. Guilt: HOST_BOUNDARY_OFF==\"1\" -> prints one SessionStart additionalContext block (<=400 bytes) containing 'DISARMATO' and a `! python3 -c \"...\"` re-arm one-liner. Innocence: unset/\"0\"/\"false\"/empty/any other value -> empty stdout, exit 0 (same fail-open discipline, same additionalContext envelope shape as escalations_alert_sessionstart.sh). scripts/tests/test_host_boundary_reminder.py exercises both cases plus the printed re-arm one-liner itself against a fixture settings.json (key removed, .bak backup byte-identical to the original, multi-line pretty-print preserved, idempotent when the key is already absent)."
         }
       },
       "exempt": {

--- a/scripts/hooks/host_boundary_reminder_sessionstart.sh
+++ b/scripts/hooks/host_boundary_reminder_sessionstart.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# host_boundary_reminder_sessionstart.sh — SessionStart reminder while
+# host_boundary is DISARMED.
+#
+# RULING (Zero, 2026-09-09): host_boundary (the guard that protects
+# ~/.claude, ~/.ssh, ~/.aws, secrets and ~/.agent/decisions from writes)
+# stays disarmed on Pro/M5/Mini via HOST_BOUNDARY_OFF=1 in each machine's
+# ~/.claude/settings.json env block, until Zero decides otherwise. A
+# disarmed guard that nobody is reminded of is cicatrix scar #2's own
+# shape (Esiste!=Armato, in reverse: here the guard genuinely does not
+# exist right now, and the risk is forgetting that fact) — this receptor
+# closes that blindness the same way escalations_alert_sessionstart.sh
+# closes the escalations-board one: a fact the harness already knows
+# (the env var) becomes something every session is actually told.
+#
+# Logic: HOST_BOUNDARY_OFF == "1" in the process env -> emit ONE short
+# Italian block (<=400 bytes) naming the ruling, what it protects, and
+# the re-arm route: a `!`-prefixed line typed at the Claude Code prompt
+# bar, which runs in the session's own shell — NOT through PreToolUse
+# hooks — so it is not itself blocked by anything. It backs up
+# ~/.claude/settings.json to .json.bak, then removes the
+# HOST_BOUNDARY_OFF key from its env block. Any other value (unset, "0",
+# "false", ...) -> print nothing, exit 0.
+#
+# FAIL-OPEN, same discipline as every sibling SessionStart receptor in
+# this directory: missing python3, malformed env, any error -> silent,
+# exit 0. A reminder hook that can crash session start is worse than no
+# reminder at all.
+#
+# Kill switch: HOST_BOUNDARY_REMINDER_ENABLED=false
+
+set -o pipefail
+
+[[ "${HOST_BOUNDARY_REMINDER_ENABLED:-true}" == "false" ]] && exit 0
+
+# Nothing to remind about unless the guard is actually disarmed.
+[[ "${HOST_BOUNDARY_OFF:-}" == "1" ]] || exit 0
+
+PY="$(command -v python3 2>/dev/null)"
+[[ -n "$PY" ]] || exit 0
+
+_TIMEOUT=()
+if command -v timeout >/dev/null 2>&1; then _TIMEOUT=(timeout 4)
+elif command -v gtimeout >/dev/null 2>&1; then _TIMEOUT=(gtimeout 4); fi
+
+"${_TIMEOUT[@]}" "$PY" - <<'PYEOF' 2>/dev/null || exit 0
+import json
+
+# Re-arm one-liner (route printed verbatim below): typed with a `!` prefix
+# at the prompt bar, runs in the session's own shell, not through
+# PreToolUse hooks. Backs up ~/.claude/settings.json to .json.bak first,
+# then drops HOST_BOUNDARY_OFF from the env block.
+ONE_LINER = (
+    "python3 -c \"import json,os;"
+    "h=os.path.expanduser('~/.claude/settings.json');"
+    "open(h+'.bak','w').write(open(h).read());"
+    "d=json.load(open(h));"
+    "d.get('env',{}).pop('HOST_BOUNDARY_OFF',0);"
+    "json.dump(d,open(h,'w'))\""
+)
+
+ctx = (
+    "\U0001f6e1️ host_boundary DISARMATO (HOST_BOUNDARY_OFF=1, ruling Zero 2026-09-09). "
+    "Protegge ~/.claude ~/.ssh ~/.aws segreti ~/.agent/decisions da scritture. "
+    f"Riarma dal prompt (bypassa tool-hook): ! {ONE_LINER}"
+)
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": ctx,
+    }
+}))
+PYEOF
+
+exit 0

--- a/scripts/hooks/host_boundary_reminder_sessionstart.sh
+++ b/scripts/hooks/host_boundary_reminder_sessionstart.sh
@@ -56,13 +56,13 @@ ONE_LINER = (
     "open(h+'.bak','w').write(open(h).read());"
     "d=json.load(open(h));"
     "d.get('env',{}).pop('HOST_BOUNDARY_OFF',0);"
-    "json.dump(d,open(h,'w'))\""
+    "json.dump(d,open(h,'w'),indent=2,ensure_ascii=False)\""
 )
 
 ctx = (
-    "\U0001f6e1️ host_boundary DISARMATO (HOST_BOUNDARY_OFF=1, ruling Zero 2026-09-09). "
-    "Protegge ~/.claude ~/.ssh ~/.aws segreti ~/.agent/decisions da scritture. "
-    f"Riarma dal prompt (bypassa tool-hook): ! {ONE_LINER}"
+    "\U0001f6e1️ host_boundary DISARMATO (HOST_BOUNDARY_OFF=1, Zero 2026-09-09). "
+    "Protegge ~/.claude ~/.ssh ~/.aws segreti ~/.agent/decisions da scrittura. "
+    f"Riarma da prompt: ! {ONE_LINER}"
 )
 
 print(json.dumps({

--- a/scripts/tests/test_host_boundary_reminder.py
+++ b/scripts/tests/test_host_boundary_reminder.py
@@ -1,0 +1,170 @@
+"""host_boundary_reminder_sessionstart.sh — SessionStart reminder while
+host_boundary is DISARMED (Zero ruling, 2026-09-09).
+
+host_boundary stays off on Pro/M5/Mini today (HOST_BOUNDARY_OFF=1 in each
+machine's ~/.claude/settings.json env block) until Zero decides otherwise.
+Nobody wired a reminder into a session that it is off — this receptor
+(sibling of escalations_alert_sessionstart.sh) closes that: if the env
+var is set, print ONE short Italian block naming the ruling, what the
+guard protects, and the re-arm route; otherwise stay silent.
+
+These tests drive the real bash script via subprocess (never mutate a
+real settings.json), verifying:
+  - guilt: HOST_BOUNDARY_OFF=1 -> valid JSON SessionStart payload whose
+    additionalContext contains "DISARMATO" and the `! python3` re-arm
+    route, under the 400-byte budget.
+  - innocence: HOST_BOUNDARY_OFF unset, or set to "0"/"false"/"" -> empty
+    stdout, exit 0.
+  - the printed one-liner itself, run against a fixture settings.json,
+    removes the HOST_BOUNDARY_OFF key, writes a .bak backup of the
+    original content, and leaves every other env key, hooks block, and
+    JSON validity untouched.
+
+Run:
+    cd ~/nuzantara/.worktrees/<this-lane>
+    bash -n scripts/hooks/host_boundary_reminder_sessionstart.sh   # syntax check
+    apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_host_boundary_reminder.py -v
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "hooks" / "host_boundary_reminder_sessionstart.sh"
+
+
+def _run_hook(extra_env: dict | None = None) -> tuple[int, str, str]:
+    env = dict(os.environ)
+    env.pop("HOST_BOUNDARY_OFF", None)
+    env["HOST_BOUNDARY_REMINDER_ENABLED"] = "true"
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(
+        ["bash", str(_SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    return result.returncode, result.stdout.strip(), result.stderr
+
+
+def _extract_one_liner(ctx: str) -> str:
+    """Pull the `python3 -c "..."` one-liner out of the printed block."""
+    m = re.search(r'! (python3 -c ".*")\s*$', ctx)
+    assert m, f"could not find the `! python3` one-liner in: {ctx!r}"
+    return m.group(1)
+
+
+# ── script exists and is syntactically valid ────────────────────────────────
+
+def test_script_exists_and_is_syntactically_valid():
+    assert _SCRIPT.is_file(), f"hook script missing at {_SCRIPT}"
+    r = subprocess.run(["bash", "-n", str(_SCRIPT)], capture_output=True, text=True)
+    assert r.returncode == 0, f"bash -n failed: {r.stderr}"
+
+
+# ── guilt: HOST_BOUNDARY_OFF=1 -> reminder block ────────────────────────────
+
+def test_host_boundary_off_1_prints_reminder():
+    rc, out, err = _run_hook({"HOST_BOUNDARY_OFF": "1"})
+    assert rc == 0, f"hook must always exit 0 (fail-open); stderr={err}"
+    assert out, "HOST_BOUNDARY_OFF=1 must print a reminder block"
+    payload = json.loads(out)
+    ctx = payload["hookSpecificOutput"]["additionalContext"]
+    assert payload["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert "DISARMATO" in ctx
+    assert "HOST_BOUNDARY_OFF" in ctx
+    assert "! python3 -c" in ctx, "the re-arm one-liner must be printed verbatim"
+    assert len(ctx.encode("utf-8")) <= 400, (
+        f"additionalContext must stay <=400 bytes, got {len(ctx.encode('utf-8'))}"
+    )
+
+
+# ── innocence: anything else -> silence ─────────────────────────────────────
+
+@pytest.mark.parametrize("value", [None, "0", "false", "", "yes"])
+def test_host_boundary_off_anything_else_is_silent(value):
+    extra_env = {} if value is None else {"HOST_BOUNDARY_OFF": value}
+    rc, out, err = _run_hook(extra_env)
+    assert rc == 0, f"hook must always exit 0 (fail-open); stderr={err}"
+    assert out == "", f"non-'1' HOST_BOUNDARY_OFF must stay silent, got: {out!r}"
+
+
+def test_kill_switch_disables_even_when_disarmed():
+    rc, out, err = _run_hook({
+        "HOST_BOUNDARY_OFF": "1",
+        "HOST_BOUNDARY_REMINDER_ENABLED": "false",
+    })
+    assert rc == 0
+    assert out == "", "kill switch must silence the receptor even when the guard is off"
+
+
+# ── the printed one-liner actually re-arms cleanly ──────────────────────────
+
+def test_printed_one_liner_removes_key_and_backs_up(tmp_path, monkeypatch):
+    fixture = {
+        "env": {
+            "HOST_BOUNDARY_OFF": "1",
+            "SOME_OTHER_KEY": "keep-me",
+        },
+        "hooks": {"SessionStart": [{"hooks": []}]},
+    }
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps(fixture, indent=2))
+    original_text = settings_path.read_text()
+
+    rc, out, _ = _run_hook({"HOST_BOUNDARY_OFF": "1"})
+    assert rc == 0 and out
+    payload = json.loads(out)
+    ctx = payload["hookSpecificOutput"]["additionalContext"]
+    one_liner = _extract_one_liner(ctx)
+
+    # Run the one-liner with HOME pointed at a fixture dir so it operates on
+    # our throwaway settings.json, never the real one.
+    home = tmp_path
+    (home / ".claude").mkdir(exist_ok=True)
+    live = home / ".claude" / "settings.json"
+    live.write_text(original_text)
+
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    r = subprocess.run(one_liner, shell=True, env=env, capture_output=True, text=True, timeout=10)
+    assert r.returncode == 0, f"one-liner must succeed: {r.stderr}"
+
+    backup = home / ".claude" / "settings.json.bak"
+    assert backup.is_file(), "one-liner must write a .bak backup before mutating"
+    assert backup.read_text() == original_text, "backup must be byte-identical to the pre-mutation file"
+
+    mutated = json.loads(live.read_text())
+    assert "HOST_BOUNDARY_OFF" not in mutated.get("env", {}), "HOST_BOUNDARY_OFF must be removed"
+    assert mutated["env"]["SOME_OTHER_KEY"] == "keep-me", "other env keys must survive untouched"
+    assert mutated["hooks"] == fixture["hooks"], "hooks block must survive untouched"
+
+
+def test_printed_one_liner_is_idempotent_when_key_already_absent(tmp_path):
+    fixture = {"env": {"SOME_OTHER_KEY": "keep-me"}, "hooks": {}}
+    home = tmp_path
+    (home / ".claude").mkdir(exist_ok=True)
+    live = home / ".claude" / "settings.json"
+    live.write_text(json.dumps(fixture, indent=2))
+
+    rc, out, _ = _run_hook({"HOST_BOUNDARY_OFF": "1"})
+    payload = json.loads(out)
+    one_liner = _extract_one_liner(payload["hookSpecificOutput"]["additionalContext"])
+
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    r = subprocess.run(one_liner, shell=True, env=env, capture_output=True, text=True, timeout=10)
+    assert r.returncode == 0, f"one-liner must be a no-op, not an error, when the key is absent: {r.stderr}"
+    mutated = json.loads(live.read_text())
+    assert mutated["env"] == {"SOME_OTHER_KEY": "keep-me"}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_host_boundary_reminder.py
+++ b/scripts/tests/test_host_boundary_reminder.py
@@ -146,6 +146,12 @@ def test_printed_one_liner_removes_key_and_backs_up(tmp_path, monkeypatch):
     assert mutated["env"]["SOME_OTHER_KEY"] == "keep-me", "other env keys must survive untouched"
     assert mutated["hooks"] == fixture["hooks"], "hooks block must survive untouched"
 
+    rewritten_text = live.read_text()
+    assert "\n" in rewritten_text.strip(), (
+        "one-liner must pretty-print with indent=2, not collapse settings.json "
+        f"onto one line (a later diff/backup would be unreadable): {rewritten_text!r}"
+    )
+
 
 def test_printed_one_liner_is_idempotent_when_key_already_absent(tmp_path):
     fixture = {"env": {"SOME_OTHER_KEY": "keep-me"}, "hooks": {}}


### PR DESCRIPTION
## Summary

Zero ruling (2026-09-09, ~15:30 WITA): `host_boundary` stays DISARMED for now (`HOST_BOUNDARY_OFF=1` in the `env` block of `~/.claude/settings.json` on Pro/M5/Mini) until Zero decides otherwise. Nothing told an opened session that fact — this adds a SessionStart reminder, sibling of `escalations_alert_sessionstart.sh`.

- New `scripts/hooks/host_boundary_reminder_sessionstart.sh`: if `HOST_BOUNDARY_OFF == "1"` in the process env, emits one short Italian block (≤400 bytes, measured 399) as the standard `hookSpecificOutput.additionalContext` JSON envelope, naming the ruling, what the guard protects (`~/.claude`, `~/.ssh`, `~/.aws`, secrets, `~/.agent/decisions`), and the re-arm route: a `!`-prefixed one-liner typed at the Claude Code prompt bar — runs in the session's own shell, **not** through PreToolUse hooks — that backs up `~/.claude/settings.json` to `.json.bak` and removes the `HOST_BOUNDARY_OFF` key. Any other value (unset/`0`/`false`/empty): prints nothing, exit 0. Fail-open throughout (missing python3, any error → silent, exit 0), same discipline as every sibling receptor in that directory.
- Registered in the repo `.claude/settings.json` SessionStart list, 5th entry alongside the existing four. Note: that group carries no `matcher` key at all for SessionStart (it already matches every session) — followed the existing convention rather than adding a literal `"matcher": "*"`, since that would be new shape for this file, not consistency with it.
- `scripts/tests/test_host_boundary_reminder.py`: 10 pytest cases — guilt (env=1 → valid JSON, DISARMATO + `! python3` route present, ≤400 bytes), innocence (unset/`0`/`false`/empty/other → silent), kill switch, and two tests that actually *run* the printed one-liner against a fixture `settings.json` (key removed, `.bak` byte-identical to the original, other env keys and the `hooks` block untouched, idempotent when the key is already absent).
- One paragraph added to `docs/runbooks/agent-worktree-broker.md`, right after this morning's context-window-guard self-cure section, pointing at the new receptor.

## Bites

Consumer: the next SessionStart on Pro/M5/Mini — all three carry `HOST_BOUNDARY_OFF=1` today — once this repo change reaches each machine's checkout.

Observation:

```
$ HOST_BOUNDARY_OFF=1 bash scripts/hooks/host_boundary_reminder_sessionstart.sh
{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "🛡️ host_boundary DISARMATO (HOST_BOUNDARY_OFF=1, ruling Zero 2026-09-09). Protegge ~/.claude ~/.ssh ~/.aws segreti ~/.agent/decisions da scritture. Riarma dal prompt (bypassa tool-hook): ! python3 -c \"import json,os;h=os.path.expanduser('~/.claude/settings.json');open(h+'.bak','w').write(open(h).read());d=json.load(open(h));d.get('env',{}).pop('HOST_BOUNDARY_OFF',0);json.dump(d,open(h,'w'))\""}}

$ HOST_BOUNDARY_OFF= bash scripts/hooks/host_boundary_reminder_sessionstart.sh
$ echo $?
0
```
(first prints the block; second prints nothing and exits 0.)

## Test plan

- [x] `bash -n scripts/hooks/host_boundary_reminder_sessionstart.sh` — syntax OK
- [x] `apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_host_boundary_reminder.py -v` — **10 passed**
- [x] `.claude/settings.json` validated as JSON after the edit
- [x] `npx prettier --write docs/runbooks/agent-worktree-broker.md` — no formatting drift

Not done: could not exercise the full CI Backend Tests suite locally (pre-push path-aware gate runs it only for backend-rag diffs); CI will run it on this PR (`.claude/settings.json` and the new shell script are outside its allowlist so the local pre-push note flags them, but they carry no backend code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)