### PR TITLE
fix(harness): generated article translations no longer floor a bot batch at Gear 3

### DIFF
--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -882,6 +882,23 @@ SIZE_TERM_EXCLUDE_SUFFIXES: tuple[str, ...] = (
     ".pdf", ".zip", ".gz", ".woff", ".woff2", ".ttf", ".otf", ".eot",
     ".mp4", ".mp3", ".wav", ".mov",
 )
+# Machine-generated article translations (2026-09-09, measured: 68 identical
+# `chore(mouth): promote hourly-translated articles` PRs open at once, every
+# one BLOCKED since 2026-09-04). scripts/translate-articles.py writes
+# `<slug>.<lang>.mdx` next to the English `<slug>.mdx` source, ~95 lines per
+# file, 20 files per hourly batch — churn 1946 > SIZE_GEAR3_THRESHOLD, so the
+# size term floored every batch at Gear 3 and no brief ever existed for a bot
+# diff nobody reviews line-by-line. The translation is a GENERATED artifact of
+# the source (regenerated on source_sha256 staleness), the same class as the
+# `generated/` directories above: it inflates churn without inflating review
+# burden. Scoped on BOTH the directory prefix and the language suffix so a
+# same-suffix decoy elsewhere in the tree, or the English source itself (no
+# language suffix), still counts in full — the reviewable artifact is the
+# source; the translation is derived from it.
+SIZE_TERM_EXCLUDE_GENERATED_TRANSLATION_DIR = "apps/mouth/src/content/articles/"
+SIZE_TERM_EXCLUDE_GENERATED_TRANSLATION_SUFFIXES: tuple[str, ...] = (
+    ".id.mdx", ".it.mdx", ".ru.mdx", ".fr.mdx",
+)
 
 
 def _is_size_term_excluded(path: str) -> bool:
@@ -912,6 +929,10 @@ def _is_size_term_excluded(path: str) -> bool:
     if name in SIZE_TERM_EXCLUDE_FILENAMES:
         return True
     if ".min." in name.lower():
+        return True
+    if p.as_posix().startswith(SIZE_TERM_EXCLUDE_GENERATED_TRANSLATION_DIR) and any(
+        name.endswith(suf) for suf in SIZE_TERM_EXCLUDE_GENERATED_TRANSLATION_SUFFIXES
+    ):
         return True
     return any(name.lower().endswith(suf) for suf in SIZE_TERM_EXCLUDE_SUFFIXES)
 

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -4285,3 +4285,37 @@ def test_path_term_exemption_innocence_a_real_new_file_header_is_still_a_header(
         ".github/workflows/a.yml",
         ".github/workflows/b.yml",
     }
+
+
+def test_size_term_net_lines_innocence_generated_translation_excluded_2026_09_09():
+    # The 68-duplicate-PR disease: 20 machine-translated .id/.it MDX files,
+    # ~97 lines each, floored every hourly promote batch at Gear 3 by size.
+    numstat = (
+        "97\t0\tapps/mouth/src/content/articles/tax-legal/x.id.mdx\n"
+        "99\t0\tapps/mouth/src/content/articles/tax-legal/x.it.mdx\n"
+        "95\t0\tapps/mouth/src/content/articles/business/y.ru.mdx\n"
+        "95\t0\tapps/mouth/src/content/articles/business/y.fr.mdx\n"
+        "40\t3\tapps/mouth/src/content/articles/tax-legal/x.mdx\n"
+    )
+    # Only the English SOURCE counts (40+3) — it is the reviewable artifact.
+    assert _size_term_net_lines(numstat) == 43
+
+
+def test_size_term_net_lines_guilt_translation_suffix_outside_content_dir_counts_2026_09_09():
+    # Same language suffix, wrong directory: a decoy named like a translation
+    # must not hide behind the exemption (superscar #3, entity not substring).
+    numstat = (
+        "500\t0\tapps/mouth/src/lib/x.id.mdx\n"
+        "500\t0\tdocs/x.it.mdx\n"
+        "500\t0\tapps/mouth/src/content/x.id.mdx\n"  # sibling dir, not articles/
+    )
+    assert _size_term_net_lines(numstat) == 1500
+
+
+def test_size_term_net_lines_guilt_english_source_and_other_mdx_still_count_2026_09_09():
+    numstat = (
+        "900\t900\tapps/mouth/src/content/articles/tax-legal/x.mdx\n"
+        "100\t0\tapps/mouth/src/content/articles/tax-legal/x.en.mdx\n"
+        "100\t0\tapps/mouth/src/content/articles/tax-legal/x.id.md\n"
+    )
+    assert _size_term_net_lines(numstat) == 2000

--- a/scripts/translate-articles-cron-wrapper.sh
+++ b/scripts/translate-articles-cron-wrapper.sh
@@ -142,6 +142,31 @@ EOF
   fi
   log "opened PR: $PR_URL"
   PR_NUM=$(print -r -- "$PR_URL" | grep -oE '[0-9]+$')
