### PR TITLE
fix(escalations): board readers order on a coerced ts, never on the raw value

### DIFF
--- a/scripts/hooks/escalations_alert_sessionstart.sh
+++ b/scripts/hooks/escalations_alert_sessionstart.sh
@@ -55,7 +55,8 @@ if command -v timeout >/dev/null 2>&1; then _TIMEOUT=(timeout 4)
 elif command -v gtimeout >/dev/null 2>&1; then _TIMEOUT=(gtimeout 4); fi
 
 "${_TIMEOUT[@]}" "$PY" - "$ESC_FILE" "$TASKS_DIR" "$FRESH_DAYS" <<'PYEOF' 2>/dev/null || exit 0
-import json, os, re, sys, time
+import json, math, os, re, sys, time
+from datetime import datetime, timezone
 
 esc_file, tasks_dir, fresh_days = sys.argv[1], sys.argv[2], int(sys.argv[3])
 now = time.time()
@@ -82,6 +83,35 @@ def _normalize_cause(summary: str) -> str:
     s = _SHA_RE.sub("<sha>", s)
     s = _NUM_RE.sub("#", s)
     return " ".join(s.split())
+
+def _ts(value) -> float:
+    # Board readers never trust writer discipline on ts: a string next to the
+    # floats (W54 dlq_autopilot ISO-8601; #6012 receptor str(now)) would
+    # TypeError the net-pending comparisons below and silence the WHOLE board
+    # at SessionStart. Numbers pass, numeric/ISO strings parse, junk is 0.0
+    # (oldest, still listed). Mirrors sentinel_lib.escalations.ts_epoch —
+    # this hook runs before any sys.path setup, so it cannot import it.
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value) if math.isfinite(value) else 0.0
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return 0.0
+        try:
+            number = float(text)
+            return number if math.isfinite(number) else 0.0
+        except ValueError:
+            pass
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return 0.0
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+    return 0.0
 
 # --- 1. live board: shared/escalations_pro.jsonl ---
 # D2.3's writer is append-only (sentinel_lib.escalations.mark_resolved): a
@@ -111,7 +141,7 @@ if os.path.isfile(esc_file):
         for d in raw:
             if str(d.get("status", "pending")).lower() == "resolved":
                 job = d.get("job") or "?"
-                ts = d.get("resolved_at", d.get("ts", 0)) or 0
+                ts = _ts(d.get("resolved_at", d.get("ts", 0)))
                 if ts >= resolved_latest_ts.get(job, -1):
                     resolved_latest_ts[job] = ts
 
@@ -119,13 +149,13 @@ if os.path.isfile(esc_file):
             if str(d.get("status", "pending")).lower() == "resolved":
                 continue  # resolution marker itself is never a board item
             job = d.get("job") or d.get("type") or "?"
-            entry_ts = d.get("ts", 0) or 0
+            entry_ts = _ts(d.get("ts", 0))
             if job in resolved_latest_ts and entry_ts <= resolved_latest_ts[job]:
                 continue  # covered by a later resolution — net-resolved, not open
             prio = str(d.get("priority") or d.get("severity") or "NORMAL").upper()
             summ = " ".join((d.get("error_summary") or "").split())[:80]
             if prio == "HIGH":
-                high.append(("escalations_pro.jsonl", job, summ, float(entry_ts) if entry_ts else 0.0))
+                high.append(("escalations_pro.jsonl", job, summ, entry_ts))
             else:
                 normal_pending += 1
     except Exception:

