### PR TITLE
feat(ci): no Vercel deployments for merge-queue refs (gh-readonly-queue/**)

### DIFF
--- a/apps/mouth/vercel.json
+++ b/apps/mouth/vercel.json
@@ -3,5 +3,11 @@
   "framework": "nextjs",
   "buildCommand": "npm run build",
   "installCommand": "cd ../.. && npm ci --include=dev",
-  "ignoreCommand": "S=\"$(git rev-parse --show-toplevel)/scripts/ci/vercel_should_build.sh\"; [ -f \"$S\" ] || exit 1; bash \"$S\"; [ $? = 0 ] && exit 0 || exit 1"
+  "ignoreCommand": "S=\"$(git rev-parse --show-toplevel)/scripts/ci/vercel_should_build.sh\"; [ -f \"$S\" ] || exit 1; bash \"$S\"; [ $? = 0 ] && exit 0 || exit 1",
+  "git": {
+    "deploymentEnabled": {
+      "gh-readonly-queue/**": false,
+      "gh-readonly-queue/*": false
+    }
+  }
 }


### PR DESCRIPTION
## What

`apps/mouth/vercel.json` gains

```json
"git": { "deploymentEnabled": { "gh-readonly-queue/**": false, "gh-readonly-queue/*": false } }
```

so Vercel creates **no deployment at all** for the merge queue's temporary refs (`gh-readonly-queue/main/pr-<n>-<sha>`). Both spellings are listed because Vercel documents minimatch syntax (`*` does not cross `/`, `**` does) without saying which options it passes; a rule that is `false` twice costs nothing and a branch matching a `true` rule would deploy anyway.

## Why

Measured 2026-09-08/10 on the project's deployment list, 48 h:

| queue-ref deployments | count | build minutes |
|---|---|---|
| READY (built) | 25 | 179 (median 7.1 min) |
| CANCELED by the ignore step | 62 | ~0.5 min each of container time |

Nobody consumes a queue-ref preview: no Vercel check is required on `main` (verified via the branch protection API), the PR already has its own preview, and production deploys from `main` after the merge. Per month that is ≈2,700 build-minutes (≈$38 at $0.014/min on the Standard machine) plus ≈930 canceled deployments that still occupy build slots and count as deployments.

Known caveat: vercel/vercel#11176 (2024) reports `deploymentEnabled` being ignored in some setups. The observation below is therefore the whole test; if queue refs still deploy after this lands, the fallback is an early `SKIP` on `VERCEL_GIT_COMMIT_REF` starting with `gh-readonly-queue/` inside `scripts/ci/vercel_should_build.sh`.

**Bites:** the Vercel project `mouth`. Consumer: every merge-queue batch on `main`. Observation, recorded here after merge: the next queue batch after this lands (`gh pr list --search "is:queued"` / merge-queue entries) produces **zero** entries in `GET /v6/deployments?projectId=…` whose `meta.githubCommitRef` starts with `gh-readonly-queue/` — neither READY nor CANCELED — while the batch's PRs still merge and `main` still deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
