### PR TITLE
fix(healer): main_required_red receptor writes a numeric ts, not a string

### DIFF
--- a/scripts/healer_receptor_main_red.py
+++ b/scripts/healer_receptor_main_red.py
@@ -281,7 +281,10 @@ def reconcile(reds: dict[str, dict], greens: set[str], *, state: dict, escalatio
             },
             "machine": writer,
             "_writer": writer,
-            "ts": str(now),
+            # ts is a NUMBER: scripts/sentinel_lib/escalations.py sorts the board on the
+            # raw value, and one string next to the floats every other writer emits
+            # makes read_all_escalations() raise TypeError (gate finding on #6002).
+            "ts": now,
         }
         _append(escalations, line)
         escalated[key] = now
@@ -291,7 +294,7 @@ def reconcile(reds: dict[str, dict], greens: set[str], *, state: dict, escalatio
         if ctx in greens:
             job = JOB_PREFIX + _slug(ctx)
             _append(escalations, {"job": job, "type": "main_required_red", "status": "resolved",
-                                  "resolved_at": str(now), "ts": str(now), "machine": writer,
+                                  "resolved_at": now, "ts": now, "machine": writer,
                                   "_writer": writer, "context": ctx})
             del open_ctx[ctx]
             out["resolved"].append(ctx)

--- a/scripts/tests/test_healer_receptor_main_red.py
+++ b/scripts/tests/test_healer_receptor_main_red.py
@@ -113,6 +113,8 @@ def test_red_two_commits_back_is_red_and_escalates_high(tmp_path):
     assert static["cure_lane"]["owner"] == "session"
     assert static["cure_lane"]["branch"].endswith("/infra/main-red-backend-static-python")
     assert rep["board"]["escalated"] == [f"{STATIC}@{MID}", f"{TESTS}@{MID}"]
+    # ts is numeric like every other board writer: read_all_escalations() sorts on it.
+    assert all(isinstance(l["ts"], float) for l in lines)
 
 
 def test_same_red_second_tick_is_deduped(tmp_path):
@@ -134,6 +136,9 @@ def test_new_sha_still_red_escalates_again_and_green_resolves(tmp_path):
     resolved = [l for l in _lines(tmp_path / "esc.jsonl") if l["status"] == "resolved"]
     assert {l["job"] for l in resolved} == {"main-required-red:backend-static-python",
                                             "main-required-red:backend-tests-python"}
+    assert all(isinstance(l["ts"], float) and isinstance(l["resolved_at"], float) for l in resolved)
+    # The mixed board (pending + resolved) must sort: this is the TypeError the string ts caused.
+    sorted(_lines(tmp_path / "esc.jsonl"), key=lambda e: e.get("ts", 0), reverse=True)
     assert json.loads((tmp_path / "state.json").read_text())["open"] == {}
 
 


### PR DESCRIPTION
## What

`scripts/healer_receptor_main_red.py` wrote `"ts": str(now)` (and `resolved_at`) on both its pending and its resolved board lines. `scripts/sentinel_lib/escalations.py::read_all_escalations()` sorts the merged board on the raw `ts` value and every other writer emits a float, so the first line this receptor wrote to a real board would have made the whole board unsortable (`TypeError: '<' not supported between 'str' and 'float'`) for every consumer: the SessionStart escalations receptor, `modus_autoloop`, `mark_resolved`. Three `str(now)` → `now`; two assertions pin the type and sort the mixed board.

Gate finding on #6002 (Opus 5 adjudication), folded here as its own concern.

## Proof

- `pytest scripts/tests/test_healer_receptor_main_red.py`: 11 passed on this branch; with the source file swapped for `origin/main`'s, 2 failed (the new assertions), so the test sees the defect.

Bites: consumer = `read_all_escalations()` in `scripts/sentinel_lib/escalations.py` (and through it the SessionStart escalations receptor on every session). Observation: `python3 -c "import sys;sys.path.insert(0,'scripts');from sentinel_lib.escalations import read_all_escalations as r;print(len(r()))"` keeps returning a count (no TypeError) after the next `main_required_red` line lands on `shared/escalations_pro.jsonl`; today the live board carries only float `ts` (checked on Pro 2026-09-09), so the receptor's first real write is the moment this is in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g48PCCkst4dvvNnQTVvsv