### PR TITLE
fix(codex-hooks): a frozen source names the END of its handoff chain, not its first hop

### DIFF
--- a/infra/codex-hooks/context_bridge.py
+++ b/infra/codex-hooks/context_bridge.py
@@ -350,18 +350,43 @@ def instructions(sid: str) -> str:
     )
 
 
+def chain_summary(state: dict[str, Any], limit: int = 6) -> str:
+    """Follow to_session links to the LAST hop and say whether it is alive or parked.
+
+    A source that only names its direct continuation sends the owner to a task that may
+    itself have handed off or parked (measured 2026-09-09: 85 -> 87 -> 8b -> 8d, parked at
+    the hop limit, while the deny text still said "work continues in 87").
+    """
+    hops: list[str] = []
+    current = state
+    while current.get("to_session") and len(hops) < limit:
+        hops.append(str(current["to_session"]))
+        try:
+            current = load(state_path(hops[-1]))
+        except ValueError:
+            break
+    if not hops:
+        return "no continuation recorded."
+    last = current
+    phase = last.get("rollover")
+    if phase == "accepted":
+        verdict = "still handing off"
+    elif phase == "needs_attention":
+        verdict = "PARKED (" + str(last.get("failure") or "hop limit") + "): open a fresh task"
+    elif phase in ("requested", "starting"):
+        verdict = "handing off right now"
+    else:
+        verdict = "LIVE: open that task"
+    return "chain " + " -> ".join(h[:8] for h in hops) + "; last hop " + hops[-1] + " is " + verdict + "."
+
+
 def frozen_reason(sid: str, state: dict[str, Any]) -> str:
     """Name the exact handoff phase, so a frozen source never retries blindly."""
     phase = state.get("rollover")
     attempt = state.get("launch_attempts", 0)
     helpers = "Only the bridge helpers (checkpoint/status/verify) run here."
     if phase == "accepted":
-        return (
-            "Handed off: work continues in Codex task "
-            + str(state.get("to_session"))
-            + ". This source is frozen; open that task. "
-            + helpers
-        )
+        return "Handed off: " + chain_summary(state) + " This source is frozen. " + helpers
     if phase == "starting":
         return (
             f"Continuation launching (attempt {attempt} of {MAX_LAUNCH_ATTEMPTS}); "

--- a/infra/codex-hooks/test_context_bridge.py
+++ b/infra/codex-hooks/test_context_bridge.py
@@ -551,7 +551,7 @@ def test_frozen_source_names_its_phase(setup: tuple) -> None:
         state.update(rollover="accepted", to_session="dest-session-9")
         bridge.save(path, state)
     reason = bridge.hook(tool)["hookSpecificOutput"]["permissionDecisionReason"]
-    assert "Codex task dest-session-9" in reason
+    assert "dest-session-9 is LIVE" in reason
     with bridge.locked(sid) as (path, state):
         state.update(rollover="needs_attention", failure="ValueError", launch_attempts=1)
         bridge.save(path, state)
@@ -576,3 +576,20 @@ def test_retry_and_release_verbs(setup: tuple) -> None:
         bridge.save(path, state)
     with pytest.raises(ValueError):
         bridge.release(sid)  # an in-flight launch must be cancelled first
+
+
+def test_accepted_source_names_the_end_of_the_chain(setup: tuple) -> None:
+    _, _, e = setup
+    sid = parked_source(setup, "TimeoutError", 1)
+    with bridge.locked(sid) as (path, state):
+        state.update(rollover="accepted", to_session="hop1-session-1")
+        bridge.save(path, state)
+    bridge.save(bridge.state_path("hop1-session-1"), {"from_session": sid, "rollover": "accepted", "to_session": "hop2-session-2"})
+    bridge.save(bridge.state_path("hop2-session-2"), {"from_session": "hop1-session-1", "rollover": "needs_attention"})
+    tool = {**e, "hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {"command": "ls"}}
+    reason = bridge.hook(tool)["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "hop1-ses -> hop2-ses" in reason and "hop2-session-2 is PARKED" in reason
+    assert "open a fresh task" in reason
+    bridge.save(bridge.state_path("hop2-session-2"), {"from_session": "hop1-session-1"})
+    reason = bridge.hook(tool)["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "hop2-session-2 is LIVE" in reason


### PR DESCRIPTION
Cherry-pick of `5f61e14c63` onto fresh `origin/main`, one concern: the PreToolUse deny text on an accepted Codex source pointed at the FIRST hop of its handoff chain instead of the last one.

Measured 2026-09-09 23:41 WITA: the owner pasted a new mandate into source `01a08685`, whose chain `87 -> 8b -> 8d` had already parked at the hop limit an hour earlier. The pointer sent them to a dead task and the model checkpointed the mandate into a source nobody would ever resume.

`chain_summary()` now follows `to_session` links (bounded) to the last hop and reports LIVE / still handing off / handing off right now / PARKED with its failure — and in the parked case tells the owner to open a fresh task. One regression test.

## Why this is a separate PR

`5f61e14c63` was deliberately EXCLUDED from #6046 (merged `8300b93d9c`): that mandate said "b23fa5c9f5 + cherry-pick 7fab171563, niente altro". Consequence: Pro's live Codex seat has been AHEAD of `main` since then — live `92c7ad2967ab…` vs main `242343520ea6…`. Reinstalling from main would have silently reverted a reviewed, live fix, so the seat was left alone and this PR brings `main` up to it instead.

Supersedes #6052 for this commit only — see the comment there.

## Verification

- `origin/main:infra/codex-hooks/context_bridge.py` blob == `5f61e14c63^:…` blob (`773cd169…`), same for the test file (`185c4a66…`): the cherry-pick applied with no adaptation.
- Resulting file sha256 `92c7ad2967ab072a96c14be8626af0d218b4b9ac9f3827cd6f5461c43b7b6e4c` — byte-identical to the reviewed tip and to Pro's live seat.
- `python3 -m pytest infra/codex-hooks/ -q` → **51 passed**.

## Bites

CONSUMER: the live Codex seat on each host, `~/.codex/hooks/nuzantara-context/context_bridge.py`, installed by `infra/codex-hooks/install.py` (already on main, not shipped by this PR).

Observation to make AFTER merge, from a detached worktree on fresh `origin/main`:

- **Pro** — live is already `92c7ad29…`; the observation is `main` REACHING it: `cmp -s` live vs `origin/main` goes from differing to identical, with no write to the live file.
- **M5 / Mini** — live is `3b72981cd5e6…` (the `658a9fc7` revision, two behind); `install.py` from main bytes moves them to `92c7ad29…` and `cmp -s` identical.

Reported in a comment on this PR before the work is called done.

## Residuals NOT in this PR

Deliberately left for a follow-up (one PR, one concern): the 2 defects in `native_claude_child_probe.py` (`--model` and `--parent-model` both default to haiku, so the prefix filter counts the parent as a child and `transport_passed` is never true; the Haiku parent emits three Agent dispatches for one child) and the 9 council residuals declared as dissent in `evidence/2026-09/agent-air-m5-infra-child-ledger-ship-0909-7c02d3ef/pack.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRgCfZacYYdLR26BnfbMU4
