### PR TITLE
fix(backup): sweep stale nuz-backup dumps off the Postgres primary before each run

### DIFF
--- a/scripts/fly-pg-backup.sh
+++ b/scripts/fly-pg-backup.sh
@@ -173,6 +173,32 @@ if [ -z "$PRIMARY_MACHINE" ]; then
 fi
 log "Primary machine: $PRIMARY_MACHINE"
 
+# Step 0: sweep stale dumps left on the primary's volume by killed runs.
+# Step 1c below removes the remote file after every attempt — but only if the
+# run gets there. Measured 2026-09-10 on the primary: 18 nuz-backup-*.sql.gz
+# (6.6 GB, 2026-06-06 .. 2026-08-29, in 0320/0335/0350 retry triplets) plus
+# their .err twins were still on /data, i.e. 45% volume use against 16% on the
+# replicas, and Fly's disk-capacity check flips the primary read-only at 90%.
+# Every one of those files belongs to a run that was killed (outer cron cap,
+# SFTP hang) before its own cleanup — the local + Tigris copies are the
+# backups; a dump on the database's own disk is never one. Older than one
+# day only, so a concurrent run's fresh file is untouched; the count is
+# logged so the nightly log can prove the sweep bites.
+STALE_PATTERN='/data/nuz-backup-*'
+STALE_LIST=$(timeout 60 "$FLY_BIN" ssh console --app "$FLY_APP" --machine "$PRIMARY_MACHINE" \
+    -C "sh -c 'find /data -maxdepth 1 -name \"nuz-backup-*\" -mtime +0 -print'" 2>/dev/null \
+    | grep -E '^/data/nuz-backup-' || true)
+STALE_COUNT=$(printf '%s\n' "$STALE_LIST" | grep -c . || true)
+if [ "${STALE_COUNT:-0}" -gt 0 ]; then
+    log "Sweeping $STALE_COUNT stale dump artefact(s) older than 1 day under $STALE_PATTERN on the primary..."
+    timeout 120 "$FLY_BIN" ssh console --app "$FLY_APP" --machine "$PRIMARY_MACHINE" \
+        -C "sh -c 'find /data -maxdepth 1 -name \"nuz-backup-*\" -mtime +0 -delete'" >/dev/null 2>&1 \
+        && log "Stale sweep done: $STALE_COUNT removed" \
+        || log "WARN: stale sweep failed — $STALE_COUNT artefact(s) still on the primary volume"
+else
+    log "Stale sweep: nothing older than 1 day under $STALE_PATTERN"
+fi
+
 # Step 1: pg_dump inside the primary → gzip to /data, then SFTP get, with retry
 REMOTE_FILE="/data/nuz-backup-$TIMESTAMP.sql.gz"
 REMOTE_ERR="/data/nuz-backup-$TIMESTAMP.err"

