### PR TITLE
feat(ci): Vercel production builds only when the diff against what is LIVE touches the bundle

### DIFF
--- a/apps/mouth/vercel.json
+++ b/apps/mouth/vercel.json
@@ -2,5 +2,6 @@
   "version": 2,
   "framework": "nextjs",
   "buildCommand": "npm run build",
-  "installCommand": "cd ../.. && npm ci --include=dev"
+  "installCommand": "cd ../.. && npm ci --include=dev",
+  "ignoreCommand": "S=\"$(git rev-parse --show-toplevel)/scripts/ci/vercel_should_build.sh\"; [ -f \"$S\" ] || exit 1; bash \"$S\"; [ $? = 0 ] && exit 0 || exit 1"
 }

--- a/evidence/brief.yml
+++ b/evidence/brief.yml
@@ -1,61 +1,108 @@
-task_id: oracle-decisiveness-spec
+task_id: vercel-prod-live-diff
 gear: 2
 l_level: L2
 gate_class: opus
 # Floor computed for this diff: `python3 scripts/evidence_pack_lint.py --print-floor
-# --changed-files-file ... --numstat-file ...` returns 2 via the SIZE term alone —
-# one research document of ~930 lines (research/visa/2026-09-06-visa-oracle-
-# decisiveness-investigation.md) plus this brief. Zero code, zero workflow, zero
-# hot-zone path. Gear 2 declared to match the floor exactly; no pack is required
-# below Gear 3.
+# --changed-files-file ... --numstat-file ...` returns 2 via the SIZE term alone — 4
+# changed files (apps/mouth/vercel.json, scripts/ci/vercel_ignore_build_step.sh,
+# scripts/ci/vercel_should_build.sh, scripts/tests/test_vercel_should_build.sh),
+# +322/-98 (net 224 lines). No hot-zone path (`--print-floor` without --numstat-file
+# returns 1). Gear 2 declared to match the floor exactly; no pack is required below
+# Gear 3.
 objective: >-
