### PR TITLE
test(visa-engine): PR-5 — gold personas, option-matrix replay and the CI gates

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
@@ -72,9 +72,12 @@ from backend.tests.services.visa_engine.gold_replay import (
     _decision_actual,
     _persona_assessment_id,
     _persona_divergences,
-    _persona_expected,
 )
-from backend.tests.services.visa_engine.test_evaluator_gold import PERSONAS, Persona
+from backend.tests.services.visa_engine.test_evaluator_gold import (
+    PERSONAS,
+    PRODUCTION_REPLAY_EXPECTATIONS,
+    Persona,
+)
 
 logger = logging.getLogger("visa_engine.gold_replay_driver")
 
@@ -341,14 +344,14 @@ def replay_offline_decisions(
 
 
 def _normalized_expected(persona: Persona) -> dict[str, Any]:
-    expected = _persona_expected(persona)
+    expected = PRODUCTION_REPLAY_EXPECTATIONS[persona.id]
     return {
-        "state": expected["state"],
-        "candidate_products": expected["candidates"],
-        "missing_facts": expected["missing_facts"],
-        "review_reason_codes": expected["review_reason_codes"],
-        "no_path_reason_codes": expected["no_path_reason_codes"],
-        "notice_codes": expected["notice_codes"],
+        "state": expected.state.value,
+        "candidate_products": list(expected.candidates),
+        "missing_facts": sorted(expected.missing),
+        "review_reason_codes": list(expected.review_codes),
+        "no_path_reason_codes": list(expected.no_path_codes),
+        "notice_codes": sorted(expected.notice_codes),
     }
 
 
@@ -487,6 +490,7 @@ def build_report(
     persona_reports: list[dict[str, Any]] = []
     for persona, decision in zip(PERSONAS, decisions, strict=True):
         expected = _normalized_expected(persona)
+        expectation_basis = PRODUCTION_REPLAY_EXPECTATIONS[persona.id]
         actual = _normalized_actual(decision)
         differences = _persona_divergences(persona.id, expected, actual)
         pack = _decision_pack(decision)
@@ -507,6 +511,10 @@ def build_report(
                 "persona_id": persona.id,
                 "label": persona.label,
                 "expected": expected,
+                "legal_basis": {
+                    "citations": list(expectation_basis.legal_citations),
+                    "rationale": expectation_basis.rationale,
+                },
                 "actual": actual,
                 "pack": pack,
                 "divergence": bool(differences),

--- a/apps/backend-rag/backend/tests/scripts/visa_engine/test_gold_replay_driver.py
+++ b/apps/backend-rag/backend/tests/scripts/visa_engine/test_gold_replay_driver.py
@@ -6,6 +6,7 @@ import json
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -18,7 +19,11 @@ from backend.services.visa_engine.api_models import (
 )
 from backend.services.visa_engine.models import ApplicantFactsData, Decision
 from backend.tests.services.visa_engine import _gold_fixtures as gf
-from backend.tests.services.visa_engine.test_evaluator_gold import PERSONAS
+from backend.tests.services.visa_engine.gold_replay import _persona_expected
+from backend.tests.services.visa_engine.test_evaluator_gold import (
+    PERSONAS,
+    PRODUCTION_REPLAY_EXPECTATIONS,
+)
 
 _GOLD_AT = gf.GOLD_EFFECTIVE_AT
 
@@ -58,13 +63,27 @@ def _fixture_report(
     *,
     explanations: dict[int, driver.AcceptedExplanation] | None = None,
 ) -> dict:
-    return driver.build_report(
-        mode="offline",
-        generated_at=_GOLD_AT,
-        decisions=decisions,
-        pack_source={"kind": "test"},
-        explanations=explanations,
-    )
+    def synthetic_expected(persona) -> dict:
+        expected = _persona_expected(persona)
+        return {
+            "state": expected["state"],
+            "candidate_products": expected["candidates"],
+            "missing_facts": expected["missing_facts"],
+            "review_reason_codes": expected["review_reason_codes"],
+            "no_path_reason_codes": expected["no_path_reason_codes"],
+            "notice_codes": expected["notice_codes"],
+        }
+
+    # These tests isolate report mechanics with the synthetic fixture pack.
+    # The production expectation table has its own signed-pack replay below.
+    with patch.object(driver, "_normalized_expected", synthetic_expected):
+        return driver.build_report(
+            mode="offline",
+            generated_at=_GOLD_AT,
+            decisions=decisions,
+            pack_source={"kind": "test"},
+            explanations=explanations,
+        )
 
 
 def test_all_canonical_personas_map_to_the_real_wire_model() -> None:
@@ -238,7 +257,20 @@ def test_offline_replay_uses_highest_signed_pack_without_claiming_it_is_active()
 def test_offline_replay_match_count_does_not_regress_below_measured_floor() -> None:
     """G-b regression floor for the offline gold-persona replay.
 
-    Measured 2026-08-23 (independently reproduced while wiring this gate):
+    Re-derived 2026-09-10 from the 20 named persona descriptions and the
+    legal citations stored in ``PRODUCTION_REPLAY_EXPECTATIONS``; then
+    independently measured against signed production pack sequence 20:
+    17/20 matched and 3 divergences remained.  The three are deliberately
+    NOT laundered into the expectation:
+
+    * persona 1: an Indonesian citizen remains outside the foreign visa set
+      under UU 6/2011 jo. UU 63/2024;
+    * persona 9: the described direct C1-to-E28A onshore conversion remains
+      unsupported under Permenkumham 22/2023 jo. 11/2024;
+    * persona 10: the described status-bridging route remains adviser-review
+      work under the same regulation.
+
+    The previous floor was measured 2026-08-23:
     ``python -m backend.scripts.visa_engine.gold_replay_driver --offline``
     against the highest-sequence signed PRODUCTION pack then in the
     repository (``rulepack-prod-012.signed.json``, sequence=12) replayed
@@ -249,7 +281,7 @@ def test_offline_replay_match_count_does_not_regress_below_measured_floor() -> N
     so a regression in the match count could land on main with every check
     green.
 
-    4 is a FLOOR to raise as divergences get cured, never a target to hold
+    17 is a FLOOR to raise as divergences get cured, never a target to hold
     steady at and never something to lower back down to make this test pass
     again. This test exists to catch the count going DOWN (a real engine or
     pack regression), not to celebrate it staying flat — if a fix legitimately
@@ -266,13 +298,28 @@ def test_offline_replay_match_count_does_not_regress_below_measured_floor() -> N
 
     summary = report["summary"]
     assert summary["personas_total"] == 20
-    assert summary["personas_match"] >= 4, (
+    assert summary["personas_match"] >= 17, (
         f"gold-persona offline replay regressed below the measured floor: "
-        f"{summary['personas_match']}/20 matched (floor=4), "
+        f"{summary['personas_match']}/20 matched (floor=17), "
         f"{summary['unexplained_divergences']} unexplained divergences "
-        f"(ceiling=16) against pack sequence={report['pack']['sequence']}"
+        f"(ceiling=3) against pack sequence={report['pack']['sequence']}"
     )
-    assert summary["unexplained_divergences"] <= 16
+    assert summary["unexplained_divergences"] <= 3
+    unexplained_persona_ids = {
+        row["persona_id"]
+        for row in report["personas"]
+        if row["divergence"]
+        and (not isinstance(row["explanation"], str) or not row["explanation"].strip())
+    }
+    assert unexplained_persona_ids == {1, 9, 10}
+
+
+def test_every_production_expectation_has_a_named_legal_basis() -> None:
+    assert set(PRODUCTION_REPLAY_EXPECTATIONS) == {persona.id for persona in PERSONAS}
+    for persona in PERSONAS:
+        expectation = PRODUCTION_REPLAY_EXPECTATIONS[persona.id]
+        assert expectation.legal_citations, persona.label
+        assert expectation.rationale, persona.label
 
 
 @pytest.mark.parametrize(

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/option_matrix.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/option_matrix.json
@@ -1,0 +1,99 @@
+{
+  "branches": [
+    {
+      "axes": [
+        {
+          "fact": "work.employer_is_indonesian_entity",
+          "values": [false, true]
+        },
+        { "fact": "work.serves_indonesian_clients", "values": [false, true] }
+      ],
+      "base_overrides": {
+        "intent.purposes": ["REMOTE_WORK"],
+        "intent.stay_days": 180,
+        "process.application_channel": "OFFSHORE",
+        "work.employer_country_code": "FR",
+        "work.indonesia_source_compensation": false
+      },
+      "expectations": {
+        "false|false": {
+          "candidates": ["E33G"],
+          "state": "SUPPORTED_CANDIDATES"
+        },
+        "false|true": { "candidates": [], "state": "HUMAN_REVIEW_REQUIRED" },
+        "true|false": { "candidates": [], "state": "NO_SUPPORTED_PATH" },
+        "true|true": { "candidates": [], "state": "NO_SUPPORTED_PATH" }
+      },
+      "id": "remote_work",
+      "legal_citations": [
+        "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+        "Kepmen M.IP-08.GR.01.01/2025"
+      ]
+    },
+    {
+      "axes": [
+        { "fact": "intent.stay_days", "values": [45, 121] },
+        {
+          "fact": "work.indonesia_source_compensation",
+          "values": [false, true]
+        }
+      ],
+      "base_overrides": {
+        "family.sponsor_confirmed": true,
+        "intent.entry_pattern": "MULTIPLE",
+        "intent.purposes": ["BUSINESS_MEETINGS"],
+        "process.application_channel": "OFFSHORE",
+        "work.employer_is_indonesian_entity": false,
+        "work.serves_indonesian_clients": false
+      },
+      "expectations": {
+        "45|false": {
+          "candidates": ["C2", "D1", "D2"],
+          "state": "SUPPORTED_CANDIDATES"
+        },
+        "45|true": { "candidates": [], "state": "NO_SUPPORTED_PATH" },
+        "121|false": {
+          "candidates": ["C2", "D1", "D2"],
+          "state": "SUPPORTED_CANDIDATES"
+        },
+        "121|true": { "candidates": [], "state": "NO_SUPPORTED_PATH" }
+      },
+      "id": "business_multi_entry",
+      "legal_citations": [
+        "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+        "Official Immigration D2 multiple-entry business-visa page"
+      ]
+    },
+    {
+      "axes": [
+        { "fact": "family.marriage_registered", "values": [false, true] },
+        { "fact": "family.sponsor_nationalities", "values": [["ID"], ["IT"]] }
+      ],
+      "base_overrides": {
+        "family.relation_to_sponsor": "SPOUSE",
+        "family.sponsor_confirmed": true,
+        "intent.purposes": ["FAMILY"],
+        "intent.stay_days": 365,
+        "person.marital_status": "MARRIED",
+        "process.application_channel": "OFFSHORE",
+        "sponsor.type": "INDIVIDUAL"
+      },
+      "expectations": {
+        "false|[\"ID\"]": { "candidates": [], "state": "NO_SUPPORTED_PATH" },
+        "false|[\"IT\"]": { "candidates": [], "state": "NO_SUPPORTED_PATH" },
+        "true|[\"ID\"]": {
+          "candidates": ["E31A"],
+          "state": "SUPPORTED_CANDIDATES"
+        },
+        "true|[\"IT\"]": { "candidates": [], "state": "NO_SUPPORTED_PATH" }
+      },
+      "id": "family_spouse",
+      "legal_citations": [
+        "UU 6/2011 jo. UU 63/2024",
+        "Official Immigration E31A family-reunification page"
+      ]
+    }
+  ],
+  "schema_version": "1.0.0",
+  "seed": 9062026
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/personas/D2__121D.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/personas/D2__121D.json
@@ -1,0 +1,44 @@
+{
+  "expected_candidates": ["D2"],
+  "expected_state": "SUPPORTED_CANDIDATES",
+  "label": "Dutch business visitor, 121-day multi-entry supplier-meeting itinerary with a confirmed local sponsor",
+  "legal_citations": [
+    "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+    "Official Immigration D2 multiple-entry business-visa page"
+  ],
+  "overrides": {
+    "family.sponsor_confirmed": {
+      "status": "KNOWN",
+      "value": true
+    },
+    "intent.desired_entry_date": {
+      "status": "KNOWN",
+      "value": "2026-09-15"
+    },
+    "intent.entry_pattern": {
+      "status": "KNOWN",
+      "value": "MULTIPLE"
+    },
+    "intent.purposes": {
+      "status": "KNOWN",
+      "value": ["BUSINESS_MEETINGS"]
+    },
+    "intent.stay_days": {
+      "status": "KNOWN",
+      "value": 121
+    },
+    "person.nationalities": {
+      "status": "KNOWN",
+      "value": ["NL"]
+    },
+    "process.application_channel": {
+      "status": "KNOWN",
+      "value": "OFFSHORE"
+    },
+    "sponsor.type": {
+      "status": "KNOWN",
+      "value": "INDIVIDUAL"
+    }
+  },
+  "product_code": "D2"
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/personas/E33G.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/personas/E33G.json
@@ -1,0 +1,36 @@
+{
+  "expected_candidates": ["E33G"],
+  "expected_state": "SUPPORTED_CANDIDATES",
+  "label": "French remote employee, clean foreign income, no Indonesian employer, clients, or compensation",
+  "legal_citations": [
+    "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+    "Kepmen M.IP-08.GR.01.01/2025"
+  ],
+  "overrides": {
+    "intent.purposes": {
+      "status": "KNOWN",
+      "value": ["REMOTE_WORK"]
+    },
+    "person.nationalities": {
+      "status": "KNOWN",
+      "value": ["FR"]
+    },
+    "work.employer_country_code": {
+      "status": "KNOWN",
+      "value": "FR"
+    },
+    "work.employer_is_indonesian_entity": {
+      "status": "KNOWN",
+      "value": false
+    },
+    "work.indonesia_source_compensation": {
+      "status": "KNOWN",
+      "value": false
+    },
+    "work.serves_indonesian_clients": {
+      "status": "KNOWN",
+      "value": false
+    }
+  },
+  "product_code": "E33G"
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_evaluator_gold.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_evaluator_gold.py
@@ -41,6 +41,25 @@ class Persona:
     expected_notice_codes: tuple[str, ...] = field(default_factory=tuple)
 
 
+@dataclass(frozen=True)
+class ProductionReplayExpectation:
+    """Legally re-derived expectation for the signed production-pack replay.
+
+    The canonical persona assertions below intentionally exercise a synthetic
+    five-product engine fixture.  Production replay must not reuse those
+    synthetic product codes or thresholds as Indonesian legal assertions.
+    """
+
+    state: DecisionState
+    candidates: tuple[str, ...] = ()
+    missing: tuple[str, ...] = ()
+    review_codes: tuple[str, ...] = ()
+    no_path_codes: tuple[str, ...] = ()
+    notice_codes: tuple[str, ...] = ()
+    legal_citations: tuple[str, ...] = ()
+    rationale: str = ""
+
+
 PERSONAS: tuple[Persona, ...] = (
     Persona(
         id=1,
@@ -295,6 +314,181 @@ PERSONAS: tuple[Persona, ...] = (
 
 assert len(PERSONAS) == 20, "gold harness must carry exactly the 20 personas from spec §7"
 assert [p.id for p in PERSONAS] == list(range(1, 21)), "persona ids must be 1..20 in order"
+
+
+# Independently re-derived from each persona's complete facts and the named
+# legal sources below.  This table is deliberately NOT generated from a
+# production evaluator run: a changed engine output remains a divergence
+# unless the cited legal reading is changed here by an independent reviewer.
+PRODUCTION_REPLAY_EXPECTATIONS: dict[int, ProductionReplayExpectation] = {
+    1: ProductionReplayExpectation(
+        state=DecisionState.NO_SUPPORTED_PATH,
+        no_path_codes=("APPLICANT_IS_INDONESIAN_CITIZEN",),
+        legal_citations=("UU 6/2011 jo. UU 63/2024 tentang Keimigrasian",),
+        rationale="An Indonesian citizen is outside the foreign-national visa product set.",
+    ),
+    2: ProductionReplayExpectation(
+        state=DecisionState.HUMAN_REVIEW_REQUIRED,
+        review_codes=("CALLING_VISA_REVIEW", "CITIZENSHIP_LIST_DIVERGENCE"),
+        legal_citations=(
+            "Daftar Negara Calling Visa - Ditjen Imigrasi",
+            "Daftar Negara Subjek Visa on Arrival - Ditjen Imigrasi",
+        ),
+        rationale="Conflicting nationality evidence cannot safely resolve either country list.",
+    ),
+    3: ProductionReplayExpectation(
+        state=DecisionState.HUMAN_REVIEW_REQUIRED,
+        review_codes=("CALLING_VISA_REVIEW",),
+        legal_citations=("Daftar Negara Calling Visa - Ditjen Imigrasi",),
+        rationale="Afghan nationality is on the Calling Visa list and requires review.",
+    ),
+    4: ProductionReplayExpectation(
+        state=DecisionState.HUMAN_REVIEW_REQUIRED,
+        review_codes=("ACTIVE_OVERSTAY",),
+        legal_citations=("UU 6/2011 jo. UU 63/2024 tentang Keimigrasian",),
+        rationale="A disclosed active overstay must be reviewed before recommending a route.",
+    ),
+    5: ProductionReplayExpectation(
+        state=DecisionState.HUMAN_REVIEW_REQUIRED,
+        review_codes=("MINOR_WITHOUT_CONFIRMED_GUARDIAN", "MINOR_GUARDIAN_PRIVACY_REVIEW"),
+        legal_citations=(
+            "Kepmen M.IP-08.GR.01.01/2025 - family visa classifications",
+        ),
+        rationale="A minor without a confirmed guardian cannot receive a public recommendation.",
+    ),
+    6: ProductionReplayExpectation(
+        state=DecisionState.HUMAN_REVIEW_REQUIRED,
+        review_codes=("MINOR_GUARDIAN_PRIVACY_REVIEW",),
+        legal_citations=(
+            "Kepmen M.IP-08.GR.01.01/2025 - family visa classifications",
+        ),
+        rationale="The family route is plausible, but the public boundary holds every minor for review.",
+    ),
+    7: ProductionReplayExpectation(
+        state=DecisionState.SUPPORTED_CANDIDATES,
+        candidates=("C1", "E31A"),
+        legal_citations=(
+            "Visa Keluarga Suami/Istri WNI (E31A) - Ditjen Imigrasi",
+            "Kepmen M.IP-08.GR.01.01/2025 - C1 classification",
+        ),
+        rationale="A registered WNI marriage supports E31A; a 30-day family visit also supports C1.",
+    ),
+    8: ProductionReplayExpectation(
+        state=DecisionState.SUPPORTED_CANDIDATES,
+        candidates=("C1",),
+        legal_citations=(
+            "Visa Keluarga Suami/Istri WNI (E31A) - Ditjen Imigrasi",
+            "Kepmen M.IP-08.GR.01.01/2025 - C1 classification",
+        ),
+        rationale="Unverified marriage blocks E31A, but does not block the complete 30-day C1 visit facts.",
+    ),
+    9: ProductionReplayExpectation(
+        state=DecisionState.NO_SUPPORTED_PATH,
+        no_path_codes=("DIRECT_ONSHORE_CONVERSION_UNSUPPORTED",),
+        legal_citations=(
+            "Permenkumham 22/2023 jo. Permenkumham 11/2024 - alih status",
+        ),
+        rationale="The described direct C1-to-E28A onshore conversion is not a supported route.",
+    ),
+    10: ProductionReplayExpectation(
+        state=DecisionState.HUMAN_REVIEW_REQUIRED,
+        review_codes=("STATUS_BRIDGING_REVIEW",),
+        legal_citations=(
+            "Permenkumham 22/2023 jo. Permenkumham 11/2024 - ITK peralihan",
+        ),
+        rationale="The same investor facts through status bridging require an adviser review.",
+    ),
+    11: ProductionReplayExpectation(
+        state=DecisionState.SUPPORTED_CANDIDATES,
+        candidates=("E33G",),
+        legal_citations=(
+            "Permenkumham 22/2023 jo. Permenkumham 11/2024 Pasal 33(2)(j)",
+        ),
+        rationale="Remote work with a foreign employer and no Indonesian clients or pay supports E33G.",
+    ),
+    12: ProductionReplayExpectation(
+        state=DecisionState.HUMAN_REVIEW_REQUIRED,
+        review_codes=("LOCAL_MARKET_ACTIVITY_REVIEW",),
+        legal_citations=(
+            "Permenkumham 22/2023 jo. Permenkumham 11/2024 Pasal 33(2)(j)",
+        ),
+        rationale="Serving Indonesian clients crosses the clean E33G activity boundary.",
+    ),
+    13: ProductionReplayExpectation(
+        state=DecisionState.NEEDS_INPUT,
+        missing=("work.serves_indonesian_clients",),
+        legal_citations=(
+            "Permenkumham 22/2023 jo. Permenkumham 11/2024 Pasal 33(2)(j)",
+        ),
+        rationale="Local-client activity is a necessary E33G boundary fact and is unprovided.",
+    ),
+    14: ProductionReplayExpectation(
+        state=DecisionState.SUPPORTED_CANDIDATES,
+        candidates=("E33G",),
+        legal_citations=(
+            "Permenkumham 22/2023 jo. Permenkumham 11/2024 Pasal 33(2)(j)",
+        ),
+        rationale="E33G covers the declared remote-work and tourism purposes together.",
+    ),
+    15: ProductionReplayExpectation(
+        state=DecisionState.SUPPORTED_CANDIDATES,
+        candidates=("E23",),
+        legal_citations=("Kepmen M.IP-08.GR.01.01/2025 - E23 classification",),
+        rationale="Confirmed Indonesian employment sponsorship supports E23, not a C1 work route.",
+    ),
+    16: ProductionReplayExpectation(
+        state=DecisionState.SUPPORTED_CANDIDATES,
+        candidates=("D12",),
+        legal_citations=(
+            "Visa Kunjungan Pra-Investasi (D12) - Ditjen Imigrasi",
+            "Kepmen M.IP-08.GR.01.01/2025 - E28A capital thresholds",
+        ),
+        rationale="Capital below E28A's threshold still supports the described pre-investment D12 visit.",
+    ),
+    17: ProductionReplayExpectation(
+        state=DecisionState.SUPPORTED_CANDIDATES,
+        candidates=("D12",),
+        legal_citations=(
+            "Visa Kunjungan Pra-Investasi (D12) - Ditjen Imigrasi",
+            "Kepmen M.IP-08.GR.01.01/2025 - E28A paid-up capital threshold",
+        ),
+        rationale="Total capital alone does not establish E28A; the complete facts support D12 instead.",
+    ),
+    18: ProductionReplayExpectation(
+        state=DecisionState.NEEDS_INPUT,
+        missing=("intent.purposes",),
+        notice_codes=("OBSOLETE_PRODUCT_CODE",),
+        legal_citations=("Kepmen M.IP-08.GR.01.01/2025 - current visa classifications",),
+        rationale="The obsolete B211A label cannot select a route without a declared purpose.",
+    ),
+    19: ProductionReplayExpectation(
+        state=DecisionState.SUPPORTED_CANDIDATES,
+        candidates=("B1", "C1"),
+        notice_codes=("OBSOLETE_PRODUCT_CODE",),
+        legal_citations=(
+            "Daftar Negara Subjek Visa on Arrival - Ditjen Imigrasi",
+            "Kepmen M.IP-08.GR.01.01/2025 - B1 and C1 classifications",
+        ),
+        rationale="A French national's complete 30-day tourism facts support both B1 and C1 alternatives.",
+    ),
+    20: ProductionReplayExpectation(
+        state=DecisionState.HUMAN_REVIEW_REQUIRED,
+        review_codes=(
+            "BRIDGING_FROM_VISIT_ITK_PROHIBITED",
+            "BRIDGING_TO_BRIDGING_PROHIBITED",
+        ),
+        legal_citations=(
+            "Permenkumham 22/2023 jo. Permenkumham 11/2024 - ITK peralihan",
+        ),
+        rationale="Unknown source status cannot rule out either prohibited bridging origin.",
+    ),
+}
+
+assert set(PRODUCTION_REPLAY_EXPECTATIONS) == set(range(1, 21))
+assert all(
+    expectation.legal_citations and expectation.rationale
+    for expectation in PRODUCTION_REPLAY_EXPECTATIONS.values()
+), "every production replay expectation needs a named legal citation and rationale"
 
 
 @pytest.fixture(scope="module")

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_gold_coverage_floor.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_gold_coverage_floor.py
@@ -69,9 +69,14 @@ def test_every_corpus_persona_is_supported_for_its_product(
 
 
 def test_corpus_file_names_match_their_product_code() -> None:
-    """``<CODE>.json`` must declare ``product_code == CODE`` — a renamed file
-    that keeps another product's expectations would otherwise pass silently."""
+    """``<CODE>[__CASE].json`` must declare ``product_code == CODE``.
+
+    A named suffix permits multiple legally distinct personas for one product;
+    the prefix still prevents a renamed fixture from silently claiming another
+    product's expectations.
+    """
     for path in sorted(CORPUS_DIR.glob("*.json")):
         spec = json.loads(path.read_text(encoding="utf-8"))
-        assert spec.get("product_code") == path.stem, path.name
-        assert path.stem in (spec.get("expected_candidates") or []), path.name
+        product_code = path.stem.split("__", 1)[0]
+        assert spec.get("product_code") == product_code, path.name
+        assert product_code in (spec.get("expected_candidates") or []), path.name

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_gold_replay_artifact.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_gold_replay_artifact.py
@@ -11,23 +11,37 @@ itself must guarantee for the gate's independent-grader flow:
 2. it is byte-deterministic (same fixed ``generated_at`` -> byte-identical
    JSON; different ``generated_at`` -> difference confined to that one key);
 3. the CLI runs in-process, exits 0, and the file it writes parses back to
-   the same zero-divergence report.
+   the same zero-divergence report;
+4. a pinned fixed-seed option matrix replays four fact permutations in each
+   of three legal branches against the highest signed production pack.
 """
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 from datetime import datetime, timezone
+from itertools import product
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
+from backend.scripts.visa_engine import gold_coverage_eval
+from backend.scripts.visa_engine.gold_replay_driver import (
+    PACKS_DIR,
+    _parse_utc,
+    select_highest_repository_pack,
+)
 from backend.tests.services.visa_engine import gold_replay
 
 _FIXED_NOW = datetime(2026, 7, 23, 12, 0, 0, tzinfo=timezone.utc)
 _OTHER_NOW = datetime(2026, 7, 24, 12, 0, 0, tzinfo=timezone.utc)
 
 _SCRIPT_PATH = Path(__file__).resolve().parents[4] / "scripts" / "visa_gold_replay.py"
+_MATRIX_PATH = Path(__file__).resolve().parent / "gold_coverage" / "fixtures" / "option_matrix.json"
+_, _MATRIX_PACK = select_highest_repository_pack(PACKS_DIR)
+_MATRIX_AS_OF = _parse_utc(_MATRIX_PACK["protected"]["signed_at"])
 
 
 def _serialize(report: dict) -> str:
@@ -41,6 +55,69 @@ def _load_cli_module() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _matrix_key(values: tuple[Any, ...]) -> str:
+    return "|".join(json.dumps(value, separators=(",", ":")) for value in values)
+
+
+def _matrix_report() -> dict[str, Any]:
+    """Replay the pinned option matrix in a fixed-seed order."""
+    artifact = json.loads(_MATRIX_PATH.read_text(encoding="utf-8"))
+    seed = int(artifact["seed"])
+    cases: list[dict[str, Any]] = []
+    pack: dict[str, Any] = {}
+
+    for branch in artifact["branches"]:
+        axes = branch["axes"]
+        combinations = list(product(*(axis["values"] for axis in axes)))
+        assert len(combinations) == 4, branch["id"]
+        assert set(branch["expectations"]) == {_matrix_key(values) for values in combinations}
+        for values in combinations:
+            case_key = _matrix_key(values)
+            raw_overrides = dict(branch["base_overrides"])
+            raw_overrides.update(
+                {axis["fact"]: value for axis, value in zip(axes, values, strict=True)}
+            )
+            overrides = {
+                fact: {"status": "KNOWN", "value": value}
+                for fact, value in raw_overrides.items()
+            }
+            result = gold_coverage_eval._evaluate(
+                overrides,
+                f"{branch['id']}:{case_key}",
+                as_of=_MATRIX_AS_OF,
+            )
+            pack = result["pack"]
+            actual = {
+                "state": result["actual"]["state"],
+                "candidates": result["actual"]["candidates"],
+            }
+            expected = branch["expectations"][case_key]
+            cases.append(
+                {
+                    "branch": branch["id"],
+                    "case": case_key,
+                    "legal_citations": branch["legal_citations"],
+                    "expected": expected,
+                    "actual": actual,
+                    "pass": actual == expected,
+                }
+            )
+
+    cases.sort(
+        key=lambda case: hashlib.sha256(
+            f"{seed}:{case['branch']}:{case['case']}".encode()
+        ).hexdigest()
+    )
+    passed = sum(case["pass"] for case in cases)
+    return {
+        "schema_version": artifact["schema_version"],
+        "seed": seed,
+        "pack": pack,
+        "cases": cases,
+        "summary": {"total": len(cases), "passed": passed, "failed": len(cases) - passed},
+    }
 
 
 def test_report_has_zero_divergences() -> None:
@@ -95,4 +172,30 @@ def test_cli_artifact_is_reproducible_across_runs(tmp_path: Path) -> None:
     argv = ["--fixed-now", _FIXED_NOW.isoformat()]
     assert cli.main([*argv, "--out", str(out_a)]) == 0
     assert cli.main([*argv, "--out", str(out_b)]) == 0
+    assert out_a.read_bytes() == out_b.read_bytes()
+
+
+def test_option_matrix_is_bounded_and_legally_anchored() -> None:
+    artifact = json.loads(_MATRIX_PATH.read_text(encoding="utf-8"))
+    assert artifact["seed"] == 9062026
+    assert len(artifact["branches"]) == 3
+    for branch in artifact["branches"]:
+        assert len(branch["axes"]) == 2
+        assert all(len(axis["values"]) == 2 for axis in branch["axes"])
+        assert len(branch["expectations"]) == 4
+        assert branch["legal_citations"]
+
+
+def test_option_matrix_replay_matches_all_twelve_pinned_cases() -> None:
+    report = _matrix_report()
+    assert report["summary"] == {"total": 12, "passed": 12, "failed": 0}, [
+        case for case in report["cases"] if not case["pass"]
+    ]
+
+
+def test_option_matrix_report_is_byte_identical_across_two_runs(tmp_path: Path) -> None:
+    out_a = tmp_path / "matrix-a.json"
+    out_b = tmp_path / "matrix-b.json"
+    out_a.write_text(_serialize(_matrix_report()), encoding="utf-8")
+    out_b.write_text(_serialize(_matrix_report()), encoding="utf-8")
     assert out_a.read_bytes() == out_b.read_bytes()

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq19_pack.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq19_pack.py
@@ -34,9 +34,11 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
+from backend.scripts.visa_engine import gold_replay_driver as driver
 from backend.scripts.visa_engine.compile_pack import (
     compile_rule_pack,
     load_rule_pack_payload,
@@ -65,6 +67,7 @@ from backend.services.visa_engine.bundle import (
 )
 from backend.services.visa_engine.compiler import DEFAULT_FACT_REGISTRY
 from backend.services.visa_engine.models import DecisionState, RulePackPayload
+from backend.tests.services.visa_engine.gold_replay import _persona_expected
 from backend.tests.services.visa_engine.test_evaluator_gold import Persona
 
 _PACKS_DIR = (
@@ -855,9 +858,21 @@ class TestInnocence:
 # ---------------------------------------------------------------------------
 
 
+#: PR-5 adds E33G and D2__121D to the shared ``gold_coverage/personas/``
+#: corpus (grown 18 -> 20; ``test_gold_coverage_floor.py`` measures all 20
+#: against the CURRENT highest signed pack). Both are supported only from
+#: seq-20 onward: E33G needed ``review.e33g.income-evidence`` retired and
+#: D2__121D needed the 60->180 stay-day cap, neither of which exists in
+#: seq-19 or earlier. This seq-19-scoped gate excludes them by name — not
+#: by loosening the assertion that the remaining 18 must all pass.
+_SEQ19_UNSUPPORTED_COVERAGE_PERSONAS = frozenset({"E33G.json", "D2__121D.json"})
+
+
 def _coverage_persona_specs() -> list[tuple[str, dict[str, Any]]]:
     specs = []
     for path in sorted(_GOLD_COVERAGE_CORPUS.glob("*.json")):
+        if path.name in _SEQ19_UNSUPPORTED_COVERAGE_PERSONAS:
+            continue
         specs.append((path.name, json.loads(path.read_text(encoding="utf-8"))))
     return specs
 
@@ -909,16 +924,45 @@ def _offline_decisions_against(
     return tuple(decisions)
 
 
+def _synthetic_expected(persona: Persona) -> dict[str, Any]:
+    """The pre-PR-5 synthetic fixture-pack contract (``gold_replay._persona_
+    expected``), independent of ``PRODUCTION_REPLAY_EXPECTATIONS``.
+
+    PR-5 re-derives ``gold_replay_driver._normalized_expected`` from each
+    persona's own legal citations to grade the SIGNED PRODUCTION pack replay
+    (seq-20 onward) — see ``test_evaluator_gold.PRODUCTION_REPLAY_
+    EXPECTATIONS``. This module's own historical measurements ("Ground
+    truth ... measured seq-18 at matches=5/20", revised 6/20 by the
+    decisiveness reorder) were pinned against the OLDER synthetic corpus
+    contract on seq-18/seq-19, packs that predate the legal re-derivation
+    entirely and are never signed or activated. Grading them against the
+    new legal table would silently swap what "divergence" means out from
+    under an already-landed, still-true historical finding — so this
+    fold-verification class keeps grading against the synthetic contract it
+    was always measured with, the same isolation PR-5 applies in
+    ``test_gold_replay_driver.py``."""
+    expected = _persona_expected(persona)
+    return {
+        "state": expected["state"],
+        "candidate_products": expected["candidates"],
+        "missing_facts": expected["missing_facts"],
+        "review_reason_codes": expected["review_reason_codes"],
+        "no_path_reason_codes": expected["no_path_reason_codes"],
+        "notice_codes": expected["notice_codes"],
+    }
+
+
 def _offline_report_for(
     compiled: compiler.CompiledRulePack, *, label: str
 ) -> dict[str, Any]:
     decisions = _offline_decisions_against(compiled, evaluated_at=AS_OF)
-    return build_report(
-        mode="offline",
-        generated_at=AS_OF,
-        decisions=decisions,
-        pack_source={"kind": "test-derived", "selection": label, "file": label},
-    )
+    with patch.object(driver, "_normalized_expected", _synthetic_expected):
+        return build_report(
+            mode="offline",
+            generated_at=AS_OF,
+            decisions=decisions,
+            pack_source={"kind": "test-derived", "selection": label, "file": label},
+        )
 
 
 @pytest.fixture(scope="module")

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq20_pack.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq20_pack.py
@@ -1048,8 +1048,8 @@ def _coverage_persona_specs() -> list[tuple[str, dict[str, Any]]]:
 
 
 class TestGoldCoverageReplay:
-    def test_corpus_has_eighteen_personas(self) -> None:
-        assert len(_coverage_persona_specs()) == 18
+    def test_corpus_has_twenty_personas(self) -> None:
+        assert len(_coverage_persona_specs()) == 20
 
     @pytest.mark.parametrize(
         "name,spec", _coverage_persona_specs(), ids=[n for n, _ in _coverage_persona_specs()]

--- a/evidence/2026-09/agent-nuzantara-backend-rag-visa-pr5-gold-gates-9309f411/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-visa-pr5-gold-gates-9309f411/brief.yml
@@ -1,0 +1,81 @@
+task_id: visa-pr5-gold-gates-0909
+gear: 2
+# Floor computed this run: `python3 scripts/evidence_pack_lint.py --print-floor
+# --changed-files-file ... --numstat-file ...` returns `2` (10 files,
+# +617/-37, churn 654 >= 400) — the SIZE term alone floors this PR at Gear 2.
+objective: >-
+  Finish PR-5 of the Visa Oracle decisiveness wave (last PR of the wave,
+  research/visa/2026-09-06-visa-oracle-decisiveness-investigation.md
+  §"PR-5 — gold personas and the CI gates", lines ~691-735, F7 disposition
+  ~866-872): separate the SIGNED-PRODUCTION-PACK legal replay contract
+  (`PRODUCTION_REPLAY_EXPECTATIONS`, re-derived per persona from its own
+  legal citation, never copied from an engine run) from the synthetic
+  20-persona fixture-pack contract the unit tests already used
+  (`gold_replay._persona_expected`); raise the offline replay floor from
+  "matches >= 4, unexplained <= 16" to "matches >= 17, the only 3
+  divergences are persona 1/9/10 by name" (closes a reviewer finding: no
+  loose 17/20, the specific three); grow `gold_coverage_replay` 18 -> 20
+  with E33G (remote work, clean foreign income) and the 121-day D2
+  multi-entry business persona (E31D and the 20-canonical-persona table
+  were already in place); add F7's bounded fixed-seed option-matrix replay
+  (3 branches x 4 fact-permutation cases = 12, seed 9062026, pinned to the
+  signed pack's own `signed_at`, never the wall clock); and isolate the
+  historical seq-18/seq-19 fold-verification gate
+  (`test_seq19_pack.py::TestGoldReplayDriverOffline`,
+  `TestGoldCoverageReplay`) from the new legal table so a pre-existing,
+  still-true historical finding is not silently re-graded against a
+  contract invented after it was measured. E33 (second home) intentionally
+  excluded — no owner GO recorded in the spec or the LIVE STATE log.
+constraints:
+  - "Never copy the engine's own current output into a gold expectation (generator is never grader) — every PRODUCTION_REPLAY_EXPECTATIONS row carries a named legal citation and rationale, enforced by an assertion in test_evaluator_gold.py."
+  - "Never weaken a legal assertion to make a historical test pass — the seq-19 fix re-scopes WHICH expectation table a replay is graded against (production vs. synthetic), it changes zero legal conclusions."
+  - "F7's option matrix stays bounded and reproducible: fixed seed, 2 axes x 2 values per branch (4 cases), byte-identical report across two runs."
+  - "gold_coverage_replay stays the fail-open catcher: 20/20 on every commit in this PR, never fewer."
+  - "No dated fixture may be a wall-clock time bomb — every persona/matrix evaluation is pinned to the highest signed pack's own `signed_at`, not `datetime.now()` (2026-08-30 clock-bomb scar)."
+acceptance:
+  - text: >-
+      WHEN the 6 targeted gold-gate files run, THEN all pass (161/161) —
+      20-persona gold replay, coverage floor (20/20), replay-artifact
+      determinism + F7 matrix (12/12), seq-20 pack gates, replay-driver
+      unit tests.
+    probe: >-
+      cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest
+      backend/tests/services/visa_engine/test_evaluator_gold.py
+      backend/tests/services/visa_engine/test_gold_coverage_floor.py
+      backend/tests/services/visa_engine/test_gold_replay_artifact.py
+      backend/tests/services/visa_engine/test_seq20_pack.py
+      backend/tests/scripts/visa_engine/test_gold_replay_driver.py
+  - text: >-
+      WHEN the historical seq-18/seq-19 fold-verification gate runs after
+      the isolation fix, THEN all 66 tests pass, including the 7 that
+      regressed when PR-5's legal table first touched them.
+    probe: >-
+      cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest
+      backend/tests/services/visa_engine/test_seq19_pack.py
+  - text: >-
+      WHEN the full visa_engine + visa_engine-scripts suite runs, THEN the
+      only failures are the 32 pre-existing DB/environment ones (31
+      asyncpg TooManyColumnsError + 1 migration-281-not-live), proved
+      identical on origin/main before this PR touched anything.
+    probe: >-
+      cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest
+      backend/tests/services/visa_engine/ backend/tests/scripts/visa_engine/
+consumer_map:
+  - "CI gate `test_gold_coverage_floor.py` — the fail-open catcher on every signed production pack from here on"
+  - "CI gate `test_interview_walk_census.py` — reads the same `gold_coverage/personas/` corpus this PR grows to 20"
+  - "`gold_replay_driver.py` — the seq-20 production replay script a consul session runs before signing/activating the NEXT pack"
+  - "`test_seq19_pack.py`'s historical fold-verification suite, now decoupled from future legal-table changes"
+risks:
+  - >-
+    The seq-19 isolation fix and the coverage-corpus scoping both live in
+    `test_seq19_pack.py`, a file outside PR-5's originally-mandated file
+    list — added because the 7 regressions Codex's session found live
+    there, not in the 9 files it had already touched; flagged explicitly
+    in the PR body for the reviewer.
+  - >-
+    E33 (second home) stays unreachable in the gold/coverage corpora,
+    same as before this PR — a deliberate scope cut, not an oversight.
+pii: >-
+  none — every persona/fixture in this diff is synthetic (Bali Zero
+  test personas, no real client data), and the option-matrix/gold
+  expectations carry only regulatory citations and boolean/enum facts.


### PR DESCRIPTION
## What

PR-5 of the Visa Oracle decisiveness wave — the LAST PR — `test-only`.

`research/visa/2026-09-06-visa-oracle-decisiveness-investigation.md`
§"PR-5 — gold personas and the CI gates" (lines ~691-735) and the F7
disposition (~866-872).

## The three gate moves, each justified by a named persona + legal citation

| # | Move | Before | After |
| - | ---- | ------ | ----- |
| 1 | 20-persona gold replay floor, re-derived from each persona's own legal description (`PRODUCTION_REPLAY_EXPECTATIONS`, never copied from an engine run) | `matches >= 4, unexplained <= 16` | `matches >= 17`, and the only unexplained divergences are **exactly persona ids {1, 9, 10}** — closes a reviewer finding that the old floor silently accepted any 17/20 |
| 2 | `gold_coverage_replay` — the fail-open catcher | 18/18 | **20/20**, adds E33G (remote work, clean foreign income) and the 121-day D2 multi-entry business persona |
| 3 | F7 bounded option-matrix replay | none | 3 branches × 4 fact-permutation cases = 12, fixed seed `9062026`, pinned to the highest signed pack's own `signed_at` (never wall-clock) |

**The 3 divergences that stay, by name, not by number:**
- persona 1: an Indonesian citizen remains outside the foreign-visa product set (UU 6/2011 jo. UU 63/2024)
- persona 9: the described direct C1→E28A onshore conversion remains unsupported (Permenkumham 22/2023 jo. 11/2024)
- persona 10: the same investor facts through status bridging remain adviser-review work (same regulation)

**E33 (second home) intentionally excluded** — no owner GO recorded in the spec or `.agents/skills/visaoracle/references/live-state-log.md`'s 2026-09-06 entries. E31D was already in the corpus before this PR.

## The 7 historical seq-18/seq-19 regressions this diff caused, and how they were resolved

Wiring `gold_replay_driver.build_report`'s `_normalized_expected` to the new
`PRODUCTION_REPLAY_EXPECTATIONS` table broke 7 tests in `test_seq19_pack.py`
— a DIFFERENT, older PR's fold-verification suite that reuses the same
driver to measure the seq-15→seq-19 E31 fail-open repair against seq-18,
pinned against the OLD synthetic fixture-pack contract (packs that predate
the legal re-derivation and are never signed or activated).

**This is not a loosened assertion — it is a scoping bug, and it is fixed
as a scoping bug.** `_offline_report_for` in `test_seq19_pack.py` now
patches `driver._normalized_expected` back to the synthetic
`gold_replay._persona_expected` contract for the duration of that file's
own seq-18/seq-19 replay — the identical isolation `test_gold_replay_driver.py`
already applies for its own report-mechanics tests. `_coverage_persona_specs`
excludes `E33G.json`/`D2__121D.json` by name from the seq-19-scoped 18-persona
check: both are provably unsupported on seq-19 (E33G needs
`review.e33g.income-evidence` retired, D2__121D needs the 60→180 stay-day
cap — neither exists before seq-20). No legal conclusion changed; the fix
tells each replay which contract it was always measured against.

Verified: all 7 pass again (`test_seq19_pack.py` 66/66, unchanged assertions).

## The 32 environment failures — proved pre-existing, not this PR's concern

```
apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest -p no:cacheprovider \
  backend/tests/services/visa_engine/ backend/tests/scripts/visa_engine/
```

Both on `origin/main` (untouched) and on this branch: **1 failed, 31 errors**
— identical test IDs both sides. 31 `asyncpg.exceptions.TooManyColumnsError:
tables can have at most 1600 columns` in `test_evaluate_endpoint.py`
(migration 281 not live in this local Postgres) + 1
`test_visa_engine_retention_fk_registry.py::test_restore_only_reapplies_the_entry_that_was_actually_unwound`
(same root cause). Reproduced explicitly on `origin/main` before touching
anything, per commit `bcef860d18`.

## Test counts

| Command | Result |
| --- | --- |
| `pytest test_evaluator_gold.py test_gold_coverage_floor.py test_gold_replay_artifact.py test_seq20_pack.py test_gold_replay_driver.py` | **161 passed** |
| `pytest test_seq19_pack.py` | **66 passed** |
| Full `visa_engine/` + `scripts/visa_engine/` suite | **1 failed, 2497 passed, 1 skipped, 31 errors** — the 32 pre-existing env failures only, identical to `origin/main` |

## Seat verdicts (generator ≠ grader)

- **Opus 5 (on-disk gate, independent read-only review of this diff):** PASS — no blockers.
- **`agy` Gemini 3.1 Pro (cross-family, same diff, 300s):** PASS — "No legal assertions are weakened, and no historical findings are falsified to pass tests." Independently confirmed the seq-19 isolation is a legitimate scoping (not a hidden regression), `PRODUCTION_REPLAY_EXPECTATIONS` is not reverse-engineered from an engine run (17/20 match, not 20/20 — a copy-paste job would show 20/20), and the F7 matrix carries no wall-clock time-bomb risk.

## Bites

**Bites:** consumer = CI gates `test_gold_coverage_floor.py` / `test_interview_walk_census.py` on `origin/main`, plus the seq-20 production replay `gold_replay_driver.py` a future consul session runs before signing/activating the next pack. Observation = `gold_coverage_replay` 20/20 and the offline replay floor holding at `>=17/20` with exactly `{1, 9, 10}` unexplained, both re-measured on the merged head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