--- a/scripts/tests/test_fly_backup_stale_sweep.py
+++ b/scripts/tests/test_fly_backup_stale_sweep.py
@@ -1,0 +1,89 @@
+"""fly-pg-backup.sh must sweep stale dumps off the primary's volume BEFORE dumping.
+
+Measured 2026-09-10: 18 `nuz-backup-*.sql.gz` (6.6 GB, 2026-06-06 .. 2026-08-29) plus
+their `.err` twins were still on the primary's /data — every one left by a run that was
+killed before its own step-1c cleanup. The primary sat at 45% volume use against 16% on
+the replicas, and Fly's disk-capacity check flips the primary read-only at 90%.
+
+These tests pin the sweep's SHAPE, not its wording: it runs before the dump, it targets
+only `/data/nuz-backup-*` at depth 1, it never touches files younger than a day (a
+concurrent run's fresh dump is safe), and its count is logged so the nightly log can
+prove it bit. Guilt and innocence both asserted (superscar #3).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKUP_SCRIPT = REPO_ROOT / "scripts" / "fly-pg-backup.sh"
+
+_FIND_DELETE_RE = re.compile(
+    r"find /data -maxdepth 1 -name \\\"nuz-backup-\*\\\" -mtime \+0 -delete"
+)
+_FIND_LIST_RE = re.compile(
+    r"find /data -maxdepth 1 -name \\\"nuz-backup-\*\\\" -mtime \+0 -print"
+)
+_DUMP_ANCHOR = "# Step 1: pg_dump inside the primary"
+_SWEEP_ANCHOR = "# Step 0: sweep stale dumps"
+
+
+def _script() -> str:
+    return BACKUP_SCRIPT.read_text(encoding="utf-8")
+
+
+def _assert_sweep_shape(text: str) -> None:
+    assert _SWEEP_ANCHOR in text, "no stale-dump sweep section"
+    assert text.index(_SWEEP_ANCHOR) < text.index(_DUMP_ANCHOR), (
+        "sweep must run before the dump"
+    )
+    assert len(_FIND_LIST_RE.findall(text)) == 1, "exactly one bounded stale listing"
+    assert len(_FIND_DELETE_RE.findall(text)) == 1, "exactly one bounded stale delete"
+    assert 'log "Sweeping $STALE_COUNT stale dump artefact(s)' in text, (
+        "count must be logged"
+    )
+    # The delete is the ONLY unbounded-in-scope rm on the primary: any other
+    # `-delete`/`rm -rf` under /data would widen the blast radius past the
+    # backup's own artefacts.
+    assert "rm -rf /data" not in text
+    assert text.count("-delete") == 1
+
+
+def test_real_script_sweeps_stale_dumps_before_dumping() -> None:
+    _assert_sweep_shape(_script())
+
+
+def test_sweep_never_touches_a_fresh_dump() -> None:
+    text = _script()
+    for match in (_FIND_LIST_RE, _FIND_DELETE_RE):
+        assert "-mtime +0" in match.pattern.replace("\\+", "+")
+    assert "-mtime -1" not in text
+    assert "-mmin" not in text
+
+
+def test_script_without_sweep_is_caught() -> None:
+    text = _script()
+    start = text.index(_SWEEP_ANCHOR)
+    end = text.index(_DUMP_ANCHOR)
+    stripped = text[:start] + text[end:]
+    try:
+        _assert_sweep_shape(stripped)
+    except AssertionError as exc:
+        assert "no stale-dump sweep section" in str(exc)
+    else:  # pragma: no cover - guilt case must fail
+        raise AssertionError("a script without the sweep passed the shape check")
+
+
+def test_sweep_after_dump_is_caught() -> None:
+    text = _script()
+    start = text.index(_SWEEP_ANCHOR)
+    end = text.index(_DUMP_ANCHOR)
+    sweep_block = text[start:end]
+    moved = text[:start] + text[end:] + "\n" + sweep_block
+    try:
+        _assert_sweep_shape(moved)
+    except AssertionError as exc:
+        assert "sweep must run before the dump" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("a sweep placed after the dump passed the shape check")


### PR DESCRIPTION
## Why

Step 1c of `scripts/fly-pg-backup.sh` removes the remote dump after every attempt — but only if the run gets there. Measured 2026-09-10 on the `nuzantara-postgres` primary (`df -h /data`, `ls /data`): **18 `nuz-backup-*.sql.gz` (6.6 GB, 2026-06-06 .. 2026-08-29, in 0320/0335/0350 retry triplets) plus their `.err` twins** were still on `/data`, every one left by a run killed before its own cleanup. Primary volume at **45%** against **16%** on both replicas (the DB itself is 3.4 GB); Fly's `disk-capacity` check flips the primary read-only at 90%. Owner mandate 2026-09-10 (Fly cost review, item 1).

## What

Step 0 (before the dump): list and delete `/data/nuz-backup-*` **older than one day** on the primary — depth 1, name-bounded, so a concurrent run's fresh file is untouched — and log the count so the nightly log proves the sweep bit. The local (`~/backups/fly-postgres`, keep 7) and Tigris (keep 30) copies are the backups; a dump on the database's own disk never was one.

Shape tests, guilt + innocence: `scripts/tests/test_fly_backup_stale_sweep.py` (sweep before the dump, exactly one bounded listing and one bounded delete, no wider `rm` under `/data`, count logged; a script without the sweep or with it after the dump is caught). `scripts/tests/test_fly_backup_timeouts.py` still green.

## ⚠️ Owner decision before merge

The first run after merge (Pro crontab, 03:00 UTC nightly) **deletes the 18 stale files (6.6 GB) on the production primary volume**. They are retry leftovers of dates whose backups already exist locally and on Tigris (30-day window) or are past every retention window. **Left unarmed on purpose** — Zero: say `go sweep` and the session arms it; or run the one-shot yourself:

```
fly ssh console -a nuzantara-postgres --machine 0801696b541568 -C "sh -c 'find /data -maxdepth 1 -name \"nuz-backup-*\" -mtime +0 -delete'"
```

Related, not in this PR (operator): the Pro crontab runs the PG backup **twice** nightly (03:00 UTC via `fly-backup.sh` AND 03:20 UTC via `cron-wrapper fly-pg-backup`, line 191 "C2.9") — both succeed, both ~430 MB, each ~25 min of `pg_dump` on a CPU-throttled primary, overlapping. Drop line 191.

## Bites

Consumer: the nightly `fly-backup` cron on Pro (`~/logs/fly-backup-YYYYMMDD.log`). Observation: the first post-merge log carries `Sweeping 18 stale dump artefact(s) older than 1 day ...` then `Stale sweep done: 18 removed`, and `fly ssh console -a nuzantara-postgres --machine 0801696b541568 -C "df -h /data"` drops from 11G/45% to ~4.4G/18%; every later night logs `Stale sweep: nothing older than 1 day`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
