### PR TITLE
feat(ci): PR collision check reports this PR against armed/queued PRs only

### DIFF
--- a/scripts/ci/pr_collision_check.py
+++ b/scripts/ci/pr_collision_check.py
@@ -90,12 +90,19 @@ succeeded) and never flip a clean 0 to 1 (they are not findings) — they
 are reported as prose so a reader cannot mistake incomplete coverage for
 a positive result, without this advisory tool's exit code lying about
 which of those two very different things happened.
+
+SUBJECT-SCOPED default (Zero mandate 2026-09-10, measured on PR #6058's own advisory
+comment: 35 add/add pairs across 40 open PRs, NONE involving #6058 — over-match in the
+reporting dimension, superscar #3). The default live run compares THIS PR (the subject)
+only against open PRs that are ARMED or QUEUED at scan time, never candidate-vs-candidate.
+`--all-open` restores the old repo-wide scan, unfiltered.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -110,6 +117,10 @@ PR_LIST_LIMIT = 500  # K9: `gh pr list --limit` — see gather_live_pr_windows.
 # omits the key shares this SAME value, so they're all mutually comparable
 # (matches this tool's pre-COMPARABILITY behavior for every old fixture).
 NO_MERGE_BASE_DECLARED = "<fixture: no merge_base declared>"
+# Non-file keys in a fixture PR's file-map: "merge_base" pre-existed,
+# "armed"/"queued" are new (declare a candidate). Skipped when parsing
+# patches — a bool/int here would crash str.splitlines().
+RESERVED_PR_KEYS = {"merge_base", "armed", "queued"}
 # `@@ -oldstart[,oldlen] +newstart[,newlen] @@` — a missing count means 1.
 _HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 Window = tuple[int, int]  # [start, end) in OLD-FILE (merge-base) coordinates
@@ -220,6 +231,14 @@ class NotCompared:
     merge_base_b: str
 
 
+@dataclass(frozen=True)
+class Candidate:
+    """An ARMED/QUEUED open PR (SUBJECT-SCOPED mode). Keyed by label
+    (e.g. "PR #6046") everywhere, matching Collision's own labels."""
+    armed: bool
+    queue_position: int | None  # None if armed-only or queued w/o a known position
+
+
 def find_collisions(pr_files: dict[str, dict[str, list[Window]]]) -> list[Collision]:
     """pr_files: {pr_label: {path: [windows]}}. A file on <2 PRs is never a
     candidate — necessary but not sufficient (trap #11). Callers that must
@@ -291,6 +310,38 @@ def find_collisions_and_uncompared(
     return collisions, not_compared
 
 
+def find_subject_collisions_and_uncompared(
+    pr_files: dict[str, dict[str, list[Window]]],
+    pr_merge_base: dict[str, str],
+    subject_label: str,
+    candidate_labels: list[str],
+) -> tuple[list[Collision], list[NotCompared]]:
+    """Compares ONLY (subject, candidate) pairs, one at a time — NEVER
+    candidate-vs-candidate (two armed PRs colliding with EACH OTHER but
+    not the subject must not be reported). Reuses
+    find_collisions_and_uncompared per pair unchanged, so its tested
+    guilt/innocence/merge-base logic is exercised exactly as before; this
+    only restricts WHICH pairs get built."""
+    subject_files = pr_files.get(subject_label, {})
+    subject_mb = pr_merge_base.get(subject_label, NO_MERGE_BASE_DECLARED)
+    all_collisions: list[Collision] = []
+    all_not_compared: list[NotCompared] = []
+    for candidate_label in candidate_labels:
+        pair_files = {
+            subject_label: subject_files,
+            candidate_label: pr_files.get(candidate_label, {}),
+        }
+        pair_mb = {
+            subject_label: subject_mb,
+            candidate_label: pr_merge_base.get(candidate_label, NO_MERGE_BASE_DECLARED),
+        }
+        collisions, not_compared = find_collisions_and_uncompared(pair_files, pair_mb)
+        all_collisions.extend(collisions)
+        all_not_compared.extend(not_compared)
+    all_collisions.sort(key=lambda c: (c.path, c.pr_a, c.pr_b))
+    return all_collisions, all_not_compared
+
+
 def format_report(
     collisions: list[Collision],
     scanned_prs: int,
@@ -354,6 +405,80 @@ def format_report(
     return "\n".join(lines)
 
 
+def format_subject_report(
+    subject_label: str,
+    collisions: list[Collision],
+    not_compared: list[NotCompared],
+    candidates: dict[str, "Candidate"],
+    truncated_scan: bool = False,
+) -> str:
+    """SUBJECT-SCOPED report: every line is scoped to `subject_label` vs
+    `candidates` (armed/queued open PRs only), never candidate-vs-
+    candidate. Keeps the SAME marker/heading and the same NOT COMPARED /
+    hot-files / advisory-footer sections as format_report; only the
+    verdict line and its evidence differ."""
+
+    def display(label: str) -> str:
+        return f"#{label.removeprefix('PR #')}" if label.startswith("PR #") else label
+
+    def status(c: "Candidate") -> str:
+        if c.queue_position is not None:
+            return f"queued, position {c.queue_position}"
+        return "queued" if not c.armed else "armed"
+
+    lines = ["## PR collision check (advisory — gates nothing)", ""]
+    if truncated_scan:
+        lines.append(
+            f"CANDIDATE SCAN TRUNCATED — the armed/queued-state query hit the "
+            f"{PR_LIST_LIMIT}-PR fetch cap; PR(s) beyond it were never "
+            "considered as candidates. Treat this run as a PARTIAL scan of "
+            "the armed/queued set, not a clean one."
+        )
+        lines.append("")
+
+    colliding_labels = sorted({c.pr_b if c.pr_a == subject_label else c.pr_a for c in collisions})
+    if collisions:
+        lines.append(
+            f"COLLISION — this PR ({display(subject_label)}) overlaps "
+            f"{len(colliding_labels)} armed/queued PR(s):"
+        )
+        fragments = []
+        for label in colliding_labels:
+            spots = [c for c in collisions if label in (c.pr_a, c.pr_b)]
+            spot_text = ", ".join(
+                f"`{c.path}` lines {(c.window_b if c.pr_a == subject_label else c.window_a)[0]}-"
+                f"{(c.window_b if c.pr_a == subject_label else c.window_a)[1]}"
+                for c in spots
+            )
+            fragments.append(f"{display(label)} ({status(candidates[label])}) on {spot_text}")
+        lines.append("  " + "; ".join(fragments))
+    else:
+        candidate_list = ", ".join(display(lbl) for lbl in sorted(candidates)) or "none"
+        lines.append(
+            f"CLEAN — this PR ({display(subject_label)}) has no add/add overlap "
+            f"with the {len(candidates)} armed/queued PR(s): {candidate_list}"
+        )
+    lines.append("")
+    lines.append(
+        f"NOT COMPARED — {len(not_compared)} pair(s) shared a file with this PR "
+        "but had DIFFERENT merge-bases, so their windows are not in the same "
+        "coordinate space and could not be checked for overlap at all (see "
+        "module docstring, COMPARABILITY)."
+    )
+    for nc in not_compared:
+        lines.append(f"  - `{nc.path}`: {nc.pr_a} vs {nc.pr_b} — different merge-bases, not compared")
+    lines.append("")
+    lines.append("Known hot files (reference — flagged above only on a live overlap):")
+    for path, note in HOT_FILES:
+        lines.append(f"  - `{path}` — {note}")
+    lines.append("")
+    lines.append(
+        "Advisory only: gates nothing. Reinstate-by-catch to a required check "
+        "needs two clean advisory weeks first (PR-3 acceptance)."
+    )
+    return "\n".join(lines)
+
+
 def _run(cmd: list[str], cwd: Path, check: bool = True) -> str:
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)
@@ -390,14 +515,32 @@ def pr_windows_from_git(repo_root: Path, base_sha: str, head_ref: str) -> tuple[
     patch = _run(["git", "diff", "--no-renames", merge_base, head_ref], repo_root)
     return merge_base, parse_multi_file_diff(patch)
 
+def gather_live_pr_windows_for_numbers(
+    repo_root: Path, base_ref: str, pr_numbers: set[int]
+) -> tuple[dict[str, dict[str, list[Window]]], dict[str, str]]:
+    """The per-PR half of gather_live_pr_windows, factored out so the
+    SUBJECT-SCOPED default path can fetch windows for ONLY {subject} |
+    candidates instead of every open PR."""
+    base_sha = _run(["git", "rev-parse", base_ref], repo_root).strip()
+    result: dict[str, dict[str, list[Window]]] = {}
+    pr_merge_base: dict[str, str] = {}
+    for number in sorted(pr_numbers):
+        label = f"PR #{number}"
+        head_sha = fetch_pr_head(repo_root, number)
+        merge_base, windows = pr_windows_from_git(repo_root, base_sha, head_sha)
+        if windows:
+            result[label] = windows
+            pr_merge_base[label] = merge_base
+    return result, pr_merge_base
+
 def gather_live_pr_windows(
     repo_root: Path, repo_slug: str, base_ref: str = DEFAULT_BASE_REF
 ) -> tuple[dict[str, dict[str, list[Window]]], dict[str, str], bool]:
-    """Returns `(pr_windows, pr_merge_base, truncated_scan)`. truncated_scan
-    is True iff `gh pr list` returned exactly PR_LIST_LIMIT entries — the
-    only signal available that more open PRs may exist beyond the fetch
-    window (K9); it can never be told apart from "exactly the limit, no
-    more" from here, so it is reported as a possibility, not a certainty."""
+    """`--all-open` legacy path: unfiltered repo-wide scan, unchanged
+    behavior. Returns `(pr_windows, pr_merge_base, truncated_scan)`;
+    truncated_scan is True iff `gh pr list` returned exactly
+    PR_LIST_LIMIT entries (K9) — reported as a possibility, not a
+    certainty."""
     raw = _run(["gh", "pr", "list", "--repo", repo_slug, "--state", "open",
                 "--json", "number", "--limit", str(PR_LIST_LIMIT)], repo_root)
     try:
@@ -408,18 +551,126 @@ def gather_live_pr_windows(
         # ("collision found"). See test_pr_collision_check.py FIX-2 tests.
         raise CollisionCheckError(f"gh pr list returned unparseable JSON: {exc}") from exc
     truncated_scan = len(pr_list) >= PR_LIST_LIMIT
-
-    base_sha = _run(["git", "rev-parse", base_ref], repo_root).strip()
-    result: dict[str, dict[str, list[Window]]] = {}
-    pr_merge_base: dict[str, str] = {}
-    for entry in pr_list:
-        label = f"PR #{entry['number']}"
-        head_sha = fetch_pr_head(repo_root, entry["number"])
-        merge_base, windows = pr_windows_from_git(repo_root, base_sha, head_sha)
-        if windows:
-            result[label] = windows
-            pr_merge_base[label] = merge_base
+    pr_numbers = {entry["number"] for entry in pr_list}
+    result, pr_merge_base = gather_live_pr_windows_for_numbers(repo_root, base_ref, pr_numbers)
     return result, pr_merge_base, truncated_scan
+
+def resolve_subject_pr_number() -> int:
+    """Subject PR number for the SUBJECT-SCOPED default. Reads
+    `GITHUB_EVENT_PATH`'s `pull_request.number` — set automatically by
+    the `pull_request:` trigger, no workflow-file edit needed — falling
+    back to `GITHUB_REF`'s `refs/pull/<N>/...` shape. Never falls back to
+    "all open PRs" silently: pass `--all-open` explicitly instead."""
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if event_path:
+        try:
+            payload = json.loads(Path(event_path).read_text())
+            number = payload.get("pull_request", {}).get("number")
+            if isinstance(number, int):
+                return number
+        except (OSError, json.JSONDecodeError):
+            pass
+    match = re.match(r"refs/pull/(\d+)/", os.environ.get("GITHUB_REF", ""))
+    if match:
+        return int(match.group(1))
+    raise CollisionCheckError(
+        "could not determine the subject PR number (GITHUB_EVENT_PATH has no "
+        "pull_request.number and GITHUB_REF is not refs/pull/<N>/...) -- pass "
+        "--all-open for the repo-wide legacy scan, or run this inside a "
+        "pull_request-triggered job"
+    )
+
+def gather_armed_candidate_pr_numbers(
+    repo_root: Path, repo_slug: str, subject_number: int, limit: int = PR_LIST_LIMIT
+) -> dict[str, Candidate]:
+    """ONE `gh api graphql` call per page fetching every open PR's
+    `autoMergeRequest`/`mergeQueueEntry`/`isInMergeQueue` state.
+    Candidates = open PRs armed OR queued, EXCLUDING the subject — the
+    cure for the over-match measured on PR #6058 (35 pairs / 40 open
+    PRs, none involving #6058). A query failure is an OPERATIONAL
+    failure (rc 2 via CollisionCheckError) -- NEVER a silent fallback to
+    `--all-open`, which would reintroduce the over-match."""
+    try:
+        owner, name = repo_slug.split("/", 1)
+    except ValueError as exc:
+        raise CollisionCheckError(f"--repo must be OWNER/NAME, got {repo_slug!r}") from exc
+
+    query = (
+        "query($owner: String!, $name: String!, $cursor: String) { "
+        "repository(owner: $owner, name: $name) { "
+        "pullRequests(states: OPEN, first: 100, after: $cursor) { "
+        "pageInfo { hasNextPage endCursor } "
+        "nodes { number autoMergeRequest { enabledAt } "
+        "mergeQueueEntry { position } isInMergeQueue } } } }"
+    )
+    candidates: dict[str, Candidate] = {}
+    cursor: str | None = None
+    fetched = 0
+    while True:
+        cmd = ["gh", "api", "graphql", "-f", f"query={query}", "-f", f"owner={owner}", "-f", f"name={name}"]
+        if cursor:
+            cmd += ["-f", f"cursor={cursor}"]
+        raw = _run(cmd, repo_root)
+        try:
+            payload = json.loads(raw)
+            errors = payload.get("errors")
+            if errors:
+                # GitHub can return partial `data` ALONGSIDE `errors` -- never
+                # continue on a partial armed/queued set, that could print a
+                # false CLEAN (review finding, codex-gpt-5.6-sol).
+                raise CollisionCheckError(f"the armed-state query returned errors: {errors[0]}")
+            conn = payload["data"]["repository"]["pullRequests"]
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            # Never "no candidates" -- must surface as CANNOT VERIFY (rc 2).
+            raise CollisionCheckError(f"the armed-state query failed: {exc}") from exc
+        for node in conn["nodes"]:
+            number = node["number"]
+            fetched += 1
+            if number == subject_number:
+                continue
+            armed = node.get("autoMergeRequest") is not None
+            mqe = node.get("mergeQueueEntry")
+            queued = mqe is not None or bool(node.get("isInMergeQueue"))
+            if armed or queued:
+                position = mqe.get("position") if mqe else None
+                candidates[f"PR #{number}"] = Candidate(armed=armed, queue_position=position)
+        if not conn["pageInfo"]["hasNextPage"]:
+            break
+        if fetched >= limit:
+            # More pages remain past the cap -- an INCOMPLETE armed/queued
+            # scan must never read as CLEAN (review finding, codex-gpt-5.6-sol).
+            raise CollisionCheckError(
+                f"the open-PR set exceeded the {limit}-PR scan cap with more "
+                "pages remaining -- armed/queued candidates beyond the cap "
+                "were never seen"
+            )
+        cursor = conn["pageInfo"]["endCursor"]
+    return candidates
+
+def gather_fixture_pr_candidates(fixture_path: Path) -> tuple[str | None, dict[str, Candidate]]:
+    """Fixture-mode counterpart of gather_armed_candidate_pr_numbers: a
+    fixture declares `"subject": "<label>"` at the top level and, per PR,
+    `"armed": true/false` and/or `"queued": true/false/<position int>`.
+    Omitting `"subject"` gets `(None, {})` -- main() reads that as "fall
+    back to the pre-existing repo-wide fixture behavior", exactly like
+    every fixture written before this key existed."""
+    try:
+        data = json.loads(fixture_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise CollisionCheckError(f"--fixture {fixture_path} is not valid JSON: {exc}") from exc
+    subject = data.get("subject")
+    if subject is None:
+        return None, {}
+    candidates: dict[str, Candidate] = {}
+    for label, files in data.get("prs", {}).items():
+        if label == subject:
+            continue
+        armed = bool(files.get("armed", False))
+        queued_raw = files.get("queued", False)
+        if armed or queued_raw:
+            position = queued_raw if isinstance(queued_raw, int) else None
+            candidates[label] = Candidate(armed=armed, queue_position=position)
+    return subject, candidates
 
 def gather_fixture_pr_windows(fixture_path: Path) -> dict[str, dict[str, list[Window]]]:
     try:
@@ -432,6 +683,8 @@ def gather_fixture_pr_windows(fixture_path: Path) -> dict[str, dict[str, list[Wi
     for label, files in data.get("prs", {}).items():
         by_file: dict[str, list[Window]] = {}
         for path, patch in files.items():
+            if path in RESERVED_PR_KEYS:  # "armed"/"queued" are bools -- never a patch string
+                continue
             windows = parse_add_windows_for_hunks(patch)
             if windows:
                 by_file[path] = windows
@@ -467,21 +720,46 @@ def main(argv: list[str] | None = None) -> int:
         "--fixture", type=Path, default=None,
         help="JSON fixture ({'prs':{'<label>':{'<path>':'<patch>'}}}) — bypasses git/gh entirely",
     )
+    parser.add_argument(
+        "--all-open", action="store_true",
+        help="repo-wide legacy scan (pre-2026-09-10) -- default now compares this PR "
+             "only against ARMED/QUEUED open PRs",
+    )
     args = parser.parse_args(argv)
 
     truncated_scan = False
+    subject_label: str | None = None
+    candidates: dict[str, Candidate] = {}
     try:
         if args.fixture:
             pr_windows = gather_fixture_pr_windows(args.fixture)
             pr_merge_base = gather_fixture_pr_merge_base(args.fixture)
-        else:
+            if not args.all_open:
+                subject_label, candidates = gather_fixture_pr_candidates(args.fixture)
+        elif args.all_open:
             pr_windows, pr_merge_base, truncated_scan = gather_live_pr_windows(
                 args.repo_root, args.repo, args.base_ref
+            )
+        else:
+            subject_number = resolve_subject_pr_number()
+            subject_label = f"PR #{subject_number}"
+            candidates = gather_armed_candidate_pr_numbers(args.repo_root, args.repo, subject_number)
+            candidate_numbers = {int(label.split("#", 1)[1]) for label in candidates}
+            pr_windows, pr_merge_base = gather_live_pr_windows_for_numbers(
+                args.repo_root, args.base_ref, {subject_number} | candidate_numbers
             )
     except CollisionCheckError as exc:
         print(f"CANNOT VERIFY — collision scan could not be assembled:\n{exc}", file=sys.stderr)
         return 2
 
+    if subject_label is not None:
+        collisions, not_compared = find_subject_collisions_and_uncompared(
+            pr_windows, pr_merge_base, subject_label, sorted(candidates)
+        )
+        print(format_subject_report(subject_label, collisions, not_compared, candidates, truncated_scan))
+        return 1 if collisions else 0
+
+    # `--all-open`, or a `--fixture` declaring no "subject" -- legacy repo-wide path.
     collisions, not_compared = find_collisions_and_uncompared(pr_windows, pr_merge_base)
 
     # K7: "shared by 2+ PRs" means exactly that -- a path's touch-count

--- a/scripts/ci/test_pr_collision_check.py
+++ b/scripts/ci/test_pr_collision_check.py
@@ -547,6 +547,10 @@ def test_find_collisions_and_uncompared_backward_compat_when_all_same_sentinel()
 def test_pr_list_truncated_at_limit_is_reported_not_silently_clean(
     monkeypatch, capsys, tmp_path: Path
 ) -> None:
+    """`--all-open` is required here: PR_LIST_LIMIT truncation is a property
+    of the legacy `gh pr list` repo-wide scan (gather_live_pr_windows),
+    which only runs under `--all-open` now that the SUBJECT-SCOPED default
+    (module docstring) fetches candidates via GraphQL instead."""
     limit = pcc.PR_LIST_LIMIT
     fake_prs = json.dumps([{"number": i} for i in range(1, limit + 1)])
 
@@ -564,7 +568,7 @@ def test_pr_list_truncated_at_limit_is_reported_not_silently_clean(
         raise AssertionError(f"unexpected command in fake_run: {cmd}")
 
     monkeypatch.setattr(pcc, "_run", fake_run)
-    rc = pcc.main(["--repo-root", str(tmp_path)])
+    rc = pcc.main(["--repo-root", str(tmp_path), "--all-open"])
     captured = capsys.readouterr()
     assert rc == 0  # no collisions found -- but must not read as confident clean
     assert "SCAN TRUNCATED" in captured.out
@@ -576,7 +580,8 @@ def test_pr_list_below_limit_is_not_reported_as_truncated(
 ) -> None:
     """Innocence guard: a scan that returns FEWER PRs than the limit must
     NOT print the truncation line -- the heuristic must not fire on an
-    ordinary small open-PR count."""
+    ordinary small open-PR count. `--all-open` for the same reason as the
+    truncation test above (this heuristic lives in the legacy scan)."""
     fake_prs = json.dumps([{"number": 1}, {"number": 2}])
 
     def fake_run(cmd, cwd, check=True):
@@ -593,7 +598,180 @@ def test_pr_list_below_limit_is_not_reported_as_truncated(
         raise AssertionError(f"unexpected command in fake_run: {cmd}")
 
     monkeypatch.setattr(pcc, "_run", fake_run)
-    rc = pcc.main(["--repo-root", str(tmp_path)])
+    rc = pcc.main(["--repo-root", str(tmp_path), "--all-open"])
     captured = capsys.readouterr()
     assert rc == 0
     assert "SCAN TRUNCATED" not in captured.out
+
+
+# ── SUBJECT-SCOPED default: compare THIS PR only against ARMED/QUEUED open
+# PRs, never candidate-vs-candidate -- guilt+innocence (superscar #3) ──────
+
+
+def _subject_fixture(tmp_path: Path, name: str, subject: str, prs: dict) -> Path:
+    fixture = tmp_path / name
+    fixture.write_text(json.dumps({"subject": subject, "prs": prs}))
+    return fixture
+
+
+def test_subject_vs_armed_candidate_overlap_is_flagged(tmp_path: Path, capsys) -> None:
+    """(a) subject vs an ARMED candidate, overlapping windows -> reported."""
+    fixture = _subject_fixture(tmp_path, "a.json", "PR #100", {
+        "PR #100": {PENDING_ARMS: "@@ -1271,6 +1271,7 @@\n" + " l\n" * 6 + "+x\n"},
+        "PR #200": {"armed": True, PENDING_ARMS: "@@ -1272,6 +1272,7 @@\n" + " l\n" * 6 + "+y\n"},
+    })
+    rc = pcc.main(["--fixture", str(fixture)])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "COLLISION" in captured.out
+    assert "#100" in captured.out and "#200" in captured.out
+    assert "armed" in captured.out
+
+
+def test_subject_overlap_with_non_candidate_pr_is_not_reported(tmp_path: Path, capsys) -> None:
+    """(b) same overlap as (a), but the other PR is not armed/queued ->
+    not a candidate, never compared, absent from the report."""
+    fixture = _subject_fixture(tmp_path, "b.json", "PR #100", {
+        "PR #100": {PENDING_ARMS: "@@ -1271,6 +1271,7 @@\n" + " l\n" * 6 + "+x\n"},
+        "PR #200": {PENDING_ARMS: "@@ -1272,6 +1272,7 @@\n" + " l\n" * 6 + "+y\n"},
+    })
+    rc = pcc.main(["--fixture", str(fixture)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "CLEAN" in captured.out
+    assert "0 armed/queued" in captured.out
+    assert "#200" not in captured.out
+
+
+def test_two_armed_candidates_colliding_with_each_other_not_subject_is_not_reported(
+    tmp_path: Path, capsys
+) -> None:
+    """(c) #200 and #300 are both candidates and collide with EACH OTHER,
+    but neither overlaps the subject -> must NOT be reported."""
+    fixture = _subject_fixture(tmp_path, "c.json", "PR #100", {
+        "PR #100": {"only_subject.txt": "@@ -1,1 +1,2 @@\n l1\n+x\n"},
+        "PR #200": {"armed": True, PENDING_ARMS: "@@ -1271,6 +1271,7 @@\n" + " l\n" * 6 + "+x\n"},
+        "PR #300": {"queued": 2, PENDING_ARMS: "@@ -1272,6 +1272,7 @@\n" + " l\n" * 6 + "+y\n"},
+    })
+    rc = pcc.main(["--fixture", str(fixture)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "CLEAN" in captured.out
+    assert "2 armed/queued" in captured.out
+    assert "#200" in captured.out and "#300" in captured.out  # candidate list, not a collision
+
+
+def test_subject_with_zero_candidates_is_clean(tmp_path: Path, capsys) -> None:
+    """(d) no other PR is armed/queued -> CLEAN, "0 armed/queued"."""
+    fixture = _subject_fixture(tmp_path, "d.json", "PR #100", {
+        "PR #100": {PENDING_ARMS: "@@ -1271,6 +1271,7 @@\n" + " l\n" * 6 + "+x\n"},
+        "PR #200": {PENDING_ARMS: "@@ -1272,6 +1272,7 @@\n" + " l\n" * 6 + "+y\n"},
+    })
+    rc = pcc.main(["--fixture", str(fixture)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "0 armed/queued" in captured.out
+
+
+def test_all_open_flag_reproduces_legacy_repo_wide_output_on_old_fixture(
+    tmp_path: Path, capsys
+) -> None:
+    """(e) `--all-open` on the old k7b fixture reproduces the pre-existing
+    repo-wide report exactly (same fixture/assertion as the k7b test above)."""
+    fixture = tmp_path / "k7b_all_open.json"
+    fixture.write_text(json.dumps({
+        "prs": {
+            "PR #1": {
+                "shared.txt": "@@ -1,1 +1,2 @@\n l1\n+x\n",
+                "only-pr1.txt": "@@ -1,1 +1,2 @@\n l1\n+x\n",
+            },
+            "PR #2": {
+                "shared.txt": "@@ -50,1 +50,2 @@\n l50\n+y\n",
+                "only-pr2.txt": "@@ -1,1 +1,2 @@\n l1\n+y\n",
+            },
+        }
+    }))
+    rc = pcc.main(["--fixture", str(fixture), "--all-open"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "1 file(s) genuinely shared" in captured.out
+
+
+def test_candidate_query_failure_yields_cannot_verify_not_clean(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """(f) the GraphQL candidate scan failing -> rc 2 CANNOT VERIFY, never
+    a silent fallback to --all-open and never a false CLEAN."""
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": {"number": 4242}}))
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+
+    def fake_run(cmd, cwd, check=True):
+        if cmd[:3] == ["gh", "api", "graphql"]:
+            raise pcc.CollisionCheckError("simulated: gh api graphql unreachable")
+        raise AssertionError(f"unexpected command in fake_run: {cmd}")
+
+    monkeypatch.setattr(pcc, "_run", fake_run)
+    rc = pcc.main(["--repo-root", str(tmp_path)])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "CANNOT VERIFY" in captured.err
+    assert captured.out == ""
+
+
+def test_gather_fixture_pr_candidates_defaults_no_subject_to_none(tmp_path: Path) -> None:
+    """Innocence guard: a fixture with no "subject" key returns (None, {})
+    -- main() reads that as "fall back to legacy repo-wide fixture mode",
+    the exact backward-compat guarantee every pre-existing fixture relies on."""
+    fixture = tmp_path / "no_subject.json"
+    fixture.write_text(json.dumps({"prs": {"PR #1": {"f.txt": "@@ -1,1 +1,2 @@\n l1\n+x\n"}}}))
+    subject, candidates = pcc.gather_fixture_pr_candidates(fixture)
+    assert subject is None
+    assert candidates == {}
+
+
+# ── review findings (codex-gpt-5.6-sol, BLOCK): a GraphQL `errors` array
+# alongside partial `data`, and the pagination cap hit with more pages
+# remaining, must both raise -- never a false CLEAN on incomplete data ────
+
+
+def test_candidate_scan_graphql_errors_field_raises_cannot_verify(tmp_path: Path, monkeypatch) -> None:
+    """GitHub can return partial `data` ALONGSIDE a top-level `errors`
+    array -- an ignored `errors` field would let an incomplete armed/queued
+    set print CLEAN. Must raise instead of continuing on it."""
+    def fake_run(cmd, cwd, check=True):
+        return json.dumps({
+            "data": {"repository": {"pullRequests": {
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                "nodes": [],
+            }}},
+            "errors": [{"message": "some fields were not returned"}],
+        })
+
+    monkeypatch.setattr(pcc, "_run", fake_run)
+    with pytest.raises(pcc.CollisionCheckError, match="errors"):
+        pcc.gather_armed_candidate_pr_numbers(tmp_path, "Bali-Zero/Teman2", subject_number=1)
+
+
+def test_candidate_scan_cap_hit_with_more_pages_raises_cannot_verify(tmp_path: Path, monkeypatch) -> None:
+    """Innocence guard's mirror: hitting the fetch cap while `hasNextPage`
+    is still True must raise, never silently stop and report the PRs seen
+    so far as a complete (and possibly false) CLEAN."""
+    pages = {"n": 0}
+
+    def fake_run(cmd, cwd, check=True):
+        pages["n"] += 1
+        start = (pages["n"] - 1) * 100 + 1
+        nodes = [
+            {"number": i, "autoMergeRequest": None, "mergeQueueEntry": None, "isInMergeQueue": False}
+            for i in range(start, start + 100)
+        ]
+        return json.dumps({"data": {"repository": {"pullRequests": {
+            "pageInfo": {"hasNextPage": True, "endCursor": f"c{pages['n']}"},
+            "nodes": nodes,
+        }}}})
+
+    monkeypatch.setattr(pcc, "_run", fake_run)
+    with pytest.raises(pcc.CollisionCheckError, match="scan cap"):
+        pcc.gather_armed_candidate_pr_numbers(tmp_path, "Bali-Zero/Teman2", subject_number=1, limit=200)


### PR DESCRIPTION
## Why

Lane 1 (R2, DIRTY prediction at open) of the 2026-09-10 queue-time mandate. The advisory `PR collision check` already existed with the right discriminator (add/add overlapping hunk windows on a shared merge-base), but its comment on PR #6058 listed **35 overlaps across 40 open PRs, none involving #6058** — the reader could not see whether their PR was at risk (superscar #3, over-match in the reporting dimension).

## What

- Default: **this PR vs open PRs that are armed (`autoMergeRequest`) or queued (`mergeQueueEntry` / `isInMergeQueue`)**, one paginated GraphQL query; pairs are only (subject, candidate).
- Subject from `GITHUB_EVENT_PATH` / `GITHUB_REF` — the workflow file is untouched.
- GraphQL `errors` or a scan hitting the page cap with pages left → rc 2 `CANNOT VERIFY`, never a partial `CLEAN`.
- `--all-open` keeps the old repo-wide table for manual use; fixtures without `subject` keep the old behaviour.

Live smoke (read-only) on #6054: 7 candidates instead of 40 open PRs, `CLEAN — this PR (#6054) has no add/add overlap with the 7 armed/queued PR(s): #5619, #5623, #5734, #6015, #6028, #6044, #6051`.

Checks: 41 tests (9 new: guilt/innocence a-f, fixture parser, the two partial-scan cures), ruff clean. Cross-family review codex-gpt-5.6-sol: BLOCK (errors field ignored; silent pagination cap) → cured → OK. Net ~456 lines, above the ~400 guide: the excess is mandated tests, flagged rather than trimmed.

Bites: consumer = the next pair of open PRs where one is armed/queued and the other touches the same hunk window (e.g. a healer-tick and a ledger PR on `PENDING-ARMS.md`) — the second PR's comment reads `COLLISION — this PR (#N) overlaps 1 armed/queued PR(s): #M (…)`, and a PR with no such overlap reads `CLEAN … with the K armed/queued PR(s): …` instead of today's 35-pair table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiibViYaJfsDSHw5sGXtEC
