### PR TITLE
feat(ci): no Vercel previews for the hourly translation branches (agent/*/mouth/hourly-*)

### DIFF
--- a/apps/mouth/vercel.json
+++ b/apps/mouth/vercel.json
@@ -7,7 +7,8 @@
   "git": {
     "deploymentEnabled": {
       "gh-readonly-queue/**": false,
-      "gh-readonly-queue/*": false
+      "gh-readonly-queue/*": false,
+      "agent/*/mouth/hourly-*": false
     }
   }
 }


### PR DESCRIPTION
## What

`apps/mouth/vercel.json` → `git.deploymentEnabled` gains `"agent/*/mouth/hourly-*": false`: no Vercel preview for the branches the hourly translation organ (`pro.translate_hourly`, `scripts/translate-articles-cron-wrapper.sh`) pushes as `agent/nuzantara/mouth/hourly-<timestamp>`.

## Why

Ruled by Zero 2026-09-10 ("go col punto 3, disabilita le preview hourly"). These PRs carry only generated `.id/.it/.ru/.fr` MDX under `apps/mouth/src/content/articles/**` — bot output nobody QAs visually — yet every one of them buys a full ~7-minute preview because the path is under `apps/mouth/`. Measured on the project's deployment list, current billing period (2026-08-12 → 09-10):

| hourly-lane previews | count | build minutes |
|---|---|---|
| READY (built) | 112 | 735 (≈26/day, ≈$11/month at $0.014/min) |
| ERROR | 1 | — |

Sampled 2026-09-08/10 the lane ran hotter: 48 READY in 48 h, 323 minutes. The wrapper never reads a Vercel preview (no `vercel`/`preview` reference in it), the PR's required checks do not include any Vercel check, and the production build after the merge still happens — the ignore step judges it against what is live.

The other `agent/*` lanes need nothing: their non-frontend previews are already CANCELED by the ignore step at ~30 s each; `agent/*/mouth/*` previews for humans stay.

**Bites:** the Vercel project `mouth`. Consumer: the next hourly translation PR (`chore(mouth): promote hourly-translated …`, branch `agent/nuzantara/mouth/hourly-*`) opened after this lands. Observation, recorded here after merge: `GET /v6/deployments?projectId=…` lists **no** deployment whose `meta.githubCommitRef` is that branch (neither READY nor CANCELED), while a human `agent/*/mouth/<name>` push still gets its preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
