### PR TITLE
fix(codex-hooks): the child probe counted its own parent as a child, so the default invocation could not pass

### DIFF
--- a/infra/codex-hooks/native_claude_child_probe.py
+++ b/infra/codex-hooks/native_claude_child_probe.py
@@ -17,6 +17,19 @@ sys.path.insert(0, str(Path(__file__).parents[1] / "claude-hooks"))
 import child_context
 
 
+def select_child_observations(observations: list[dict]) -> list[dict]:
+    """Children are identified by the hook event that produced the observation.
+
+    SubagentStop carries the CHILD's transcript; SessionStart carries the PARENT's.
+    Selecting on a `claude-<family>-` model prefix instead — as this probe did until
+    2026-09-10 — counts the parent as a child whenever parent and child share a
+    family, which is exactly the case for the default invocation (`--model haiku`
+    with `--parent-model claude-haiku-4-5`): the count then never equals
+    `--children` and `transport_passed` can never be true on any host.
+    """
+    return [o for o in observations if o.get("hook_event_name") == "SubagentStop"]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", choices=("haiku", "sonnet", "opus"), default="haiku")
@@ -83,7 +96,7 @@ def main() -> None:
         else f"Read {root / 'fixture.txt'} twice sequentially (second Read after the first result), report its number."
     )
     role = "Explore"
-    prompt = f"Bounded native child probe, explicitly authorized delegation. Use Agent exactly {args.children} time(s), all in ONE parallel dispatch message, subagent_type {role} and model {args.model} explicitly. Give each only this assignment: {assignment} Read-only, no edits, no network, no replacements, no memories, expected result42. Wait for every result then independently Read the same fixture yourself, compare42 and return CLAUDE_CHILD_PROBE_OK. No other work."
+    prompt = f"Bounded native child probe, explicitly authorized delegation. Emit EXACTLY ONE assistant message containing EXACTLY {args.children} Agent tool call(s) — the probe measures parallel dispatch and fails if the calls arrive in separate messages or if there are more than {args.children}. Do not retry, do not re-dispatch, do not add a verification agent. subagent_type {role} and model {args.model} explicitly. Give each only this assignment: {assignment} Read-only, no edits, no network, no replacements, no memories, expected result42. Wait for every result then independently Read the same fixture yourself, compare42 and return CLAUDE_CHILD_PROBE_OK. No other work."
     env = {k: v for k, v in os.environ.items() if k not in ("ANTHROPIC_API_KEY",)}
     env["CONTEXT_JUMP_NO_SPAWN"] = "1"
     outpath = root / "probe.jsonl"
@@ -151,6 +164,9 @@ def main() -> None:
                     {
                         **child_context.snapshot(path.read_text()),
                         "capacity_scope": event.get("capacity_scope"),
+                        # The event IS the parent/child discriminator. SubagentStop
+                        # carries the child's transcript, SessionStart the parent's.
+                        "hook_event_name": event["hook_event_name"],
                     }
                 )
     for r in starts:
@@ -197,16 +213,22 @@ def main() -> None:
         "observed_events": sorted({r["hook_event_name"] for r in metadata}),
     }
     # A successful transport with UNKNOWN usage is not a measured-budget proof.
