### PR TITLE
fix(codex-hooks): accept a continuation on the destination's claim, never cancel a slow launch, retry transient handoffs

### DIFF
--- a/infra/codex-hooks/README.md
+++ b/infra/codex-hooks/README.md
@@ -19,10 +19,17 @@ CLI for fresh continuations. It does not modify the Claude/Fable hook files.
   reasoning effort, approval policy and supported sandbox settings. Original
   text instructions and later steering are read transiently from native
   rollouts; generated continuation wrappers are not added again on each hop.
-- A destination must acknowledge that exact source and emit an actual model or
-  tool event within 45 seconds. Creating a thread alone is insufficient. A
-  failed or late launch retains the source and checkpoint as needs_attention.
-  The maximum chain length is three hops. No GUI automation is involved.
+- A destination must acknowledge that exact source: its own SessionStart hook
+  claims the source under the launch nonce, and that claim is the acceptance
+  (1.2.0). Creating a thread alone is insufficient; a model or tool event
+  without a claim still rejects the destination. The supervisor waits up to 240
+  seconds for the claim, while one Stop hook blocks at most 45 seconds and then
+  leaves the launch `starting` rather than cancelling it — the next Stop
+  re-checks. A failed launch parks the source as needs_attention; transient
+  failures (timeout, destination exit, unconfirmed) are retried by the next
+  Stop up to three launch attempts, other failures wait for the operator
+  (`retry` re-arms, `release` unfreezes the source over threshold). The
+  maximum chain length is three hops. No GUI automation is involved.
 - Verification executes real argv commands, records exit codes and hashes, and
   binds the receipt to HEAD, tracked changes and untracked contents. Any later
   edit invalidates it. Stop requests verification when changes lack a current

--- a/infra/codex-hooks/context_bridge.py
+++ b/infra/codex-hooks/context_bridge.py
@@ -28,10 +28,16 @@ from typing import Any, Iterator
 from rpc import binary_path
 from mandate_budget import observe as budget_observe, reserve as budget_reserve
 
-VERSION = "1.1.0"
-HANDSHAKE_SECONDS = 45
+VERSION = "1.2.0"
+HANDSHAKE_SECONDS = 45  # one Stop hook blocks at most this long waiting for the destination
+ACKNOWLEDGE_SECONDS = 240  # the supervisor waits this long for the destination to claim the source
+MAX_LAUNCH_ATTEMPTS = 3
 POLL_SECONDS = 1
 MANDATE_SECONDS = 3600
+# Launch failures the next Stop may retry on its own (bounded by MAX_LAUNCH_ATTEMPTS).
+TRANSIENT_FAILURES = frozenset(
+    {"continuation_not_confirmed", "TimeoutError", "RuntimeError", "destination_failed"}
+)
 SELF = Path(__file__).resolve()
 EVENTS = (
     "SessionStart",
@@ -342,6 +348,39 @@ def instructions(sid: str) -> str:
         "The coordinator owns a total deadline and all attempts, retries, replacements, depth "
         "and concurrent children. Receipt success is execution evidence, not independent acceptance."
     )
+
+
+def frozen_reason(sid: str, state: dict[str, Any]) -> str:
+    """Name the exact handoff phase, so a frozen source never retries blindly."""
+    phase = state.get("rollover")
+    attempt = state.get("launch_attempts", 0)
+    helpers = "Only the bridge helpers (checkpoint/status/verify) run here."
+    if phase == "accepted":
+        return (
+            "Handed off: work continues in Codex task "
+            + str(state.get("to_session"))
+            + ". This source is frozen; open that task. "
+            + helpers
+        )
+    if phase == "starting":
+        return (
+            f"Continuation launching (attempt {attempt} of {MAX_LAUNCH_ATTEMPTS}); "
+            "end this turn and wait for the destination to acknowledge. " + helpers
+        )
+    if phase == "needs_attention":
+        failure = str(state.get("failure"))
+        if failure in TRANSIENT_FAILURES and attempt < MAX_LAUNCH_ATTEMPTS:
+            cure = "End this turn: the next Stop retries the handoff automatically. "
+        else:
+            cure = (
+                "Operator decision needed: "
+                + shlex.join([sys.executable, str(SELF), "retry", sid])
+                + " re-arms the handoff; "
+                + shlex.join([sys.executable, str(SELF), "release", sid])
+                + " lets this source continue over threshold. "
+            )
+        return f"Handoff attempt {attempt} failed ({failure}). " + cure + helpers
+    return "Context threshold reached. " + instructions(sid)
 
 
 def native_child(payload: dict[str, Any]) -> tuple[str, str, str] | None:
