### PR TITLE
fix(hooks): window_jump.sh drives Ghostty through its native AppleScript API, keystrokes only as fallback

### DIFF
--- a/infra/claude-hooks/window_jump.sh
+++ b/infra/claude-hooks/window_jump.sh
@@ -6,25 +6,38 @@
 # l'handoff, incollalo in una finestra nuova e chiudi la tua" — automatic, no
 # human). The CLI has no way to open a window or end a session from a hook
 # (research/operations/2026-09-09-window-jump-automatic-handoff-it.md §2), so
-# this script does both from outside: System Events for the window, and for the
-# old session `/exit` typed into its window FIRST, then — measured 2026-09-09
-# 12:53 on the live probe: three `/exit` keystrokes left the probe claude alive,
-# two SIGINTs ended it — a SIGINT×2 fallback on the old claude PID (the guard's
-# own parent, carried in the jump file as `from_pid`).
+# this script does both from outside.
+#
+# TWO ROUTES, tried in this order:
+#
+#   NATIVE — Ghostty ≥ 1.3 ships an AppleScript dictionary (`new window`,
+#   `input text`, `send key`, `close window`, window/terminal `id`s that are
+#   STABLE handles). The new window is created and addressed by id: nothing is
+#   typed "into whatever is in front", so the two failure modes measured on
+#   2026-09-09 (Pro 15:36, M5 17:59: "⌘N did not bring a new window to front
+#   (front='?')" — Ghostty not the active app, System Events blind) cannot
+#   happen. Needs `macos-applescript = true` in the Ghostty config (the 1.3
+#   default) — when it is off, Ghostty answers "AppleScript is disabled" and
+#   we fall through.
+#
+#   KEYSTROKE (fallback) — System Events: remember the front Ghostty window by
+#   NAME, ⌘N, verify a NEW window is front, type `nz-jump <from>`. Kept for
+#   Ghostty < 1.3 or the option switched off; every miss is logged, never
+#   retried blind. Nothing is typed into a window that is not verified front —
+#   a wrong keystroke in Zero's other window is worse than an idle one.
+#
+# Either way: nz-jump starts a fresh claude; SessionStart hook
+# context_jump_resume.py injects the handoff and stamps `to_session`; we wait
+# (≤ JUMP_WAIT_S) for it, then end the OLD session: `/exit` into its terminal
+# when we hold a handle to it, then — measured 2026-09-09 12:53 on the live
+# probe: three `/exit` keystrokes left the probe claude alive, two SIGINTs
+# ended it — SIGINT×2 on the old claude PID (the guard's own parent, carried
+# in the jump file as `from_pid`), and finally `close window` on the old
+# window id (native route only; the keystroke route cannot close safely).
 #
 # Contract: $1 = from_session. Reads ~/.organism/context-guard/pending-jump-<from>.json
 # (per-session file: two windows jumping at once never overwrite each other).
-#   1. remember the OLD window = the front Ghostty window NOW (Claude Code sets
-#      the terminal title to the session title, so the name is a handle);
-#   2. ⌘N; verify a NEW window is front (name changed); type `nz-jump <from>`,
-#      Enter — nz-jump starts a fresh claude; the SessionStart hook
-#      context_jump_resume.py injects the handoff and stamps `to_session`;
-#   3. wait (≤ JUMP_WAIT_S) for `to_session`; then raise the OLD window by name,
-#      verify it is front, type `/exit`; wait ≤ EXIT_WAIT_S for from_pid to die;
-#      if still alive: kill -INT ×2. Nothing is typed into a window that is not
-#      verified front — a wrong keystroke in Zero's other window is worse than
-#      an idle one; every miss is logged, never retried blind.
-# Kill switch: CONTEXT_JUMP_OFF=1.
+# Kill switch: CONTEXT_JUMP_OFF=1. Test seam: OSASCRIPT=<stub> (tests only).
 set -u
 FROM="${1:-}"
 STATE_DIR="$HOME/.organism/context-guard"
@@ -32,19 +45,67 @@ PENDING="$STATE_DIR/pending-jump-$FROM.json"
 LOG="$STATE_DIR/jump.log"
 JUMP_WAIT_S="${JUMP_WAIT_S:-120}"
 EXIT_WAIT_S="${EXIT_WAIT_S:-20}"
