### PR TITLE
fix(ci): fly cost guard goes red on findings, ceilings match the 2026-09-10 footprint

### DIFF
--- a/.github/workflows/cron-fly-cost-alert.yml
+++ b/.github/workflows/cron-fly-cost-alert.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 10, not 5: the job now checks out the guard script and actions/checkout on
+    # this repo intermittently takes ~2 min (lint_workflow_timeout_floor.py).
+    timeout-minutes: 10
     env:
       EXPECTED_APPS: "nuzantara-rag,nuzantara-postgres"
       # Ceilings sit AT the footprint measured 2026-09-10 (7 machines, 6 started,

--- a/.github/workflows/cron-fly-cost-alert.yml
+++ b/.github/workflows/cron-fly-cost-alert.yml
@@ -23,7 +23,8 @@ jobs:
     env:
       EXPECTED_APPS: "nuzantara-rag,nuzantara-postgres"
       # Ceilings sit AT the footprint measured 2026-09-10 (7 machines, 6 started,
-      # 12288 MB started RAM, 77 GB volumes, 0 paid IPv4). The previous values
+      # 12288 MB started RAM, 11 started shared CPUs, 77 GB volumes, 0 paid
+      # IPv4). The previous values
       # (6 / 60 / 1) had been breached since the third Postgres node landed on
       # 2026-08-18 and every weekly run still concluded "success" because the
       # inline check only emitted ::warning:: — cicatrix #2, Esiste≠Armato.
@@ -32,6 +33,7 @@ jobs:
       MAX_TOTAL_MACHINES: "7"
       MAX_STARTED_MACHINES: "6"
       MAX_STARTED_MEMORY_MB: "12288"
+      MAX_STARTED_CPUS: "11"
       MAX_TOTAL_VOLUME_GB: "77"
       MAX_DEDICATED_IPV4: "0"
     steps:

--- a/.github/workflows/cron-fly-cost-alert.yml
+++ b/.github/workflows/cron-fly-cost-alert.yml
@@ -20,107 +20,35 @@ jobs:
     timeout-minutes: 5
     env:
       EXPECTED_APPS: "nuzantara-rag,nuzantara-postgres"
-      MAX_TOTAL_MACHINES: "6"
-      MAX_TOTAL_VOLUME_GB: "60"
-      MAX_DEDICATED_IPV4: "1"
+      # Ceilings sit AT the footprint measured 2026-09-10 (7 machines, 6 started,
+      # 12288 MB started RAM, 77 GB volumes, 0 paid IPv4). The previous values
+      # (6 / 60 / 1) had been breached since the third Postgres node landed on
+      # 2026-08-18 and every weekly run still concluded "success" because the
+      # inline check only emitted ::warning:: — cicatrix #2, Esiste≠Armato.
+      # Lower these when the Postgres node/volume cuts land; never raise them
+      # to silence a finding without a cost decision by the owner.
+      MAX_TOTAL_MACHINES: "7"
+      MAX_STARTED_MACHINES: "6"
+      MAX_STARTED_MEMORY_MB: "12288"
+      MAX_TOTAL_VOLUME_GB: "77"
+      MAX_DEDICATED_IPV4: "0"
     steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            scripts/fly_cost_guard.py
+          sparse-checkout-cone-mode: false
+
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Inventory billable Fly.io resources
         id: check
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: |
-          set -euo pipefail
-          python3 <<'PY'
-          import json
-          import os
-          import subprocess
-
-
-          def fly_json(*args):
-              result = subprocess.run(
-                  ["flyctl", *args, "--json"],
-                  check=True,
-                  capture_output=True,
-                  text=True,
-              )
-              return json.loads(result.stdout)
-
-
-          expected = {
-              name.strip()
-              for name in os.environ["EXPECTED_APPS"].split(",")
-              if name.strip()
-          }
-          apps = fly_json("apps", "list")
-          app_names = {app.get("Name") or app.get("ID") for app in apps}
-          app_names.discard(None)
-
-          machine_count = 0
-          started_count = 0
-          volume_gb = 0
-          dedicated_ipv4 = 0
-          inventory_errors = []
-
-          for app in sorted(app_names):
-              try:
-                  status = fly_json("status", "--app", app)
-                  machines = status.get("Machines") or []
-                  machine_count += len(machines)
-                  started_count += sum(m.get("state") == "started" for m in machines)
-              except Exception as exc:
-                  inventory_errors.append(f"{app}:status:{type(exc).__name__}")
-
-              try:
-                  volumes = fly_json("volumes", "list", "--app", app)
-                  volume_gb += sum(int(v.get("size_gb") or 0) for v in volumes)
-              except Exception as exc:
-                  inventory_errors.append(f"{app}:volumes:{type(exc).__name__}")
-
-              try:
-                  addresses = fly_json("ips", "list", "--app", app)
-                  dedicated_ipv4 += sum(ip.get("Type") == "v4" for ip in addresses)
-              except Exception as exc:
-                  inventory_errors.append(f"{app}:ips:{type(exc).__name__}")
-
-          unexpected_apps = sorted(app_names - expected)
-          missing_apps = sorted(expected - app_names)
-          limits = {
-              "machines": int(os.environ["MAX_TOTAL_MACHINES"]),
-              "volume_gb": int(os.environ["MAX_TOTAL_VOLUME_GB"]),
-              "dedicated_ipv4": int(os.environ["MAX_DEDICATED_IPV4"]),
-          }
-          findings = []
-          if unexpected_apps:
-              findings.append("unexpected apps=" + ",".join(unexpected_apps))
-          if missing_apps:
-              findings.append("missing apps=" + ",".join(missing_apps))
-          if machine_count > limits["machines"]:
-              findings.append(f"machines {machine_count}>{limits['machines']}")
-          if volume_gb > limits["volume_gb"]:
-              findings.append(f"volumes {volume_gb}GB>{limits['volume_gb']}GB")
-          if dedicated_ipv4 > limits["dedicated_ipv4"]:
-              findings.append(
-                  f"dedicated IPv4 {dedicated_ipv4}>{limits['dedicated_ipv4']}"
-              )
-          if inventory_errors:
-              findings.append("inventory errors=" + ",".join(inventory_errors))
-
-          report = (
-              f"Apps: {len(app_names)} | Machines: {started_count}/{machine_count} started | "
-              f"Volumes: {volume_gb} GB | Dedicated IPv4: {dedicated_ipv4}"
-          )
-          alert = "\n".join(findings)
-          output_path = os.environ["GITHUB_OUTPUT"]
-          with open(output_path, "a", encoding="utf-8") as output:
-              output.write("report<<EOF\n" + report + "\nEOF\n")
-              output.write("alert<<EOF\n" + alert + "\nEOF\n")
-
-          print(report)
-          if findings:
-              print("::warning::Fly resource guard: " + "; ".join(findings))
-          PY
+        # Exits 1 on any finding: the run goes RED and the Telegram step (always())
+        # still reports. Logic + guilt/innocence tests live in
+        # scripts/fly_cost_guard.py and scripts/tests/test_fly_cost_guard.py.
+        run: python3 scripts/fly_cost_guard.py
 
       - name: Telegram alert
         if: always() && steps.check.outputs.report != ''

--- a/evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/brief.yml
@@ -1,0 +1,87 @@
+task_id: fly-cost-guard-red-on-findings
+gear: 3
+l_level: L2
+gate_class: opus
+# Floor computed for THIS diff (re-run 2026-09-09T16:47:25Z):
+# `git diff --name-only origin/main...HEAD > /tmp/6044_changed.txt && git diff
+# --numstat origin/main...HEAD > /tmp/6044_numstat.txt && python3
+# scripts/evidence_pack_lint.py --print-floor --changed-files-file
+# /tmp/6044_changed.txt --numstat-file /tmp/6044_numstat.txt` returns 3 via the
+# PATH term alone (.github/workflows/cron-fly-cost-alert.yml is hot-zone by
+# `HOTZONE_PATTERNS`'s `.github/workflows/*` entry). Gear 3 declared to match.
+objective: >-
+  Make the weekly Fly.io resource guard (cron-fly-cost-alert.yml, Mon 01:00
+  UTC) fail on findings instead of merely warning, and carry ceilings equal to
+  the measured 2026-09-10 footprint (7 machines / 6 started / 12288 MB started
+  RAM / 77 GB volumes / 0 paid IPv4) — owner mandate 2026-09-10 item 4. The
+  inline `::warning::`-only guard had been silently breached since the third
+  Postgres replica landed on 2026-08-18 (volumes 77GB > the old 60GB ceiling,
+  machines 7 > the old 6) and every one of the 8 scheduled runs since still
+  concluded `success` — cicatrix family #2, Esiste≠Armato. The guard logic
+  moves out of an inline `python3 <<'PY'` heredoc into `scripts/fly_cost_guard.py`
+  (a pure `evaluate()` plus a `flyctl` collector), gains a guilt+innocence test
+  module, exits 1 with `::error::` on any finding, and the workflow's own
+  `timeout-minutes` moves 5→10 to budget the new `actions/checkout` step
+  (sparse-checkout of just the script) per `lint_workflow_timeout_floor.py`.
+constraints:
+  - >-
+    No `fly.toml` edit, anywhere. Every Fly interaction is read-only
+    (`apps list` / `status` / `volumes list` / `ips list` via `flyctl ...
+    --json`) — the guard observes billable inventory, it never mutates it.
+  - >-
+    No secret is echoed, printed or committed. `FLY_API_TOKEN` stays scoped to
+    the one step's `env:` exactly as before this PR; the script never logs it.
+  - >-
+    One-PR-one-concern target is ~400 net lines where the work allows —
+    exceeded here (+730/-157, net +573 at e4441c7eb8) because a 102-line live
+    inventory fixture (`fly_inventory_2026-09-10.json`, dumped from the real
+    fleet) and a 238-line guilt+innocence test module ship in the same PR as
+    the 232-line guard script they prove; splitting the fixture/tests into a
+    follow-up PR would leave the guard merged untested for one merge-queue
+    cycle, which is a worse trade on a hot-zone workflow file.
+  - >-
+    Council NOT convened (modus anti-sperpero: convene only if divergent
+    priors can change the answer AND error cost >15x tokens AND genuine
+    parallel breadth — none apply to a deterministic threshold script with a
+    14-case guilt/innocence corpus). One independent, non-Anthropic
+    adversarial seat (Codex CLI, read-only sandbox) dispatched instead of a
+    2-seat COUNCIL_REVIEW_SEATS quorum; see `seat_override` in pack.yml.
+acceptance:
+  - text: >-
+      A1: WHEN scripts/tests/test_fly_cost_guard.py and
+      scripts/tests/test_fly_workflow_guards.py are run under pytest SHALL
+      exit 0 with every case passing (14 total: guilt+innocence for each of
+      machines/started-machines/started-RAM/volumes/dedicated-IPv4, the
+      unexpected/missing-apps and inventory-errors findings, the CLI exit
+      code, env-vs-flag ceiling precedence, and the live flyctl JSON shapes).
+    probe: >-
+      apps/backend-rag/.venv/bin/python -m pytest
+      scripts/tests/test_fly_cost_guard.py
+      scripts/tests/test_fly_workflow_guards.py -q
+  - text: >-
+      A2: WHEN scripts/fly_cost_guard.py is run against the captured
+      2026-09-10 fixture with the script's own default ceilings (which now
+      equal the measured footprint) SHALL exit 0 and print "within limits".
+    probe: >-
+      python3 scripts/fly_cost_guard.py --inventory-json
+      scripts/tests/fixtures/fly_inventory_2026-09-10.json
+  - text: >-
+      A3: WHERE any single ceiling is set 1 unit below the measured footprint
+      SHALL exit 1 with an `::error::Fly resource guard: ...` finding —
+      proves the guard is not merely green by construction.
+    probe: >-
+      python3 scripts/fly_cost_guard.py --inventory-json
+      scripts/tests/fixtures/fly_inventory_2026-09-10.json --max-volume-gb 76
+  - text: >-
+      A4: WHEN the deterministic gear floor is recomputed from this PR's own
+      changed-file set SHALL be 3, equal to the declared gear (never below
+      it, per harness-v2 §1 monotonia).
+    probe: >-
+      python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file
+      /tmp/6044_changed.txt --numstat-file /tmp/6044_numstat.txt
+  - text: >-
+      A5: WHEN scripts/lint_workflow_timeout_floor.py is run after the
+      checkout-budget fix (timeout-minutes 5→10) SHALL exit 0 clean.
+    probe: python3 scripts/lint_workflow_timeout_floor.py
+appetite:
+  wall_clock_hours: 2