@@ -657,6 +696,7 @@ def hook(payload: dict[str, Any]) -> dict[str, Any]:
             raise ValueError("invalid threshold")
         over = state.get("used", 0) >= state.get("window", float("inf")) * fraction
         over = over and state.get("observed") != state.get("ignore_observed")
+        over = over and not state.get("threshold_released")
         if over and not state.get("rollover"):
             state["rollover"] = "requested"
         save(path, state)
@@ -667,9 +707,7 @@ def hook(payload: dict[str, Any]) -> dict[str, Any]:
             "needs_attention",
         ):
             if not helper_command(payload, sid):
-                return context_output(
-                    event, "Context threshold reached. " + instructions(sid), deny=True
-                )
+                return context_output(event, frozen_reason(sid, state), deny=True)
         if event == "PostToolUse" and over:
             return context_output(
                 event, "Context threshold reached. " + instructions(sid)
@@ -681,6 +719,21 @@ def hook(payload: dict[str, Any]) -> dict[str, Any]:
                 + instructions(sid),
             )
     if event == "Stop":
+        if (
+            state.get("rollover") == "needs_attention"
+            and state.get("failure") in TRANSIENT_FAILURES
+            and state.get("launch_attempts", 0) < MAX_LAUNCH_ATTEMPTS
+            and state.get("checkpoint", {}).get("remaining")
+        ):
+            # A transient launch failure is retried by the next Stop, never by the model.
+            with locked(sid) as (path, latest):
+                if latest.get("rollover") == "needs_attention":
+                    latest["rollover"] = "requested"
+                    latest.pop("failure", None)
+                    save(path, latest)
+                    state = latest
+        if state.get("rollover") == "starting":
+            return await_acceptance(sid)
         if state.get("rollover") == "requested":
             if not state.get("checkpoint"):
                 if payload.get("stop_hook_active"):
@@ -831,7 +884,7 @@ def launch(sid: str, max_hops: int) -> dict[str, Any]:
             return {"systemMessage": reason}
         state.update(
             rollover="starting",
-            launch_deadline=time.time() + HANDSHAKE_SECONDS,
+            launch_deadline=time.time() + ACKNOWLEDGE_SECONDS,
             launch_nonce=uuid.uuid4().hex,
             launch_attempts=state.get("launch_attempts", 0) + 1,
         )
@@ -845,8 +898,30 @@ def launch(sid: str, max_hops: int) -> dict[str, Any]:
             stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
+    return await_acceptance(sid)
+
+
+def supervisor_alive(state: dict[str, Any]) -> bool:
+    pid = state.get("supervisor_pid")
+    if state.get("supervisor_finished") or not isinstance(pid, int):
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def await_acceptance(sid: str) -> dict[str, Any]:
+    """Block one Stop for at most HANDSHAKE_SECONDS; a slow destination is not a dead one.
+
+    Until 1.1.0 this flipped the source to needs_attention at 45 s and the supervisor
+    then killed a destination that had already claimed the source (measured 2026-09-09:
+    claim at +4 s, first model event still pending at +45 s on a 100 KB xhigh prompt).
+    Only the supervisor's own verdict, its death, or the acknowledge deadline end a launch.
+    """
     until = time.monotonic() + HANDSHAKE_SECONDS
