### PR TITLE
fix(hooks): context_window_guard reports the jump as attempted or recorded, never as started

### DIFF
--- a/infra/claude-hooks/context_window_guard.py
+++ b/infra/claude-hooks/context_window_guard.py
@@ -265,22 +265,28 @@ def _first_user_mandate(transcript_path: str) -> str:
     return ""
 
 
-def _write_pending_jump(payload: dict, model: str, handoff_path: Path, mandate: str) -> bool:
+def _write_pending_jump(payload: dict, model: str, handoff_path: Path, mandate: str):
     """Write pending-jump-<session>.json and, on a Ghostty seat, spawn
-    window_jump.sh detached. Returns True when a jump was raised."""
+    window_jump.sh detached. Returns what was actually done, so the deny text
+    can say it honestly: "spawned" (the window gesture was STARTED — its
+    outcome is only in jump.log, the hook does not wait for it), "recorded"
+    (file written, no gesture: headless seat or no script) or None (nothing
+    raised). Measured 2026-09-09 on M5 (session 461e7cb5) and Pro (e82f9c09):
+    two of three gestures failed AFTER the hook had already printed AVVIATO,
+    so the operator read "started" and waited for a window that never came."""
     if os.environ.get("CONTEXT_JUMP_OFF") == "1":
-        return False
+        return None
     from_session = str(payload.get("session_id") or "unknown")
     path = _pending_jump_path(from_session)
     if path.exists():
-        return False  # already raised for this session: the file IS the rate limit
+        return None  # already raised for this session: the file IS the rate limit
     link = _chain_link(from_session)
     try:
         hops = int((link or {}).get("hops", 0)) + 1
     except (TypeError, ValueError):
         hops = 1
     if hops > JUMP_MAX_HOPS:
-        return False
+        return None
     jump = {
         "from_session": from_session,
         "from_pid": os.getppid(),  # the claude process this hook runs under
@@ -300,16 +306,17 @@ def _write_pending_jump(payload: dict, model: str, handoff_path: Path, mandate: 
         tmp.write_text(json.dumps(jump, indent=2), encoding="utf-8")
         tmp.replace(path)
     except OSError:
-        return False
+        return None
     if jump["seat"] == "ghostty" and sys.platform == "darwin" and _window_jump_script().exists() \
             and os.environ.get("CONTEXT_JUMP_NO_SPAWN") != "1":
         try:
             subprocess.Popen(["bash", str(_window_jump_script()), from_session],
                              stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
                              stderr=subprocess.DEVNULL, start_new_session=True)
+            return "spawned"
         except OSError:
-            pass
-    return True
+            return "recorded"
+    return "recorded"
 
 
 def _load_module_from_path(path: Path, name: str):
@@ -581,9 +588,15 @@ def main() -> int:
         f"[context_window_guard] Contesto ≈{tokens_k}K token = {pct_i}% della finestra "
         f"(soglia {role} {threshold_i}%). Modello: {model}; finestra assunta {window_k}K ({reason}). "
         f"Handoff: {handoff_str}.\n"
-        + ("Salto di finestra AVVIATO: la finestra nuova si apre da sola con il mandato; chiudi il turno.\n"
-           if jumped else
-           "Salto non avviato (kill switch, cap salti o già in corso).\n")
+        + (f"Salto di finestra TENTATO (window_jump.sh in background, esito SOLO in "
+           f"{_jump_dir() / 'jump.log'}): se entro ~15s non compare una finestra nuova con il "
+           f"mandato, aprine una tu e scrivi: nz-jump {session_id}. Chiudi il turno.\n"
+           if jumped == "spawned" else
+           f"Salto REGISTRATO ({_pending_jump_path(session_id).name}), nessun gesto di finestra "
+           f"(seat headless: il wrapper claude-cascade fa l'hop; a mano: nz-jump {session_id}). "
+           "Chiudi il turno.\n"
+           if jumped == "recorded" else
+           f"Salto non avviato (kill switch, cap salti o già in corso: esito in {_jump_dir() / 'jump.log'}).\n")
         + f"1) Finestra nuova: claude --model {model} poi /resume.\n"
         f"2) Finestra sbagliata su QUESTA macchina? Dal prompt bar (bypassa i tool-hook): "
         f"! {ESCAPE_ONE_LINER}\n"

--- a/infra/claude-hooks/test_context_window_jump.py
+++ b/infra/claude-hooks/test_context_window_jump.py
@@ -52,7 +52,8 @@ def test_first_trip_writes_pending_jump_and_says_so():
     assert j and j["from_session"] == "s-one" and j["to_session"] is None
     assert j["hops"] == 1 and j["seat"] == "headless" and isinstance(j["from_pid"], int)
     assert j["handoff_path"].endswith("precompact-handoff-s-one.json")
-    assert "Salto di finestra AVVIATO" in err
+    # Headless seat: no gesture was made, so the deny must not claim one.
+    assert "Salto REGISTRATO" in err and "nz-jump s-one" in err and "AVVIATO" not in err
 
 
 def test_second_trip_same_session_does_not_rewrite_the_jump():
@@ -110,9 +111,29 @@ def test_handoff_carries_the_first_user_mandate_plain_string():
 
 
 def test_ghostty_seat_is_recorded_but_spawn_is_suppressed_in_tests():
-    rc, _, _, home = run_gate("Bash", {"command": "ls"}, tokens=TRIP, session_id="s-gh",
-                              env_extra={"TERM_PROGRAM": "ghostty", "CONTEXT_JUMP_NO_SPAWN": "1"})
+    rc, _, err, home = run_gate("Bash", {"command": "ls"}, tokens=TRIP, session_id="s-gh",
+                                env_extra={"TERM_PROGRAM": "ghostty", "CONTEXT_JUMP_NO_SPAWN": "1"})
     assert rc == 2 and _jump(home, "s-gh")["seat"] == "ghostty"
+    assert "Salto REGISTRATO" in err  # spawn suppressed = no gesture = never "started"
+
+
+def test_ghostty_spawn_is_reported_as_attempted_not_started(tmp_path=None):
+    # A real spawn: the script is a stub that exits 1 (the gesture FAILED, as
+    # ⌘N did on M5 2026-09-09 17:59). The hook cannot know that — it does not
+    # wait — so it must say TENTATO + where the outcome is + the manual gesture,
+    # and never AVVIATO.
+    home = pathlib.Path(tempfile.mkdtemp())
+    hooks = home / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    (hooks / "window_jump.sh").write_text("#!/bin/bash\nexit 1\n")
+    rc, _, err, _ = run_gate("Bash", {"command": "ls"}, tokens=TRIP, session_id="s-spawn", home=home,
+                             env_extra={"TERM_PROGRAM": "ghostty"})
+    assert rc == 2 and _jump(home, "s-spawn")["seat"] == "ghostty"
+    if sys.platform == "darwin":
+        assert "Salto di finestra TENTATO" in err and "jump.log" in err and "nz-jump s-spawn" in err
+    else:
+        assert "Salto REGISTRATO" in err
+    assert "AVVIATO" not in err
 
 
 # ---------------- innocence ----------------


### PR DESCRIPTION
## What

The deny text of `infra/claude-hooks/context_window_guard.py` said **«Salto di finestra AVVIATO: la finestra nuova si apre da sola»** the instant `window_jump.sh` was spawned. The hook does not wait for the gesture. Measured 2026-09-09: two of three gestures failed AFTER that line was printed (Pro 15:36 session e82f9c09, M5 17:59 session 461e7cb5 — `jump.log`: `⌘N did not bring a new window to front (front='?'): nothing typed`). The operator read "started" and waited for a window that never came; on a headless seat (Pro cap probe today, hop 1) the seat itself reported "the new window opens by itself" when no window exists at all.

`_write_pending_jump` now returns what it actually did:
- `"spawned"` → deny says **TENTATO**, names `jump.log` as the only place the outcome lives, and gives the manual gesture `nz-jump <session>`;
- `"recorded"` (headless seat, no script, spawn suppressed) → deny says **REGISTRATO**, no window gesture, the cascade wrapper does the hop;
- `None` → unchanged "non avviato", now pointing at `jump.log` too.

The jump file, hop chain, handoff and rate limit are untouched. Message-only plus the return value that feeds it.

## Proof

- `pytest infra/claude-hooks/test_context_window_jump.py test_context_window_guard.py test_context_jump_resume.py`: 39 passed. New test `test_ghostty_spawn_is_reported_as_attempted_not_started` spawns a stub `window_jump.sh` that exits 1 and asserts the deny says TENTATO + `jump.log` + `nz-jump s-spawn` and never AVVIATO; the headless test now asserts REGISTRATO.

Bites: consumer = every interactive and headless Claude seat on M5/Pro/Mini whose PreToolUse runs `~/.claude/hooks/context_window_guard.py` (HOME-fork pair declared in `infra/home-fork/declared-pairs.json`, so the healer propagates it). Observation: the next guard trip on any seat prints `Salto di finestra TENTATO … jump.log` or `Salto REGISTRATO …` in the deny block; `grep -c AVVIATO ~/.claude/hooks/context_window_guard.py` returns 0 on all three machines after the HOME copy is refreshed by this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g48PCCkst4dvvNnQTVvsv