### PR TITLE
chore(kbli-navigator): remove the dead vercel.json

### DIFF
--- a/apps/kbli-navigator/vercel.json
+++ b/apps/kbli-navigator/vercel.json
@@ -1,3 +1,0 @@
-{
-  "alias": ["kbli-navigator-rebuild.vercel.app"]
-}


### PR DESCRIPTION
## What

Deletes `apps/kbli-navigator/vercel.json` (`{"alias": ["kbli-navigator-rebuild.vercel.app"]}`).

## Why

The file names a Vercel project that does not exist. `vercel project ls --scope nuzantara-2026` on 2026-09-10 lists exactly two projects, `mouth` and `knowledge`; the KBLI routes ship inside `apps/mouth` (`/kbli/*`). Nothing reads this file — `git grep` finds the path only in a 2026-07-19 research capture and in the kbli-navigator skill's prose, both describing it as legacy — and a config that points at a phantom project is where a future "why is kbli-navigator not deploying" hunt starts.

## Pre-push note

The `consumer-map` pre-push guard blocked the first push with 7 hits on the bare basename `vercel.json`: 4 docs-mentions and 3 "LIVE" lines in `.github/workflows/frontend-live-sentinel.yml`, which name the root `vercel.json` and `apps/mouth/vercel.json` in its `paths:` filter — a basename collision the tool itself declares as a proxy over-match (cicatrix #3). Verified no consumer names `apps/kbli-navigator/vercel.json`; pushed with the documented kill switch `PREPUSH_SKIP_CONSUMER_MAP=1`, not `--no-verify`.

**Bites:** the repo tree. Observation: `git show origin/main:apps/kbli-navigator/vercel.json` fails after merge, and the Frontend Live Sentinel's next scheduled run on `main` stays green (its `paths:` never named this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