-    while time.monotonic() < until:
+    while True:
         latest = load(state_path(sid))
         if latest.get("rollover") == "accepted":
             return {
@@ -854,16 +929,30 @@ def launch(sid: str, max_hops: int) -> dict[str, Any]:
                 "stopReason": "Continuation accepted: " + latest["to_session"],
                 "systemMessage": "Work continues in Codex task " + latest["to_session"],
             }
-        if latest.get("rollover") == "needs_attention":
+        if latest.get("rollover") != "starting":
             break
+        if "supervisor_pid" in latest and not supervisor_alive(latest):
+            break  # the supervisor died without recording a verdict
+        if time.time() > latest.get("launch_deadline", 0) + POLL_SECONDS:
+            break
+        if time.monotonic() >= until:
+            return {
+                "systemMessage": "Continuation still launching (attempt "
+                + str(latest.get("launch_attempts", 0))
+                + f" of {MAX_LAUNCH_ATTEMPTS}); the destination has not acknowledged yet. "
+                "Source frozen, not cancelled: end the turn again to re-check."
+            }
         time.sleep(0.1)
-    # Never terminate the source on an unconfirmed launch; invalidate late acceptance.
     with locked(sid) as (path, latest):
-        latest["rollover"] = "needs_attention"
-        latest.setdefault("failure", "continuation_not_confirmed")
-        save(path, latest)
+        if latest.get("rollover") == "starting":
+            latest["rollover"] = "needs_attention"
+            latest.setdefault("failure", "continuation_not_confirmed")
+            save(path, latest)
+    failure = str(load(state_path(sid)).get("failure"))
     return {
-        "systemMessage": "Continuation not confirmed. Source preserved; inspect context bridge status."
+        "systemMessage": "Continuation not confirmed ("
+        + failure
+        + "). Source preserved; end the turn to retry, or inspect context bridge status."
     }
 
 
@@ -948,6 +1037,7 @@ def continue_session(sid: str) -> None:
             try:
                 msg = messages.get(timeout=POLL_SECONDS)
             except queue.Empty:
+                msg = {}
                 if proc.poll() is not None:
                     reader.join(timeout=2)
                     if not messages.empty():
@@ -955,33 +1045,37 @@ def continue_session(sid: str) -> None:
                     raise RuntimeError(
                         "owned destination exited without completion"
                     ) from None
-                if accepted or time.time() < state["launch_deadline"]:
-                    continue
-                raise TimeoutError("destination handshake expired") from None
+                if not accepted and time.time() >= state["launch_deadline"]:
+                    raise TimeoutError("destination handshake expired") from None
             kind, item = msg.get("type"), msg.get("item", {})
             if kind == "thread.started":
                 to = msg["thread_id"]
             progress = kind in ("item.started", "item.completed") and item.get(
                 "type"
             ) in ("agent_message", "reasoning", "command_execution", "mcp_tool_call")
-            if not accepted and to and progress:
+            if not accepted and to:
+                # The destination's SessionStart hook claims this exact source under the
+                # launch nonce. That claim is the acknowledgement; the first model event
+                # may take longer than any handshake on a large high-effort prompt.
                 child = load(state_path(to))
-                if child.get("from_session") != sid:
+                claimed = child.get("from_session") == sid
+                if progress and not claimed:
                     raise ValueError("destination did not acknowledge exact source")
-                with locked(sid) as (path, latest):
-                    if (
-                        latest.get("rollover") != "starting"
-                        or time.time() > latest["launch_deadline"]
-                    ):
-                        raise TimeoutError("source cancelled late continuation")
-                    latest.update(
-                        to_session=to, rollover="accepted", accepted_at=time.time()
+                if claimed:
+                    with locked(sid) as (path, latest):
+                        if (
+                            latest.get("rollover") != "starting"
+                            or time.time() > latest["launch_deadline"]
+                        ):
+                            raise TimeoutError("source cancelled late continuation")
+                        latest.update(
+                            to_session=to, rollover="accepted", accepted_at=time.time()
+                        )
+                        save(path, latest)
+                    accepted = True
+                    budget_observe(
+                        state_dir() / "mandates", state.get("mandate_root", sid), to
                     )
-                    save(path, latest)
-                accepted = True
-                budget_observe(
-                    state_dir() / "mandates", state.get("mandate_root", sid), to
-                )
             if kind in ("turn.completed", "turn.failed", "bridge/eof"):
                 status = "completed" if kind == "turn.completed" else "failed"
                 with locked(sid) as (path, latest):
@@ -1033,6 +1127,41 @@ def continue_session(sid: str) -> None:
                 )
 
 