+
+  # Supersede every OLDER open promote PR (2026-09-09: 68 identical copies were
+  # open at once, one per hour since 2026-09-04, each burning a full CI run).
+  # The hourly batch is cumulative by construction — staleness is re-detected
+  # from main every run, so the newest PR carries everything an older one
+  # carried — and an older copy can only merge first and turn this one into an
+  # empty diff. Scope: same title prefix AND same branch prefix (entity, not
+  # substring). A PR already occupying a merge-queue slot is left alone: it is
+  # about to land and closing it would evict it (queue_unstick.py's rule 1).
+  OLDER=$(gh pr list --state open --search "chore(mouth): promote hourly-translated in:title" \
+      --json number,headRefName \
+      --jq ".[] | select(.number != $PR_NUM) | select(.headRefName | startswith(\"agent/nuzantara/mouth/hourly-\")) | .number" 2>>"$LOG")
+  for old in ${(f)OLDER}; do
+    QUEUED=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){mergeQueueEntry{state}}}}' \
+        -f o=Bali-Zero -f r=Teman2 -F n="$old" --jq '.data.repository.pullRequest.mergeQueueEntry // "null"' 2>>"$LOG")
+    if [ "$QUEUED" != "null" ] && [ -n "$QUEUED" ]; then
+      log "keeping older promote PR #$old — in merge queue ($QUEUED)"
+      continue
+    fi
+    if gh pr close "$old" --delete-branch --comment "Superseded by $PR_URL — the hourly translation batch is cumulative, this older copy only burned CI (translate-articles-cron-wrapper.sh)." >>"$LOG" 2>&1; then
+      log "closed superseded promote PR #$old"
+    else
+      log "WARN: could not close superseded promote PR #$old"
+    fi
+  done
   # NOT --squash: once a merge queue governs main, the ruleset owns the merge
   # method and --squash is rejected outright (pipeline-ship skill, 2026-07-27+).
   RUN_NOTE=""


### PR DESCRIPTION
## Disease (measured 2026-09-09, M5 session)

68 identical `chore(mouth): promote hourly-translated articles (20 file(s))` PRs open at once, every one BLOCKED on `Harness floor recompute` since the last one that landed (#5663, 2026-09-04). Each batch: 20 machine-translated `<slug>.<lang>.mdx` files, ~97 lines each, churn 1946 > `SIZE_GEAR3_THRESHOLD` 1828 → floor 3 by size, no brief exists for a bot diff → red → the hourly cron re-opens a fresh identical copy → 68 full CI runs (backend shards, Playwright, CodeQL…) for one 20-file batch, and every real PR queued behind them on the runners.

## Cure (one concern: a bot translation batch must be able to land)

- `scripts/evidence_pack_lint.py` — `apps/mouth/src/content/articles/**/*.{id,it,ru,fr}.mdx` excluded from the size term, same class as `generated/`: a derived artifact regenerated on `source_sha256` staleness, inflating churn without inflating review burden. Scoped on BOTH the directory prefix AND the language suffix — the English source (`<slug>.mdx`), a same-suffix decoy outside `content/articles/`, and any other extension still count in full (superscar #3: entity, not substring). Guilt + innocence tests added (3).
- `scripts/translate-articles-cron-wrapper.sh` — after opening the new PR, every OLDER open promote PR (same title prefix AND `agent/nuzantara/mouth/hourly-` branch prefix) is closed as superseded and its branch deleted, unless it already holds a merge-queue slot (closing would evict it — queue_unstick.py rule 1). The batch is cumulative by construction, so the newest copy carries everything.

Not in this PR: the 68 duplicates were closed by hand this session (kept #6010, the newest); `auto-merge-whitelist.yml --delete-branch` bug and the `antidotes` ledger-tier diet ship as their own PRs.

## Proof (local, this checkout)

```
$ pytest scripts/tests/test_evidence_pack_lint.py -q        → 558 passed
$ compute_floor(#6010 real numstat)  → files 20, churn_counted 0, floor 1 (none)   [was floor 3 (size)]
$ compute_floor(this diff)           → floor 1 (none)  — no brief required
$ zsh -n scripts/translate-articles-cron-wrapper.sh          → OK
```
`test_translate_freshness.py` has 2 pre-existing failures (orphan-on-disk test) that fail identically on origin/main — untouched here.

Bites: `Harness floor recompute` on PR #6010 (or the next hourly promote PR) reports `FLOOR: 1` instead of `FLOOR: 3 / size` and the PR merges via its already-armed auto-merge; the following `com.balizero.translate.hourly` tick on Pro logs `closed superseded promote PR #…` (or no older PR to close) in `~/logs/translate-hourly-wrapper.log` once Pro's main checkout has pulled this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138RpRu7a2wu5au2ChA67VC