--- a/evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/pack.yml
@@ -20,17 +20,17 @@ seat_override: >-
   authoring session, not merely relayed.
 diff:
   net_lines: >-
-    5 files, +730/-157 (net +573) measured by `git diff --numstat
-    origin/main...HEAD` at e4441c7eb8, which includes the cure of the three
-    P1 dissent items below (new ceiling, fail-closed parsing, wrapped app
-    listing, 4 new/renamed tests) on top of the first cut. Per file: the
-    workflow edit (cron-fly-cost-alert.yml) replaces the inline python with
-    a script call and carries the six ceilings; the guard script
-    (fly_cost_guard.py) is 280 lines; the live-inventory fixture is 102
-    lines; the test module is 321 lines (17 cases); the superseded
-    inline-guard test is removed (62 lines deleted from
-    test_fly_workflow_guards.py). Zero frontend, zero fly.toml, zero
-    migration.
+    Code diff at the graded sha e4441c7eb8: the workflow edit
+    (cron-fly-cost-alert.yml) replaces the inline python with a script call
+    and carries the six ceilings; the guard script (fly_cost_guard.py) is
+    new; the live-inventory fixture (fly_inventory_2026-09-10.json) is new;
+    the test module (test_fly_cost_guard.py, 17 cases) is new; the
+    superseded inline-guard test is removed from
+    test_fly_workflow_guards.py. Zero frontend, zero fly.toml, zero
+    migration. Exact line counts are not narrated here on purpose: the
+    evidence pack itself is part of the PR diff, so any figure written into
+    it drifts with every pack edit — the gate's own receipt records the
+    `git diff --numstat` it observed.
   behaviour_change: >-
     The weekly guard (cron-fly-cost-alert.yml, Mon 01:00 UTC) moves from
     `::warning::`-only (never failed the job, 8/8 scheduled runs "success"

--- a/evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/pack.yml
@@ -257,6 +257,36 @@ receipts:
     exit: 0
     ts: "2026-09-09T17:37:43Z"
     seat: claude-opus-5
+  - claim: >-
+      Rerun of the two apt-flaked jobs (run 34382963914, ATTEMPT 2, same head
+      e4441c7eb8) confirms the diagnosis and does NOT change the verdict:
+      "Visa Oracle fullstack smoke" (job 102575719863) failed again at
+      17:39:32Z at the identical step and on the identical line —
+      `E: Failed to fetch
+      https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz
+      Hash Sum mismatch` / "Failed to install browsers" — so the Google apt
+      mirror was still serving a stale index, a persisting upstream
+      condition and not a one-shot; "E2E Tests (Playwright)" was CANCELLED
+      mid-flight at 17:40:13Z (not failed) and the attempt concluded
+      "cancelled" because the conductor pushed the evidence commit
+      95fe453e54 to the branch, which the workflow's cancel-in-progress
+      concurrency honours. Neither outcome is reachable from this diff: both
+      jobs die before any repo code executes, and 95fe453e54 adds only
+      evidence/ — `git diff --numstat e4441c7eb8 95fe453e54 -- ':!evidence'`
+      prints nothing, i.e. the graded code tree is byte-identical at the new
+      head.
+    cmd: >-
+      gh api repos/Bali-Zero/Teman2/actions/runs/34382963914/attempts/2/jobs;
+      gh run view --job 102575719863 --log-failed; git diff --numstat
+      e4441c7eb8 95fe453e54 -- ':!evidence'
+    result: >-
+      attempt 2 = cancelled (Visa Oracle fullstack smoke failure at "Install
+      Playwright browsers" — Hash Sum mismatch; E2E Tests (Playwright)
+      cancelled by the 95fe453e54 push; Test Summary failure as their
+      fan-in); code delta e4441c7eb8..95fe453e54 outside evidence/ = 0 lines.
+    exit: 0
+    ts: "2026-09-09T17:42:29Z"
+    seat: claude-opus-5
 spend:
   wall_clock_hours: 2.5
   adversarial_rounds: 1

--- a/evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/pack.yml
@@ -1,0 +1,477 @@
+brief_ref: evidence/brief.yml
+plan_ref: "PR #6044 (agent/nuzantara/infra/fly-cost-guard) — owner mandate 2026-09-10 item 4."
+lanes:
+  - lane: fly-cost-guard-build
+    role: build
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - lane: fly-cost-guard-refute
+    role: review
+    seat: "codex-cli-0.153.4 (adversarial refuter, read-only sandbox)"
+seat_override: >-
+  Gear-3 diff is a Fly.io cost-guard cron fix (deterministic threshold script,
+  14-case guilt+innocence corpus, no engine/PII/ground-truth surface touched)
+  — modus anti-sperpero: council convenes only when divergent priors can
+  change the answer AND error cost >15x tokens AND genuine parallel breadth;
+  none apply here. One independent, non-Anthropic adversarial seat (Codex
+  CLI, read-only sandbox) was dispatched instead of assembling a 2-seat
+  COUNCIL_REVIEW_SEATS quorum (codex-gpt-5.6-sol / kimi-code/k3 /
+  tp1-qwen3.8-max) with a journal.jsonl — its findings are recorded in
+  `dissent` below, each independently re-verified against the code by the
+  authoring session, not merely relayed.
+diff:
+  net_lines: >-
+    5 files, +730/-157 (net +573) measured by `git diff --numstat
+    origin/main...HEAD` at e4441c7eb8, which includes the cure of the three
+    P1 dissent items below (new ceiling, fail-closed parsing, wrapped app
+    listing, 4 new/renamed tests) on top of the first cut. Per file: the
+    workflow edit (cron-fly-cost-alert.yml) replaces the inline python with
+    a script call and carries the six ceilings; the guard script
+    (fly_cost_guard.py) is 280 lines; the live-inventory fixture is 102
+    lines; the test module is 321 lines (17 cases); the superseded
+    inline-guard test is removed (62 lines deleted from
+    test_fly_workflow_guards.py). Zero frontend, zero fly.toml, zero
+    migration.
+  behaviour_change: >-
+    The weekly guard (cron-fly-cost-alert.yml, Mon 01:00 UTC) moves from
+    `::warning::`-only (never failed the job, 8/8 scheduled runs "success"
+    while the fleet was over the old ceilings since 2026-08-18) to
+    `::error::` + exit 1 on any finding. Ceilings move from the 2026-06-era
+    defaults (6 machines / 60 GB / 1 paid IPv4) to the measured 2026-09-10
+    footprint (7 machines / 6 started / 12288 MB started RAM / 77 GB volumes
+    / 0 paid IPv4) plus two new dimensions (started-machine count,
+    started-memory) the old inline guard never checked at all.
+receipts:
+  - claim: >-
+      Deterministic gear floor recomputed from THIS PR's actual changed-file
+      list is 3 (path term — .github/workflows/cron-fly-cost-alert.yml is
+      hot-zone), matching the declared gear and the "Harness floor recompute"
+      FAIL message that demanded this pack.
+    cmd: >-
+      git diff --name-only origin/main...HEAD > /tmp/6044_changed.txt && git
+      diff --numstat origin/main...HEAD > /tmp/6044_numstat.txt && python3
+      scripts/evidence_pack_lint.py --print-floor --changed-files-file
+      /tmp/6044_changed.txt --numstat-file /tmp/6044_numstat.txt
+    result: "3"
+    exit: 0
+    ts: "2026-09-09T16:47:25Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      The superseded inline `::warning::`-only guard's scheduled runs never
+      went red although the fleet was over the old ceilings since
+      2026-08-18 (third Postgres replica) — 8/8 scheduled runs concluded
+      "success", 2026-07-20 through 2026-09-07 (cicatrix family #2,
+      Esiste≠Armato).
+    cmd: >-
+      gh run list --workflow=cron-fly-cost-alert.yml --limit 8 --json
+      conclusion,createdAt
+    result: >-
+      8/8 conclusion=success: 2026-07-20T04:35:32Z, 2026-07-27T04:36:26Z,
+      2026-08-03T04:30:31Z, 2026-08-10T03:11:03Z, 2026-08-17T02:19:01Z,
+      2026-08-24T02:22:05Z, 2026-08-31T06:43:59Z, 2026-09-07T05:45:09Z.
+    exit: 0
+    ts: "2026-09-09T16:47:26Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      The third red check on this PR (Backend Shard 1, job 102555772518)
+      failed at container initialization, not inside this PR's own tests —
+      an unrelated infra flake, not a defect this diff introduced.
+    cmd: >-
+      gh api repos/Bali-Zero/Teman2/actions/jobs/102555772518 --jq
+      '[.steps[]|select(.conclusion=="failure")|.name]'
+    result: '["Initialize containers","Upload shard receipts"]'
+    exit: 0
+    ts: "2026-09-09T16:47:28Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      The live Fly footprint measured directly (not just via the checked-in
+      fixture) matches the fixture and the new ceilings exactly: 4+3=7
+      machines (6 started; api 3072 MB, rag 2048 MB, drive 1024 MB x2 one
+      stopped, pg 3x2048 MB), volumes 2x1GB (rag) + 3x25GB (pg) = 77 GB, IPs
+      2 dedicated v6 + 1 shared v4 + zero dedicated v4.
+    cmd: >-
+      fly machine list -a nuzantara-rag; fly machine list -a
+      nuzantara-postgres; fly volumes list -a nuzantara-rag; fly volumes list
+      -a nuzantara-postgres; fly ips list -a nuzantara-rag
+    result: >-
+      nuzantara-rag: 4 machines (7817d92c4117d8 api started 3072MB,
+      48ee717b736948 drive stopped 1024MB, 2874974fe6e158 drive started
+      1024MB, 1781e5eda03438 rag started 2048MB), volumes
+      vol_vde56p7dnjwwew34 1GB + vol_rnzwkm1m8leey98r 1GB. nuzantara-postgres:
+      3 machines all started x2048MB, volumes 3x25GB. rag ips: 2x v6
+      (dedicated ingress) + 1x v4 (shared ingress, 66.241.124.44) — zero
+      dedicated v4.
+    exit: 0
+    ts: "2026-09-09T16:47:35Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      GUILT — under the pre-fix default volume ceiling (75 GB), the measured
+      77 GB footprint trips the guard: exit 1 with an `::error::` finding.
+    cmd: >-
+      python3 scripts/fly_cost_guard.py --inventory-json
+      scripts/tests/fixtures/fly_inventory_2026-09-10.json --max-volume-gb 75
+    result: >-
+      "Apps: 2 | Machines: 6/7 started (limit 6/7) | Started RAM: 12288 MB
+      (limit 12288) | Volumes: 77 GB (limit 75) | Dedicated IPv4: 0 (limit
+      0)" then "::error::Fly resource guard: volumes 77GB>75GB"
+    exit: 1
+    ts: "2026-09-09T16:48:16Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      INNOCENCE — under the script's shipped default ceilings (now equal to
+      the measured footprint), the same fixture passes clean: exit 0,
+      "within limits".
+    cmd: >-
+      python3 scripts/fly_cost_guard.py --inventory-json
+      scripts/tests/fixtures/fly_inventory_2026-09-10.json
+    result: >-
+      "Apps: 2 | Machines: 6/7 started (limit 6/7) | Started RAM: 12288 MB
+      (limit 12288) | Volumes: 77 GB (limit 77) | Dedicated IPv4: 0 (limit
+      0)" then "Fly resource guard: within limits"
+    exit: 0
+    ts: "2026-09-09T16:48:16Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      A3 acceptance probe — any +1 GB breach over the measured footprint
+      (ceiling lowered by 1 to 76) goes red.
+    cmd: >-
+      python3 scripts/fly_cost_guard.py --inventory-json
+      scripts/tests/fixtures/fly_inventory_2026-09-10.json --max-volume-gb 76
+    result: '"::error::Fly resource guard: volumes 77GB>76GB"'
+    exit: 1
+    ts: "2026-09-09T16:48:16Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      A1 — both test modules pass in full: 14 cases (guilt+innocence per
+      dimension, unexpected/missing-apps, inventory errors, CLI exit code,
+      env-vs-flag precedence, and the real flyctl JSON shapes for
+      machines/volumes/ips).
+    cmd: >-
+      apps/backend-rag/.venv/bin/python -m pytest
+      scripts/tests/test_fly_cost_guard.py
+      scripts/tests/test_fly_workflow_guards.py -q
+    result: "14 passed in 0.88s"
+    exit: 0
+    ts: "2026-09-09T16:48:29Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: ruff is clean on the three changed/added Python files.
+    cmd: >-
+      apps/backend-rag/.venv/bin/python -m ruff check
+      scripts/fly_cost_guard.py scripts/tests/test_fly_cost_guard.py
+      scripts/tests/test_fly_workflow_guards.py
+    result: "All checks passed!"
+    exit: 0
+    ts: "2026-09-09T16:48:32Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      A5 — the workflow-timeout-floor lint is clean after the checkout
+      budget fix (timeout-minutes 5→10, to cover the new sparse-checkout
+      step per this repo's own measured ~2 min `actions/checkout` variance).
+    cmd: python3 scripts/lint_workflow_timeout_floor.py
+    result: "workflow timeout floor: clean (157 jobs scanned, floor 10m)"
+    exit: 0
+    ts: "2026-09-09T16:48:32Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      CURE of the three P1 dissent items (e4441c7eb8): the corpus grows from
+      14 to 17 cases and passes in full — guilt for one extra started CPU
+      ("started cpus 12>11"), guilt for a started machine without
+      memory_mb/cpus and a volume without an integer size_gb ("inventory
+      errors=...missing", RAM/volume totals exclude the unreadable rows),
+      innocence for the stopped standby carrying no size, guilt for a
+      failing `flyctl apps list` (exit 1, no traceback, "missing apps=" +
+      "inventory errors=apps:list:CalledProcessError", report line still
+      written to GITHUB_OUTPUT).
+    cmd: >-
+      apps/backend-rag/.venv/bin/python -m pytest
+      scripts/tests/test_fly_cost_guard.py
+      scripts/tests/test_fly_workflow_guards.py -q -p no:cacheprovider
+    result: "17 passed in 1.03s"
+    exit: 0
+    ts: "2026-09-09T17:28:06Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      INNOCENCE after the cure — the live fixture still passes under the
+      shipped ceilings, and the report now carries the sixth dimension
+      ("Started CPUs: 11 (limit 11)").
+    cmd: >-
+      python3 scripts/fly_cost_guard.py --inventory-json
+      scripts/tests/fixtures/fly_inventory_2026-09-10.json
+    result: >-
+      Apps: 2 | Machines: 6/7 started (limit 6/7) | Started RAM: 12288 MB
+      (limit 12288) | Started CPUs: 11 (limit 11) | Volumes: 77 GB (limit
+      77) | Dedicated IPv4: 0 (limit 0) / Fly resource guard: within limits
+    exit: 0
+    ts: "2026-09-09T17:28:06Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      GUILT after the cure — the same fixture under a CPU ceiling one below
+      the footprint goes red.
+    cmd: >-
+      python3 scripts/fly_cost_guard.py --inventory-json
+      scripts/tests/fixtures/fly_inventory_2026-09-10.json
+      --max-started-cpus 10
+    result: "::error::Fly resource guard: started cpus 11>10"
+    exit: 1
+    ts: "2026-09-09T17:28:06Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      The workflow env block and the script defaults agree on all six
+      ceilings (test_workflow_ceilings_match_script_defaults), the workflow
+      still parses, ruff is clean on both Python files and the
+      workflow-timeout-floor lint is clean after the cure.
+    cmd: >-
+      ruff check scripts/fly_cost_guard.py scripts/tests/test_fly_cost_guard.py
+      && ruff format --check scripts/tests/test_fly_cost_guard.py && python3
+      -c "import yaml; yaml.safe_load(open('.github/workflows/cron-fly-cost-alert.yml'))"
+      && python3 scripts/lint_workflow_timeout_floor.py
+    result: >-
+      All checks passed! / 1 file already formatted / yaml ok / workflow
+      timeout floor: clean (157 jobs scanned, floor 10m)
+    exit: 0
+    ts: "2026-09-09T17:28:06Z"
+    seat: "session (Pro, Fable 5.1 conducting)"
+  - claim: >-
+      CI on the graded head e4441c7eb8: 69 SUCCESS, 2 SKIPPED, 1 NEUTRAL,
+      4 FAILURE. "Harness floor recompute" is red by construction (no gate
+      verdict posted yet). The other three are one upstream apt flake and
+      its aggregate: "E2E Tests (Playwright)" and "Visa Oracle fullstack
+      smoke" both died in the step "Install Playwright browsers" on
+      `E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/.../Packages.gz
+      Hash Sum mismatch` (the Google apt index was rebuilt mid-run: "Release
+      file created at: 17:16:59" vs "Last modification reported: 09:41:12"),
+      before a single line of repo code ran; "Test Summary" only aggregates
+      them (BACKEND/MCP/EVALUATOR/FRONTEND/PACKAGES_CORE all "success",
+      E2E_RESULT "failure"). This diff contains zero JS/TS, zero frontend and
+      zero package-manifest change, so it cannot reach that step; the same
+      "Tests & Coverage" workflow concluded success on four other refs
+      between 17:05 and 17:21 UTC.
+    cmd: >-
+      gh pr view 6044 --json headRefOid,statusCheckRollup; gh run view --job
+      102572658219 --log-failed; gh run view --job 102572658242 --log-failed;
+      gh run view --job 102575262805 --log-failed
+    result: >-
+      head=e4441c7eb8dc33d878ac2c7fe6706d90cbf33caa; conclusions
+      {"SUCCESS":69,"SKIPPED":2,"NEUTRAL":1,"FAILURE":4}; the three
+      non-harness failures are the Playwright browser install apt hash-sum
+      mismatch and the Test Summary aggregate of it.
+    exit: 0
+    ts: "2026-09-09T17:37:43Z"
+    seat: claude-opus-5
+spend:
+  wall_clock_hours: 2.5
+  adversarial_rounds: 1
+appetite_exceeded: >-
+  wall_clock_hours 2.5 vs the brief's 2: the extra half hour is the cure of
+  the three P1 dissent items (e4441c7eb8), which the refuter surfaced after
+  the first cut was complete and which the conducting session chose to fix
+  in-PR rather than ship a guard that fails open on a flyctl schema change.
+pii_scan: clean
+pii_scan_note: >-
+  Nothing in this diff, brief or pack transcribes client/OSINT data. The
+  changed surface is infra billing metadata (Fly machine/volume/IP
+  inventory, machine IDs, app names, GB/MB counts) and CI workflow YAML —
+  no applicant, client or WhatsApp data anywhere in scope. Grepped the full
+  diff for email/phone/passport/KTP/NPWP/WhatsApp/@gmail/@balizero patterns:
+  zero hits.
+bites:
+  consumer: "the scheduled `cron - fly cost alert` run (Mon 01:00 UTC) and its Telegram report"
+  where: ci
+  observe: >-
+    python3 scripts/fly_cost_guard.py --inventory-json
+    scripts/tests/fixtures/fly_inventory_2026-09-10.json
+  expect: exit0
+dissent:
+  - seat: "codex-cli-0.153.4 (adversarial refuter, read-only sandbox, dispatched on the raw diff)"
+    objection: >-
+      [P1] The guard collects `cpus` per machine (`_machine_row()`,
+      fly_cost_guard.py:74) but `evaluate()` never reads it — only
+      `memory_mb` feeds the started-RAM finding. A machine can move from
+      shared-cpu-1x to shared-cpu-8x, or from shared to performance CPU kind,
+      at constant RAM, and the report/findings are byte-identical while the
+      Fly bill rises. `cpu_kind` is not even collected.
+    status: CONFIRMED
+    resolution: >-
+      Verified directly: `grep -n cpus scripts/fly_cost_guard.py` shows
+      `cpus` collected at line 74 and nowhere else in the file; `evaluate()`
+      (lines 113-163) references only `state` and `memory_mb` from each
+      machine row, never `cpus`. Real, unfixed gap in this PR's scope — a
+      CPU-tier upgrade at constant RAM is invisible to this guard. Not fixed
+      here (read-only evidence-authoring mandate); flagged for the
+      conducting session.
+    disposition: >-
+      CURED in e4441c7eb8: `cpus` now feeds a sixth ceiling
+      (`started_cpus`, env MAX_STARTED_CPUS=11 = the measured footprint:
+      api 2 + rag 2 + drive 1 + 3x postgres 2), reported as "Started CPUs:
+      N (limit M)" and proven by test_one_more_started_cpu_is_guilty plus
+      the CLI guilt receipt above. `cpu_kind` (shared vs performance) is
+      still not collected: a performance-CPU switch at equal count stays
+      invisible — accepted as a declared, narrower residual risk, recorded
+      in the PR body for the next ceiling revision.
+  - seat: "codex-cli-0.153.4 (adversarial refuter)"
+    objection: >-
+      [P1] The parser fails OPEN on an unexpected flyctl JSON shape: a
+      missing `config.guest.memory_mb` reads as `0` (line 67), a missing
+      `Machines` key reads as `[]` (line 91), a missing `size_gb` reads as
+      `0` (line 98), a missing `Type` reads as `None` so it never counts as
+      a dedicated IPv4 (line 106/129) — an inventory the parser doesn't
+      understand reads as "zero resources", not as an error. Aggravated by
+      `superfly/flyctl-actions/setup-flyctl` pinning the ACTION by SHA but
+      not the `flyctl` CLI version it installs, which defaults to `latest`.
+    status: CONFIRMED
+    resolution: >-
+      Verified each cited line by reading fly_cost_guard.py directly (all
+      four `or 0`/bare-`.get()` fallbacks are exactly as described) and
+      confirmed the action's own `action.yml`
+      (raw.githubusercontent.com/superfly/flyctl-actions/master/setup-flyctl/action.yml):
+      `version: {default: latest, ...}` — no version pin in this workflow.
+      A future flyctl schema change (e.g. a field rename) would silently
+      read as an empty/cheap inventory rather than as `inventory errors`.
+      Real gap, not fixed here — a `flyctl` version pin plus required-field
+      validation is a natural follow-up, flagged for the conducting session.
+    disposition: >-
+      CURED in e4441c7eb8 for the billed fields: memory_mb, cpus and
+      size_gb are no longer coerced with `or 0`; a started machine or a
+      volume whose size is missing/non-integer is an `inventory errors=`
+      finding and its row is excluded from the totals (proven by
+      test_missing_sizes_fail_closed_only_on_what_is_billed, guilt and
+      innocence). A missing `Machines` key still reads as [] and a missing
+      `Type` as "not dedicated": the first is caught by the started-count
+      dropping below the footprint only if a ceiling is also a floor, which
+      this guard is not — accepted residual, since the expected-apps check
+      and the six ceilings bound the blast radius to "under-report", and
+      the weekly Telegram report shows the counts to a human. The flyctl
+      version pin is deliberately NOT added here: a pinned CLI drifts from
+      the API and is a second concern (owner-visible in the PR body).
+  - seat: "codex-cli-0.153.4 (adversarial refuter)"
+    objection: >-
+      [P1] `apps = fly_json("apps", "list")` (collect_inventory, line 85)
+      sits OUTSIDE every try/except in the function — the first `try:`
+      starts at line 90, after this call. If it raises, `main()` never
+      reaches `write_github_output()`/`print(report)`, so `steps.check.outputs.report`
+      is never set and the Telegram step's `if: always() && ... report != ''`
+      is false — the run goes red with NO alert sent. The new step comment
+      ("the Telegram step (always()) still reports") overclaims for this
+      failure class.
+    status: CONFIRMED
+    resolution: >-
+      Verified: `grep -n "apps = fly_json\|try:" scripts/fly_cost_guard.py`
+      shows the unguarded call at line 85 and the first `try:` at line 90.
+      HOWEVER: this exact shape — `apps = fly_json("apps", "list")` with no
+      surrounding try — was already present, unchanged, in the SUPERSEDED
+      inline guard (see the diff's minus-side under "Inventory billable
+      Fly.io resources"), so this is an INHERITED defect, not a regression
+      this PR introduced; the old `::warning::`-only guard would have failed
+      the exact same way (Python traceback, no GITHUB_OUTPUT) on this same
+      class of failure. Real and worth a follow-up (wrap the apps-list call,
+      or emit a minimal report/alert output before it), but out of THIS PR's
+      claimed scope ("exits 1 on any finding") and not fixed here.
+    disposition: >-
+      CURED in e4441c7eb8: the app listing sits in its own try/except; on
+      failure the error is recorded as `apps:list:<Exc>`, every expected
+      app is reported missing, the report line is still written to
+      GITHUB_OUTPUT (so the Telegram step fires) and the exit is 1 — proven
+      by test_failed_app_listing_is_a_finding_with_a_report through a fake
+      flyctl that exits 2 on `apps list`. The step comment's promise ("the
+      Telegram step (always()) still reports") is now true for this class.
+  - seat: "codex-cli-0.153.4 (adversarial refuter)"
+    objection: >-
+      [P2] The Telegram delivery step has two fail-open paths, both
+      pre-existing and untouched by this diff: missing `BOT`/`CHAT` secrets
+      prints a diagnostic and `exit 0` (workflow line ~64), and any
+      curl/network/HTTP failure is swallowed by `|| true` (line ~72). If the
+      inventory is innocent the whole workflow stays green even with the
+      alert channel disarmed — which now contradicts this PR's own
+      operational promise that findings surface via Telegram.
+    status: CONFIRMED
+    resolution: >-
+      Verified against the current workflow file: `[ -z "$BOT" ] || [ -z
+      "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }` and `curl
+      ... || true` are both present verbatim and both untouched by this PR's
+      diff (the diff's unified context stops right at the "Telegram alert"
+      step name — the body below it is unchanged). Pre-existing scope, not
+      introduced here; flagged rather than silently accepted, since the new
+      guard's exit-1-on-finding behavior raises the stakes of a silent
+      Telegram failure. Not fixed here (would be a second concern under
+      one-PR-one-concern).
+    disposition: >-
+      ACCEPTED, not cured: pre-existing and out of scope. The exit-1 guard
+      now makes GitHub's own red-run notification the primary alarm; the
+      Telegram message is the secondary channel. Recorded in the PR body as
+      a follow-up candidate (fail the step when the secrets are absent).
+  - seat: "codex-cli-0.153.4 (adversarial refuter)"
+    objection: >-
+      [P2] `test_live_collection_through_flyctl_reads_the_real_json_shapes`
+      claims to verify the real flyctl JSON shapes but only replays a fake
+      `flyctl` binary the test itself hardcodes (Machines/config.guest.memory_mb/size_gb/Type
+      literals at test_fly_cost_guard.py:170-204) — it can catch an internal
+      regression but cannot fail when the REAL flyctl output changes, which
+      is the risk its name claims to cover.
+      Also: `test_workflow_calls_the_script_and_checks_it_out` asserts only
+      two substrings (script call present, `actions/checkout@` present) and
+      would pass with a wrong sparse-checkout path or the checkout placed
+      after the run step; `_workflow_limits()` stringifies every YAML value
+      via `str(v)` before comparison, so it cannot force the ceilings to
+      stay YAML-quoted.
+    status: CONFIRMED
+    resolution: >-
+      Verified the test file directly: the fake flyctl script IS exactly
+      what it claims to validate against, confirming the naming overclaim.
+      Independently cross-checked the REAL shape myself (this pack's own
+      receipts): `flyctl ips list -a nuzantara-rag --json` returns `Type:
+      "v6"/"v6"/"shared_v4"` and the checked-in fixture
+      (fly_inventory_2026-09-10.json, dumped from live flyctl) matches
+      byte-for-byte — so the fake's assumed shape is CORRECT TODAY, this is
+      a test-robustness/naming gap (silent on a future flyctl schema drift)
+      rather than an active bug. The workflow-checkout and ceiling-quoting
+      sub-points are real coverage gaps but Codex's own follow-up correctly
+      downgrades the quoting one: the current YAML IS correctly quoted, and
+      a GitHub Actions `env:` value reaches the process as a string
+      regardless of YAML quoting style, so there is no live runtime path
+      where this actually breaks — test-strength gap only. Not fixed here.
+    disposition: >-
+      PARTLY CURED in e4441c7eb8: the test is renamed
+      test_collection_through_a_fake_flyctl_replaying_the_observed_json_shapes
+      and its docstring states what it proves (parsing of the shapes
+      observed 2026-09-10) and what it cannot (that flyctl still emits
+      them — only the live weekly run does). The workflow-checkout and
+      env-quoting sub-points are left as test-strength gaps with no live
+      failure path, per the refuter's own downgrade.
+  - seat: "codex-cli-0.153.4 (adversarial refuter)"
+    objection: >-
+      Initial attack surface I asked it to probe: are the flyctl `--json`
+      field assumptions themselves wrong (`Type` "v4" vs "shared_v4",
+      `size_gb`, `config.guest.memory_mb`)? After investigation the refuter
+      retracted this line of attack in full: "`Type: 'v4'` indica davvero
+      l'IPv4 dedicato; `shared_v4` è quello condiviso... confermato
+      dall'implementazione ufficiale di flyctl IP rendering.
+      `config.guest.memory_mb` è coerente con i tipi ufficiali di fly-go.
+      `size_gb` è la forma corrente dei volumi. Lo sparse checkout... è
+      valido... Nel workflow attuale i ceiling sono correttamente quotati."
+    status: RETRACTED
+    resolution: >-
+      Independently corroborated, not just relayed: this pack's own live
+      receipts (`fly machine/volumes/ips list --json` against
+      nuzantara-rag/nuzantara-postgres, and the checked-in fixture dump)
+      show the exact same field names/values the script consumes, matching
+      production byte-for-byte. Recorded here rather than omitted, per
+      harness-v2 §5 — a hypothesis the refuter investigated and disproved is
+      still a dissent entry, not silence.
+gate_verdict:
+  verdict: PASS
+  seat: claude-opus-5
+  graded_sha: e4441c7eb8 # pragma: allowlist secret — a git sha, short on purpose; detect-secrets still reads this one as hex entropy
+  conditions: []
+  reasons:
+    - "A1 re-run on the graded head: `apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_fly_cost_guard.py scripts/tests/test_fly_workflow_guards.py -q -p no:cacheprovider` = 17 passed in 1.18s, exit 0 — matches the pack's cure receipt count."
+    - "A2 innocence re-run: `python3 scripts/fly_cost_guard.py --inventory-json scripts/tests/fixtures/fly_inventory_2026-09-10.json` exits 0 printing all six dimensions — `Apps: 2 | Machines: 6/7 started (limit 6/7) | Started RAM: 12288 MB (limit 12288) | Started CPUs: 11 (limit 11) | Volumes: 77 GB (limit 77) | Dedicated IPv4: 0 (limit 0)`."
+    - "A3 guilt re-run, both directions: `--max-started-cpus 10` exits 1 with `::error::Fly resource guard: started cpus 11>10` and `--max-volume-gb 76` exits 1 with `::error::Fly resource guard: volumes 77GB>76GB` — the guard is not green by construction, and the ::warning::-that-never-failed of cicatrix #2 is gone (the script returns 1 whenever findings is non-empty, fly_cost_guard.py:272-274)."
+    - "Ceilings ARE the measured footprint, in both places at once: DEFAULT_LIMITS (fly_cost_guard.py:47-54) = {7, 6, 12288, 11, 77, 0} and the workflow env block (cron-fly-cost-alert.yml:33-38) carries the same six values; test_workflow_ceilings_match_script_defaults asserts equality, so a ceiling raised in one file alone turns the suite red."
+    - "The three P1 dissent `disposition:` claims verified against the code at e4441c7eb8, not relayed: (a) `cpus` now feeds the sixth ceiling — evaluate() adds it at fly_cost_guard.py:168 and reports/judges it at 194-195 and 207; (b) fail-closed on unreadable billed fields — no `or 0` survives, `_int_or_none` returns None and evaluate() names `<app>:machine <id>:<field> missing` / `<app>:volume <id>:size_gb missing` at 157-174, excluding the row from the totals (proven by test_missing_sizes_fail_closed_only_on_what_is_billed asserting `Started RAM: 9216 MB` after the 3072 MB row is dropped); (c) the app listing is wrapped at 109-113 and returns an inventory carrying `apps:list:<Exc>`, so main() still reaches write_github_output() and the Telegram step's `report != ''` guard holds — proven by test_failed_app_listing_is_a_finding_with_a_report through a fake flyctl that exits 2, asserting exit 1, no `Traceback`, and `report<<EOF\nApps: 0 | Machines: 0/0 started` in $GITHUB_OUTPUT."
+    - "Not W81 theater: the guilt cases mutate the LIVE-captured fixture (fly_inventory_2026-09-10.json, whose totals the pack's own `fly machine/volumes/ips list` receipts corroborate) by exactly one unit per dimension and assert the exact finding string — they would fail if evaluate() stopped judging that dimension. The one test that does replay its own fake binary is now named and documented for exactly that limit (test_collection_through_a_fake_flyctl_replaying_the_observed_json_shapes, docstring: it proves parsing, not that flyctl still emits the shapes)."
+    - "Secret boundary intact: `FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}` appears once, under the `check` step's own `env:` (cron-fly-cost-alert.yml:50-51); the new `actions/checkout@v7` step (the repo's dominant pin, 121 of 128 uses) and the setup-flyctl step receive no token, the sparse-checkout fetches only `scripts/fly_cost_guard.py`, and the script — stdlib-only, so the one-file checkout is sufficient — never prints an env value."
+    - "Countable claims hold: `git diff --numstat origin/main...HEAD` = 5 files, +730/-157, matching `diff.net_lines` verbatim (fixture 102 lines exact, 62 lines deleted from test_fly_workflow_guards.py exact); the pytest count 17 matches the cure receipt. Two ~-qualified figures round low (fly_cost_guard.py is 280 lines, not ~270; test_fly_cost_guard.py is 321, not ~300) and the BRIEF's constraint line still quotes the pre-cure +597/-157 net +440 — stale prose, not a false receipt: the pack's own diff block is measured at the graded sha."
+    - "Static gates re-run clean on the graded head: `ruff check` + `ruff format --check` on both Python files = All checks passed! / 2 files already formatted; `yaml.safe_load` of the workflow parses; `python3 scripts/lint_workflow_timeout_floor.py` = clean (157 jobs scanned, floor 10m), so the 5→10 timeout move is the lint's own floor, not a guess."
+    - "Residual fail-open, declared and bounded, not discovered by me as new: a flyctl status without a `Machines` key still reads as [] and an IP without `Type` still reads as not-dedicated, so a schema rename in those two places under-reports rather than errors. The blast radius is one-directional (ceilings are maxima, never floors, so under-reporting can only hide a breach, never invent one) and the weekly Telegram report prints the counts to a human; `cpu_kind` (shared vs performance) is likewise still uncollected. All three are recorded in the pack's dispositions as accepted residuals for the next ceiling revision — acceptable for a guard whose predecessor could not fail at all."
+    - "Evidence-pack lint re-run exactly as CI stages it (repo-root shim, changed-files and numstat from `git diff ... origin/main...HEAD`) ends `evidence_pack_lint: clean`, exit 0, with only the two NOTICE lines (appetite 2.5h vs 2h acknowledged; council_run overridden by `seat_override` — one non-Anthropic adversarial seat instead of a 2-seat quorum, defensible for a deterministic threshold script)."
+    - "CI on e4441c7eb8: 69 SUCCESS / 2 SKIPPED / 1 NEUTRAL / 4 FAILURE. Only `Harness floor recompute` is red by construction; the other three are infrastructure noise unrelated to this diff — `E2E Tests (Playwright)` and `Visa Oracle fullstack smoke` both died in `Install Playwright browsers` on an apt `Hash Sum mismatch` fetching Google's chrome-stable index (rebuilt mid-run), before any repo code executed, and `Test Summary` merely aggregates them. The diff touches no JS/TS, no frontend, no package manifest, and the same workflow concluded success on four other refs within the preceding 20 minutes."
+pending_proofs: []

--- a/scripts/fly_cost_guard.py
+++ b/scripts/fly_cost_guard.py
@@ -2,12 +2,16 @@
 """Fly.io weekly resource guard — billable inventory against hard ceilings.
 
 Fly exposes no supported billing API, so spend is guarded by INVENTORY: machine
-count, started machine count, started memory (the actual compute cost driver),
-provisioned volume GB and dedicated IPv4s across the expected apps. Any finding
-makes the process exit non-zero so the workflow run goes RED — a `::warning::`
-that leaves the job green is a guard that cannot sound (cicatrix #2,
-Esiste≠Armato: the previous inline version had breached thresholds for weeks
-and every run was "success").
+count, started machine count, started memory and started CPUs (the compute cost
+drivers), provisioned volume GB and dedicated IPv4s across the expected apps.
+Any finding makes the process exit non-zero so the workflow run goes RED — a
+`::warning::` that leaves the job green is a guard that cannot sound (cicatrix
+#2, Esiste≠Armato: the previous inline version had breached thresholds for
+weeks and every run was "success").
+
+The guard fails CLOSED on what it cannot read: a started machine whose memory
+or CPU count is missing from flyctl's JSON, a volume without a size, or a
+flyctl call that errors, is a finding — never a silent 0 that reads as savings.
 
 Usage:
     fly_cost_guard.py                       # live: shells out to flyctl
@@ -31,15 +35,20 @@ from typing import Any
 DEFAULT_EXPECTED_APPS = "nuzantara-rag,nuzantara-postgres"
 
 # Measured live 2026-09-10 (fly machine list / volumes list / ips list):
-#   nuzantara-rag      4 machines (api 3072MB, rag 2048MB, drive 1024MB x2 — one
-#                      stopped standby), 2x1GB volumes, 0 dedicated IPv4
-#   nuzantara-postgres 3 machines x 2048MB, 3x25GB volumes (77 GB total with the two 1 GB rag volumes), 0 dedicated IPv4
+#   nuzantara-rag      4 machines (api 3072MB/2cpu, rag 2048MB/2cpu, drive
+#                      1024MB/1cpu x2 — one stopped standby), 2x1GB volumes,
+#                      0 dedicated IPv4
+#   nuzantara-postgres 3 machines x 2048MB/2cpu, 3x25GB volumes (77 GB total
+#                      with the two 1 GB rag volumes), 0 dedicated IPv4
 # Ceilings sit AT today's footprint: one more machine, one started standby, one
-# extra GB of RAM, one extended volume or one paid IPv4 turns the run red.
+# extra GB of RAM, one extra shared CPU (a shared-cpu-4x upgrade keeps the RAM
+# figure and doubles the compute bill), one extended volume or one paid IPv4
+# turns the run red.
 DEFAULT_LIMITS: dict[str, int] = {
     "machines": 7,
     "started_machines": 6,
     "started_memory_mb": 12288,
+    "started_cpus": 11,
     "volume_gb": 77,
     "dedicated_ipv4": 0,
 }
@@ -48,6 +57,7 @@ LIMIT_ENV = {
     "machines": "MAX_TOTAL_MACHINES",
     "started_machines": "MAX_STARTED_MACHINES",
     "started_memory_mb": "MAX_STARTED_MEMORY_MB",
+    "started_cpus": "MAX_STARTED_CPUS",
     "volume_gb": "MAX_TOTAL_VOLUME_GB",
     "dedicated_ipv4": "MAX_DEDICATED_IPV4",
 }
@@ -63,6 +73,16 @@ def fly_json(*args: str) -> Any:
     return json.loads(result.stdout)
 
 
+def _int_or_none(value: Any) -> int | None:
+    """A missing or unparsable field stays None so evaluate() can name it."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _machine_row(machine: dict[str, Any]) -> dict[str, Any]:
     config = machine.get("config") or {}
     guest = config.get("guest") or {}
@@ -70,8 +90,8 @@ def _machine_row(machine: dict[str, Any]) -> dict[str, Any]:
     return {
         "id": machine.get("id"),
         "state": machine.get("state"),
-        "memory_mb": int(guest.get("memory_mb") or 0),
-        "cpus": int(guest.get("cpus") or 0),
+        "memory_mb": _int_or_none(guest.get("memory_mb")),
+        "cpus": _int_or_none(guest.get("cpus")),
         "group": metadata.get("fly_process_group"),
     }
 
@@ -81,10 +101,17 @@ def collect_inventory() -> dict[str, Any]:
 
     A partial inventory must still be judged: a flyctl hiccup on one app is a
     FINDING (inventory errors), not a silent "0 machines" that reads as savings.
+    The same holds for the app listing itself: when it fails, every expected app
+    is reported missing and the error is named, instead of a traceback that
+    leaves the Telegram step with no report.
     """
-    apps = fly_json("apps", "list")
-    app_names = sorted({app.get("Name") or app.get("ID") for app in apps} - {None})
     inventory: dict[str, Any] = {"apps": {}, "errors": []}
+    try:
+        apps = fly_json("apps", "list")
+    except Exception as exc:  # noqa: BLE001 — a failed listing is a finding
+        inventory["errors"].append(f"apps:list:{type(exc).__name__}")
+        return inventory
+    app_names = sorted({app.get("Name") or app.get("ID") for app in apps} - {None})
     for app in app_names:
         entry: dict[str, Any] = {"machines": [], "volumes": [], "ips": []}
         try:
@@ -95,7 +122,7 @@ def collect_inventory() -> dict[str, Any]:
         try:
             volumes = fly_json("volumes", "list", "--app", app)
             entry["volumes"] = [
-                {"id": v.get("id"), "size_gb": int(v.get("size_gb") or 0)}
+                {"id": v.get("id"), "size_gb": _int_or_none(v.get("size_gb"))}
                 for v in volumes
             ]
         except Exception as exc:  # noqa: BLE001
@@ -118,14 +145,33 @@ def evaluate(
     """Pure judgement: (report line, findings). Empty findings == innocent."""
     apps = inventory.get("apps") or {}
     app_names = set(apps)
-    machine_count = started_count = started_memory_mb = volume_gb = dedicated_ipv4 = 0
-    for entry in apps.values():
+    machine_count = started_count = started_memory_mb = started_cpus = 0
+    volume_gb = dedicated_ipv4 = 0
+    errors = list(inventory.get("errors") or [])
+    for app, entry in apps.items():
         for m in entry.get("machines") or []:
             machine_count += 1
-            if m.get("state") == "started":
-                started_count += 1
-                started_memory_mb += int(m.get("memory_mb") or 0)
-        volume_gb += sum(int(v.get("size_gb") or 0) for v in entry.get("volumes") or [])
+            if m.get("state") != "started":
+                continue
+            started_count += 1
+            # Fail closed: a started machine with no readable size is a finding,
+            # not a free machine. `or 0` here would let a flyctl schema change
+            # report every started machine as costing nothing.
+            for field in ("memory_mb", "cpus"):
+                value = m.get(field)
+                if not isinstance(value, int) or value <= 0:
+                    errors.append(f"{app}:machine {m.get('id')}:{field} missing")
+                    continue
+                if field == "memory_mb":
+                    started_memory_mb += value
+                else:
+                    started_cpus += value
+        for v in entry.get("volumes") or []:
+            size = v.get("size_gb")
+            if not isinstance(size, int) or size <= 0:
+                errors.append(f"{app}:volume {v.get('id')}:size_gb missing")
+                continue
+            volume_gb += size
         dedicated_ipv4 += sum(ip.get("type") == "v4" for ip in entry.get("ips") or [])
 
     findings: list[str] = []
@@ -145,11 +191,12 @@ def evaluate(
         findings.append(
             f"started memory {started_memory_mb}MB>{limits['started_memory_mb']}MB"
         )
+    if started_cpus > limits["started_cpus"]:
+        findings.append(f"started cpus {started_cpus}>{limits['started_cpus']}")
     if volume_gb > limits["volume_gb"]:
         findings.append(f"volumes {volume_gb}GB>{limits['volume_gb']}GB")
     if dedicated_ipv4 > limits["dedicated_ipv4"]:
         findings.append(f"dedicated IPv4 {dedicated_ipv4}>{limits['dedicated_ipv4']}")
-    errors = inventory.get("errors") or []
     if errors:
         findings.append("inventory errors=" + ",".join(errors))
 
@@ -157,6 +204,7 @@ def evaluate(
         f"Apps: {len(app_names)} | Machines: {started_count}/{machine_count} started "
         f"(limit {limits['started_machines']}/{limits['machines']}) | "
         f"Started RAM: {started_memory_mb} MB (limit {limits['started_memory_mb']}) | "
+        f"Started CPUs: {started_cpus} (limit {limits['started_cpus']}) | "
         f"Volumes: {volume_gb} GB (limit {limits['volume_gb']}) | "
         f"Dedicated IPv4: {dedicated_ipv4} (limit {limits['dedicated_ipv4']})"
     )

--- a/scripts/fly_cost_guard.py
+++ b/scripts/fly_cost_guard.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Fly.io weekly resource guard — billable inventory against hard ceilings.
+
+Fly exposes no supported billing API, so spend is guarded by INVENTORY: machine
+count, started machine count, started memory (the actual compute cost driver),
+provisioned volume GB and dedicated IPv4s across the expected apps. Any finding
+makes the process exit non-zero so the workflow run goes RED — a `::warning::`
+that leaves the job green is a guard that cannot sound (cicatrix #2,
+Esiste≠Armato: the previous inline version had breached thresholds for weeks
+and every run was "success").
+
+Usage:
+    fly_cost_guard.py                       # live: shells out to flyctl
+    fly_cost_guard.py --inventory-json f    # offline: evaluate a captured inventory
+    fly_cost_guard.py --dump-inventory f    # live: also write the inventory (fixture capture)
+
+Thresholds come from env (MAX_*), matching the workflow's `env:` block, or from
+the --max-* flags. The report/alert lines are appended to $GITHUB_OUTPUT when
+set, so the Telegram step keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+DEFAULT_EXPECTED_APPS = "nuzantara-rag,nuzantara-postgres"
+
+# Measured live 2026-09-10 (fly machine list / volumes list / ips list):
+#   nuzantara-rag      4 machines (api 3072MB, rag 2048MB, drive 1024MB x2 — one
+#                      stopped standby), 2x1GB volumes, 0 dedicated IPv4
+#   nuzantara-postgres 3 machines x 2048MB, 3x25GB volumes (77 GB total with the two 1 GB rag volumes), 0 dedicated IPv4
+# Ceilings sit AT today's footprint: one more machine, one started standby, one
+# extra GB of RAM, one extended volume or one paid IPv4 turns the run red.
+DEFAULT_LIMITS: dict[str, int] = {
+    "machines": 7,
+    "started_machines": 6,
+    "started_memory_mb": 12288,
+    "volume_gb": 77,
+    "dedicated_ipv4": 0,
+}
+
+LIMIT_ENV = {
+    "machines": "MAX_TOTAL_MACHINES",
+    "started_machines": "MAX_STARTED_MACHINES",
+    "started_memory_mb": "MAX_STARTED_MEMORY_MB",
+    "volume_gb": "MAX_TOTAL_VOLUME_GB",
+    "dedicated_ipv4": "MAX_DEDICATED_IPV4",
+}
+
+
+def fly_json(*args: str) -> Any:
+    result = subprocess.run(
+        ["flyctl", *args, "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _machine_row(machine: dict[str, Any]) -> dict[str, Any]:
+    config = machine.get("config") or {}
+    guest = config.get("guest") or {}
+    metadata = config.get("metadata") or {}
+    return {
+        "id": machine.get("id"),
+        "state": machine.get("state"),
+        "memory_mb": int(guest.get("memory_mb") or 0),
+        "cpus": int(guest.get("cpus") or 0),
+        "group": metadata.get("fly_process_group"),
+    }
+
+
+def collect_inventory() -> dict[str, Any]:
+    """Shell out to flyctl once per app/resource; errors are recorded, never fatal.
+
+    A partial inventory must still be judged: a flyctl hiccup on one app is a
+    FINDING (inventory errors), not a silent "0 machines" that reads as savings.
+    """
+    apps = fly_json("apps", "list")
+    app_names = sorted({app.get("Name") or app.get("ID") for app in apps} - {None})
+    inventory: dict[str, Any] = {"apps": {}, "errors": []}
+    for app in app_names:
+        entry: dict[str, Any] = {"machines": [], "volumes": [], "ips": []}
+        try:
+            status = fly_json("status", "--app", app)
+            entry["machines"] = [_machine_row(m) for m in status.get("Machines") or []]
+        except Exception as exc:  # noqa: BLE001 — flyctl/JSON failures are findings
+            inventory["errors"].append(f"{app}:status:{type(exc).__name__}")
+        try:
+            volumes = fly_json("volumes", "list", "--app", app)
+            entry["volumes"] = [
+                {"id": v.get("id"), "size_gb": int(v.get("size_gb") or 0)}
+                for v in volumes
+            ]
+        except Exception as exc:  # noqa: BLE001
+            inventory["errors"].append(f"{app}:volumes:{type(exc).__name__}")
+        try:
+            addresses = fly_json("ips", "list", "--app", app)
+            # Type is "v4" for a paid dedicated IPv4, "shared_v4" for the free one.
+            entry["ips"] = [{"type": ip.get("Type")} for ip in addresses]
+        except Exception as exc:  # noqa: BLE001
+            inventory["errors"].append(f"{app}:ips:{type(exc).__name__}")
+        inventory["apps"][app] = entry
+    return inventory
+
+
+def evaluate(
+    inventory: dict[str, Any],
+    expected_apps: set[str],
+    limits: dict[str, int],
+) -> tuple[str, list[str]]:
+    """Pure judgement: (report line, findings). Empty findings == innocent."""
+    apps = inventory.get("apps") or {}
+    app_names = set(apps)
+    machine_count = started_count = started_memory_mb = volume_gb = dedicated_ipv4 = 0
+    for entry in apps.values():
+        for m in entry.get("machines") or []:
+            machine_count += 1
+            if m.get("state") == "started":
+                started_count += 1
+                started_memory_mb += int(m.get("memory_mb") or 0)
+        volume_gb += sum(int(v.get("size_gb") or 0) for v in entry.get("volumes") or [])
+        dedicated_ipv4 += sum(ip.get("type") == "v4" for ip in entry.get("ips") or [])
+
+    findings: list[str] = []
+    unexpected_apps = sorted(app_names - expected_apps)
+    missing_apps = sorted(expected_apps - app_names)
+    if unexpected_apps:
+        findings.append("unexpected apps=" + ",".join(unexpected_apps))
+    if missing_apps:
+        findings.append("missing apps=" + ",".join(missing_apps))
+    if machine_count > limits["machines"]:
+        findings.append(f"machines {machine_count}>{limits['machines']}")
+    if started_count > limits["started_machines"]:
+        findings.append(
+            f"started machines {started_count}>{limits['started_machines']}"
+        )
+    if started_memory_mb > limits["started_memory_mb"]:
+        findings.append(
+            f"started memory {started_memory_mb}MB>{limits['started_memory_mb']}MB"
+        )
+    if volume_gb > limits["volume_gb"]:
+        findings.append(f"volumes {volume_gb}GB>{limits['volume_gb']}GB")
+    if dedicated_ipv4 > limits["dedicated_ipv4"]:
+        findings.append(f"dedicated IPv4 {dedicated_ipv4}>{limits['dedicated_ipv4']}")
+    errors = inventory.get("errors") or []
+    if errors:
+        findings.append("inventory errors=" + ",".join(errors))
+
+    report = (
+        f"Apps: {len(app_names)} | Machines: {started_count}/{machine_count} started "
+        f"(limit {limits['started_machines']}/{limits['machines']}) | "
+        f"Started RAM: {started_memory_mb} MB (limit {limits['started_memory_mb']}) | "
+        f"Volumes: {volume_gb} GB (limit {limits['volume_gb']}) | "
+        f"Dedicated IPv4: {dedicated_ipv4} (limit {limits['dedicated_ipv4']})"
+    )
+    return report, findings
+
+
+def limits_from_env(environ: dict[str, str]) -> dict[str, int]:
+    return {
+        key: int(environ.get(env_name, DEFAULT_LIMITS[key]))
+        for key, env_name in LIMIT_ENV.items()
+    }
+
+
+def write_github_output(report: str, alert: str, path: str | None) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as output:
+        output.write("report<<EOF\n" + report + "\nEOF\n")
+        output.write("alert<<EOF\n" + alert + "\nEOF\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--inventory-json", help="evaluate this captured inventory instead of flyctl"
+    )
+    parser.add_argument(
+        "--dump-inventory", help="write the live inventory to this path"
+    )
+    parser.add_argument(
+        "--expected-apps",
+        default=os.environ.get("EXPECTED_APPS", DEFAULT_EXPECTED_APPS),
+        help="comma-separated app names that must exist and be the only ones",
+    )
+    for key, env_name in LIMIT_ENV.items():
+        parser.add_argument(
+            f"--max-{key.replace('_', '-')}",
+            type=int,
+            dest=key,
+            help=f"overrides ${env_name}",
+        )
+    args = parser.parse_args(argv)
+
+    limits = limits_from_env(dict(os.environ))
+    for key in LIMIT_ENV:
+        value = getattr(args, key)
+        if value is not None:
+            limits[key] = value
+    expected = {name.strip() for name in args.expected_apps.split(",") if name.strip()}
+
+    if args.inventory_json:
+        with open(args.inventory_json, encoding="utf-8") as handle:
+            inventory = json.load(handle)
+    else:
+        inventory = collect_inventory()
+        if args.dump_inventory:
+            with open(args.dump_inventory, "w", encoding="utf-8") as handle:
+                json.dump(inventory, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+
+    report, findings = evaluate(inventory, expected, limits)
+    alert = "\n".join(findings)
+    write_github_output(report, alert, os.environ.get("GITHUB_OUTPUT"))
+    print(report)
+    if findings:
+        print("::error::Fly resource guard: " + "; ".join(findings))
+        return 1
+    print("Fly resource guard: within limits")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/fixtures/fly_inventory_2026-09-10.json
+++ b/scripts/tests/fixtures/fly_inventory_2026-09-10.json
@@ -1,0 +1,102 @@
+{
+  "apps": {
+    "nuzantara-postgres": {
+      "ips": [
+        {
+          "type": "private_v6"
+        }
+      ],
+      "machines": [
+        {
+          "cpus": 2,
+          "group": "app",
+          "id": "78113d4f67d938",
+          "memory_mb": 2048,
+          "state": "started"
+        },
+        {
+          "cpus": 2,
+          "group": "app",
+          "id": "5683e090f3d228",
+          "memory_mb": 2048,
+          "state": "started"
+        },
+        {
+          "cpus": 2,
+          "group": "app",
+          "id": "0801696b541568",
+          "memory_mb": 2048,
+          "state": "started"
+        }
+      ],
+      "volumes": [
+        {
+          "id": "vol_r1lzm7pg3k1e7794",
+          "size_gb": 25
+        },
+        {
+          "id": "vol_vgnl9ynmq05plnj4",
+          "size_gb": 25
+        },
+        {
+          "id": "vol_vgnx72gmld9k0zz4",
+          "size_gb": 25
+        }
+      ]
+    },
+    "nuzantara-rag": {
+      "ips": [
+        {
+          "type": "v6"
+        },
+        {
+          "type": "v6"
+        },
+        {
+          "type": "shared_v4"
+        }
+      ],
+      "machines": [
+        {
+          "cpus": 2,
+          "group": "api",
+          "id": "7817d92c4117d8",
+          "memory_mb": 3072,
+          "state": "started"
+        },
+        {
+          "cpus": 1,
+          "group": "drive",
+          "id": "48ee717b736948",
+          "memory_mb": 1024,
+          "state": "stopped"
+        },
+        {
+          "cpus": 1,
+          "group": "drive",
+          "id": "2874974fe6e158",
+          "memory_mb": 1024,
+          "state": "started"
+        },
+        {
+          "cpus": 2,
+          "group": "rag",
+          "id": "1781e5eda03438",
+          "memory_mb": 2048,
+          "state": "started"
+        }
+      ],
+      "volumes": [
+        {
+          "id": "vol_vde56p7dnjwwew34",
+          "size_gb": 1
+        },
+        {
+          "id": "vol_rnzwkm1m8leey98r",
+          "size_gb": 1
+        }
+      ]
+    }
+  },
+  "errors": []
+}

--- a/scripts/tests/test_fly_cost_guard.py
+++ b/scripts/tests/test_fly_cost_guard.py
@@ -1,0 +1,238 @@
+"""Guilt / innocence tests for scripts/fly_cost_guard.py.
+
+Innocence: the inventory captured live on 2026-09-10 passes the ceilings the
+workflow ships with. Guilt: every ceiling, breached by exactly one unit, turns
+into a named finding AND a non-zero exit — a guard that only warns is not a
+guard (cicatrix #2).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "fly_cost_guard.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "cron-fly-cost-alert.yml"
+FIXTURE = ROOT / "scripts" / "tests" / "fixtures" / "fly_inventory_2026-09-10.json"
+
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import fly_cost_guard  # noqa: E402
+
+EXPECTED = {"nuzantara-rag", "nuzantara-postgres"}
+
+
+def _inventory() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _workflow_limits() -> dict[str, int]:
+    env = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["run"]["env"]
+    return fly_cost_guard.limits_from_env({k: str(v) for k, v in env.items()})
+
+
+def test_workflow_ceilings_match_script_defaults() -> None:
+    assert _workflow_limits() == fly_cost_guard.DEFAULT_LIMITS
+
+
+def test_workflow_calls_the_script_and_checks_it_out() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "python3 scripts/fly_cost_guard.py" in text
+    assert "actions/checkout@" in text
+    assert "python3 <<'PY'" not in text, "inline guard resurrected"
+    assert "flyctl bills view" not in text
+    assert "Current month cost" not in text
+
+
+def test_live_fixture_is_innocent_under_workflow_ceilings() -> None:
+    report, findings = fly_cost_guard.evaluate(
+        _inventory(), EXPECTED, _workflow_limits()
+    )
+    assert findings == []
+    assert report.startswith("Apps: 2 | Machines: 6/7 started (limit 6/7)")
+    assert "Started RAM: 12288 MB (limit 12288)" in report
+    assert "Volumes: 77 GB (limit 77)" in report
+    assert "Dedicated IPv4: 0 (limit 0)" in report
+
+
+def test_one_more_machine_is_guilty() -> None:
+    inv = _inventory()
+    inv["apps"]["nuzantara-rag"]["machines"].append(
+        {"id": "extra", "state": "stopped", "memory_mb": 256, "cpus": 1, "group": "api"}
+    )
+    _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == ["machines 8>7"]
+
+
+def test_started_standby_is_guilty_on_count_and_memory() -> None:
+    inv = _inventory()
+    standby = next(
+        m for m in inv["apps"]["nuzantara-rag"]["machines"] if m["state"] == "stopped"
+    )
+    standby["state"] = "started"
+    _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == ["started machines 7>6", "started memory 13312MB>12288MB"]
+
+
+def test_one_more_gb_of_ram_is_guilty() -> None:
+    inv = _inventory()
+    rag = next(
+        m for m in inv["apps"]["nuzantara-rag"]["machines"] if m["group"] == "rag"
+    )
+    rag["memory_mb"] += 1024
+    _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == ["started memory 13312MB>12288MB"]
+
+
+def test_extended_volume_is_guilty() -> None:
+    inv = _inventory()
+    inv["apps"]["nuzantara-postgres"]["volumes"][0]["size_gb"] += 1
+    _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == ["volumes 78GB>77GB"]
+
+
+def test_paid_ipv4_is_guilty_but_shared_ipv4_is_not() -> None:
+    inv = _inventory()
+    assert any(ip["type"] == "shared_v4" for ip in inv["apps"]["nuzantara-rag"]["ips"])
+    _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == []
+    inv["apps"]["nuzantara-rag"]["ips"].append({"type": "v4"})
+    _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == ["dedicated IPv4 1>0"]
+
+
+def test_unexpected_missing_apps_and_inventory_errors_are_findings() -> None:
+    inv = _inventory()
+    inv["apps"]["fly-builder-legacy"] = {"machines": [], "volumes": [], "ips": []}
+    del inv["apps"]["nuzantara-postgres"]
+    inv["errors"] = ["nuzantara-rag:ips:CalledProcessError"]
+    _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == [
+        "unexpected apps=fly-builder-legacy",
+        "missing apps=nuzantara-postgres",
+        "inventory errors=nuzantara-rag:ips:CalledProcessError",
+    ]
+
+
+def _run(
+    args: list[str], env_extra: dict[str, str], cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **env_extra},
+        cwd=cwd,
+    )
+
+
+def test_cli_exit_code_is_the_verdict(tmp_path: Path) -> None:
+    output = tmp_path / "github-output"
+    env = {"GITHUB_OUTPUT": str(output)}
+    innocent = _run(["--inventory-json", str(FIXTURE)], env, tmp_path)
+    assert innocent.returncode == 0, innocent.stderr
+    assert "within limits" in innocent.stdout
+
+    guilty_inv = copy.deepcopy(_inventory())
+    guilty_inv["apps"]["nuzantara-postgres"]["volumes"][0]["size_gb"] = 26
+    guilty_path = tmp_path / "guilty.json"
+    guilty_path.write_text(json.dumps(guilty_inv), encoding="utf-8")
+    guilty = _run(["--inventory-json", str(guilty_path)], env, tmp_path)
+    assert guilty.returncode == 1
+    assert "::error::Fly resource guard: volumes 78GB>77GB" in guilty.stdout
+    github_output = output.read_text(encoding="utf-8")
+    assert "alert<<EOF\n\nEOF" in github_output  # innocent run wrote an empty alert
+    assert "alert<<EOF\nvolumes 78GB>77GB\nEOF" in github_output
+
+
+def test_env_ceilings_override_defaults_and_flags_override_env(tmp_path: Path) -> None:
+    tight = _run(
+        ["--inventory-json", str(FIXTURE)], {"MAX_TOTAL_VOLUME_GB": "76"}, tmp_path
+    )
+    assert tight.returncode == 1
+    assert "volumes 77GB>76GB" in tight.stdout
+    relaxed = _run(
+        ["--inventory-json", str(FIXTURE), "--max-volume-gb", "77"],
+        {"MAX_TOTAL_VOLUME_GB": "76"},
+        tmp_path,
+    )
+    assert relaxed.returncode == 0, relaxed.stdout
+
+
+def test_live_collection_through_flyctl_reads_the_real_json_shapes(
+    tmp_path: Path,
+) -> None:
+    """Same fake flyctl the inline guard was tested with, now against the script.
+
+    Shapes mirror `flyctl ... --json` as observed 2026-09-10: `status` nests
+    guest memory under config.guest, `ips list` reports the free shared IPv4
+    as Type "shared_v4" and a paid one as "v4".
+    """
+    fake_flyctl = tmp_path / "flyctl"
+    fake_flyctl.write_text(
+        """#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+app = args[args.index("--app") + 1] if "--app" in args else None
+if args[:2] == ["apps", "list"]:
+    data = [{"Name": "nuzantara-rag"}, {"Name": "nuzantara-postgres"}, {"Name": "fly-builder-legacy"}]
+elif args[0] == "status":
+    counts = {
+        "nuzantara-rag": ["started", "started", "started", "stopped"],
+        "nuzantara-postgres": ["started", "started"],
+        "fly-builder-legacy": ["stopped"],
+    }
+    data = {"Machines": [
+        {"id": f"{app}-{i}", "state": state,
+         "config": {"guest": {"memory_mb": 2048, "cpus": 2}, "metadata": {"fly_process_group": "app"}}}
+        for i, state in enumerate(counts[app])
+    ]}
+elif args[:2] == ["volumes", "list"]:
+    sizes = {"nuzantara-rag": [1, 1], "nuzantara-postgres": [25, 25], "fly-builder-legacy": [50]}
+    data = [{"id": f"vol{i}", "size_gb": size} for i, size in enumerate(sizes[app])]
+elif args[:2] == ["ips", "list"]:
+    data = [{"Type": "v4"}, {"Type": "shared_v4"}] if app == "nuzantara-rag" else []
+else:
+    raise SystemExit(f"unexpected flyctl args: {args}")
+print(json.dumps(data))
+""",
+        encoding="utf-8",
+    )
+    fake_flyctl.chmod(fake_flyctl.stat().st_mode | stat.S_IXUSR)
+    dump = tmp_path / "inventory.json"
+    result = _run(
+        ["--dump-inventory", str(dump)],
+        {
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "MAX_TOTAL_MACHINES": "6",
+            "MAX_TOTAL_VOLUME_GB": "60",
+        },
+        tmp_path,
+    )
+    assert result.returncode == 1
+    assert "Apps: 3 | Machines: 5/7 started" in result.stdout
+    assert "Started RAM: 10240 MB" in result.stdout
+    assert "Volumes: 102 GB" in result.stdout
+    for finding in (
+        "unexpected apps=fly-builder-legacy",
+        "machines 7>6",
+        "volumes 102GB>60GB",
+        "dedicated IPv4 1>0",
+    ):
+        assert finding in result.stdout
+    captured = json.loads(dump.read_text(encoding="utf-8"))
+    assert captured["apps"]["nuzantara-rag"]["ips"] == [
+        {"type": "v4"},
+        {"type": "shared_v4"},
+    ]
+    assert captured["errors"] == []

--- a/scripts/tests/test_fly_cost_guard.py
+++ b/scripts/tests/test_fly_cost_guard.py
@@ -59,6 +59,7 @@ def test_live_fixture_is_innocent_under_workflow_ceilings() -> None:
     assert findings == []
     assert report.startswith("Apps: 2 | Machines: 6/7 started (limit 6/7)")
     assert "Started RAM: 12288 MB (limit 12288)" in report
+    assert "Started CPUs: 11 (limit 11)" in report
     assert "Volumes: 77 GB (limit 77)" in report
     assert "Dedicated IPv4: 0 (limit 0)" in report
 
@@ -79,7 +80,11 @@ def test_started_standby_is_guilty_on_count_and_memory() -> None:
     )
     standby["state"] = "started"
     _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
-    assert findings == ["started machines 7>6", "started memory 13312MB>12288MB"]
+    assert findings == [
+        "started machines 7>6",
+        "started memory 13312MB>12288MB",
+        "started cpus 12>11",
+    ]
 
 
 def test_one_more_gb_of_ram_is_guilty() -> None:
@@ -90,6 +95,50 @@ def test_one_more_gb_of_ram_is_guilty() -> None:
     rag["memory_mb"] += 1024
     _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
     assert findings == ["started memory 13312MB>12288MB"]
+
+
+def test_one_more_started_cpu_is_guilty() -> None:
+    inv = _inventory()
+    rag = next(
+        m for m in inv["apps"]["nuzantara-rag"]["machines"] if m["group"] == "rag"
+    )
+    rag["cpus"] += 1
+    _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == ["started cpus 12>11"]
+
+
+def test_missing_sizes_fail_closed_only_on_what_is_billed() -> None:
+    """A started machine or a volume with no readable size is a finding.
+
+    Innocence: the stopped standby carries no size and stays silent — a
+    stopped machine is not billed for compute. Guilt: strip the size from a
+    started machine and from a volume; neither may read as 0 (= savings).
+    """
+    inv = _inventory()
+    standby = next(
+        m for m in inv["apps"]["nuzantara-rag"]["machines"] if m["state"] == "stopped"
+    )
+    standby["memory_mb"] = None
+    del standby["cpus"]
+    _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == []
+
+    api = next(
+        m for m in inv["apps"]["nuzantara-rag"]["machines"] if m["group"] == "api"
+    )
+    api["memory_mb"] = None
+    del api["cpus"]
+    volume = inv["apps"]["nuzantara-postgres"]["volumes"][0]
+    volume["size_gb"] = "25"  # a string is not a size the guard will add up
+    report, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == [
+        "inventory errors="
+        f"nuzantara-postgres:volume {volume['id']}:size_gb missing,"
+        f"nuzantara-rag:machine {api['id']}:memory_mb missing,"
+        f"nuzantara-rag:machine {api['id']}:cpus missing"
+    ]
+    assert "Started RAM: 9216 MB" in report  # 12288 minus the unreadable 3072
+    assert "Volumes: 52 GB" in report
 
 
 def test_extended_volume_is_guilty() -> None:
@@ -167,24 +216,16 @@ def test_env_ceilings_override_defaults_and_flags_override_env(tmp_path: Path) -
     assert relaxed.returncode == 0, relaxed.stdout
 
 
-def test_live_collection_through_flyctl_reads_the_real_json_shapes(
-    tmp_path: Path,
-) -> None:
-    """Same fake flyctl the inline guard was tested with, now against the script.
-
-    Shapes mirror `flyctl ... --json` as observed 2026-09-10: `status` nests
-    guest memory under config.guest, `ips list` reports the free shared IPv4
-    as Type "shared_v4" and a paid one as "v4".
-    """
-    fake_flyctl = tmp_path / "flyctl"
-    fake_flyctl.write_text(
-        """#!/usr/bin/env python3
+FAKE_FLYCTL = """#!/usr/bin/env python3
 import json
+import os
 import sys
 
 args = sys.argv[1:]
 app = args[args.index("--app") + 1] if "--app" in args else None
 if args[:2] == ["apps", "list"]:
+    if os.environ.get("FAKE_FLYCTL_APPS_LIST_FAILS"):
+        raise SystemExit(2)
     data = [{"Name": "nuzantara-rag"}, {"Name": "nuzantara-postgres"}, {"Name": "fly-builder-legacy"}]
 elif args[0] == "status":
     counts = {
@@ -205,10 +246,27 @@ elif args[:2] == ["ips", "list"]:
 else:
     raise SystemExit(f"unexpected flyctl args: {args}")
 print(json.dumps(data))
-""",
-        encoding="utf-8",
-    )
+"""
+
+
+def _install_fake_flyctl(tmp_path: Path) -> None:
+    fake_flyctl = tmp_path / "flyctl"
+    fake_flyctl.write_text(FAKE_FLYCTL, encoding="utf-8")
     fake_flyctl.chmod(fake_flyctl.stat().st_mode | stat.S_IXUSR)
+
+
+def test_collection_through_a_fake_flyctl_replaying_the_observed_json_shapes(
+    tmp_path: Path,
+) -> None:
+    """A FAKE flyctl on PATH, replaying the shapes observed 2026-09-10.
+
+    This proves the collector's parsing of those shapes and the end-to-end
+    exit code — it does not prove flyctl still emits them (only the live
+    weekly run does). Shapes: `status` nests guest memory/cpus under
+    config.guest, `ips list` reports the free shared IPv4 as Type "shared_v4"
+    and a paid one as "v4".
+    """
+    _install_fake_flyctl(tmp_path)
     dump = tmp_path / "inventory.json"
     result = _run(
         ["--dump-inventory", str(dump)],
@@ -222,6 +280,7 @@ print(json.dumps(data))
     assert result.returncode == 1
     assert "Apps: 3 | Machines: 5/7 started" in result.stdout
     assert "Started RAM: 10240 MB" in result.stdout
+    assert "Started CPUs: 10 (limit 11)" in result.stdout
     assert "Volumes: 102 GB" in result.stdout
     for finding in (
         "unexpected apps=fly-builder-legacy",
@@ -236,3 +295,27 @@ print(json.dumps(data))
         {"type": "shared_v4"},
     ]
     assert captured["errors"] == []
+
+
+def test_failed_app_listing_is_a_finding_with_a_report(tmp_path: Path) -> None:
+    """`flyctl apps list` failing must not crash past the report: every expected
+    app reads as missing, the error is named, exit is 1 and the Telegram step
+    still gets a report line."""
+    _install_fake_flyctl(tmp_path)
+    output = tmp_path / "github-output"
+    result = _run(
+        [],
+        {
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "FAKE_FLYCTL_APPS_LIST_FAILS": "1",
+            "GITHUB_OUTPUT": str(output),
+        },
+        tmp_path,
+    )
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert "missing apps=nuzantara-postgres,nuzantara-rag" in result.stdout
+    assert "inventory errors=apps:list:CalledProcessError" in result.stdout
+    assert "report<<EOF\nApps: 0 | Machines: 0/0 started" in output.read_text(
+        encoding="utf-8"
+    )

--- a/scripts/tests/test_fly_workflow_guards.py
+++ b/scripts/tests/test_fly_workflow_guards.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-import stat
 import subprocess
 import sys
 
@@ -83,64 +82,3 @@ def test_restart_detector_keeps_unexpected_crash_recovery() -> None:
     assert "crashed=crashed" in result.stdout
 
 
-def test_cost_guard_reports_resource_drift_without_fake_billing(tmp_path: Path) -> None:
-    workflow = (WORKFLOWS / "cron-fly-cost-alert.yml").read_text(encoding="utf-8")
-    assert "flyctl bills view" not in workflow
-    assert "Current month cost" not in workflow
-
-    fake_flyctl = tmp_path / "flyctl"
-    fake_flyctl.write_text(
-        """#!/usr/bin/env python3
-import json
-import sys
-
-args = sys.argv[1:]
-app = args[args.index("--app") + 1] if "--app" in args else None
-if args[:2] == ["apps", "list"]:
-    data = [
-        {"Name": "nuzantara-rag"},
-        {"Name": "nuzantara-postgres"},
-        {"Name": "fly-builder-legacy"},
-    ]
-elif args[0] == "status":
-    counts = {
-        "nuzantara-rag": ["started", "started", "started", "stopped"],
-        "nuzantara-postgres": ["started", "started"],
-        "fly-builder-legacy": ["stopped"],
-    }
-    data = {"Machines": [{"state": state} for state in counts[app]]}
-elif args[:2] == ["volumes", "list"]:
-    sizes = {"nuzantara-rag": [1, 1], "nuzantara-postgres": [25, 25], "fly-builder-legacy": [50]}
-    data = [{"size_gb": size} for size in sizes[app]]
-elif args[:2] == ["ips", "list"]:
-    data = [{"Type": "v4"}] if app == "nuzantara-rag" else []
-else:
-    raise SystemExit(f"unexpected flyctl args: {args}")
-print(json.dumps(data))
-""",
-        encoding="utf-8",
-    )
-    fake_flyctl.chmod(fake_flyctl.stat().st_mode | stat.S_IXUSR)
-    output = tmp_path / "github-output"
-    env = {
-        **os.environ,
-        "PATH": f"{tmp_path}:{os.environ['PATH']}",
-        "EXPECTED_APPS": "nuzantara-rag,nuzantara-postgres",
-        "MAX_TOTAL_MACHINES": "6",
-        "MAX_TOTAL_VOLUME_GB": "60",
-        "MAX_DEDICATED_IPV4": "1",
-        "GITHUB_OUTPUT": str(output),
-    }
-    result = subprocess.run(
-        [sys.executable, "-c", _embedded_python("cron-fly-cost-alert.yml")],
-        check=True,
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-    github_output = output.read_text(encoding="utf-8")
-
-    assert "Apps: 3 | Machines: 5/7 started | Volumes: 102 GB" in result.stdout
-    assert "unexpected apps=fly-builder-legacy" in github_output
-    assert "machines 7>6" in github_output
-    assert "volumes 102GB>60GB" in github_output


### PR DESCRIPTION
## Why

`cron-fly-cost-alert.yml` had been breached for three weeks (7 machines vs MAX 6, 77 GB volumes vs MAX 60 — since the third Postgres node landed 2026-08-18) and every weekly run still concluded **success**: the inline check only emitted `::warning::`. A guard whose findings cannot fail the job is cicatrix #2 (Esiste≠Armato). Owner mandate 2026-09-10 (Fly cost review, item 4).

## What

- `scripts/fly_cost_guard.py` — the inline Python extracted: pure `evaluate(inventory, expected, limits)`, flyctl collection separate, **exit 1 + `::error::` on any finding**. `$GITHUB_OUTPUT` report/alert unchanged, Telegram step keeps `if: always()`.
- Ceilings set AT today's measured footprint: 7 machines / 6 started / 12288 MB started RAM / 77 GB volumes / 0 paid IPv4. Two new dimensions (started machines, started RAM) because RAM is the compute cost driver and a standby waking up is a cost event the old counts could not see. Lower them when the Postgres node/volume cuts land.
- Workflow now checks out only the script (sparse) and runs it.

## Guilt / innocence

`scripts/tests/test_fly_cost_guard.py` (14 tests, green locally with the backend venv):
- innocence: the inventory captured live 2026-09-10 (`scripts/tests/fixtures/fly_inventory_2026-09-10.json`) → 0 findings, exit 0. Also run live on Pro before opening: `Apps: 2 | Machines: 6/7 started (limit 6/7) | Started RAM: 12288 MB (limit 12288) | Volumes: 77 GB (limit 77) | Dedicated IPv4: 0 (limit 0)` → `within limits`, exit 0.
- guilt: each ceiling breached by one unit → the named finding and exit 1 (`machines 8>7`, `started machines 7>6` + `started memory 13312MB>12288MB`, `volumes 78GB>77GB`, `dedicated IPv4 1>0`, unexpected/missing app, inventory error). The fake-flyctl test moved from `test_fly_workflow_guards.py` and now asserts the non-zero exit.

## Bites

Consumer: the scheduled run of `cron - fly cost alert` (Mon 01:00 UTC). Observation: the run after merge prints the report with `(limit 6/7)` / `(limit 77)` and concludes `success`; a `workflow_dispatch` run will be triggered right after merge to observe the same line before the Monday schedule. Any future breach turns the run red instead of green-with-warning.

## Adversarial review (Codex, read-only) and cure — e4441c7eb8

Three P1 findings, all confirmed against the code and cured in-PR: the collected `cpus` fed no ceiling (now `MAX_STARTED_CPUS=11`, the measured footprint); missing `memory_mb`/`cpus`/`size_gb` read as 0 and failed open (now an `inventory errors=` finding, rows excluded from the totals); `flyctl apps list` failing crashed before any report was written (now a named finding, every expected app reported missing, report still written for Telegram). Corpus 14 → 17 cases. Full record in the evidence pack under `evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/`.

## Residual risks, declared (not cured here — each would be a second concern)

- `cpu_kind` (shared vs performance) is not collected: a performance-CPU switch at equal count is invisible to the guard. Next ceiling revision.
- A missing `Machines` key in `flyctl status --json` still reads as no machines; the guard has ceilings, not floors, so this can only under-report. The weekly Telegram report shows the counts to a human.
- `superfly/flyctl-actions/setup-flyctl` installs `latest` flyctl; deliberately not pinned (a pinned CLI drifts from the API).
- Telegram step is pre-existing fail-open (missing secrets → exit 0; curl `|| true`). With the guard now exiting 1, GitHub's red-run notification is the primary alarm; the Telegram message is secondary. Follow-up candidate: fail the step when the secrets are absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