+def retry(sid: str) -> dict[str, Any]:
+    """Operator verb: re-arm a parked handoff so the next Stop launches it again."""
+    with locked(sid) as (path, state):
+        if state.get("rollover") != "needs_attention":
+            raise ValueError("only a needs_attention source can be retried")
+        if not state.get("checkpoint", {}).get("remaining"):
+            raise ValueError("retry needs a checkpoint with remaining work")
+        state["rollover"] = "requested"
+        for field in ("failure", "cancel_requested"):
+            state.pop(field, None)
+        save(path, state)
+        return {"retry_armed": True, "launch_attempts": state.get("launch_attempts", 0)}
+
+
+def release(sid: str) -> dict[str, Any]:
+    """Operator verb: unfreeze a parked source; the owner decided it continues here.
+
+    A launch still in flight must be cancelled first, so the supervisor records its
+    own verdict instead of racing this write.
+    """
+    with locked(sid) as (path, state):
+        if state.get("rollover") not in ("needs_attention", "requested"):
+            raise ValueError("release applies to a parked (needs_attention/requested) source")
+        state["released"] = {
+            "from": state.get("rollover"),
+            "failure": state.get("failure"),
+            "at": time.time(),
+        }
+        for field in ("rollover", "failure", "cancel_requested", "launch_nonce"):
+            state.pop(field, None)
+        state["threshold_released"] = True
+        save(path, state)
+        return {"released": True}
+
+
 def cancel(sid: str) -> None:
     """Signal only the supervisor that owns this exact launch; never kill by guessed PID."""
     with locked(sid) as (path, state):
@@ -1052,6 +1181,12 @@ def main() -> int:
         if verb == "cancel":
             cancel(sys.argv[2])
             print('{"cancellation_requested":true}')
