### PR TITLE
feat(proprioception): child calibration receptor — VALID/MISSING/EXPIRED/VERSION-MISMATCH/UNKNOWN per host/profile/model [pilot arm A]

### DIFF
--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -79,6 +79,7 @@ KNOWN_BOUNDARY_CLASSES = [
     "home<->home",              # the SAME control-plane file on two machines (global CLAUDE.md, 2026-08-31)
     "door<->door",              # the SAME rule in each CLI's auto-loaded door file (2026-08-31)
     "process<->cwd",            # a headless claude CLI process vs. its own working dir / worktree registration (2026-09-01)
+    "model<->calibration",      # configured child models vs. their stored context-window calibration (2026-09-10)
 ]
 
 SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=15",
@@ -1697,6 +1698,108 @@ def probe_headless_zombies(root: Path, args: dict, timeout: int) -> tuple[str, i
     return classify_headless_zombies(processes, registered)
 
 
+# -------------------------------------------------------- child calibration
+
+def _cc_current_version(bound: int) -> str | None:
+    """Running `claude` CLI's version, or None if undeterminable — never raises."""
+    try:
+        out = subprocess.run(["claude", "--version"], capture_output=True, text=True, timeout=bound)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.split()[0] if out.returncode == 0 and out.stdout.strip() else None
+
+def _cc_classify_model(cc, model: str, version: str | None, scope_val: str | None,
+                       dir_ok: bool, dir_files: list[Path]) -> tuple[str, str | None]:
+    """UNKNOWN wins if version/scope/dir is undeterminable. Else VALID/EXPIRED
+    come from the exact (model, version, scope) path (TTL reused via `cc.TTL`
+    — #3); VERSION-MISMATCH from a scan for the same model+scope under
+    another version; MISSING is what's left."""
+    if version is None or scope_val is None or not dir_ok:
+        return "UNKNOWN", None
+    current = cc.scoped_path(model, version, scope_val)
+    if current.exists():
+        try:
+            rec = json.loads(current.read_text())
+            m, v, w, s, obs = rec["model"], rec["version"], rec["window"], rec["scope"], rec["observed_at"]
+        except (OSError, ValueError, KeyError, TypeError):
+            return "UNKNOWN", None  # malformed record AT the configured model's path
+        if (m != model or v != version or s != scope_val or type(w) is not int
+                or not (16000 <= w <= 2_000_000) or isinstance(obs, bool) or not isinstance(obs, (int, float))):
+            return "UNKNOWN", None
+        age = time.time() - obs
+        return ("VALID" if 0 <= age <= cc.TTL else "EXPIRED"), None
+    for f in dir_files:
+        try:
+            rec = json.loads(f.read_text())
+        except (OSError, ValueError):
+            continue  # unrelated malformed file — not this model's expected path, not a finding
+        if (isinstance(rec, dict) and rec.get("model") == model
+                and rec.get("scope") == scope_val and rec.get("version") != version):
+            return "VERSION-MISMATCH", rec.get("version") if isinstance(rec.get("version"), str) else None
+    return "MISSING", None
+
+def probe_child_calibration(root: Path, args: dict, timeout: int) -> tuple[str, int, list[str]]:
+    """VALID/MISSING/EXPIRED/VERSION-MISMATCH/UNKNOWN per (host, profile, model).
+    Read-only (#1); child_context.py absence degrades to UNPROBEABLE, never a
+    crash (#2/#3). Only `configured` models are classified — a retired
+    model's stale record is no finding (§2). Evidence: host, profile dir
+    name, model, status only — no scope hash/session_id/content (#4)."""
+    import importlib.util
+    cc_path = root / "infra" / "claude-hooks" / "child_context.py"
+    try:
+        cc_spec = importlib.util.spec_from_file_location("_child_context_probe", cc_path)
+        cc = importlib.util.module_from_spec(cc_spec)
+        cc_spec.loader.exec_module(cc)
+    except Exception:
+        return UNPROBEABLE, 0, [f"{cc_path} unavailable — calibration is UNKNOWN for every triple"]
+
+    roster = list(dict.fromkeys(args.get("models", [])))  # verbatim, de-duped, never de-suffixed
+    version = _cc_current_version(min(timeout, 5))
+    host = machine_label()
+    ev, n_bad, triples = [], 0, 0
+    for prof in args.get("profiles", ["~/.claude"]):
+        profile_dir = Path(os.path.expanduser(prof))
+        if not profile_dir.is_dir():
+            continue  # this profile doesn't exist on this machine — not a finding
+        configured = list(roster)
+        for name in ("settings.json", "settings.local.json"):
+            fp = profile_dir / name
+            if not fp.is_file():
+                continue
+            try:
+                data = json.loads(fp.read_text())
+            except (OSError, ValueError):
+                continue
+            m = data.get("model") if isinstance(data, dict) else None
+            if isinstance(m, str) and m not in configured:
+                configured.append(m)  # taken VERBATIM — a `[1m]` spelling stays exactly that
+
+        old_seat = os.environ.get("CLAUDE_CONFIG_DIR")
+        os.environ["CLAUDE_CONFIG_DIR"] = str(profile_dir)
+        try:
+            try:
+                scope_val = cc.scope(str(root))
+            except Exception:
+                scope_val = None
+            capdir = cc.scoped_path("_probe_", "_probe_", "_probe_").parent
+            try:
+                dir_files = list(capdir.glob("*.json")) if capdir.is_dir() else []
+                dir_ok = True
+            except OSError:
+                dir_files, dir_ok = [], False
+            for model in configured:
+                triples += 1
+                status, other_v = _cc_classify_model(cc, model, version, scope_val, dir_ok, dir_files)
+                n_bad += status != "VALID"
+                detail = f" (other version: {other_v})" if other_v else ""
+                ev.append(f"{host}:{prof}:{model}: {status}{detail}")
+        finally:
+            (os.environ.pop("CLAUDE_CONFIG_DIR", None) if old_seat is None
+             else os.environ.__setitem__("CLAUDE_CONFIG_DIR", old_seat))
+    if triples == 0:
+        return UNPROBEABLE, 0, ["no configured profile exists on this machine"]
+    return (DIVERGED if n_bad else RECONCILED), n_bad, ev
+
 BUILTINS = {
     "git_alignment": probe_git_alignment,
     "executed_code_currency": probe_executed_code_currency,
@@ -1707,6 +1810,7 @@ BUILTINS = {
     "canon_blocks": probe_canon_blocks,
     "door_canon_parity": probe_door_canon_parity,
     "headless_zombies": probe_headless_zombies,
+    "child_calibration": probe_child_calibration,
 }
 
 
@@ -2200,6 +2304,17 @@ DEFAULT_REGISTRY: list[dict] = [
                     "it, this receptor never does. P2 (unregistered worktree): `git worktree "
                     "list` no longer knows this path -- re-register with `git worktree add` if "
                     "the work is still wanted, or let the process finish and clean up by hand.",
+    },
+    {
+        "id": "child_calibration", "type": "builtin", "target": "child_calibration",
+        "class": "model<->calibration", "severity": "P3",
+        "boundary": "configured child models <-> ~/.claude/state/child-context-capacities/",
+        "machines": ["all"], "tags": ["fast"], "timeout_sec": 15,
+        "args": {"models": ["claude-haiku-4-5-20251001", "claude-sonnet-5", "claude-opus-5"],
+                 "profiles": ["~/.claude", "~/.claude-acct2"]},
+        "fix_hint": "MISSING/EXPIRED/VERSION-MISMATCH: re-run the owned native calibration probe "
+                    "(child_context.py::calibrate) for that model/profile. UNKNOWN: fix the "
+                    "unreadable input (CLI version, scope, or the capacities dir) first.",
     },
 ]
 

--- a/scripts/tests/test_proprioception_child_calibration.py
+++ b/scripts/tests/test_proprioception_child_calibration.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Guilt + innocence for `probe_child_calibration` (scripts/proprioception.py).
+
+Every case builds a synthetic root carrying the REAL child_context.py (never a
+copy) plus a synthetic profile — never this machine's real `~/.claude`
+(superscar #1: a test on real state passes/fails for the wrong reasons).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SPEC = importlib.util.spec_from_file_location("proprioception", _HERE.parents[1] / "proprioception.py")
+assert _SPEC and _SPEC.loader
+pp = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(pp)
+_CC_SOURCE = (_HERE.parents[2] / "infra" / "claude-hooks" / "child_context.py").read_text()
+
+def _scope(root: Path, profile: Path) -> str:
+    """Ground-truth scope for fixtures — the real function, not a guess."""
+    old = os.environ.get("CLAUDE_CONFIG_DIR")
+    os.environ["CLAUDE_CONFIG_DIR"] = str(profile)
+    try:
+        s = importlib.util.spec_from_file_location("_cc_fixture", root / "infra" / "claude-hooks" / "child_context.py")
+        m = importlib.util.module_from_spec(s)
+        s.loader.exec_module(m)
+        return m.scope(str(root))
+    finally:
+        (os.environ.pop("CLAUDE_CONFIG_DIR", None) if old is None
+         else os.environ.__setitem__("CLAUDE_CONFIG_DIR", old))
+
+@contextlib.contextmanager
+def _case(settings: dict | None = None):
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        root = tmp / "repo"
+        (root / "infra" / "claude-hooks").mkdir(parents=True)
+        (root / "infra" / "claude-hooks" / "child_context.py").write_text(_CC_SOURCE)
+        prof = tmp / "profile"
+        prof.mkdir()
+        if settings is not None:
+            (prof / "settings.json").write_text(json.dumps(settings))
+        yield root, prof
+
+def _record(profile: Path, model: str, version: str, scope_val: str,
+            window: int = 200000, age: float = 3600.0, raw: str | None = None) -> None:
+    capdir = profile / "state" / "child-context-capacities"
+    capdir.mkdir(parents=True, exist_ok=True)
+    key = hashlib.sha256(json.dumps([model, version, scope_val]).encode()).hexdigest()
+    body = raw if raw is not None else json.dumps({
+        "model": model, "version": version, "window": window, "scope": scope_val,
+        "observed_at": time.time() - age, "source": "test", "session_id": "s"})
+    (capdir / f"{key}.json").write_text(body)
+
+def _run(root: Path, profile: Path, models: list[str], version: str | None = "9.9.9"):
+    orig = pp._cc_current_version
+    pp._cc_current_version = lambda bound: version
+    try:
+        return pp.probe_child_calibration(root, {"models": models, "profiles": [str(profile)]}, 15)
+    finally:
+        pp._cc_current_version = orig
+
+def test_valid_fresh_matching_record_in_range():
+    with _case() as (root, prof):
+        _record(prof, "claude-sonnet-5", "9.9.9", _scope(root, prof))
+        status, n, ev = _run(root, prof, ["claude-sonnet-5"])
+        assert status == pp.RECONCILED and n == 0 and any(e.endswith(": VALID") for e in ev), (status, n, ev)
+
+def test_missing_configured_model_has_no_record():
+    with _case() as (root, prof):
+        status, n, ev = _run(root, prof, ["claude-opus-5"])
+        assert status == pp.DIVERGED and n == 1 and any(e.endswith(": MISSING") for e in ev), ev
+
+def test_expired_older_than_ttl():
+    with _case() as (root, prof):
+        _record(prof, "claude-sonnet-5", "9.9.9", _scope(root, prof), age=7 * 86400 + 100)
+        _, n, ev = _run(root, prof, ["claude-sonnet-5"])
+        assert n == 1 and any(e.endswith(": EXPIRED") for e in ev), ev
+
+def test_expired_negative_age_future_observed_at():
+    with _case() as (root, prof):
+        _record(prof, "claude-sonnet-5", "9.9.9", _scope(root, prof), age=-100)
+        _, n, ev = _run(root, prof, ["claude-sonnet-5"])
+        assert n == 1 and any(e.endswith(": EXPIRED") for e in ev), ev
+
+def test_version_mismatch_same_model_and_scope_other_version():
+    with _case() as (root, prof):
+        _record(prof, "claude-sonnet-5", "1.0.0", _scope(root, prof))
+        _, n, ev = _run(root, prof, ["claude-sonnet-5"], version="9.9.9")
+        assert n == 1 and any("VERSION-MISMATCH" in e for e in ev), ev
+
+def test_unknown_current_version_undeterminable():
+    with _case() as (root, prof):
+        _record(prof, "claude-sonnet-5", "9.9.9", _scope(root, prof))  # a VALID record, still UNKNOWN
+        _, n, ev = _run(root, prof, ["claude-sonnet-5"], version=None)
+        assert n == 1 and any(e.endswith(": UNKNOWN") for e in ev), ev
+
+def test_unknown_malformed_record_for_configured_model():
+    with _case() as (root, prof):
+        _record(prof, "claude-sonnet-5", "9.9.9", _scope(root, prof), raw="{not json")
+        _, n, ev = _run(root, prof, ["claude-sonnet-5"])
+        assert n == 1 and any(e.endswith(": UNKNOWN") for e in ev), ev
+
+def test_record_for_a_non_configured_model_is_ignored():
+    with _case() as (root, prof):
+        _record(prof, "claude-old-retired", "9.9.9", _scope(root, prof))
+        status, n, ev = _run(root, prof, ["claude-sonnet-5"])  # sonnet-5 itself is MISSING
+        assert status == pp.DIVERGED and n == 1 and not any("claude-old-retired" in e for e in ev), ev
+
+def test_settings_model_value_is_reported_verbatim():
+    with _case(settings={"model": "claude-fable-5-1[1m]"}) as (root, prof):
+        _, n, ev = _run(root, prof, [])
+        assert n == 1 and any(e.endswith("claude-fable-5-1[1m]: MISSING") for e in ev), ev
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL {name}: {exc}")
+    print(f"\n{'FAILED' if failures else 'OK'} — {failures} failure(s)")
+    raise SystemExit(1 if failures else 0)


### PR DESCRIPTION
Pilot mission 1, **arm A** (baseline: single Sonnet 5 builder). Implements D3 of
`infra/codex-hooks/FABLE-MEASUREMENTS-2026-09-09.md`.

One read-only builtin probe `child_calibration` in `scripts/proprioception.py` reporting,
per `(host, profile, model)`, whether the child context-window calibration is
`VALID` / `MISSING` / `EXPIRED` / `VERSION-MISMATCH` / `UNKNOWN`, reading
`~/.claude/state/child-context-capacities/` and evaluating only currently configured
models. `TTL`, `scope()` and `scoped_path()` are reused from
`infra/claude-hooks/child_context.py` (guarded import → `UNPROBEABLE`, never a crash);
a settings `model` spelling such as `claude-fable-5-1[1m]` is taken verbatim and never
de-suffixed. +250/-0 over two files.

**Do not merge and do not arm auto-merge.** This PR is one arm of a measured pilot;
Fable and Astra adjudicate the two arms before either lands.

Bites: consumer is `python3 scripts/proprioception.py --json --no-report --probes child_calibration`,
run by the Dux on M5 at the pushed SHA `87b4e79e75`. Observed output row:

```
{"id": "child_calibration", "class": "model<->calibration", "status": "DIVERGED",
 "severity": "P3", "n_findings": 5, "duration_ms": 396,
 "evidence": ["m5:~/.claude:claude-haiku-4-5-20251001: VALID",
              "m5:~/.claude:claude-sonnet-5: VALID",
              "m5:~/.claude:claude-opus-5: VALID",
              "m5:~/.claude:claude-fable-5-1[1m]: MISSING",
              "m5:~/.claude-acct2:claude-haiku-4-5-20251001: MISSING"]}
```

A sha256 manifest of `~/.claude/state/child-context-capacities/` was byte-identical
before and after that run — the receptor is read-only in fact, not only by intent.

Checks run by the Dux (not by the builder — generator is never grader):
`test_proprioception_child_calibration.py` 9/9 PASS · `proprioception.py --selftest` OK
(registry valid, 19 probes) · ruff introduces 0 new diagnostics (the 3 pre-existing E741
in untouched code are unchanged) · diff limited to the two intended files, +250/-0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTWkpZ4DgmQK98HwKJuLzD
