### PR TITLE
chore(gitignore): un-exclude docs/reports/ so committed CI reports are not silently dropped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,16 @@ reports/
 # nothing. Git cannot re-include a file whose PARENT directory is excluded, so the directory
 # itself is un-excluded here — negating only the contents would not work.
 !research/**/reports/
+# Same disease, second victim (2026-09-10): the weekly measure-only CI reports
+# (scripts/ci/change_map_coverage.py, scripts/ci/flaky_harvest.py) write their committed,
+# reviewable output to docs/reports/<name>/<date>.md — a normal deliverable, not generated
+# noise — and the bare `reports/` rule above silently ate it too, identically to the research
+# incident documented right above. Un-exclude the whole docs/reports tree rather than adding
+# a third one-off negation the next report generator would also need to discover. The
+# DIRECTORY itself is un-excluded, not just its contents: git cannot re-include files under a
+# parent directory it is still excluding.
+!docs/reports/
+!docs/reports/**
 *.md.report
 *.json.report
 sentinel-results/


### PR DESCRIPTION
The bare `reports/` rule in `.gitignore` excludes `docs/reports/` at any depth — the same disease as the 2026-08-31 research-reports incident documented next to it. The weekly measure-only CI reports of the 2026-09-10 queue-time mandate (change-map coverage, flaky harvest) land in `docs/reports/<name>/<date>.md` as reviewable deliverables; without this negation `git add` drops them silently (both builders hit it independently). Directory and contents un-excluded, matching the `research/` precedent. Shipped alone so the two report PRs do not carry the same add/add hunk.

Verified in the worktree: `git add --dry-run docs/reports/.probe` → `add 'docs/reports/.probe'`.

Bites: consumer = PR #6065 (flaky harvest) and the change-map coverage PR — their `docs/reports/**` files show up in `git diff --stat` on main after merge, and `git check-ignore docs/reports/x.md` on main exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiibViYaJfsDSHw5sGXtEC