+            return 0
+        if verb == "retry":
+            print(json.dumps(retry(sys.argv[2])))
+            return 0
+        if verb == "release":
+            print(json.dumps(release(sys.argv[2])))
             return 0
         if verb == "attention":
             print(

--- a/infra/codex-hooks/test_context_bridge.py
+++ b/infra/codex-hooks/test_context_bridge.py
@@ -359,3 +359,220 @@ def test_unacknowledged_child_cannot_execute_tools(
         == "deny"
     )
     assert bridge.hook({**e, "hook_event_name": "Stop"})["continue"] is False
+
+
+# --- 1.2.0: acknowledgement is the destination's claim, not its first model event ---
+
+FAKE_DESTINATION = """
+import json, sys, time
+sys.stdin.read()
+thread, delay = sys.argv[-2], float(sys.argv[-1])
+print(json.dumps({"type": "thread.started", "thread_id": thread}), flush=True)
+time.sleep(delay)
+print(json.dumps({"type": "item.started", "item": {"type": "reasoning"}}), flush=True)
+print(json.dumps({"type": "turn.completed"}), flush=True)
+"""
+
+
+def mandate_transcript(log: Path, used: int, window: int) -> None:
+    rows = [
+        {
+            "type": "turn_context",
+            "payload": {
+                "model": "gpt-test",
+                "effort": "low",
+                "approval_policy": "never",
+                "sandbox_policy": {"type": "read-only"},
+            },
+        },
+        {
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "Reply READY and stop."},
+        },
+        {
+            "type": "event_msg",
+            "timestamp": "2026-09-09T05:00:00Z",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "model_context_window": window,
+                    "last_token_usage": {"total_tokens": used},
+                },
+            },
+        },
+    ]
+    log.write_text("".join(json.dumps(r) + "\n" for r in rows))
+
+
+def parked_source(setup: tuple, failure: str, attempts: int) -> str:
+    _, log, e = setup
+    sid = e["session_id"]
+    mandate_transcript(log, 401, 1000)
+    bridge.hook({**e, "hook_event_name": "PreToolUse"})
+    bridge.checkpoint(sid, {"objective": "o", "next_action": "n", "remaining": ["x"]})
+    with bridge.locked(sid) as (path, state):
+        state.update(rollover="needs_attention", failure=failure, launch_attempts=attempts)
+        bridge.save(path, state)
+    return sid
+
+
+def test_destination_claim_accepts_before_first_model_event(
+    setup: tuple, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import threading
+    import time
+
+    repo, log, e = setup
+    sid = e["session_id"]
+    mandate_transcript(log, 401, 1000)
+    bridge.hook({**e, "hook_event_name": "PreToolUse"})
+    bridge.checkpoint(sid, {"objective": "o", "next_action": "n", "remaining": ["x"]})
+    with bridge.locked(sid) as (path, state):
+        state.update(
+            rollover="starting",
+            launch_nonce="nonce-1",
+            launch_deadline=time.time() + 60,
+            launch_attempts=1,
+        )
+        bridge.save(path, state)
+    fake = tmp_path / "fake_codex.py"
+    fake.write_text(FAKE_DESTINATION)
+    dest_log = tmp_path / "dest.jsonl"
+    dest_log.write_text("")
+    started = time.time()
+    with patch.object(
+        bridge,
+        "continuation_command",
+        return_value=[sys.executable, str(fake), "dest-session-1", "6"],
+    ):
+        worker = threading.Thread(target=bridge.continue_session, args=(sid,))
+        worker.start()
+        time.sleep(0.5)
+        # The destination's own SessionStart hook claims the exact source under the nonce.
+        monkeypatch.setenv("CODEX_CONTEXT_FROM_SESSION", sid)
+        monkeypatch.setenv("CODEX_CONTEXT_NONCE", "nonce-1")
+        bridge.hook(
+            {
+                "session_id": "dest-session-1",
+                "cwd": str(repo),
+                "transcript_path": str(dest_log),
+                "hook_event_name": "SessionStart",
+            }
+        )
+        monkeypatch.delenv("CODEX_CONTEXT_FROM_SESSION")
+        monkeypatch.delenv("CODEX_CONTEXT_NONCE")
+        for _ in range(40):
+            if bridge.load(bridge.state_path(sid)).get("rollover") == "accepted":
+                break
+            time.sleep(0.1)
+        accepted = bridge.load(bridge.state_path(sid))
+        assert accepted["rollover"] == "accepted"
+        assert accepted["to_session"] == "dest-session-1"
+        assert accepted["accepted_at"] - started < 5  # before the 6 s first model event
+        worker.join(timeout=15)
+    final = bridge.load(bridge.state_path(sid))
+    assert final["destination_status"] == "completed"
+    assert final["owned_exit_code"] == 0  # the accepted destination was never terminated
+
+
+def test_stop_wait_expiry_keeps_launch_starting(
+    setup: tuple, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import time
+
+    _, log, e = setup
+    sid = e["session_id"]
+    mandate_transcript(log, 401, 1000)
+    bridge.hook({**e, "hook_event_name": "PreToolUse"})
+    bridge.checkpoint(sid, {"objective": "o", "next_action": "n", "remaining": ["x"]})
+    fake = tmp_path / "fake_codex.py"
+    # thread.started, then 3 s of silence, then exit: no claim ever arrives.
+    fake.write_text(
+        "#!" + sys.executable + "\n"
+        "import json, sys, time\n"
+        "sys.stdin.read()\n"
+        'print(json.dumps({"type": "thread.started", "thread_id": "silent-dest-1"}), flush=True)\n'
+        "time.sleep(3)\n"
+    )
+    fake.chmod(0o755)
+    monkeypatch.setenv("CODEX_CONTEXT_BINARY", str(fake))
+    monkeypatch.setattr(bridge, "HANDSHAKE_SECONDS", 0.5)
+    result = bridge.launch(sid, 3)
+    assert "still launching" in result["systemMessage"]
+    state = bridge.load(bridge.state_path(sid))
+    assert state["rollover"] == "starting"  # the Stop wait expired; nothing was cancelled
+    assert state["launch_attempts"] == 1
+    for _ in range(100):
+        state = bridge.load(bridge.state_path(sid))
+        if state.get("rollover") == "needs_attention":
+            break
+        time.sleep(0.1)
+    assert state["rollover"] == "needs_attention"
+    assert state["failure"] == "destination_failed"  # the supervisor's verdict, not the Stop hook's
+    assert "to_session" not in state
+
+
+def test_stop_retries_transient_failure_bounded(setup: tuple) -> None:
+    _, _, e = setup
+    sid = parked_source(setup, "TimeoutError", 1)
+    calls: list[str] = []
+
+    def fake_launch(session: str, max_hops: int) -> dict:
+        calls.append(bridge.load(bridge.state_path(session))["rollover"])
+        return {"systemMessage": "launched"}
+
+    with patch.object(bridge, "launch", side_effect=fake_launch):
+        assert bridge.hook({**e, "hook_event_name": "Stop"}) == {"systemMessage": "launched"}
+    assert calls == ["requested"]
+    with bridge.locked(sid) as (path, state):
+        state.update(rollover="needs_attention", failure="TimeoutError", launch_attempts=3)
+        bridge.save(path, state)
+    with patch.object(bridge, "launch", side_effect=fake_launch):
+        bridge.hook({**e, "hook_event_name": "Stop"})
+    assert calls == ["requested"]  # attempt cap reached: no fourth launch
+    assert bridge.load(bridge.state_path(sid))["rollover"] == "needs_attention"
+    with bridge.locked(sid) as (path, state):
+        state.update(failure="mandate_dispatch_budget", launch_attempts=1)
+        bridge.save(path, state)
+    with patch.object(bridge, "launch", side_effect=fake_launch):
+        bridge.hook({**e, "hook_event_name": "Stop"})
+    assert calls == ["requested"]  # a non-transient failure is never retried on its own
+
+
+def test_frozen_source_names_its_phase(setup: tuple) -> None:
+    _, _, e = setup
+    sid = parked_source(setup, "TimeoutError", 1)
+    tool = {**e, "hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {"command": "ls"}}
+    out = bridge.hook(tool)["hookSpecificOutput"]
+    assert out["permissionDecision"] == "deny"
+    assert "attempt 1 failed (TimeoutError)" in out["permissionDecisionReason"]
+    assert "retries the handoff automatically" in out["permissionDecisionReason"]
+    with bridge.locked(sid) as (path, state):
+        state.update(rollover="accepted", to_session="dest-session-9")
+        bridge.save(path, state)
+    reason = bridge.hook(tool)["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "Codex task dest-session-9" in reason
+    with bridge.locked(sid) as (path, state):
+        state.update(rollover="needs_attention", failure="ValueError", launch_attempts=1)
+        bridge.save(path, state)
+    reason = bridge.hook(tool)["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "Operator decision needed" in reason and " retry " in reason
+
+
+def test_retry_and_release_verbs(setup: tuple) -> None:
+    _, _, e = setup
+    sid = parked_source(setup, "ValueError", 3)
+    assert bridge.retry(sid)["retry_armed"] is True
+    assert bridge.load(bridge.state_path(sid))["rollover"] == "requested"
+    with pytest.raises(ValueError):
+        bridge.retry(sid)  # only a parked source re-arms
+    assert bridge.release(sid)["released"] is True
+    state = bridge.load(bridge.state_path(sid))
+    assert "rollover" not in state and state["threshold_released"] is True
+    tool = {**e, "hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {"command": "ls"}}
+    assert bridge.hook(tool) == {}  # still over threshold, but the owner released it
+    with bridge.locked(sid) as (path, state):
+        state.update(rollover="starting")
+        bridge.save(path, state)
+    with pytest.raises(ValueError):
+        bridge.release(sid)  # an in-flight launch must be cancelled first


### PR DESCRIPTION
## What

Third required change for the codex-context-bridge branch, born from live evidence on Pro tonight (after R1/R2 of the 21:20 re-review). Targets the branch, not `main`, so the diff is the fix alone: the branch owner folds it before the shipping session merges the bridge.

**Failure measured** (Pro, Codex source `01a08630-759b`, 2026-09-09 20:50 WITA): the destination `codex exec` claimed the source at **+4 s**, its first model event was still pending at **+45 s** (~100 KB xhigh prompt), `launch()` flipped the source to `needs_attention`, the supervisor read that as a cancel and **terminated the accepted destination** (`owned_exit_code -15`, `failure TimeoutError`). `needs_attention` had no retry path, so the source stayed frozen with every tool denied — the state Codex itself described as "cannot unblock on its own".

## Change

- **Acceptance = the destination's claim.** The destination's SessionStart hook writes `from_session` for the exact source under the launch nonce; that is checked on every poll and accepts immediately. A model/tool event without a claim still rejects the destination.
- **A Stop never cancels a launch.** One Stop blocks ≤ `HANDSHAKE_SECONDS` (45) and then reports "still launching", leaving `rollover=starting`. The supervisor waits `ACKNOWLEDGE_SECONDS` (240); only its own verdict, its death, or the deadline park the source. The next Stop re-checks.
- **Bounded automatic retry.** A parked source with a transient failure (`continuation_not_confirmed`, `TimeoutError`, `RuntimeError`, `destination_failed`) is re-armed by the next Stop, ≤ `MAX_LAUNCH_ATTEMPTS` (3). Other failures wait for the operator.
- **Operator verbs** `retry <sid>` (re-arm) and `release <sid>` (unfreeze over threshold, `threshold_released`); `release` refuses an in-flight launch (cancel first, so the supervisor records its own verdict).
- **PreToolUse deny text names the phase**: accepted → task id to open; starting → attempt N of 3; needs_attention → failure and cure.
- `VERSION 1.2.0`, README handshake paragraph rewritten.

## Verification

| check | result |
|---|---|
| `pytest test_context_bridge.py test_child_lifecycle.py` | 50 passed (18 + 27 existing, 5 new) |
| new: claim accepts before the first model event, destination never terminated | `accepted_at − start < 5 s`, `owned_exit_code 0` |
| new: Stop-wait expiry leaves `starting`; supervisor's own verdict parks it | `destination_failed` written by the supervisor, not the hook |
| new: transient retry bounded at 3; non-transient never auto-retried | pass |
| new: phase-named deny; `retry`/`release` verbs | pass |
| **live on Pro** (installed via `install.py`, seat `~/.codex`, 1.2.0) | synthetic source → real `codex exec gpt-5.6-sol low read-only`: Stop returned `continue:false` in **5 s**, `accepted_at` **4.4 s** after supervisor start, destination's first model item **14 s later**, reply `BRIDGE-PROOF-OK`, `destination_status completed`, `owned_exit_code 0`. State: `~/.codex/state/nuzantara-context/live-rollover-proof-1788960297.json`, rollout `01a08658-0f55`. |

Bites: consumer = the Codex seat on Pro (`~/.codex/hooks/nuzantara-context/context_bridge.py`, live bytes == this branch, install backup `nuzantara-context-backups/1788960290071995000`); observation = the live handoff above (`accepted_at` before the destination's first model event, destination completed, not terminated) and `context_bridge.py status live-rollover-proof-1788960297` reading `rollover=accepted`.

Not in scope, left as measured: the three `exit 127` + one invalid-JSON SessionStart hook failures Codex printed at app start could not be reproduced outside the app (all 12 SessionStart commands exit 0 under a minimal PATH); the escalations-board writer of `docs/specs/codex-needs-attention-board-v1.md` stays post-merge as the spec orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)