--- a/scripts/sentinel_lib/escalations.py
+++ b/scripts/sentinel_lib/escalations.py
@@ -18,9 +18,11 @@ bounded-retention pruning. The SQLite mirror lives OUTSIDE the git tree
 """
 import json
 import logging
+import math
 import os
 import socket
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 _logger = logging.getLogger("sentinel_lib.escalations")
@@ -43,6 +45,46 @@ _HOSTNAME_TO_MACHINE = {
 def _current_machine() -> str:
     hostname = socket.gethostname()
     return _HOSTNAME_TO_MACHINE.get(hostname, "pro")  # default: pro (conservative)
+
+
+def ts_epoch(value) -> float:
+    """Coerce a board record's ``ts``/``resolved_at`` to epoch seconds for ordering.
+
+    The board is append-only and MULTI-writer (this module, zsh wrappers, the
+    healer receptors) and every writer is supposed to emit a float. Twice one
+    did not — dlq_autopilot wrote an ISO-8601 string (W54, 2026-05-23) and the
+    main_required_red receptor wrote ``str(now)`` (#6012, 2026-09-09) — and one
+    string next to the floats made ``sorted(..., key=ts)`` raise TypeError for
+    EVERY consumer at once: the SessionStart receptor, modus_autoloop,
+    mark_resolved. Fixing each writer closes one instance and leaves the class
+    open, so the readers stop depending on writer discipline: numbers pass
+    through, numeric strings and ISO-8601 strings are parsed, anything else
+    (None, empty, garbage, NaN) orders as 0.0 — OLDEST, never dropped. A bad
+    ts may hide a line's age; it must never hide the line or take the board
+    down. The record itself is not rewritten (immutable log, superscar #9).
+    """
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value) if math.isfinite(value) else 0.0
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return 0.0
+        try:
+            number = float(text)
+        except ValueError:
+            number = None
+        if number is not None:
+            return number if math.isfinite(number) else 0.0
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return 0.0
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+    return 0.0
 
 
 def write_escalation(entry: dict) -> None:
@@ -122,7 +164,7 @@ def read_all_escalations(include_resolved: bool = False) -> list[dict]:
         except OSError:
             pass
 
-    return sorted(entries, key=lambda e: e.get("ts", 0), reverse=True)
+    return sorted(entries, key=lambda e: ts_epoch(e.get("ts")), reverse=True)
 
 
 def mark_resolved(job_id: str) -> int:
@@ -160,5 +202,5 @@ def is_job_open(job_id: str) -> bool:
     entries = [e for e in read_all_escalations(include_resolved=True) if e.get("job") == job_id]
     if not entries:
         return False
-    latest = max(entries, key=lambda e: e.get("ts", 0))
+    latest = max(entries, key=lambda e: ts_epoch(e.get("ts")))
     return latest.get("status") != "resolved"

--- a/scripts/tests/test_escalations_alert_sessionstart.py
+++ b/scripts/tests/test_escalations_alert_sessionstart.py
@@ -84,6 +84,29 @@ class TestNetPending:
         assert "1 HIGH-priority open" in ctx
         assert "fly_backup" in ctx
 
+    def test_string_ts_line_neither_silences_the_board_nor_breaks_net_pending(self, tmp_path, tasks_dir):
+        """One writer emitting a string ts (W54 ISO-8601, #6012 str(now)) must
+        not TypeError the net-pending comparisons and silence the WHOLE board
+        at SessionStart: the open HIGH item still surfaces, and an ISO-stamped
+        resolution still nets out the float-stamped pending it follows."""
+        esc = tmp_path / "escalations_pro.jsonl"
+        _write_jsonl(esc, [
+            {"job": "healed_job", "status": "pending", "priority": "HIGH",
+             "error_summary": "exit 1", "ts": 100},
+            {"job": "healed_job", "status": "resolved",
+             "resolved_at": "1970-01-01T00:03:20Z", "ts": "1970-01-01T00:03:20Z"},
+            {"job": "still_open", "status": "pending", "priority": "HIGH",
+             "error_summary": "boom", "ts": "150.0"},
+            {"job": "junk_ts", "status": "pending", "priority": "HIGH",
+             "error_summary": "no clock", "ts": "yesterday"},
+        ])
+        out = _run_hook(esc, tasks_dir)
+        assert out is not None, "a string ts must not silence the board"
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "2 HIGH-priority open" in ctx, ctx
+        assert "still_open" in ctx and "junk_ts" in ctx
+        assert "healed_job" not in ctx, "ISO-stamped resolution must still net out the pending"
+
     def test_innocence_resolved_pending_vanishes(self, tmp_path, tasks_dir):
         esc = tmp_path / "escalations_pro.jsonl"
         _write_jsonl(esc, [

--- a/scripts/tests/test_sentinel_lib_escalations.py
+++ b/scripts/tests/test_sentinel_lib_escalations.py
@@ -68,3 +68,42 @@ def test_unrelated_job_resolution_does_not_leak(isolated_queue: Path) -> None:
     escalations.write_escalation({"job": "job-x", "status": "resolved", "ts": 200})
     assert escalations.is_job_open("job-x") is False
     assert escalations.is_job_open("job-y") is True
+
+
+# --- ts coercion: readers never depend on writer discipline (W54, #6012) ---
+
+
+def test_ts_epoch_coerces_every_shape_a_writer_has_emitted() -> None:
+    """Numbers pass through; numeric strings and ISO-8601 strings (W54's
+    dlq_autopilot shape, #6012's str(now) shape) parse; junk orders as 0.0."""
+    assert escalations.ts_epoch(1700000000) == 1700000000.0
+    assert escalations.ts_epoch(1700000000.5) == 1700000000.5
+    assert escalations.ts_epoch("1700000000.5") == 1700000000.5  # #6012: str(time.time())
+    assert escalations.ts_epoch("2026-05-23T11:55:24Z") == 1779537324.0  # W54: strftime ISO
+    assert escalations.ts_epoch("2026-05-23T11:55:24+00:00") == 1779537324.0
+    for junk in (None, "", "   ", "yesterday", float("nan"), True, {"ts": 1}, []):
+        assert escalations.ts_epoch(junk) == 0.0, junk
+
+
+def test_mixed_ts_board_reads_whole_and_sorts_newest_first(isolated_queue: Path) -> None:
+    """The defect the gate found on #6002: one string ts on the board made
+    sorted(..., key=ts) raise TypeError for EVERY consumer. A mixed board
+    must read in full, in the right order, with the unreadable line kept."""
+    escalations.write_escalation({"job": "float-old", "status": "pending", "ts": 1779537000.0})
+    escalations.write_escalation({"job": "iso-mid", "status": "pending", "ts": "2026-05-23T11:55:24Z"})
+    escalations.write_escalation({"job": "str-new", "status": "pending", "ts": "1779538000.0"})
+    escalations.write_escalation({"job": "junk", "status": "pending", "ts": "yesterday"})
+    board = escalations.read_all_escalations()
+    assert [e["job"] for e in board] == ["str-new", "iso-mid", "float-old", "junk"]
+    # The record is returned as written — the reader orders, it never rewrites.
+    assert next(e for e in board if e["job"] == "iso-mid")["ts"] == "2026-05-23T11:55:24Z"
+
+
+def test_is_job_open_collapses_across_string_and_float_ts(isolated_queue: Path) -> None:
+    """A pending line with a string ts and a resolution with a float ts must
+    still collapse to the newest record: resolved after pending → closed."""
+    escalations.write_escalation({"job": "job-mixed", "status": "pending", "ts": "2026-05-23T11:55:24Z"})
+    escalations.write_escalation({"job": "job-mixed", "status": "resolved", "ts": 1779537400.0})
+    assert escalations.is_job_open("job-mixed") is False
+    escalations.write_escalation({"job": "job-mixed", "status": "pending", "ts": "1779537500.0"})
+    assert escalations.is_job_open("job-mixed") is True


### PR DESCRIPTION
## What

The escalations board (`shared/escalations_pro.jsonl`) is append-only and multi-writer, and every writer is supposed to emit a float `ts`. Twice one did not — `dlq_autopilot` wrote an ISO-8601 string (W54, 2026-05-23) and the `main_required_red` receptor wrote `str(now)` (#6012, gate finding on #6002) — and each time one string next to the floats broke EVERY consumer at once. #6012 fixed the writer; this closes the class on the reader side:

- `scripts/sentinel_lib/escalations.py`: new `ts_epoch()` coerces numbers, numeric strings and ISO-8601 strings to epoch seconds and orders anything else (None, empty, junk, NaN) as `0.0` — oldest, never dropped. `read_all_escalations()` and `is_job_open()` sort/collapse on it. Records are returned as written (immutable log, superscar #9).
- `scripts/hooks/escalations_alert_sessionstart.sh`: the SessionStart receptor's embedded Python gets the same coercion inline (it runs before any `sys.path` setup, so it cannot import the library); the net-pending comparisons no longer touch the raw value.

## Proof

- `pytest scripts/tests/test_sentinel_lib_escalations.py scripts/tests/test_escalations_alert_sessionstart.py scripts/tests/test_healer_receptor_main_red.py`: 34 passed. The 4 new tests, run against `origin/main`'s copies of the two source files, fail (4 failed, 19 passed) — the tests see the defect.
- Observed on Pro 2026-09-09 on a COPY of the live board (217 lines, all float `ts`) with one synthetic ISO-`ts` HIGH line added, never on the real file:

| board copy | `origin/main` hook | this branch's hook |
|---|---|---|
| string line appended LAST | `20 HIGH-priority open across 10 group(s)` — the string line silently dropped | `21 HIGH … 11 group(s)` |
| string line prepended FIRST | **silent** — no output at all, the whole board vanishes at SessionStart | `21 HIGH … 11 group(s)` |
| `read_all_escalations()` on the FIRST variant | `TypeError: '<' not supported between instances of 'str' and 'float'` | 190 records |

So on main the failure mode depends on WHERE the bad line lands: last → one line lost, anywhere else → everything after it lost, first → the receptor goes mute. The mute case is the one the gate predicted on #6002.

Bites: consumer = the SessionStart escalations receptor (`scripts/hooks/escalations_alert_sessionstart.sh`) and `read_all_escalations()` (through it `modus_autoloop`, `modus_enqueue`, `mark_resolved`, `escalations_rotate`). Observation: after merge, on Pro's live checkout, `ESCALATIONS_FILE_OVERRIDE=<copy of shared/escalations_pro.jsonl with one ISO-ts line prepended> bash scripts/hooks/escalations_alert_sessionstart.sh` prints the full HIGH board (21 open across 11 groups today) instead of nothing — and the real board keeps reading in full the day any writer emits a string `ts` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