-  Land the Visa Oracle decisiveness investigation as ONE intervention spec
-  (research/visa/2026-09-06-visa-oracle-decisiveness-investigation.md): the
-  measured root causes of the "This needs a human" dead-end on the public
-  funnel (blanket ACTIVITY_BOUNDARY flag, NEEDS_INPUT chains for never-asked
-  facts, evaluator gate-unknown blocking ahead of purpose feasibility, pack
-  caps at the initial grant, E33G review rule duplicate, eight unaskable
-  ITAS-sponsor gates), the 43-walk census (36 dead-end / 7 supported / 0
-  no-path today), the five-PR wave in fixed order (PR-0 census gate, PR-1
-  seq-20 fold, PR-2 evaluator reorder, PR-3 interview, PR-4 flag narrowing),
-  the six owner rulings recorded on 2026-09-06, and the refuted proposals
-  that must not be re-investigated.
+  Change the Vercel Ignored Build Step for the `mouth` project so a PRODUCTION
+  deployment skips when `git diff <live> HEAD` touches no bundle path (apps/mouth/**,
+  packages/**, root package.json/package-lock.json, vercel.json), where `live` is the
+  commit production is actually serving right now, read from
+  https://kita.balizero.com/api/health's `.commit` field — the same probe the Frontend
+  Live Sentinel and mini.vercel_autopromote already trust. Preview deployments keep the
+  existing merge-base rule untouched. The Ignored Build Step pointer moves out of the
+  Vercel dashboard field and into apps/mouth/vercel.json as `ignoreCommand`, with the
+  dashboard field kept only as a fallback. Measured on main: 301 commits in the last 7
+  days, 79 of which touch a bundle path — so production builds are expected to drop
+  from roughly 35/day to roughly 11/day, ~1,000 build-minutes/week, ~$60/month at
+  $0.014/build-minute.
 constraints:
   - >-
-    Documentation only. This PR changes no engine code, no interview code,
-    no signed pack and no workflow; every change it describes ships in its
-    own PR of the wave, each with its own tests and its own gate.
+    Fail OPEN everywhere a signal is missing or ambiguous: probe unreachable, no
+    `.commit` field in the health response, live sha unknown or not fetchable, or
+    live == HEAD all resolve to BUILD. The only unacceptable failure mode is a SKIP
+    when a BUILD was actually needed — a false BUILD only costs build-minutes, a
+    false SKIP ships nothing.
   - >-
-    The six rulings are recorded verbatim as the owner's decision
-    ("seguo le tue raccomandazioni, go", 2026-09-06) and are not to be
-    re-litigated in the wave PRs; a builder that disagrees writes the
-    disagreement into its PR body, not into the code.
+    The script exits only 0 (BUILD) or 1 (SKIP) — any other exit code is a Vercel
+    deployment ERROR, not a third outcome, and must not happen by construction.
   - >-
-    No client PII: every walk, persona and probe in the document is
-    synthetic; the three production probes carry no identifying fact.
+    Never log a fetch URL or raw git stderr — either may carry credentials (e.g. a
+    token embedded in a private remote URL) and Vercel build logs are not a secrets
+    boundary.
   - >-
-    The R1 adversarial review is by a non-Anthropic seat (Gemini 3.1 Pro via
-    `agy`), briefed to refute the diagnosis, the rulings, the wave order and
-    the measurements; its findings are recorded in the document's own
-    "Adversarial review" section together with the disposition of each.
+    No production environment variable is touched, no manual deploy, no
+    `vercel --prod` — this PR only changes the Ignored Build Step's own decision
+    script and its wiring in apps/mouth/vercel.json.
+  - >-
+    The comparison base is deliberately NOT `VERCEL_GIT_PREVIOUS_SHA` — that is the
+    previous DEPLOYMENT ATTEMPT, not the previous deployment that actually shipped,
+    and strands superseded frontend commits under a skipped-build streak (the
+    2026-08-15..18 freeze, #4309, was caused by exactly this). It is also
+    deliberately NOT `HEAD^` — the merge queue pushes batches of up to 4 squash
+    commits at once and Vercel deploys the tip, so `HEAD^..HEAD` can hide a
+    frontend-touching commit earlier in the same batch.
 acceptance:
   - text: >-
-      A1: WHEN the document is checked by scripts/check_adversarial_review.py
-      SHALL pass — frontmatter `adversarial_review:` names a known seat and
-      the body carries an "Adversarial review" section.
-    probe: scripts/check_adversarial_review.py --files research/visa/2026-09-06-visa-oracle-decisiveness-investigation.md
+      A1: WHEN scripts/tests/test_vercel_should_build.sh runs on macOS and on
+      ubuntu-24.04 SHALL pass 48/48.
+    probe: scripts/tests/test_vercel_should_build.sh
   - text: >-
-      A2: WHEN prettier checks the document SHALL report no violation (no
-      inline code span crosses a line break).
-    probe: npx --no-install prettier --check research/visa/2026-09-06-visa-oracle-decisiveness-investigation.md
+      A2: WHERE the corpus header's mutation-kill census is read SHALL show every
+      mutation killed — always-build (4), base=VERCEL_GIT_PREVIOUS_SHA (4),
+      base=HEAD^ (8), probe-failure-treated-as-SKIP (4), positional-grep-extraction
+      (1) — with none surviving.
+    probe: scripts/tests/test_vercel_should_build.sh
   - text: >-
-      A3: WHERE §4 names a PR of the wave, SHALL name its files, its exact
-      change, its guilt and innocence tests, its size bound and its
-      prove-live observation — the builder needs nothing outside the spec.
-    probe: grep -c "^### PR-" research/visa/2026-09-06-visa-oracle-decisiveness-investigation.md
+      A3: WHEN scripts/ci/vercel_should_build.sh dry-runs against the real probe on
+      origin/main SHALL emit SKIP for the 14 docs-only commits after live commit
+      882ac94, and SHALL emit BUILD when re-run from an older, bundle-touching
+      frontend commit.
+    probe: scripts/ci/vercel_should_build.sh
   - text: >-
-      A4: WHEN the deterministic floor is recomputed from this PR's changed
-      files SHALL be 2, and the declared gear SHALL equal it.
-    probe: python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file <changed> --numstat-file <numstat>
+      A4 Bites: WHEN this PR merges and the first docs-only commit lands on main
+      SHALL appear in `GET /v6/deployments?target=production` as CANCELED with
+      "should-build: production: comparing HEAD against live ... -> SKIP" in its
+      build log, WHILE kita.balizero.com/api/health keeps serving the newest
+      bundle-relevant commit AND the Frontend Live Sentinel stays green.
+    probe: >-
+      curl https://kita.balizero.com/api/health ; vercel deployments list --target
+      production
+assumptions:
+  - text: >-
+      kita.balizero.com/api/health exposes the live commit as a JSON `.commit`
+      field.
+    status: verified
+    probe: >-
+      curl -s https://kita.balizero.com/api/health -> verified 2026-09-10:
+      {"status":"ok","commit":"882ac94..."}
+  - text: >-
+      GitHub will serve any reachable commit sha to a shallow fetch, including one
+      not on the default branch tip.
+    status: verified
+    probe: git fetch --depth=1 origin <live-sha> against this repo, exit 0
+  - text: >-
+      mini.vercel_autopromote promotes a READY build to production within ~2
+      minutes of it finishing.
+    status: unverified
+    probe: >-
+      observe a production promotion timestamp minus its build-finished timestamp
+      over the next 5 promotions; a dead organ degrades to build-every-commit
+      (fail-open), never to a stale site, so this assumption bounds cost, not
+      correctness.
+  - text: >-
+      Adversarial review (Claude Sonnet, spalla-review) found no blocking issue;
+      three suggestions were applied — JSON-parser extraction of the live commit
+      (node/python3/grep fallback chain), a `timeout` wrapper on both production
+      fetches, and a corpus parity check between FRONTEND_RE, BUNDLE_PATHS and the
+      Frontend Live Sentinel's own paths.
+    status: verified
+    probe: scripts/tests/test_vercel_should_build.sh
 appetite:
-  wall_clock_hours: 1
+  wall_clock_hours: 2

--- a/scripts/ci/vercel_ignore_build_step.sh
+++ b/scripts/ci/vercel_ignore_build_step.sh
@@ -1,4 +1,7 @@
-# The exact string held in the Vercel project's `commandForIgnoringBuildStep`.
+# The exact string held in the Vercel project's `commandForIgnoringBuildStep` — and, since
+# 2026-09-10, in apps/mouth/vercel.json as `ignoreCommand`, which OVERRIDES the dashboard field
+# (the dashboard copy is the fallback if the key is ever dropped from the file). The corpus
+# asserts the two are byte-identical; change this line and the JSON together.
 #
 # It lives here for one reason: on 2026-07-29 that field held a bare invocation of
 # scripts/ci/vercel_should_build.sh, the script was not on main yet, bash exited 127, and

--- a/scripts/ci/vercel_should_build.sh
+++ b/scripts/ci/vercel_should_build.sh
@@ -119,6 +119,36 @@ verdict_from_changed() { # verdict_from_changed <changed-file-list>
   esac
 }
 
+# The TOP-LEVEL `commit` of the health body, validated as a 40-hex sha, or empty. A JSON parser
+# when one is at hand (node is always in Vercel's container: it is what builds the app), so a
+# body that ever grows a second commit-shaped field (`previousCommit`, a deployments array)
+# cannot be mis-read by a positional grep — the wrong sha picked is a false SKIP, the one
+# direction this script must never take (raised by the adversarial review of #6042). The
+# anchored grep is the fallback where no parser exists; empty on any doubt, and empty builds.
+live_commit_of() { # live_commit_of <health-body>
+  local raw=
+  if command -v node >/dev/null 2>&1; then
+    raw=$(printf '%s' "$1" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{const c=JSON.parse(d).commit;process.stdout.write(typeof c==="string"?c:"")}catch(e){}})' 2>/dev/null)
+  elif command -v python3 >/dev/null 2>&1; then
+    raw=$(printf '%s' "$1" | python3 -c 'import json,sys
+try:
+    c=json.load(sys.stdin).get("commit")
+    sys.stdout.write(c if isinstance(c,str) else "")
+except Exception:
+    pass' 2>/dev/null)
+  else
+    raw=$(printf '%s' "$1" | grep -oE '"commit"[[:space:]]*:[[:space:]]*"[0-9a-f]{40}"' | head -1 | grep -oE '[0-9a-f]{40}')
+  fi
+  printf '%s' "$raw" | grep -oE '^[0-9a-f]{40}$' | head -1
+}
+
+# A fetch that stalls past Vercel's own step budget kills the WRAPPER, and a killed wrapper is
+# a deployment ERROR, not a build — outside the `[ $? = 0 ] && exit 0 || exit 1` normaliser.
+# GNU `timeout` exists in Vercel's container and on CI; where it does not (a Mac), run bare.
+with_timeout() { # with_timeout <seconds> <command...>
+  if command -v timeout >/dev/null 2>&1; then timeout "$@"; else shift; "$@"; fi
+}
+
 # PRODUCTION. Compare HEAD against the commit production is serving, never against a previous
 # attempt (see the header). Every path that cannot establish the live commit builds.
 production_verdict() {
@@ -127,7 +157,7 @@ production_verdict() {
     log "production: live probe failed -> BUILD (fail-open)"
     exit 1
   fi
-  live=$(printf '%s' "$body" | grep -oE '"commit"[[:space:]]*:[[:space:]]*"[0-9a-f]{40}"' | head -1 | grep -oE '[0-9a-f]{40}')
+  live=$(live_commit_of "$body")
   if [ -z "$live" ]; then
     log "production: live probe exposes no 40-hex commit -> BUILD (fail-open)"
     exit 1
@@ -147,9 +177,9 @@ production_verdict() {
       log "production: live commit ${live:0:9} not in clone and no repo URL to fetch it -> BUILD (fail-open)"
       exit 1
     fi
-    git fetch --no-tags --depth=200 "$url" "$PROD_BRANCH" >/dev/null 2>&1 || true
+    with_timeout 90 git fetch --no-tags --depth=200 "$url" "$PROD_BRANCH" >/dev/null 2>&1 || true
     if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
-      git fetch --no-tags --depth=1 "$url" "$live" >/dev/null 2>&1 || true
+      with_timeout 90 git fetch --no-tags --depth=1 "$url" "$live" >/dev/null 2>&1 || true
     fi
     if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
       log "production: live commit ${live:0:9} not fetchable -> BUILD (fail-open)"

--- a/scripts/ci/vercel_should_build.sh
+++ b/scripts/ci/vercel_should_build.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Vercel "Ignored Build Step" — decides whether this commit can change what the browser
-# receives. Wired into the project's `commandForIgnoringBuildStep`, which is capped at 256
-# characters, so the field holds only a pointer to this file and the reasoning lives here.
+# receives. Wired in twice with the SAME line: apps/mouth/vercel.json `ignoreCommand` (wins,
+# versioned with the tree it judges) and the project's `commandForIgnoringBuildStep` (the
+# fallback if the file ever drops the key). Both are capped at 256 characters, so the field
+# holds only a pointer to this file and the reasoning lives here.
 #
 # CONTRACT — read this twice, it is not the usual shell convention:
 #   exit 0  -> SKIP the build
@@ -23,7 +25,7 @@
 # Two consequences, both load-bearing:
 #   1. Every path in this file exits 0 or 1 and nothing else. Pinned by a test that greps for
 #      any other literal exit code, because a `exit 2` added later would look harmless.
-#   2. The project setting must NORMALISE, never point here bare:
+#   2. The pointer must NORMALISE, never point here bare:
 #        S="$(git rev-parse --show-toplevel)/scripts/ci/vercel_should_build.sh"; [ -f "$S" ] || exit 1; bash "$S"; [ $? = 0 ] && exit 0 || exit 1
 #      so a missing file, a syntax error, or a signal all become BUILD instead of ERROR. And it
 #      is armed only AFTER this file is on main — the ordering that was skipped.
@@ -49,10 +51,26 @@
 # to compare against: the merge-base with the production branch, which is exactly "what this
 # branch changes". Anything that cannot be established still builds.
 #
-# WHAT IS DELIBERATELY NOT OPTIMISED: the production branch never skips on a missing previous
-# SHA. Comparing main against main yields an empty diff, i.e. "skip", and that single line
-# would be a machine for freezing production — the failure this repo spent 2026-07-27 and
-# 2026-07-28 recovering from. It is guarded explicitly and tested.
+# PRODUCTION (rewritten 2026-09-10; the 2026-08-18 version built EVERY production commit).
+# The base for a production deployment is neither `VERCEL_GIT_PREVIOUS_SHA` nor `HEAD^`:
+#   * VERCEL_GIT_PREVIOUS_SHA names the previous ATTEMPT — skips and cancellations included —
+#     so it advances past a frontend commit whose own build never shipped, and no later diff
+#     spans that commit again. That stranded balizero.com on a 2026-08-15 build for three
+#     days (#4309), and is why the interim rule was "production never skips".
+#   * HEAD^ is the previous commit, not the previous PUSH. The merge queue lands batches of up
+#     to four squash commits in one push and Vercel deploys the tip, so HEAD^..HEAD sees only
+#     the last PR of the batch; a frontend PR earlier in the same batch is invisible to it.
+# The only base that answers the real question — "does this commit change what is LIVE?" — is
+# the commit production is serving, and production says so itself: kita.balizero.com/api/health
+# returns `{"commit": "<sha>"}` (the probe the Frontend Live Sentinel and the mini.vercel_autopromote
+# organ already trust). Diff that against HEAD; no frontend path -> SKIP. Any doubt -> BUILD:
+# probe down, field missing, sha unknown and unfetchable, live == HEAD. A dead autopromote organ
+# degrades to today's behaviour (every commit builds), never to a stale site, because the live
+# sha then stops moving and every later diff keeps spanning the unshipped change.
+# Measured before arming: 301 commits on main in 7 days, 79 of which change the bundle — this
+# rule builds 79, the interim rule built ~245 (one per push). Tests pin the batch shape, the
+# stranded shape and every fail-open path. SHOULD_BUILD_LIVE_PROBE_URL overrides the probe
+# (test seam and emergency lever; a `file://` URL works).
 #
 # Tests: scripts/tests/test_vercel_should_build.sh (guilt + innocence, run in a real git repo).
 
@@ -65,59 +83,97 @@ set -u
 # a real build log, not from the setting: the build ran `next build --webpack` (the apps/mouth
 # value), never the root file's `npm run build -w apps/mouth`. It is still matched here on
 # purpose — if a root `vercel.json` ever comes back, rebuilding on it is the fail-open answer.
+# Keep in step with BUNDLE_PATHS in scripts/vercel_prod_deploy.py and the `paths:` of
+# .github/workflows/frontend-live-sentinel.yml: a commit they call bundle-relevant must BUILD
+# here, or the sentinel goes red for a build this script declined to make.
 FRONTEND_RE='^(apps/mouth/|packages/|package\.json|package-lock\.json|vercel\.json|apps/mouth/vercel\.json)'
 
 PROD_BRANCH="${VERCEL_GIT_PROD_BRANCH:-main}"
 REF="${VERCEL_GIT_COMMIT_REF:-}"
 BASE="${VERCEL_GIT_PREVIOUS_SHA:-}"
+LIVE_PROBE_URL="${SHOULD_BUILD_LIVE_PROBE_URL:-https://kita.balizero.com/api/health}"
 
 log() { printf 'should-build: %s\n' "$1" >&2; }
 
-# Production never skips. Not on a missing previous SHA, and not on a present one.
-#
-# The guard used to live inside the `[ -z "$BASE" ]` block below, on the reasoning that the danger
-# was comparing main against main and reading the empty diff as "nothing to build". That named the
-# right danger and only half the doors. On main `VERCEL_GIT_PREVIOUS_SHA` is normally SET, so the
-# block was skipped whole and the guard inside it never ran.
-#
-# WHAT VERCEL_GIT_PREVIOUS_SHA ACTUALLY CONTAINED, measured rather than read off the docs. Vercel
-# documents it as the last SUCCESSFUL deployment for the project and branch. On 2026-08-18 that
-# was demonstrably not what arrived. The production build of 98ab65ab logged:
-#
-#     should-build: no frontend path in 18 changed file(s) -> SKIP
-#
-# Eighteen. Walking main's first-parent history and diffing each candidate against 98ab65ab, the
-# only commits that produce exactly 18 changed files are 5deddb30e / 41cd6b786 / e61c9e076 /
-# b6cb85034 — all landed the SAME DAY. The last successful production deployment, f6dfda99 from
-# 2026-08-15, sits 272 files back with 30 frontend paths among them, and would have produced
-# BUILD. #4178 sits 39 files back, also with frontend paths. So the base was neither: it had
-# already advanced past both, onto commits that never shipped anything.
-#
-# The exact SHA cannot be pinned from the log (four candidates give 18, the log does not print
-# the base). What IS established is the direction, and it is the whole point: the base advances
-# past commits whose builds never shipped, so a frontend commit that is superseded once is never
-# seen by any later diff again. It is stranded for good.
-#
-# The visible cost: balizero.com served the 2026-08-15 build for three days while main ran 75
-# commits ahead, and kept publishing `Avg reply: 2 min` — measured false against 189 message
-# pairs, average ~9h — for three days after #4178 removed it. Every check was green throughout.
-#
+# The repository URL Vercel itself advertises in the build env (VERCEL_GIT_REPO_OWNER/SLUG; the
+# repo is public, an anonymous fetch suffices). SHOULD_BUILD_FETCH_URL overrides it — test seam
+# and emergency lever. Empty when nothing can be constructed. The value may carry credentials
+# or another sensitive locator and must never be copied into Vercel logs.
+repo_fetch_url() {
+  if [ -n "${SHOULD_BUILD_FETCH_URL:-}" ]; then
+    printf '%s' "$SHOULD_BUILD_FETCH_URL"
+  elif [ -n "${VERCEL_GIT_REPO_OWNER:-}" ] && [ -n "${VERCEL_GIT_REPO_SLUG:-}" ]; then
+    printf 'https://github.com/%s/%s.git' "$VERCEL_GIT_REPO_OWNER" "$VERCEL_GIT_REPO_SLUG"
+  fi
+}
+
+# Verdict from a list of changed files. Judge grep by its exit code explicitly: 0 = matched,
+# 1 = no match, >=2 = grep itself failed. Collapsing that into `&& exit 1 || exit 0` would turn a
+# grep error into a SKIP — the one outcome this script must never produce by accident.
+verdict_from_changed() { # verdict_from_changed <changed-file-list>
+  printf '%s\n' "$1" | grep -qE "$FRONTEND_RE"
+  case $? in
+    0) log "frontend paths changed -> BUILD"; exit 1 ;;
+    1) log "no frontend path in $(printf '%s\n' "$1" | grep -c .) changed file(s) -> SKIP"; exit 0 ;;
+    *) log "grep failed -> BUILD (fail-open)"; exit 1 ;;
+  esac
+}
+
+# PRODUCTION. Compare HEAD against the commit production is serving, never against a previous
+# attempt (see the header). Every path that cannot establish the live commit builds.
+production_verdict() {
+  local body live head_sha url changed
+  if ! body=$(curl -fsS --max-time 20 "$LIVE_PROBE_URL" 2>/dev/null); then
+    log "production: live probe failed -> BUILD (fail-open)"
+    exit 1
+  fi
+  live=$(printf '%s' "$body" | grep -oE '"commit"[[:space:]]*:[[:space:]]*"[0-9a-f]{40}"' | head -1 | grep -oE '[0-9a-f]{40}')
+  if [ -z "$live" ]; then
+    log "production: live probe exposes no 40-hex commit -> BUILD (fail-open)"
+    exit 1
+  fi
+  head_sha=$(git rev-parse HEAD 2>/dev/null) || { log "cannot resolve HEAD -> BUILD"; exit 1; }
+  if [ "$live" = "$head_sha" ]; then
+    log "production: live commit equals HEAD (a redeploy) -> BUILD"
+    exit 1
+  fi
+  if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
+    # The container's clone is shallow and may not hold the live commit. Cheapest first: the
+    # production branch's recent history (the live commit is normally a few days back), then
+    # the exact sha (GitHub serves any reachable sha to a shallow fetch). The URL, never a
+    # named remote: measured 2026-08-10, the container has no usable `origin`.
+    url=$(repo_fetch_url)
+    if [ -z "$url" ]; then
+      log "production: live commit ${live:0:9} not in clone and no repo URL to fetch it -> BUILD (fail-open)"
+      exit 1
+    fi
+    git fetch --no-tags --depth=200 "$url" "$PROD_BRANCH" >/dev/null 2>&1 || true
+    if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
+      git fetch --no-tags --depth=1 "$url" "$live" >/dev/null 2>&1 || true
+    fi
+    if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
+      log "production: live commit ${live:0:9} not fetchable -> BUILD (fail-open)"
+      exit 1
+    fi
+    log "production: fetched live commit ${live:0:9}"
+  fi
+  if ! changed=$(git diff --name-only "$live" HEAD 2>/dev/null); then
+    log "production: git diff failed against live ${live:0:9} -> BUILD (fail-open)"
+    exit 1
+  fi
+  log "production: comparing HEAD against live ${live:0:9}"
+  verdict_from_changed "$changed"
+}
+
 # WHY THE TEST IS `VERCEL_ENV` FIRST. The branch comparison alone is not the deployment
 # environment: `vercel --prod` can promote a non-production branch, and that deployment is
 # production no matter what its ref says. `VERCEL_ENV` is the documented system variable for
 # exactly this question, so it leads; the branch test stays as the second arm because
 # `VERCEL_GIT_PROD_BRANCH` may be absent (the `:-main` fallback is correct for this repo) and
 # because the corpus runs the script outside Vercel entirely, where only the ref exists.
-#
-# Direction of failure is settled by the asymmetry at the top of this file: an unnecessary
-# production build costs ~6 minutes, a wrongly skipped one serves stale code across the whole
-# public surface until a human happens to notice. NOT claimed: that this is free. The 2026-07-29
-# measurement (83% of build minutes in PR previews) says where the historical minutes went, and
-# cannot price builds that were skipped and so never appear in it. The marginal cost of building
-# every production commit is unmeasured here; it is accepted, not shown to be zero.
 if [ "${VERCEL_ENV:-}" = "production" ] || { [ -n "$REF" ] && [ "$REF" = "$PROD_BRANCH" ]; }; then
-  log "production deployment (env='${VERCEL_ENV:-unset}' ref='${REF:-unset}') -> BUILD (a previous SHA names an earlier ATTEMPT, not what is live)"
-  exit 1
+  log "production deployment (env='${VERCEL_ENV:-unset}' ref='${REF:-unset}') -> judged against what is live, never a previous attempt"
+  production_verdict
 fi
 
 if [ -z "$BASE" ]; then
@@ -135,11 +191,6 @@ if [ -z "$BASE" ]; then
   # "cannot fetch" and nothing else. A fail-open branch that does not say WHICH stage opened
   # cannot be repaired from its own evidence. So: cheapest-first resolution, each stage
   # announcing itself without replaying Git stderr, which may contain an authenticated URL.
-  # (The production check that used to sit here has moved above this block, where it also sees the
-  # deployments that DO carry a previous SHA — the case this block never reaches, and the one that
-  # froze production. A first deployment with no previous SHA still exists and is still covered,
-  # now by the same check one level up. Leaving a copy here would be unreachable code that reads
-  # like a second line of defence.)
 
   # (1) The merge queue puts the BASE COMMIT in the ref name:
   #     gh-readonly-queue/<base-branch>/pr-<n>-<base-sha>
@@ -173,27 +224,20 @@ if [ -z "$BASE" ]; then
   # — so every first deployment fell through to fail-open and bought a full 1,755-page build:
   # the exact 89%-of-waste case this block exists to close, inert for a second reason after
   # the 2026-07-30 rework fixed the first. The cure is to fetch the production branch straight
-  # from the repository URL that Vercel itself advertises in the build env
-  # (VERCEL_GIT_REPO_OWNER/SLUG; the repo is public, an anonymous fetch suffices).
-  # SHOULD_BUILD_FETCH_URL overrides the constructed URL — test seam and emergency lever.
-  # Every failure still exits 1 (BUILD), with each failed transport named. Git stderr is never
-  # logged because it can normalize and repeat credentials or query tokens from the fetch URL.
+  # from the repository URL (repo_fetch_url above). Every failure still exits 1 (BUILD), with
+  # each failed transport named. Git stderr is never logged because it can normalize and repeat
+  # credentials or query tokens from the fetch URL.
   if [ -z "$BASE" ]; then
     fetched=
     if git fetch --no-tags --depth=200 origin "$PROD_BRANCH" >/dev/null 2>&1; then
       fetched=origin
     else
-      FETCH_URL="${SHOULD_BUILD_FETCH_URL:-}"
-      if [ -z "$FETCH_URL" ] && [ -n "${VERCEL_GIT_REPO_OWNER:-}" ] && [ -n "${VERCEL_GIT_REPO_SLUG:-}" ]; then
-        FETCH_URL="https://github.com/${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}.git"
-      fi
+      FETCH_URL=$(repo_fetch_url)
       if [ -z "$FETCH_URL" ]; then
         log "cannot fetch $PROD_BRANCH (no origin, no repo env to build a URL) -> BUILD (fail-open). origin fetch failed"
         exit 1
       fi
       if git fetch --no-tags --depth=200 "$FETCH_URL" "$PROD_BRANCH" >/dev/null 2>&1; then
-        # The override is an operational seam and may contain credentials or another
-        # sensitive locator. The fetch target must never be copied into Vercel logs.
         fetched=url
       else
         log "cannot fetch $PROD_BRANCH from origin or URL -> BUILD (fail-open). origin fetch failed | URL fetch failed"
@@ -224,12 +268,4 @@ if ! CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null); then
   exit 1
 fi
 
-# Judge grep by its exit code explicitly: 0 = matched, 1 = no match, >=2 = grep itself failed.
-# Collapsing that into `&& exit 1 || exit 0` would turn a grep error into a SKIP — the one
-# outcome this script must never produce by accident.
-printf '%s\n' "$CHANGED" | grep -qE "$FRONTEND_RE"
-case $? in
-  0) log "frontend paths changed -> BUILD"; exit 1 ;;
-  1) log "no frontend path in $(printf '%s\n' "$CHANGED" | grep -c .) changed file(s) -> SKIP"; exit 0 ;;
-  *) log "grep failed -> BUILD (fail-open)"; exit 1 ;;
-esac
+verdict_from_changed "$CHANGED"

--- a/scripts/tests/test_vercel_should_build.sh
+++ b/scripts/tests/test_vercel_should_build.sh
@@ -195,6 +195,12 @@ VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$MAIN_TIP" \
   run SKIP "main, docs-only delta vs what is LIVE -> skips"
 VERCEL_ENV=production VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= \
   run SKIP "same, VERCEL_ENV=production and no previous SHA -> still skips (the SHA is not consulted)"
+# A body that carries a second commit-shaped field must not be mis-read: the TOP-LEVEL `commit`
+# is the live one. The decoy comes first and names HEAD itself, so picking it reads "redeploy ->
+# BUILD" where the real live commit reads "docs-only -> SKIP" — a wrong pick is visible.
+probe_says "{\"deployments\":[{\"commit\":\"$DOCS_ON_MAIN\"}],\"commit\":\"$MAIN_TIP\"}"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= \
+  run SKIP "probe with a decoy commit field before the real one -> the top-level key is read"
 
 # GUILT, the stranded shape (balizero.com frozen 2026-08-15..18): a frontend commit whose own
 # build never shipped, then a docs commit. VERCEL_GIT_PREVIOUS_SHA points at the frontend
@@ -461,6 +467,45 @@ if [ "$IGNORE_CMD" = "$POINTER" ]; then
   PASS=$((PASS+1)); printf '  ok    %-58s %s\n' "apps/mouth/vercel.json ignoreCommand == pointer" "identical"
 else
   FAIL=$((FAIL+1)); printf '  FAIL  %-58s\n        vercel.json: %s\n        pointer:     %s\n' "apps/mouth/vercel.json ignoreCommand == pointer" "$IGNORE_CMD" "$POINTER"
+fi
+
+# Three lists say what "bundle-relevant" means — FRONTEND_RE here, BUNDLE_PATHS in
+# scripts/vercel_prod_deploy.py (what the autopromote organ promotes) and the `paths:` of
+# .github/workflows/frontend-live-sentinel.yml (what the sentinel demands be live). A commit the
+# other two call relevant that this script declines to BUILD is a red sentinel for a build that
+# was never made. GUILT direction only: every path they name must match FRONTEND_RE. Skipped,
+# loudly, where the two files are not present (a copy of these four files outside the repo).
+REPO_TOP="$(cd "$(dirname "$SCRIPT")/../.." && pwd)"
+ORGAN="$REPO_TOP/scripts/vercel_prod_deploy.py"
+SENTINEL="$REPO_TOP/.github/workflows/frontend-live-sentinel.yml"
+FRONTEND_RE_LIVE=$(sed -n "s/^FRONTEND_RE='\(.*\)'$/\1/p" "$SCRIPT" | head -1)
+if [ -f "$ORGAN" ] && [ -f "$SENTINEL" ] && [ -n "$FRONTEND_RE_LIVE" ]; then
+  ORGAN_PATHS=$(python3 - "$ORGAN" <<'PY'
+import ast,sys
+src=open(sys.argv[1]).read()
+for node in ast.walk(ast.parse(src)):
+    if isinstance(node,ast.Assign) and any(getattr(t,"id","")=="BUNDLE_PATHS" for t in node.targets):
+        print("\n".join(ast.literal_eval(node.value)))
+PY
+)
+  SENTINEL_PATHS=$(awk '/^on:/{on=1} on&&/^  push:/{p=1} p&&/^    paths:/{q=1;next} q&&/^      - /{gsub(/^      - "?|"?$/,"");print;next} q&&!/^      - /{exit}' "$SENTINEL" | grep -v 'frontend-live-sentinel.yml')
+  MISMATCH=
+  while IFS= read -r pat; do
+    [ -n "$pat" ] || continue
+    # A directory (no extension, or a `/**` glob) is exercised by a file inside it.
+    sample=${pat%/\*\*}; sample=${sample%/}; case "$sample" in *.*) ;; *) sample="$sample/x" ;; esac
+    printf '%s\n' "$sample" | grep -qE "$FRONTEND_RE_LIVE" || MISMATCH="$MISMATCH $pat"
+  done <<EOF_PATHS
+$ORGAN_PATHS
+$SENTINEL_PATHS
+EOF_PATHS
+  if [ -z "$MISMATCH" ]; then
+    PASS=$((PASS+1)); printf '  ok    %-58s %s\n' "FRONTEND_RE covers BUNDLE_PATHS + sentinel paths" "$(printf '%s\n' "$ORGAN_PATHS" "$SENTINEL_PATHS" | grep -c .) paths"
+  else
+    FAIL=$((FAIL+1)); printf '  FAIL  %-58s not matched:%s\n' "FRONTEND_RE covers BUNDLE_PATHS + sentinel paths" "$MISMATCH"
+  fi
+else
+  printf '  skip  %-58s %s\n' "FRONTEND_RE covers BUNDLE_PATHS + sentinel paths" "organ/sentinel not present beside this copy"
 fi
 
 run_pointer() { # run_pointer <expected: BUILD|SKIP> <label> <script-body|MISSING>

--- a/scripts/tests/test_vercel_should_build.sh
+++ b/scripts/tests/test_vercel_should_build.sh
@@ -234,8 +234,14 @@ git -C "$WORK" reset -q --hard "$MAIN_TIP"
 
 # The live sha is not in the clone (Vercel's clone is shallow). It is fetched by sha from the
 # repository URL — the object lives in upstream on a branch this clone never fetched.
+# `-b main` is load-bearing: the bare upstream was `git init`ed with the host's default branch
+# name as HEAD, which is `master` on a stock CI runner, so an unqualified clone checks out an
+# unborn branch, the "live" commit is born without the frontend base file, and the diff against
+# it reads a frontend DELETION -> BUILD. Measured 2026-09-10: green on a Mac with
+# init.defaultBranch=main, red on ubuntu-latest, for exactly that reason.
 SIDE="$ROOT/side"
-git clone -q "$UPSTREAM" "$SIDE"
+git clone -q -b main "$UPSTREAM" "$SIDE"
+[ -f "$SIDE/apps/mouth/app/page.tsx" ] || { FAIL=$((FAIL+1)); printf '  FAIL  %-58s\n' "fixture: side clone must carry the frontend base"; }
 git -C "$SIDE" config user.email t@example.com
 git -C "$SIDE" config user.name t
 git -C "$SIDE" checkout -q -b live-only

--- a/scripts/tests/test_vercel_should_build.sh
+++ b/scripts/tests/test_vercel_should_build.sh
@@ -16,6 +16,12 @@
 #   * dropping vercel.json from the paths    -> 1 fails
 #   * fetch failure treated as SKIP          -> 1 fails
 #   * removing the production guard entirely -> 4 fail  (measured 2026-08-18)
+#   * production arm rewritten 2026-09-10 to diff against what is LIVE. Measured on the
+#     46-case corpus of that day:
+#       - production always builds (the 2026-08-18 interim rule)      -> 4 fail
+#       - production judged against VERCEL_GIT_PREVIOUS_SHA            -> 4 fail (the freeze case among them)
+#       - production judged against HEAD^ (Vercel's documented example) -> 8 fail (batch, freeze, rollback)
+#       - live-probe failure read as SKIP                              -> 4 fail
 #   * keying it on the literal "main" instead of $PROD_BRANCH -> 2 fail, one in each direction
 #   * dropping the VERCEL_ENV arm, leaving the branch test alone -> 1 fail
 #   * making the guard unconditional (`if true`) -> 11 fail. Recorded because it is the shape a
@@ -59,9 +65,24 @@ SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../ci" && pwd)/vercel_should_build.
 # per-case assignments below still win, because the caller's environment beats this default.
 export VERCEL_ENV=
 
+# The production arm asks what is LIVE through a probe URL. The corpus never touches the real
+# endpoint: by default it points at a file that does not exist, so every production case that
+# does not stage its own probe exercises the fail-open path (BUILD). Cases that want a verdict
+# write a health body and point the probe at it — curl reads `file://` URLs like any other.
+PROBE_DIR=$(mktemp -d)
+export SHOULD_BUILD_LIVE_PROBE_URL="file://$PROBE_DIR/does-not-exist.json"
+probe_says() { # probe_says <sha|raw-json> ; sets the probe to a body carrying that commit
+  case "$1" in
+    *"{"*) printf '%s' "$1" > "$PROBE_DIR/health.json" ;;
+    *) printf '{"status":"ok","commit":"%s"}' "$1" > "$PROBE_DIR/health.json" ;;
+  esac
+  export SHOULD_BUILD_LIVE_PROBE_URL="file://$PROBE_DIR/health.json"
+}
+probe_dead() { export SHOULD_BUILD_LIVE_PROBE_URL="file://$PROBE_DIR/does-not-exist.json"; }
+
 PASS=0; FAIL=0
 ROOT=$(mktemp -d)
-trap 'rm -rf "$ROOT"' EXIT
+trap 'rm -rf "$ROOT" "$PROBE_DIR"' EXIT
 
 # --- a repo with a real remote, so `git fetch origin main` works like it does on Vercel ------
 UPSTREAM="$ROOT/upstream.git"
@@ -144,48 +165,119 @@ VERCEL_GIT_COMMIT_REF=ops/cron VERCEL_GIT_PREVIOUS_SHA= \
   run SKIP "first deploy of a multi-commit backend/ops branch"
 
 echo
-echo "=== THE PRODUCTION GUARD: main must never skip, with or without a previous SHA"
-# Comparing main against main gives an empty diff. Without the guard this single case would
-# freeze balizero.com and every subdomain — the 2026-07-27 outage, re-created by an optimisation.
+echo "=== PRODUCTION: judged against what is LIVE, never against a previous attempt"
+# The probe is the only base production trusts. Without it (dead URL, no field, unknown sha)
+# every shape below builds — the 2026-07-27 outage re-created by an optimisation is the one
+# outcome this arm may never produce, so the fail-open cases come first.
 git -C "$WORK" checkout -q main
+probe_dead
 VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= \
-  run BUILD "main with no previous deployment"
+  run BUILD "main, probe unreachable, no previous SHA -> builds"
 VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$MAIN_TIP" \
-  run BUILD "main against its own tip (base == HEAD)"
+  run BUILD "main, probe unreachable, previous SHA == HEAD -> builds"
+probe_says '{"status":"ok"}'
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= \
+  run BUILD "main, probe answers without a .commit field -> builds"
+probe_says '{"status":"ok","commit":"abc123"}'
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= \
+  run BUILD "main, probe .commit is not a 40-hex sha -> builds"
+probe_says "$MAIN_TIP"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= \
+  run BUILD "main, live == HEAD (a redeploy of the served commit) -> builds"
 
-# The shape that actually froze production on 2026-08-18, and that neither line above can reach.
-# On main `VERCEL_GIT_PREVIOUS_SHA` is normally SET and names an EARLIER commit, so the empty-BASE
-# guard never runs and the base==HEAD guard never fires: the diff decides. The diff is honest and
-# the verdict is still wrong, because that variable holds the last ATTEMPTED deployment — skips
-# and cancellations included — not what is live. A frontend commit whose own build was superseded
-# falls behind the base and no later diff ever spans it again.
-#
-# Both of these were SKIP before the guard moved out of the empty-BASE block. Live consequence:
-# balizero.com served a 2026-08-15 build for three days while main ran 75 commits ahead with 30
-# frontend files among them, and kept publishing `Avg reply: 2 min` after we had measured it false.
-PROD_PREV=$MAIN_TIP
+# The saving: a docs-only commit on top of what is live skips. This is the ~220-builds-a-week
+# case measured 2026-09-09 (301 main commits in 7 days, 79 touching the bundle), and the shape
+# the 2026-08-18 interim rule paid for in full by building every one of them.
 commit "docs/prod-note.md" "a docs-only commit landing on main"
-VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
-  run BUILD "main, docs-only delta vs an EARLIER main commit (the 2026-08-18 freeze)"
+DOCS_ON_MAIN=$(git -C "$WORK" rev-parse HEAD)
+probe_says "$MAIN_TIP"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$MAIN_TIP" \
+  run SKIP "main, docs-only delta vs what is LIVE -> skips"
+VERCEL_ENV=production VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= \
+  run SKIP "same, VERCEL_ENV=production and no previous SHA -> still skips (the SHA is not consulted)"
 
-PROD_PREV=$(git -C "$WORK" rev-parse HEAD)
+# GUILT, the stranded shape (balizero.com frozen 2026-08-15..18): a frontend commit whose own
+# build never shipped, then a docs commit. VERCEL_GIT_PREVIOUS_SHA points at the frontend
+# ATTEMPT, so a diff against it is docs-only; the diff against what is LIVE is not.
+commit "apps/mouth/app/stranded.tsx" "a frontend commit whose build was superseded"
+STRANDED=$(git -C "$WORK" rev-parse HEAD)
 commit ".claude/skills/modus/PENDING-ARMS.md" "a ledger line, also on main"
-VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
-  run BUILD "main, a second docs-only delta in a row (how the freeze persists)"
+probe_says "$MAIN_TIP"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$STRANDED" \
+  run BUILD "main, docs-only vs the previous ATTEMPT but frontend vs LIVE -> builds (the freeze)"
+
+# GUILT, the batch shape: the merge queue lands up to four squash commits in ONE push and Vercel
+# deploys the tip. `git diff HEAD^ HEAD` (Vercel's documented example) sees only the last commit
+# of the batch — here docs-only — and would skip a frontend PR that landed one commit earlier.
+# Against what is LIVE the batch is one diff and the frontend change is in it.
+probe_says "$DOCS_ON_MAIN"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$DOCS_ON_MAIN" \
+  run BUILD "main, batch of [frontend, docs] pushed at once, live = before the batch -> builds"
+
+# INNOCENCE after a build ships: once production serves the frontend commit, the docs commit on
+# top of it is a docs-only delta again.
+probe_says "$STRANDED"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$STRANDED" \
+  run SKIP "main, live has caught up to the frontend commit, docs on top -> skips"
+
+# A rollback: production serves an OLDER commit than the newest frontend change. The diff spans
+# the rolled-back change, so this builds — the same answer the interim rule gave, and the
+# autopromote organ's to make, not this script's.
+probe_says "$MAIN_TIP"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= \
+  run BUILD "main, production rolled back behind a frontend commit -> builds"
+
+# The frontend commit above must not leak into the branches the rest of the corpus cuts from
+# main: every later merge-base diff would carry it and every docs-only SKIP would turn BUILD.
+git -C "$WORK" checkout -q main
+git -C "$WORK" reset -q --hard "$MAIN_TIP"
+
+# The live sha is not in the clone (Vercel's clone is shallow). It is fetched by sha from the
+# repository URL — the object lives in upstream on a branch this clone never fetched.
+SIDE="$ROOT/side"
+git clone -q "$UPSTREAM" "$SIDE"
+git -C "$SIDE" config user.email t@example.com
+git -C "$SIDE" config user.name t
+git -C "$SIDE" checkout -q -b live-only
+mkdir -p "$SIDE/docs" && echo "served" > "$SIDE/docs/served-elsewhere.md"
+git -C "$SIDE" add -A && git -C "$SIDE" commit -q -m "the commit production serves, unknown to this clone"
+git -C "$SIDE" push -q origin live-only
+LIVE_ELSEWHERE=$(git -C "$SIDE" rev-parse HEAD)
+git -C "$UPSTREAM" config uploadpack.allowAnySHA1InWant true
+if git -C "$WORK" cat-file -e "${LIVE_ELSEWHERE}^{commit}" 2>/dev/null; then
+  FAIL=$((FAIL+1)); printf '  FAIL  %-58s %s\n' "fixture: live sha must be absent from the clone" "present"
+fi
+commit "docs/after-live.md" "docs on main, live commit sits on another branch"
+probe_says "$LIVE_ELSEWHERE"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= SHOULD_BUILD_FETCH_URL="$UPSTREAM" \
+  run_log_safe SKIP "live sha absent from the clone, fetched by sha from the URL -> docs-only skips" "fetched live commit" "$UPSTREAM"
+# A second unknown live sha — the first one is in the clone now, fetched by the case above.
+echo "served again" > "$SIDE/docs/served-elsewhere-2.md"
+git -C "$SIDE" add -A && git -C "$SIDE" commit -q -m "another commit production serves, unknown to this clone"
+git -C "$SIDE" push -q origin live-only
+probe_says "$(git -C "$SIDE" rev-parse HEAD)"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= SHOULD_BUILD_FETCH_URL="$ROOT/does-not-exist.git" \
+  run BUILD "live sha absent and the URL is dead -> builds (fail-open)"
+probe_says "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= SHOULD_BUILD_FETCH_URL="$UPSTREAM" \
+  run BUILD "live sha that no repository has -> builds (fail-open)"
+probe_dead
 
 # INNOCENCE. The guard must key on "is this the production branch", not on the literal string
 # main. Point production elsewhere and main is an ordinary branch again, skipping exactly as
 # before — without this, a hardcoded name would silently disable the whole optimisation on every
 # other branch the day production is renamed, and nothing would say so.
+PROD_PREV=$(git -C "$WORK" rev-parse HEAD)
+commit "docs/renamed-prod.md" "docs only, main no longer production"
 VERCEL_GIT_PROD_BRANCH=release VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
   run SKIP "main is NOT production when VERCEL_GIT_PROD_BRANCH names another branch"
 
-# ...and whichever branch IS production inherits the guard.
+# ...and whichever branch IS production inherits the arm (probe dead -> builds).
 git -C "$WORK" checkout -q -b release main
 PROD_PREV=$(git -C "$WORK" rev-parse HEAD)
 commit "docs/release-note.md" "docs only, on the configured production branch"
 VERCEL_GIT_PROD_BRANCH=release VERCEL_GIT_COMMIT_REF=release VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
-  run BUILD "the configured production branch gets the guard, whatever it is called"
+  run BUILD "the configured production branch gets the arm, whatever it is called"
 
 # The ref is not the environment. `vercel --prod` promotes whatever branch it is pointed at, and
 # that deployment is production however its ref reads — so a branch test alone can skip a real
@@ -193,13 +285,14 @@ VERCEL_GIT_PROD_BRANCH=release VERCEL_GIT_COMMIT_REF=release VERCEL_GIT_PREVIOUS
 # directly. Raised by an adversarial review of the first version of this fix, which keyed on the
 # branch alone; the case below is that review's own repro.
 VERCEL_ENV=production VERCEL_GIT_COMMIT_REF=release VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
-  run BUILD "VERCEL_ENV=production on a NON-production branch (vercel --prod)"
+  run BUILD "VERCEL_ENV=production on a NON-production branch (vercel --prod), probe dead"
 
 # INNOCENCE for that arm: a preview is still a preview, and a docs-only preview still skips.
 # Without this, keying on the environment could quietly become "always build".
 VERCEL_ENV=preview VERCEL_GIT_COMMIT_REF=release VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
   run SKIP "VERCEL_ENV=preview, docs-only delta -> still skips"
 git -C "$WORK" checkout -q main
+git -C "$WORK" reset -q --hard "$MAIN_TIP"
 
 echo
 echo "=== OFFLINE BASE RESOLUTION (added 2026-07-30 after the armed guard proved inert)"
@@ -352,6 +445,16 @@ if [ "$PLEN" -le 256 ]; then
   PASS=$((PASS+1)); printf '  ok    %-58s %s chars\n' "pointer fits the 256-char API limit" "$PLEN"
 else
   FAIL=$((FAIL+1)); printf '  FAIL  %-58s %s chars (API rejects >256)\n' "pointer fits the 256-char API limit" "$PLEN"
+fi
+
+# The same line lives in apps/mouth/vercel.json as `ignoreCommand`, where it OVERRIDES the
+# dashboard field. Two copies drift silently unless something compares them, so this does.
+VJSON="$(dirname "$SCRIPT")/../../apps/mouth/vercel.json"
+IGNORE_CMD=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("ignoreCommand",""))' "$VJSON" 2>/dev/null)
+if [ "$IGNORE_CMD" = "$POINTER" ]; then
+  PASS=$((PASS+1)); printf '  ok    %-58s %s\n' "apps/mouth/vercel.json ignoreCommand == pointer" "identical"
+else
+  FAIL=$((FAIL+1)); printf '  FAIL  %-58s\n        vercel.json: %s\n        pointer:     %s\n' "apps/mouth/vercel.json ignoreCommand == pointer" "$IGNORE_CMD" "$POINTER"
 fi
 
 run_pointer() { # run_pointer <expected: BUILD|SKIP> <label> <script-body|MISSING>


### PR DESCRIPTION
## What

The Vercel Ignored Build Step for `mouth` now lets a **production** deployment skip when the diff between the commit production is **serving** and `HEAD` touches no bundle path (`apps/mouth/**`, `packages/**`, root `package.json`/`package-lock.json`, `vercel.json`). Previews keep the existing merge-base rule. The pointer line moves into `apps/mouth/vercel.json` as `ignoreCommand` (versioned; the dashboard field stays as fallback) and the corpus asserts it is byte-identical to `scripts/ci/vercel_ignore_build_step.sh`.

## Why

Measured 2026-09-09/10 on the project's deployment list and `origin/main`:

| | value |
|---|---|
| commits on main, last 7 days | 301 |
| of which touch a bundle path | 79 (26%) |
| production deployments, last 48 h | 70 (64 READY, median build 6.0 min, 385 build-min) |
| build machine | Standard, fixed — $0.014 / build-minute, no included minutes on Pro |

The 2026-08-18 interim rule (#4309) built every production commit because `VERCEL_GIT_PREVIOUS_SHA` names the previous **attempt**, not what is live, and stranded a superseded frontend commit (balizero.com frozen 2026-08-15..18). Vercel's documented `git diff HEAD^ HEAD` is wrong here for a second reason: the merge queue pushes batches of up to 4 squash commits at once and Vercel deploys the tip, so `HEAD^..HEAD` hides a frontend PR earlier in the batch. The only base that answers "does this commit change what is live?" is the live commit itself, which production exposes at `kita.balizero.com/api/health` (`.commit`) — the same probe `frontend-live-sentinel.yml` and `mini.vercel_autopromote` already trust.

Simulated on the last 7 days of main: this rule builds **79** production deployments instead of ~245 — about 11/day instead of ~35/day, ≈1,000 build-minutes/week ≈ $60/month at the current rate.

## Fail-open, by construction

Every path that cannot establish the live commit builds: probe down, no `.commit`, not a 40-hex sha, sha not in the (shallow) clone and not fetchable from the repo URL, `live == HEAD`. A dead `mini.vercel_autopromote` degrades to today's behaviour (every commit builds), never to a stale site: the live sha stops moving and every later diff keeps spanning the unshipped change.

## Evidence

- Corpus `scripts/tests/test_vercel_should_build.sh`: **48 cases, 48 pass** (was 35), on macOS and on ubuntu 24.04 (git 2.43, node 18) in a container. New cases pin the docs-only SKIP, the stranded shape (freeze), the batch shape, rollback, `live == HEAD`, fetch-by-sha via the repo URL, and each fail-open path.
- Mutations: interim always-build → 4 fail · base = `VERCEL_GIT_PREVIOUS_SHA` → 4 fail · base = `HEAD^` → 8 fail · probe failure read as SKIP → 4 fail · live sha via positional grep instead of a JSON parser → 1 fail (the decoy-field case).
- Shallow-clone simulation (`git clone --depth=10`, live commit 14 back and absent): fetched from the constructed GitHub URL, verdict SKIP in 3 s.
- Dry-run against the **real** probe: checkout of `origin/main` (14 docs-only commits after live `882ac94`) → `no frontend path in 48 changed file(s) -> SKIP`; older frontend commit → `frontend paths changed -> BUILD`.
- `git fetch --depth=1 <repo-url> <sha>` verified against GitHub (tree diff across two shallow fetches: 48 files).

## Adversarial review

spalla-review (Sonnet, generator ≠ grader): no blockers; ran the corpus and the always-build mutation independently. Three suggestions, all applied in the third commit: JSON-parser extraction of the live commit (a positional grep could pick a decoy field — a false SKIP), `timeout` on the two production fetches (a stalled fetch kills the wrapper outside the exit normaliser), and a corpus check that `FRONTEND_RE` covers `BUNDLE_PATHS` and the sentinel's `paths:` (11 paths).

First CI round was red on one fixture: the bare upstream's HEAD is `master` on a stock runner, so an unqualified clone produced a "live" commit without the frontend base file. Fixed with `-b main` plus a fixture assertion; green on the Linux container before re-push.

## Bites

**Bites:** the Vercel project `mouth`. Consumer: every push to `main`. Observation, to be recorded here after merge: the first docs-only merge on `main` after this lands shows up in `vercel ls mouth` / `GET /v6/deployments?target=production` as `CANCELED` with `should-build: production: comparing HEAD against live … -> SKIP` in its build log, while `curl -fsS https://kita.balizero.com/api/health` keeps returning the newest bundle-relevant commit and the Frontend Live Sentinel stays green. Success criterion (24 h): production builds ≈10/day, down from ≈35.

Not in this PR (separate concerns, sequenced after this one on the same file): `git.deploymentEnabled` for `gh-readonly-queue/**`, and the `apps/kbli-navigator/vercel.json` removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
