### PR TITLE
perf(ci): classify three measured paths that kept the merge queue in the full battery

### DIFF
--- a/scripts/ci/change_map.py
+++ b/scripts/ci/change_map.py
@@ -74,6 +74,33 @@ EXACT_RULES: dict[str, set[str] | frozenset[str]] = {
     # touch.
     ".claude/settings.json": {"fleet_ops"},
     ".claude/settings.local.json": {"fleet_ops"},
+    # detect-secrets baseline, not app code — .github/workflows/security.yml
+    # and immune-enforcement.yml read it to run the secrets scanner; none of
+    # the six tests.yml product suites do (verified: no match in tests.yml,
+    # apps/, packages/). Measured 7-day window 2026-09-02..09 (379
+    # merge_group runs of tests.yml): before this entry it sat in
+    # unknown_paths on 6 merge-queue batches (PRs #5825, #5833, #5841,
+    # #5846, #6031, #6046, 2026-09-06..09) and 10 pull_request runs, forcing
+    # run_all=True on top of an otherwise docs/evidence-only diff each time.
+    # `security_sensitive` is the domain scripts/ci/security_gate_flags.py
+    # reads to pick scanners; since 2026-09-05 it grants none of the six
+    # product suites on its own (see the `_suggested_jobs` comment below).
+    ".secrets.baseline": {"security_sensitive"},
+    # prettier-changed-files.yml and the husky pre-commit hook read this;
+    # none of the six product suites do. Measured 7-day window
+    # 2026-09-02..09: unknown_paths on 6 merge-queue batches, all re-queues
+    # of PR #5769 on 2026-09-05.
+    ".prettierignore": {"fleet_ops"},
+    # Fleet topology map. Before this entry it fell into unknown_paths and
+    # forced run_all=True (all six product suites) although it IS read by
+    # backend code (verified by grep, 2026-09-10):
+    # apps/backend-rag/backend/llm/deepseek_client.py,
+    # apps/backend-rag/backend/app/routers/article_composer.py, and
+    # apps/backend-rag/backend/tests/services/council/test_no_deepseek_regression.py.
+    # backend_python is the narrower, correct guilt — backend-tests +
+    # e2e-tests, not all six. Measured 7-day window 2026-09-02..09: unknown
+    # on 1 merge-queue batch and 6 pull_request runs.
+    "FLEET_TOPOLOGY.json": {"backend_python"},
     "package.json": {
         "mouth",
         "admin_dashboard",

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -939,6 +939,66 @@ class ChangeMapTests(unittest.TestCase):
         self.assertTrue(result["domains"]["backend_python"])
         self.assertIn("backend-tests", result["suggested_jobs"])
 
+    def test_innocence_secrets_baseline_and_prettierignore_skip_every_test_job(
+        self,
+    ) -> None:
+        # Measured 7-day window 2026-09-02..09 (379 merge_group runs of
+        # tests.yml): .secrets.baseline sat in unknown_paths on 6
+        # merge-queue batches (PRs #5825, #5833, #5841, #5846, #6031, #6046)
+        # and 10 pull_request runs; .prettierignore was unknown on 6 queue
+        # batches (all re-queues of PR #5769, 2026-09-05). Neither is read
+        # by any of the six tests.yml product suites.
+        for path in (".secrets.baseline", ".prettierignore"):
+            with self.subTest(path=path):
+                result = cm.classify([path])
+                self.assertFalse(result["run_all"])
+                self.assertEqual(result["reason"], "classified")
+                self.assertEqual(result["unknown_paths"], [])
+                self.assertEqual(result["suggested_jobs"], [])
+
+    def test_guilt_fleet_topology_edit_runs_the_backend_suite_that_reads_it(
+        self,
+    ) -> None:
+        # FLEET_TOPOLOGY.json is read by backend code (verified by grep,
+        # 2026-09-10): apps/backend-rag/backend/llm/deepseek_client.py,
+        # apps/backend-rag/backend/app/routers/article_composer.py, and
+        # apps/backend-rag/backend/tests/services/council/test_no_deepseek_regression.py.
+        # Before this entry it fell into unknown_paths and forced run_all
+        # (all six suites); backend_python is the narrower, correct guilt.
+        result = cm.classify(["FLEET_TOPOLOGY.json"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["reason"], "classified")
+        self.assertEqual(
+            result["suggested_jobs"], cm._suggested_jobs({"backend_python"}, False)
+        )
+        self.assertEqual(result["suggested_jobs"], ["backend-tests", "e2e-tests"])
+
+    def test_guilt_secrets_baseline_combined_with_backend_change_still_selects_backend(
+        self,
+    ) -> None:
+        # security_sensitive contributes nothing to _suggested_jobs() on its
+        # own (2026-09-05); it must not suppress a co-changed backend_python
+        # path either.
+        result = cm.classify(
+            [".secrets.baseline", "apps/backend-rag/backend/app/main.py"]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertTrue(result["domains"]["security_sensitive"])
+        self.assertTrue(result["domains"]["backend_python"])
+        self.assertEqual(result["suggested_jobs"], ["backend-tests", "e2e-tests"])
+
+    def test_innocence_siblings_of_the_new_exact_rules_stay_fail_open(self) -> None:
+        # EXACT means exact: a file that merely resembles one of the three
+        # new EXACT_RULES entries above must not inherit its classification.
+        for path in (
+            ".secrets.baseline.bak",
+            "apps/x/FLEET_TOPOLOGY.json",
+        ):
+            with self.subTest(path=path):
+                result = cm.classify([path])
+                self.assertTrue(result["run_all"])
+                self.assertEqual(result["unknown_paths"], [path])
+
     def test_innocence_guard_conformance_registry_skips_every_test_job(self) -> None:
         # infra/guard-conformance/ is more specific than the "infra/"
         # catch-all and must win — before this entry the registry inherited


### PR DESCRIPTION
## Why

Lane 2 of the 2026-09-10 queue-time mandate (R1b). The premise "Backend Tests skipped on 13 % of merge_group runs vs ~60 % eligible" was measured and does **not** hold: over 2026-09-02..09 (379 merge_group + 681 pull_request runs of `tests.yml`, every job readable) the queue skipped Backend Tests on 38.8 % of batches vs 28.9 % on the PR lane, and the 09-02..04 cluster of full batteries was the stale `SCRIPTS_COUPLING` census (`enumeration_failed` on 142 runs, 0 since 2026-09-05). Since 09-05 the queue skips Backend on 134/206 batches. Of the 72 that ran it, 25 were `unclassified_paths`; two files account for 12.

| path | measured | readers | domain |
|---|---|---|---|
| `.secrets.baseline` | 6 queue batches, 10 PR runs | `security.yml`, `immune-enforcement.yml` — none of the six suites | `security_sensitive` |
| `.prettierignore` | 6 queue batches (re-queues of #5769) | `prettier-changed-files.yml`, husky | `fleet_ops` |
| `FLEET_TOPOLOGY.json` | 1 batch, 6 PR runs — fail-open bought all six suites | `deepseek_client.py`, `article_composer.py` | `backend_python` (backend + e2e only) |

Exact-match only; `.secrets.baseline.bak` and `apps/x/FLEET_TOPOLOGY.json` stay fail-open (tested). No allowlist widening beyond these three measured paths; the weekly coverage report (Lane 3) will keep measuring the residual.

Checks run: corpus `python3 scripts/ci/test_change_map.py` 75 OK, pytest 75 passed / 62 subtests, ruff clean, `scripts_coupling_census.py --check` up to date.

Bites: consumer = the `Change map` job of the next merge-queue batch whose diff carries `.secrets.baseline` (every evidence-bearing agent PR that touches it) — its notice line reads `reason=classified` with `Backend Shard 1-3` skipped and `Backend Tests (Python)` green, where the same diff shape read `unclassified_paths` on 2026-09-09 (batches pr-6031, pr-6046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiibViYaJfsDSHw5sGXtEC
