### PR TITLE
fix(claude-hooks): a window opened by hand is never a continuation — resume hook claims only the jump named by NZ_JUMP_FROM

### DIFF
--- a/.claude/skills/window-jump/SKILL.md
+++ b/.claude/skills/window-jump/SKILL.md
@@ -36,7 +36,12 @@ Ghostty, solo macOS). Dettaglio storico:
 5. **`nz-jump`** (`~/.claude/scripts/nz-jump`) entra nel `cwd` vecchio e lancia un `claude`
    **fresco** — mai `--resume/--continue/--fork-session`, che riporterebbero il contesto.
 6. **`context_jump_resume.py`** (SessionStart della nuova finestra) inietta mandato +
-   handoff come `additionalContext` e timbra `to_session` nel file pending.
+   handoff come `additionalContext` e timbra `to_session` nel file pending — **solo** nella
+   finestra aperta PER quel salto: `nz-jump` (e l'hop del wrapper cascade) esportano
+   `NZ_JUMP_FROM=<sid>`, e il hook legge solo quel file. Un `claude` aperto a mano, senza
+   `NZ_JUMP_FROM`, non è mai una continuazione: resta muto anche con un pending fresco nello
+   stesso cwd (fino al 2026-09-09 pescava «il più fresco non reclamato» e per 15 minuti dopo
+   ogni guard una finestra di Zero partiva da sola sul mandato vecchio).
 7. `window_jump.sh` vede `to_session` (poll 1s, max `JUMP_WAIT_S`) e chiude la vecchia:
    `/exit` nel terminale vecchio **per id** (rotta native) o rialzando la finestra per nome
    (rotta keystroke); se il PID sopravvive, `SIGINT` ×2 su `from_pid`; e solo quando quel

--- a/evidence/2026-09/agent-nuzantara-infra-jump-resume-explicit-only-c963dd2c/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-infra-jump-resume-explicit-only-c963dd2c/brief.yml
@@ -1,0 +1,46 @@
+task_id: jump-resume-explicit-only
+gear: 1
+l_level: L1
+gate_class: opus
+objective: >-
+  A window opened by hand is never a continuation. Zero, Pro 2026-09-09 23:50:
+  "quando apro comincia a fare quello che vuole e non aspetta il mio prompt" —
+  and, in the same breath, "il context jump è un'altra cosa, non intaccare il
+  salto legittimo". context_jump_resume.py (SessionStart, every session) had a
+  fallback: with no NZ_JUMP_FROM in the env it claimed the freshest unclaimed
+  same-cwd pending-jump. So for MAX_AGE_S (15 min) after every guard trip, any
+  plain `claude` Zero opened in ~/nuzantara was handed the stale mandate plus
+  "continua senza chiedere" and stamped as that jump's destination. The
+  launcher knows the id (nz-jump.sh and claude-cascade.sh both export
+  NZ_JUMP_FROM); nobody else is a continuation. The fallback is removed, the
+  explicit path is untouched, and the legitimate jump keeps working.
+constraints:
+  - >-
+    The legitimate jump is not touched: window_jump.sh types `nz-jump <sid>`,
+    nz-jump.sh exports NZ_JUMP_FROM, claude-cascade.sh sets it on the hop
+    (line 535). Those paths are exercised by the existing corpora, all green.
+  - >-
+    The innocence filters (claimed, stale, own session, kill switch) are now
+    asserted ON the explicit path, so they cannot pass for the wrong reason.
+  - >-
+    Merged is not armed (cicatrix #1): the live copy under ~/.claude/hooks on
+    Pro, M5 and Mini is refreshed from origin/main after the merge, never from
+    a local branch, and lint_home_fork compares against origin/main.
+  - >-
+    No PII: the jump file carries a session id, a cwd, a model name and the
+    owner's own mandate text.
+acceptance:
+  - >-
+    WHEN a fresh, unclaimed pending-jump from THIS cwd exists and the session
+    starts with no NZ_JUMP_FROM, THEN the hook prints nothing, exits 0 and the
+    file's to_session stays null (test_hand_opened_window_never_claims_a_jump,
+    test_two_fresh_jumps_and_no_launcher_id_stamp_nothing).
+  - >-
+    WHEN NZ_JUMP_FROM names a fresh unclaimed jump, THEN it is injected and
+    stamped exactly as before, whatever the cwd
+    (test_fresh_unclaimed_jump_is_injected_and_stamped,
+    test_explicit_from_session_is_honoured_whatever_the_cwd).
+  - >-
+    WHEN the named jump is claimed, stale, our own, or CONTEXT_JUMP_OFF=1, THEN
+    mute and unstamped, on the explicit path.
+pii_scan: clean

--- a/infra/claude-hooks/context_jump_resume.py
+++ b/infra/claude-hooks/context_jump_resume.py
@@ -8,8 +8,18 @@ and the new window is opened by window_jump.sh / nz-jump (interactive) or by
 the cascade wrapper re-invoking `claude -p` (headless). This hook runs at the
 start of EVERY session (SessionStart, matcher `startup`) and:
 
-  - picks the FRESHEST jump file that is unclaimed (`to_session` null), fresh
-    (< MAX_AGE_S), raised from THIS cwd (realpath) and not by this session;
+  - picks ONLY the jump this window was opened FOR: `NZ_JUMP_FROM=<from>` in
+    the env, set by nz-jump.sh (interactive, typed by window_jump.sh or by a
+    human) and by the cascade wrapper's hop (headless). That file must still be
+    unclaimed (`to_session` null), fresh (< MAX_AGE_S) and not our own;
+  - a window opened BY HAND (plain `claude`, no NZ_JUMP_FROM) gets NOTHING.
+    Until 2026-09-09 it fell back to "the freshest unclaimed same-cwd jump",
+    so for 15 minutes after every guard trip any window Zero opened in
+    ~/nuzantara was handed a stale mandate plus "continua senza chiedere" and
+    started working on its own instead of waiting for the owner's prompt
+    (Zero, Pro 2026-09-09 23:50: "quando apro comincia a fare quello che vuole
+    e non aspetta il mio prompt"). The launcher knows the id, so it says it;
+    nobody else is a continuation;
   - injects it as `additionalContext` (the documented SessionStart field): the
     original mandate in full (carried in the jump file across hops — the hop-2
     transcript's first prompt is nz-jump's stub, not the mandate), successful
@@ -46,34 +56,32 @@ def _load(p: Path):
 
 def pick_jump(state_dir: Path, cwd: str, session_id: str, now: float | None = None,
               want: str | None = None):
-    """The jump this session was opened FOR.
+    """The jump this session was opened FOR — and only that one.
 
     `want` (NZ_JUMP_FROM in the env, set by nz-jump.sh and by the cascade
-    wrapper's hop) names the originating session outright: only that file is
-    considered, still only if unclaimed, fresh and not our own. Without it —
-    a window opened by hand — fall back to the freshest unclaimed, fresh,
-    same-cwd jump not raised by this session. Cross-family review (codex,
-    2026-09-09) showed the fallback alone lets a stranger session in the same
-    cwd claim a jump meant for another window; the launcher knows the id, so
-    it says it."""
+    wrapper's hop) names the originating session outright: that file is
+    considered, still only if unclaimed, fresh and not our own. Without it
+    the answer is None: a window opened by hand is Zero's window, not a
+    continuation. Cross-family review (codex, 2026-09-09) had already shown
+    the old same-cwd fallback let a stranger session claim a jump meant for
+    another window; the same evening it handed a hand-opened interactive
+    session a stale mandate. `cwd` is kept in the signature for the payload
+    but is no longer a filter — the launcher has already cd'd into the jump's
+    cwd, and a hand-opened window is refused whatever its cwd."""
+    if not want:
+        return None
     now = time.time() if now is None else now
-    best, best_ts = None, -1.0
-    candidates = [state_dir / f"pending-jump-{want}.json"] if want else state_dir.glob("pending-jump-*.json")
-    for p in candidates:
-        j = _load(p)
-        if not isinstance(j, dict) or j.get("to_session"):
-            continue
-        try:
-            ts = float(j.get("ts") or 0)
-        except (TypeError, ValueError):
-            continue
-        if now - ts > MAX_AGE_S or j.get("from_session") == session_id:
-            continue
-        if not want and j.get("cwd") and os.path.realpath(str(j["cwd"])) != os.path.realpath(cwd):
-            continue
-        if ts > best_ts:
-            best, best_ts = (p, j), ts
-    return best
+    p = state_dir / f"pending-jump-{want}.json"
+    j = _load(p)
+    if not isinstance(j, dict) or j.get("to_session"):
+        return None
+    try:
+        ts = float(j.get("ts") or 0)
+    except (TypeError, ValueError):
+        return None
+    if now - ts > MAX_AGE_S or j.get("from_session") == session_id:
+        return None
+    return (p, j)
 
 
 def build_context(jump: dict, handoff: dict | None) -> str:

--- a/infra/claude-hooks/test_context_jump_resume.py
+++ b/infra/claude-hooks/test_context_jump_resume.py
@@ -1,9 +1,12 @@
 """Guilt + innocence for context_jump_resume.py (SessionStart injector).
 
 Runs the hook as a subprocess with HOME pointed at a temp dir (same isolation
-as every sibling gate here). Guilt: a fresh unclaimed jump from this cwd is
-injected and stamped. Innocence: consumed, stale, foreign-cwd, kill switch,
-the originating session itself, and a session with no jump at all stay mute.
+as every sibling gate here). Guilt: the jump named by NZ_JUMP_FROM, fresh and
+unclaimed, is injected and stamped. Innocence: consumed, stale, kill switch,
+the originating session itself, a session with no jump at all — and, since
+2026-09-09, a window opened BY HAND (no NZ_JUMP_FROM) with a fresh unclaimed
+jump sitting right there in its own cwd: that window is the owner's, it stays
+mute and stamps nothing.
 """
 from __future__ import annotations
 
@@ -51,7 +54,7 @@ def _run(home, session_id="new", cwd=None, env_extra=None):
 # ---------------- guilt ----------------
 def test_fresh_unclaimed_jump_is_injected_and_stamped():
     home = _home_with_jump(os.getcwd())
-    rc, out, jump = _run(home)
+    rc, out, jump = _run(home, env_extra={"NZ_JUMP_FROM": "old"})
     assert rc == 0 and out is not None
     ctx = out["hookSpecificOutput"]["additionalContext"]
     assert "SALTO DI FINESTRA" in ctx and "MANDATO IN CATENA" in ctx  # jump-file mandate wins
@@ -61,7 +64,7 @@ def test_fresh_unclaimed_jump_is_injected_and_stamped():
 
 def test_missing_handoff_still_injects_a_recovery_context():
     home = _home_with_jump(os.getcwd(), handoff=False)
-    rc, out, jump = _run(home)
+    rc, out, jump = _run(home, env_extra={"NZ_JUMP_FROM": "old"})
     assert rc == 0 and "handoff non leggibile" in out["hookSpecificOutput"]["additionalContext"]
     assert jump["to_session"] == "new"
 
@@ -69,44 +72,55 @@ def test_missing_handoff_still_injects_a_recovery_context():
 # ---------------- innocence ----------------
 def test_already_claimed_jump_is_mute():
     home = _home_with_jump(os.getcwd(), to_session="someone-else")
-    rc, out, jump = _run(home)
+    rc, out, jump = _run(home, env_extra={"NZ_JUMP_FROM": "old"})
     assert rc == 0 and out is None and jump["to_session"] == "someone-else"
 
 
 def test_stale_jump_is_mute():
     home = _home_with_jump(os.getcwd(), age_s=20 * 60)
+    rc, out, jump = _run(home, env_extra={"NZ_JUMP_FROM": "old"})
+    assert rc == 0 and out is None and jump["to_session"] is None
+
+
+def test_hand_opened_window_never_claims_a_jump():
+    # Zero opens a plain `claude` in ~/nuzantara two minutes after a guard trip:
+    # a fresh, unclaimed jump from THIS cwd is sitting there. No NZ_JUMP_FROM
+    # -> the window is the owner's, not a continuation: mute, nothing stamped.
+    home = _home_with_jump(os.getcwd())
     rc, out, jump = _run(home)
     assert rc == 0 and out is None and jump["to_session"] is None
 
 
-def test_foreign_cwd_is_mute():
+def test_explicit_from_session_is_honoured_whatever_the_cwd():
+    # the launcher already cd'd into the jump's cwd; the id is the evidence
     home = _home_with_jump("/somewhere/else")
-    rc, out, jump = _run(home)
-    assert rc == 0 and out is None and jump["to_session"] is None
+    rc, out, jump = _run(home, env_extra={"NZ_JUMP_FROM": "old"})
+    assert rc == 0 and out is not None and jump["to_session"] == "new"
 
 
 def test_originating_session_never_claims_its_own_jump():
     home = _home_with_jump(os.getcwd())
-    rc, out, jump = _run(home, session_id="old")
+    rc, out, jump = _run(home, session_id="old", env_extra={"NZ_JUMP_FROM": "old"})
     assert rc == 0 and out is None and jump["to_session"] is None
 
 
 def test_kill_switch_is_mute():
     home = _home_with_jump(os.getcwd())
-    rc, out, jump = _run(home, env_extra={"CONTEXT_JUMP_OFF": "1"})
+    rc, out, jump = _run(home, env_extra={"CONTEXT_JUMP_OFF": "1", "NZ_JUMP_FROM": "old"})
     assert rc == 0 and out is None and jump["to_session"] is None
 
 
-def test_freshest_unclaimed_jump_wins_and_only_it_is_stamped():
+def test_two_fresh_jumps_and_no_launcher_id_stamp_nothing():
+    # the 2026-09-09 fallback picked the freshest; now neither is touched
     home = _home_with_jump(os.getcwd(), age_s=120)
     d = home / ".organism" / "context-guard"
     (d / "pending-jump-newer.json").write_text(json.dumps({
         "from_session": "newer", "to_session": None, "cwd": os.getcwd(), "hops": 1,
         "ts": time.time(), "mandate": "NEWER"}))
     rc, out, old = _run(home)
-    assert "NEWER" in out["hookSpecificOutput"]["additionalContext"]
+    assert rc == 0 and out is None
     assert old["to_session"] is None
-    assert json.loads((d / "pending-jump-newer.json").read_text())["to_session"] == "new"
+    assert json.loads((d / "pending-jump-newer.json").read_text())["to_session"] is None
 
 
 def test_no_jump_file_is_mute():


### PR DESCRIPTION
## Summary

Zero, Pro 2026-09-09 23:50 WITA: *"quando apro comincia a fare quello che vuole e non aspetta il mio prompt"* — and, in the same breath, *"il context jump è un'altra cosa, non intaccare il salto legittimo"*.

`context_jump_resume.py` runs at the start of **every** session (SessionStart, `startup`). Without `NZ_JUMP_FROM` in the env it fell back to *"the freshest unclaimed pending-jump from this cwd"*. So for `MAX_AGE_S` (15 min) after each guard trip, any plain `claude` Zero opened in `~/nuzantara` was handed the stale mandate plus *"continua da lì, senza chiedere"*, stamped as that jump's `to_session`, and — on the owner's first keystroke — went off working the old session's mandate instead of answering. The cross-family review of 2026-09-09 (codex) had already named the fallback as the way a stranger session steals a jump meant for another window; the same evening it stole one from the owner.

**The launcher knows the id, so it says it.** `nz-jump.sh` exports `NZ_JUMP_FROM` (typed by `window_jump.sh` on either route, or by a human in manual recovery) and `claude-cascade.sh` sets it on the headless hop (`hop_env+=(NZ_JUMP_FROM=…)`, line 535). Nobody else is a continuation.

- `infra/claude-hooks/context_jump_resume.py` — `pick_jump()` returns `None` without `want`; the explicit path is byte-for-byte the same checks as before (unclaimed, fresh, not our own). `cwd` stays in the signature for the payload but is no longer a filter: the launcher has already `cd`'d into the jump's cwd, and a hand-opened window is refused whatever its cwd.
- `infra/claude-hooks/test_context_jump_resume.py` — the guilt tests now run on the explicit path; the innocence filters (claimed, stale, own session, kill switch) are asserted **on that path** so they cannot pass for the wrong reason. Two new innocence cases: a hand-opened window with a fresh same-cwd jump stays mute and stamps nothing; two fresh jumps and no launcher id touch neither. One new guilt case: the explicit id is honoured whatever the cwd.
- `.claude/skills/window-jump/SKILL.md` — step 6 states the rule.
- `evidence/2026-09/agent-nuzantara-infra-jump-resume-explicit-only-c963dd2c/brief.yml` — gear 1 via SIZE (`evidence_pack_lint.py --print-floor` on this diff = **1**).

The legitimate jump is not touched: `window_jump.sh`, `nz-jump.sh`, `context_window_guard.py` are unchanged.

| suite | result |
|---|---|
| `pytest infra/claude-hooks/test_context_jump_resume.py` | **12 passed** |
| `CONTEXT_JUMP_NO_SPAWN=1 pytest test_context_window_jump.py test_context_window_guard.py test_context_jump_resume.py` | **52 passed** |
| `pytest scripts/tests/test_claude_cascade_shell.py` (the headless hop that sets `NZ_JUMP_FROM`) | **83 passed** |
| `ruff check` on both files, `py_compile` | clean |

## Bites

**Bites:** the next plain `claude` the owner opens in `~/nuzantara` on Pro/M5/Mini inside the 15 minutes after a guard trip. Consumer: `~/.claude/hooks/context_jump_resume.py` on each seat, refreshed from `origin/main` after this merges (merged is not armed — cicatrix #1; `lint_home_fork` compares live against `origin/main`). Observation that proves it is in force, made on the **installed** file with `HOME` pointed at a temp dir holding a fresh unclaimed same-cwd jump: no `NZ_JUMP_FROM` → empty stdout, exit 0, `to_session` still `null`; `NZ_JUMP_FROM=<from>` → `SALTO DI FINESTRA` injected and `to_session` stamped. The jump that opened the session writing this PR (`97bbe4c7 → 923b2663`, `jump.log` 23:55:31 "new session … is up") went through `nz-jump`, i.e. the explicit path this change keeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