-    child_observations = [
-        o
-        for o in observations
-        if str(o.get("model") or "").startswith("claude-" + args.model + "-")
-    ]
+    # Select children by the hook event that produced the observation, never by a
+    # model-name prefix: the parent's own SessionStart observation matches that
+    # prefix whenever parent and child share a family, which is the case for every
+    # invocation where --model and --parent-model agree. The model stays an
+    # ASSERTION below, so a child answering on the wrong model still fails.
+    child_observations = select_child_observations(observations)
+    evidence["child_models_expected"] = all(
+        str(o.get("model") or "").startswith("claude-" + args.model + "-")
+        for o in child_observations
+    )
     evidence["transport_passed"] = (
         run.returncode == 0
         and evidence["success"]
         and len(states) == args.children
         and len(child_observations) == args.children
+        and evidence["child_models_expected"]
         and evidence["parallel_dispatch_counts"] == [args.children]
     )
     evidence["passed"] = evidence["transport_passed"] and (

--- a/infra/codex-hooks/test_native_claude_child_probe.py
+++ b/infra/codex-hooks/test_native_claude_child_probe.py
@@ -1,0 +1,63 @@
+"""Regression cases for the native child probe's parent/child discrimination.
+
+The probe shipped a default invocation that could not pass on any host: it
+selected child observations by a `claude-<family>-` model prefix, and the parent
+dispatcher runs `claude-haiku-4-5` while `--model` defaults to `haiku`, so the
+parent's own SessionStart observation was counted as a child. `transport_passed`
+requires `len(child_observations) == args.children`; with the parent included the
+count was always one too high. R2 was accepted on a diff check without a native
+run, which is why this went unmeasured.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from native_claude_child_probe import select_child_observations
+
+PARENT = {
+    "hook_event_name": "SessionStart",
+    "model": "claude-haiku-4-5",
+    "capacity_scope": "scope-a",
+}
+CHILD = {
+    "hook_event_name": "SubagentStop",
+    "model": "claude-haiku-4-5-20251001",
+    "capacity_scope": "scope-a",
+}
+
+
+def test_parent_sharing_the_child_family_is_not_counted_as_a_child():
+    # The exact shape of the default invocation: both sides are haiku, so any
+    # model-prefix filter returns 2 here. Only the event discriminates.
+    assert select_child_observations([PARENT, CHILD]) == [CHILD]
+
+
+def test_a_prefix_filter_would_have_returned_the_parent_too():
+    # Pins WHY the event is the discriminator: this is the old predicate, and it
+    # is still true of the parent. If this assertion ever fails, the prefix filter
+    # became safe again and this test's premise needs revisiting.
+    assert PARENT["model"].startswith("claude-haiku-")
+    assert CHILD["model"].startswith("claude-haiku-")
+
+
+def test_child_count_matches_children_for_a_parallel_dispatch():
+    observations = [PARENT] + [dict(CHILD) for _ in range(4)]
+    assert len(select_child_observations(observations)) == 4
+
+
+def test_an_unlabelled_observation_is_not_a_child():
+    # Defensive: a snapshot that lost its event tag must not silently pass as a
+    # child. Cannot-verify is not a verdict.
+    assert select_child_observations([{"model": "claude-haiku-4-5-20251001"}]) == []
+
+
+def test_a_child_on_a_different_model_is_still_a_child():
+    # Selection is by event; the MODEL is asserted separately by the probe, so a
+    # child answering on the wrong model must reach that assertion rather than
+    # vanish from the count.
+    other = dict(CHILD, model="claude-sonnet-5")
+    assert select_child_observations([PARENT, other]) == [other]


### PR DESCRIPTION
Closes the first of the two probe defects declared as residuals when #6046 shipped, and reports that the second one did not survive measurement.

## The defect

`observations` is built from TWO hook events (`native_claude_child_probe.py:138-149`):
`SubagentStop` carries the CHILD's transcript, `SessionStart` carries the PARENT's.
The child filter ignored that and selected on a `claude-<family>-` model prefix.

With the shipped defaults — `--model haiku`, `--parent-model claude-haiku-4-5` — the
parent's own observation matches `claude-haiku-` and was counted as a child.
`transport_passed` requires `len(child_observations) == args.children`, so the count
was always one too high: **the default invocation could not pass on any host.**

The discriminator was already in the payload. It is now `hook_event_name ==
"SubagentStop"`, and the model survives as an assertion (`child_models_expected`)
rather than as the selector — a child answering on the wrong model still fails
instead of silently disappearing from the count.

## The second defect did NOT reproduce — parent default left alone

The residual also reported a Haiku parent emitting three Agent dispatches for one
child. My plan was to raise `--parent-model`. The measurement says otherwise:

| run | parent | passed | `parallel_dispatch_counts` |
|---|---|---|---|
| default | `claude-haiku-4-5` | true | `[1]` |
| control 1 | `claude-haiku-4-5` | true | `[1]` |
| control 2 | `claude-haiku-4-5` | true | `[1]` |
| control 3 | `claude-haiku-4-5` | true | `[1]` |

Three controls plus the default run, all `[1]`. So **the parent default is unchanged**:
raising it would have been a modification with no measurement behind it, and it would
have made every probe run more expensive for no proven gain. What IS changed is the
parent prompt, which now names the failure mode ("EXACTLY ONE assistant message", no
retry, no extra verification agent) instead of only the goal — cheap, and it addresses
the reported shape if it was ever real. If the three-dispatch behaviour returns, the
assertion still catches it; it is not being suppressed.

## Native run, because a diff check is what caused this

R2 was accepted on a diff check without a native run — that is precisely why the
default was broken and nobody saw it. Default invocation, no flags, final code:

```
passed=true  transport_passed=true  parallel_dispatch_counts=[1]  child_models_expected=true
child: claude-haiku-4-5-20251001  measurement=calibrated  pretool_count=2
       used=3702/200000  denials=None
```

Warmup calibrated `claude-sonnet-5` at 1,000,000 and `claude-haiku-4-5-20251001` at
200,000 from the CLI's own `canonicalModel`.

## Bites

CONSUMER: the probe itself, run with NO flags on M5. Before this PR that invocation
could not return `passed=true` by construction; the run above is the observation, made
on this branch's code, not on a plan. The selection logic is now a module-level
function so the property is pinned without a native run: 5 regression cases, and
restoring the old prefix predicate kills 4 of them (the 5th asserts only on the model
strings, so it correctly survives). `pytest infra/codex-hooks/ -q` → **56 passed**.

## Still open, not in this PR

The 8 remaining council residuals, which group into three concerns and will land
separately: ledger accounting in `mandate_budget.py` (#9 `unstarted_ttl` vs
`ACKNOWLEDGE_SECONDS`, #12 `needs_attention` latching, #15 the dead depth branch,
#16 the stop-before-start leak); the Codex side (#10 missing `active_ttl`, #11
release-after-block ordering); and the operator verbs (#5 `release()` during an
in-flight launch, #6 `TRANSIENT_FAILURES` classifying by exception type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRgCfZacYYdLR26BnfbMU4