+OSASCRIPT="${OSASCRIPT:-osascript}"
 mkdir -p "$STATE_DIR"
 log() { echo "[$(date '+%F %T')] [$FROM] $*" >> "$LOG"; }
+# A zombie (exited, parent has not reaped it yet) answers kill -0: it is dead.
+alive() { [ -n "${1:-}" ] && kill -0 "$1" 2>/dev/null && [[ "$(ps -o stat= -p "$1" 2>/dev/null)" != Z* ]]; }
 jget() { python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get(sys.argv[2]) or '')" "$PENDING" "$1" 2>/dev/null; }
 
 [ "${CONTEXT_JUMP_OFF:-0}" = "1" ] && { log "disabled by CONTEXT_JUMP_OFF"; exit 0; }
 [ "$(uname)" = "Darwin" ] || { log "not macOS: no window gesture"; exit 0; }
 [ -n "$FROM" ] && [ -f "$PENDING" ] || { log "no pending-jump file for '$FROM'"; exit 1; }
 FROM_PID=$(jget from_pid)
+CWD=$(jget cwd)
 
-# AppleScript takes the window name as an ARGUMENT (on run argv), never spliced
-# into source: a title with a quote or backslash must not become code.
-AS="$STATE_DIR/window_jump.applescript"
-cat > "$AS" <<'EOF'
+# AppleScript takes every value as an ARGUMENT (on run argv), never spliced
+# into source: a title, a path or a session id with a quote or backslash must
+# not become code.
+AS_NATIVE="$STATE_DIR/window_jump_native.applescript"
+cat > "$AS_NATIVE" <<'EOF'
+on run argv
+  set act to item 1 of argv
+  tell application "Ghostty"
+    if act is "old-id" then
+      -- The window this hook runs in is the one the operator is looking at
+      -- when Ghostty is the active app; otherwise the ONLY terminal whose
+      -- title names this session (Claude Code titles the tab after the
+      -- mandate; nz-jump's stub names the session). Two or none: unknown —
+      -- better an old window left open than /exit typed into the wrong one.
+      set sid to item 2 of argv
+      set found to {}
+      try
+        if frontmost then return id of front window
+      end try
+      repeat with w in windows
+        try
+          if (name of w) contains sid then set end of found to id of w
+        end try
+      end repeat
+      if (count of found) is 1 then return item 1 of found
+      return ""
+    else if act is "new-window" then
+      set cfg to new surface configuration
+      if (item 2 of argv) is not "" then set initial working directory of cfg to item 2 of argv
+      set w to new window with configuration cfg
+      delay 1.0
+      return id of w
+    else if act is "type-into" then
+      set w to window id (item 2 of argv)
+      set t to focused terminal of selected tab of w
+      input text (item 3 of argv) to t
+      send key "enter" to t
+      return "ok"
+    else if act is "close-window" then
+      close window (window id (item 2 of argv))
+      return "ok"
+    end if
+  end tell
+end run
+EOF
+
+AS_KEYS="$STATE_DIR/window_jump.applescript"
+cat > "$AS_KEYS" <<'EOF'
 on run argv
   set act to item 1 of argv
   tell application "Ghostty" to activate
@@ -75,16 +136,44 @@ on run argv
 end run
 EOF
 
-OLD_NAME=$(osascript "$AS" front-name 2>/dev/null || true)
-log "old window: '${OLD_NAME:-?}' pid=${FROM_PID:-?}"
+ROUTE=""
+OLD_ID=""
+OLD_NAME=""
+NEW_ID=""
 
-NEW_NAME=$(osascript "$AS" new-window 2>/dev/null || true)
-if [ -z "$NEW_NAME" ] || [ "$NEW_NAME" = "$OLD_NAME" ]; then
-    log "⌘N did not bring a new window to front (front='${NEW_NAME:-?}'): nothing typed"; exit 1
+# ---- NATIVE route -----------------------------------------------------------
+NERR="$STATE_DIR/.native-$FROM.err"
+if OLD_ID=$("$OSASCRIPT" "$AS_NATIVE" old-id "${FROM:0:8}" 2>"$NERR"); then
+    NEW_ID=$("$OSASCRIPT" "$AS_NATIVE" new-window "$CWD" 2>"$NERR" || true)
+    if [ -n "$NEW_ID" ] && "$OSASCRIPT" "$AS_NATIVE" type-into "$NEW_ID" "nz-jump $FROM" >/dev/null 2>"$NERR"; then
+        ROUTE="native"
+        log "native: old window id='${OLD_ID:-?}' pid=${FROM_PID:-?}; new window id='$NEW_ID' opened, 'nz-jump $FROM' sent"
+    elif [ -n "$NEW_ID" ]; then
+        log "native: new window id='$NEW_ID' opened but input FAILED ($(tr '\n' ' ' < "$NERR" | cut -c1-160)): nothing typed"
+        rm -f "$NERR"; exit 1
+    else
+        log "native: new window FAILED ($(tr '\n' ' ' < "$NERR" | cut -c1-160)): falling back to keystrokes"
+    fi
+else
+    log "native route unavailable ($(tr '\n' ' ' < "$NERR" | cut -c1-120)): falling back to keystrokes"
 fi
-osascript "$AS" type-here "$NEW_NAME" "nz-jump $FROM" >/dev/null 2>&1 || { log "front window changed before typing (expected '$NEW_NAME'): nothing typed"; exit 1; }
-log "new window '$NEW_NAME' opened, 'nz-jump $FROM' typed"
+rm -f "$NERR"
 
+# ---- KEYSTROKE route (fallback) ---------------------------------------------
+if [ -z "$ROUTE" ]; then
+    OLD_NAME=$("$OSASCRIPT" "$AS_KEYS" front-name 2>/dev/null || true)
+    log "keys: old window: '${OLD_NAME:-?}' pid=${FROM_PID:-?}"
+    NEW_NAME=$("$OSASCRIPT" "$AS_KEYS" new-window 2>/dev/null || true)
+    if [ -z "$NEW_NAME" ] || [ "$NEW_NAME" = "$OLD_NAME" ]; then
+        log "keys: ⌘N did not bring a new window to front (front='${NEW_NAME:-?}'): nothing typed"; exit 1
+    fi
+    "$OSASCRIPT" "$AS_KEYS" type-here "$NEW_NAME" "nz-jump $FROM" >/dev/null 2>&1 \
+        || { log "keys: front window changed before typing (expected '$NEW_NAME'): nothing typed"; exit 1; }
+    ROUTE="keys"
+    log "keys: new window '$NEW_NAME' opened, 'nz-jump $FROM' typed"
+fi
+
+# ---- wait for the new session to claim the jump -----------------------------
 deadline=$(( $(date +%s) + JUMP_WAIT_S ))
 TO=""
 while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -93,21 +182,42 @@ done
 [ -n "$TO" ] || { log "new session did not report within ${JUMP_WAIT_S}s: old window left open"; exit 2; }
 log "new session $TO is up"
 
-[ -n "$OLD_NAME" ] || { log "old window name unknown: not closing"; exit 0; }
-if osascript "$AS" raise-type "$OLD_NAME" "/exit" >/dev/null 2>&1; then
-    log "/exit typed into old window"
+# ---- end the OLD session -----------------------------------------------------
+if [ "$ROUTE" = "native" ]; then
+    if [ -n "$OLD_ID" ] && [ "$OLD_ID" != "$NEW_ID" ]; then
+        "$OSASCRIPT" "$AS_NATIVE" type-into "$OLD_ID" "/exit" >/dev/null 2>&1 \
+            && log "/exit typed into old window id=$OLD_ID" \
+            || log "old window id=$OLD_ID gone or refused input: /exit NOT typed"
+    else
+        log "old window id unknown: /exit NOT typed (SIGINT fallback only, window left open)"
+    fi
 else
-    log "old window not found by name or front changed: /exit NOT typed"
+    if [ -n "$OLD_NAME" ] && "$OSASCRIPT" "$AS_KEYS" raise-type "$OLD_NAME" "/exit" >/dev/null 2>&1; then
+        log "/exit typed into old window"
+    else
+        log "old window not found by name or front changed: /exit NOT typed"
+    fi
 fi
-if [ -n "$FROM_PID" ] && kill -0 "$FROM_PID" 2>/dev/null; then
+if alive "$FROM_PID"; then
     deadline=$(( $(date +%s) + EXIT_WAIT_S ))
-    while [ "$(date +%s)" -lt "$deadline" ] && kill -0 "$FROM_PID" 2>/dev/null; do sleep 2; done
-    if kill -0 "$FROM_PID" 2>/dev/null; then
+    while [ "$(date +%s)" -lt "$deadline" ] && alive "$FROM_PID"; do sleep 2; done
+    if alive "$FROM_PID"; then
         kill -INT "$FROM_PID" 2>/dev/null; sleep 1; kill -INT "$FROM_PID" 2>/dev/null; sleep 3
-        kill -0 "$FROM_PID" 2>/dev/null && log "old session pid $FROM_PID STILL alive after /exit + SIGINT×2 (left)" \
+        alive "$FROM_PID" && log "old session pid $FROM_PID STILL alive after /exit + SIGINT×2 (left)" \
                                         || log "old session pid $FROM_PID ended by SIGINT×2 (fallback)"
     else
         log "old session pid $FROM_PID ended by /exit"
+    fi
+fi
+# Close the old window only when its claude is gone (a live child would make
+# Ghostty ask "close running process?") and only when we hold its id.
+if [ "$ROUTE" = "native" ] && [ -n "$OLD_ID" ] && [ "$OLD_ID" != "$NEW_ID" ]; then
+    if alive "$FROM_PID"; then
+        log "old window id=$OLD_ID NOT closed: pid $FROM_PID still alive"
+    elif "$OSASCRIPT" "$AS_NATIVE" close-window "$OLD_ID" >/dev/null 2>&1; then
+        log "old window id=$OLD_ID closed"
+    else
+        log "old window id=$OLD_ID close FAILED (left open)"
     fi
 fi
 exit 0

--- a/infra/ghostty/fleet.ghostty
+++ b/infra/ghostty/fleet.ghostty
@@ -231,18 +231,21 @@ macos-option-as-alt = right
 macos-auto-secure-input = true
 macos-secure-input-indication = true
 
-# AppleScript control of the terminal is OFF. It defaults to ON (measured), and
-# it is the one macOS surface here that ships permissive: with it enabled, any
-# process that can run osascript gets "AppleScript object lookup for windows,
-# tabs, and terminals" on a terminal that holds this fleet's live shells.
-#
-# Measured before closing it: nothing in this repo, nothing in ~/scripts and no
-# LaunchAgent drives Ghostty through AppleScript, so nothing loses a capability.
-#
-# The neighbouring surface, `macos-shortcuts`, is left alone on purpose: its
-# default is already `ask` — Shortcuts can create terminals, send text and run
-# commands, but only after a permission prompt the human sees once.
-macos-applescript = false
+# AppleScript control of the terminal is ON — re-opened 2026-09-09 for the
+# window jump (Ruling Zero 2026-09-09: a session at its context threshold
+# opens a new window with the handoff and closes its own, no human). It was
+# closed on 2026-08-19 on the premise that "nothing in this repo drives Ghostty
+# through AppleScript, so nothing loses a capability"; that premise no longer
+# holds: ~/.claude/hooks/window_jump.sh (canon infra/claude-hooks/) creates the
+# new window, types `nz-jump <session>` and later `/exit` BY WINDOW ID through
+# this dictionary. Measured 2026-09-09: the keystroke route it used before
+# (System Events ⌘N + typing into "whatever is in front") failed 2 of 3 times
+# because Ghostty was not the active app — and that route is the SAME surface
+# (any process under Ghostty's Accessibility grant can already type into any
+# window), so enabling the dictionary does not widen what an osascript-capable
+# process can do here; it makes the sanctioned gesture addressable and safe.
+# Flip back to false only together with CONTEXT_JUMP_OFF=1 on this machine.
+macos-applescript = true
 
 # ─── Safety ────────────────────────────────────────────────────────────────
 # PIN of the upstream default, kept explicit for the same reason as

--- a/scripts/tests/test_window_jump_shell.py
+++ b/scripts/tests/test_window_jump_shell.py
@@ -1,0 +1,183 @@
+"""window_jump.sh — the gesture, exercised with a stubbed `osascript`.
+
+The script drives Ghostty through AppleScript; no CI runner has a GUI, so the
+seam is OSASCRIPT=<stub>. The stub records every call (action + argv) and
+answers per MODE, and the test asserts the ORDER of gestures, what is typed
+where, and the log line for every miss — the contract that failed live on
+2026-09-09 (Pro 15:36, M5 17:59: ⌘N without a new front window, and the
+guard already claiming "AVVIATO").
+"""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "infra" / "claude-hooks" / "window_jump.sh"
+
+pytestmark = pytest.mark.skipif(platform.system() != "Darwin",
+                                reason="window_jump.sh exits 0 before any gesture off macOS")
+
+STUB = r'''#!/bin/bash
+# osascript stub: $1 = script path, $2 = action, rest = args. MODE from env.
+echo "$(basename "$1") $2 ${3:-} ${4:-}" >> "$STUB_LOG"
+case "$(basename "$1")|$2|$STUB_MODE" in
+  *native*"|old-id|native-disabled"|*native*"|old-id|keys-"*) echo "execution error: AppleScript is disabled by the macos-applescript configuration. (-1743)" >&2; exit 1 ;;
+  *native*"|old-id|native-no-old")     echo ""; exit 0 ;;
+  *native*"|old-id|"*)                 echo "win-OLD"; exit 0 ;;
+  *native*"|new-window|"*)             echo "win-NEW"; exit 0 ;;
+  *native*"|type-into|"*)              echo "ok"; exit 0 ;;
+  *native*"|close-window|"*)           echo "ok"; exit 0 ;;
+  window_jump.applescript"|front-name|"*)  echo "old title"; exit 0 ;;
+  window_jump.applescript"|new-window|keys-front-stuck") echo "old title"; exit 0 ;;
+  window_jump.applescript"|new-window|"*)  echo "new title"; exit 0 ;;
+  window_jump.applescript"|type-here|"*)   echo "ok"; exit 0 ;;
+  window_jump.applescript"|raise-type|"*)  echo "ok"; exit 0 ;;
+esac
+exit 1
+'''
+
+
+def _home(tmp_path: Path, from_pid: int, *, cwd: str = "/tmp/wd") -> tuple[Path, Path]:
+    home = tmp_path / "home"
+    state = home / ".organism" / "context-guard"
+    state.mkdir(parents=True)
+    pending = state / "pending-jump-sess-1234-abcd.json"
+    pending.write_text(json.dumps({"from_session": "sess-1234-abcd", "from_pid": from_pid,
+                                   "to_session": None, "cwd": cwd, "hops": 1, "ts": time.time(),
+                                   "seat": "ghostty", "model": "claude-sonnet-5"}))
+    stub = tmp_path / "osascript"
+    stub.write_text(STUB)
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+    return home, pending
+
+
+def _run(home: Path, mode: str, *, claim_after: float | None = 0.5, from_pid: int | None = None):
+    """Run the script; optionally stamp to_session after `claim_after` seconds
+    (the SessionStart hook of the new window would)."""
+    pending = home / ".organism" / "context-guard" / "pending-jump-sess-1234-abcd.json"
+    env = {"HOME": str(home), "PATH": "/usr/bin:/bin", "OSASCRIPT": str(home.parent / "osascript"),
+           "STUB_MODE": mode, "STUB_LOG": str(home / "calls.log"),
+           "JUMP_WAIT_S": "6", "EXIT_WAIT_S": "1"}
+    p = subprocess.Popen(["bash", str(SCRIPT), "sess-1234-abcd"], env=env,
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if claim_after is not None:
+        time.sleep(claim_after)
+        d = json.loads(pending.read_text())
+        d["to_session"] = "sess-NEW"
+        pending.write_text(json.dumps(d))
+    rc = p.wait(timeout=30)
+    calls = (home / "calls.log").read_text().splitlines() if (home / "calls.log").exists() else []
+    log = (home / ".organism" / "context-guard" / "jump.log").read_text()
+    return rc, calls, log
+
+
+def _sleeper() -> subprocess.Popen:
+    # A stand-in for the old claude: dies on SIGINT, like the measured fallback.
+    return subprocess.Popen([sys.executable, "-c", "import time\nwhile True: time.sleep(0.2)"])
+
+
+# ---------------- native route ----------------
+def test_native_route_opens_by_id_types_into_new_then_exits_and_closes_old(tmp_path):
+    old = _sleeper()
+    try:
+        home, _ = _home(tmp_path, old.pid)
+        rc, calls, log = _run(home, "native-ok")
+    finally:
+        old.kill()
+    assert rc == 0, log
+    assert calls[:3] == ["window_jump_native.applescript old-id sess-123 ",
+                         "window_jump_native.applescript new-window /tmp/wd ",
+                         "window_jump_native.applescript type-into win-NEW nz-jump sess-1234-abcd"]
+    assert "window_jump_native.applescript type-into win-OLD /exit" in calls
+    assert calls[-1] == "window_jump_native.applescript close-window win-OLD "
+    assert not any(c.startswith("window_jump.applescript") for c in calls), "native route must never touch System Events"
+    assert "new session sess-NEW is up" in log and "old window id=win-OLD closed" in log
+    assert "SIGINT" in log  # the sleeper ignores /exit, so the fallback ended it
+
+
+def test_native_unknown_old_window_never_types_exit_and_leaves_it_open(tmp_path):
+    old = _sleeper()
+    try:
+        home, _ = _home(tmp_path, old.pid)
+        rc, calls, log = _run(home, "native-no-old")
+    finally:
+        old.kill()
+    assert rc == 0
+    assert not any("type-into win-OLD" in c or "close-window" in c for c in calls)
+    assert "old window id unknown: /exit NOT typed" in log and "window left open" in log
+
+
+def test_native_old_window_not_closed_while_old_claude_alive(tmp_path):
+    # from_pid that ignores SIGINT: the window must stay (Ghostty would prompt).
+    old = subprocess.Popen([sys.executable, "-c",
+                            "import signal,time\nsignal.signal(signal.SIGINT, signal.SIG_IGN)\nwhile True: time.sleep(0.2)"])
+    try:
+        home, _ = _home(tmp_path, old.pid)
+        rc, calls, log = _run(home, "native-ok")
+    finally:
+        old.kill()
+    assert rc == 0
+    assert not any("close-window" in c for c in calls)
+    assert "STILL alive" in log and "NOT closed" in log
+
+
+# ---------------- fallback route ----------------
+def test_native_disabled_falls_back_to_keystrokes(tmp_path):
+    home, _ = _home(tmp_path, 0)
+    rc, calls, log = _run(home, "native-disabled")
+    assert rc == 0, log
+    assert "native route unavailable" in log and "AppleScript is disabled" in log
+    assert calls[1:] == ["window_jump.applescript front-name  ",
+                         "window_jump.applescript new-window  ",
+                         "window_jump.applescript type-here new title nz-jump sess-1234-abcd",
+                         "window_jump.applescript raise-type old title /exit"]
+    assert "'nz-jump sess-1234-abcd' typed" in log and "/exit typed into old window" in log
+
+
+def test_keystroke_route_types_nothing_when_no_new_window_came_to_front(tmp_path):
+    # The 2026-09-09 17:59 failure on M5: ⌘N, front window unchanged.
+    home, _ = _home(tmp_path, 0)
+    rc, calls, log = _run(home, "keys-front-stuck", claim_after=None)
+    assert rc == 1
+    assert not any("type-here" in c or "raise-type" in c for c in calls)
+    assert "did not bring a new window to front" in log and "nothing typed" in log
+
+
+# ---------------- innocence ----------------
+def test_new_session_never_claims_leaves_old_window_open(tmp_path):
+    old = _sleeper()
+    try:
+        home, _ = _home(tmp_path, old.pid)
+        rc, calls, log = _run(home, "native-ok", claim_after=None)
+        assert rc == 2
+        assert old.poll() is None, "old session must not be ended when the new one never came up"
+    finally:
+        old.kill()
+    assert not any("/exit" in c or "close-window" in c for c in calls)
+    assert "did not report within 6s: old window left open" in log
+
+
+def test_kill_switch_and_missing_file(tmp_path):
+    home, pending = _home(tmp_path, 0)
+    env = {"HOME": str(home), "PATH": "/usr/bin:/bin", "OSASCRIPT": str(tmp_path / "osascript"),
+           "STUB_LOG": str(home / "calls.log"), "STUB_MODE": "native-ok", "CONTEXT_JUMP_OFF": "1"}
+    assert subprocess.run(["bash", str(SCRIPT), "sess-1234-abcd"], env=env).returncode == 0
+    env.pop("CONTEXT_JUMP_OFF")
+    assert subprocess.run(["bash", str(SCRIPT), "no-such-session"], env=env).returncode == 1
+    assert not (home / "calls.log").exists(), "no gesture without a pending file or with the switch off"
+
+
+def test_values_reach_applescript_as_argv_never_spliced(tmp_path):
+    # A cwd with a quote must arrive verbatim as an argument.
+    home, _ = _home(tmp_path, 0, cwd="/tmp/it's \"here\"")
+    rc, calls, _ = _run(home, "native-ok")
+    assert rc == 0
+    assert "window_jump_native.applescript new-window /tmp/it's \"here\" " in calls


### PR DESCRIPTION
## What

Two of three live window jumps on 2026-09-09 (Pro 15:36, M5 17:59) died at the gesture: `⌘N did not bring a new window to front (front='?')`. System Events could not even read the front Ghostty window because Ghostty was not the active app, and the script refused (correctly) to type into an unverified window.

Ghostty 1.3.1 (installed on M5 and Pro) ships an AppleScript dictionary: `new window`, `input text`, `send key`, `close window`, `front window`, and **stable window/terminal ids**. `infra/claude-hooks/window_jump.sh` now:

- **NATIVE route** — creates the new window with the session's cwd, gets its id, sends `nz-jump <session>` + Enter **to that id** (nothing is typed "into whatever is in front"); identifies the old window as `front window` when Ghostty is active, else the ONLY window titled after the session, else unknown (logged, never guessed); after the new session claims the jump, types `/exit` into the old window by id, SIGINT×2 fallback on `from_pid` as before, and `close window` on the old id once the old claude is gone (never while alive: Ghostty would prompt).
- **KEYSTROKE route** — the previous System Events flow, unchanged, taken only when the dictionary answers "AppleScript is disabled" or the native window creation fails.
- Zombie-aware liveness (`alive()`), `OSASCRIPT` test seam, every value passed as AppleScript argv (never spliced).

Second commit: `infra/ghostty/fleet.ghostty` re-opens `macos-applescript` (closed 2026-08-19 on the premise "nothing drives Ghostty through AppleScript", which this PR makes false; the keystroke route is the same Accessibility surface, so nothing new is exposed). The file records the reasoning and the paired kill switch `CONTEXT_JUMP_OFF=1`.

## Proof

- `pytest scripts/tests/test_window_jump_shell.py`: 8 passed (native order of gestures, unknown-old-window leaves it open, window not closed while old claude alive, fallback order, ⌘N-stuck types nothing, unclaimed jump ends nothing, kill switch, argv quoting).
- Live on M5 and Pro after the config reload (2026-09-09 20:06–20:12 WITA): `new window` → id `tab-group-…`, `input text` + Enter ran `echo NZ-JUMP-NATIVE-TEST-*` in it, `close window` by id closed it; `count of windows` back to the previous value. Ghostty was NOT the active app on M5 during the probe (Chrome was) — the exact condition that killed the keystroke route.

Bites: consumer = `~/.claude/hooks/window_jump.sh` on M5 and Pro (installed by this session from this branch) spawned by `context_window_guard.py` on the next trip of an interactive seat. Observation: the next `~/.organism/context-guard/jump.log` entry reads `native: … new window id='tab-group-…' opened, 'nz-jump <sid>' sent` followed by `new session <id> is up`; this session triggers one deliberate jump of itself right after arming and posts that log excerpt here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g48PCCkst4dvvNnQTVvsv