### PR TITLE
fix(codex-hooks): a reservation the ledger swept too early, and one a stop could never claim

### DIFF
--- a/infra/codex-hooks/context_bridge.py
+++ b/infra/codex-hooks/context_bridge.py
@@ -30,7 +30,10 @@ from mandate_budget import observe as budget_observe, reserve as budget_reserve
 
 VERSION = "1.2.0"
 HANDSHAKE_SECONDS = 45  # one Stop hook blocks at most this long waiting for the destination
-ACKNOWLEDGE_SECONDS = 240  # the supervisor waits this long for the destination to claim the source
+# Imported, not redeclared: the ledger's unstarted sweep uses the SAME window to
+# decide whether a reserved row is mid-handshake, and two independent literals
+# drifted apart once already (60 s vs 240 s).
+from mandate_budget import ACKNOWLEDGE_SECONDS  # noqa: E402
 MAX_LAUNCH_ATTEMPTS = 3
 POLL_SECONDS = 1
 MANDATE_SECONDS = 3600

--- a/infra/codex-hooks/mandate_budget.py
+++ b/infra/codex-hooks/mandate_budget.py
@@ -11,6 +11,17 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator
 
+# The supervisor waits this long for a destination to claim its source. It is the
+# SAME window that decides whether a still-reserved row is mid-handshake or
+# abandoned, so the two must be derived from one another and not merely agree:
+# context_bridge.py imports this name. Until 2026-09-10 the sweep below defaulted
+# to 60 s against this 240 s handshake, so any concurrent reserve() under a shared
+# NUZANTARA_MANDATE_ID swept a HEALTHY mid-handshake row to expired_unstarted —
+# leaving the max_active count (cap drift) and orphaning the later accept, which
+# then found no reserved row to bind and recorded "observed without a dispatch
+# reservation".
+ACKNOWLEDGE_SECONDS = 240
+
 
 @contextmanager
 def ledger(root: Path, mandate: str) -> Iterator[dict[str, Any]]:
@@ -62,7 +73,7 @@ def reserve(
         for row in reservations.values():
             if row["status"] == "reserved" and time.time() - row[
                 "created"
-            ] > limits.get("unstarted_ttl", 60):
+            ] > limits.get("unstarted_ttl", ACKNOWLEDGE_SECONDS):
                 row["status"] = "expired_unstarted"
             elif row["status"] == "active" and limits.get("active_ttl"):
                 heartbeat = max(row.get("heartbeat", row["created"]), row["created"])
@@ -197,7 +208,12 @@ def observe(
             ),
             None,
         )
-        if bound is None and not stopped:
+        if bound is None:
+            # Claim the pending reservation whether this is a start OR a stop. Under
+            # reordered or missing hook delivery a SubagentStop can arrive first; when
+            # the claim was gated on `not stopped` the row stayed `reserved` while the
+            # child was recorded stopped, so the slot leaked until unstarted_ttl swept
+            # it and the ledger reported attention for a child that had returned fine.
             bound = next(
                 (r for r in reservations.values() if r["status"] == "reserved"), None
             )

--- a/infra/codex-hooks/test_ledger_reservation_binding.py
+++ b/infra/codex-hooks/test_ledger_reservation_binding.py
@@ -1,0 +1,115 @@
+"""Two council residuals on how a reservation binds to its child.
+
+Both were declared, not fixed, when the child ledger shipped (#6046):
+
+  * the unstarted sweep defaulted to 60 s against context_bridge's 240 s
+    handshake, so a concurrent reserve() under a shared mandate id swept a
+    HEALTHY mid-handshake row to expired_unstarted;
+  * observe() claimed a pending reservation only for a START, so a stop that
+    arrived first (reordered or missing hook delivery) left the row `reserved`
+    while the child was recorded stopped.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import mandate_budget as budget
+
+LIMITS = {"max_active": 4, "max_attempts": 8, "max_seconds": 600, "max_depth": 1}
+
+
+def _state(root: Path, mandate: str = "root") -> dict:
+    path = root / (hashlib.sha256(mandate.encode()).hexdigest() + ".json")
+    return json.loads(path.read_text())
+
+
+def _rows(root: Path) -> list[dict]:
+    return list(_state(root).get("reservations", {}).values())
+
+
+# --- residual: unstarted_ttl vs ACKNOWLEDGE_SECONDS -------------------------
+
+
+def test_unstarted_sweep_defaults_to_the_handshake_window():
+    # Derived, not merely equal: two independent literals drifted once already.
+    assert budget.ACKNOWLEDGE_SECONDS == 240
+
+    from context_bridge import ACKNOWLEDGE_SECONDS as bridge_window
+
+    assert bridge_window is budget.ACKNOWLEDGE_SECONDS
+
+
+def test_a_row_younger_than_the_handshake_is_not_swept(tmp_path: Path) -> None:
+    assert budget.reserve(tmp_path, "root", "one", LIMITS) is None
+    # Age it past the OLD 60 s default but well inside the 240 s handshake.
+    state = _state(tmp_path)
+    for row in state["reservations"].values():
+        row["created"] = time.time() - 100
+    path = tmp_path / (hashlib.sha256(b"root").hexdigest() + ".json")
+    path.write_text(json.dumps(state))
+
+    assert budget.reserve(tmp_path, "root", "two", LIMITS) is None
+    statuses = {r["status"] for r in _rows(tmp_path)}
+    assert "expired_unstarted" not in statuses
+
+
+def test_a_row_older_than_the_handshake_is_still_swept(tmp_path: Path) -> None:
+    # The cure must not disable the sweep, only stop it firing early.
+    assert budget.reserve(tmp_path, "root", "one", LIMITS) is None
+    state = _state(tmp_path)
+    for row in state["reservations"].values():
+        row["created"] = time.time() - (budget.ACKNOWLEDGE_SECONDS + 60)
+    path = tmp_path / (hashlib.sha256(b"root").hexdigest() + ".json")
+    path.write_text(json.dumps(state))
+
+    assert budget.reserve(tmp_path, "root", "two", LIMITS) is None
+    assert "expired_unstarted" in {r["status"] for r in _rows(tmp_path)}
+
+
+# --- residual: a stop observed before its start -----------------------------
+
+
+def test_a_stop_before_its_start_claims_the_reservation(tmp_path: Path) -> None:
+    assert budget.reserve(tmp_path, "root", "one", LIMITS) is None
+    # No start observation ever arrives — the stop is delivered first.
+    budget.observe(tmp_path, "root", "child-a", stopped=True)
+
+    rows = _rows(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["child"] == "child-a"
+    assert rows[0]["status"] == "returned_unverified"
+
+
+def test_a_stop_before_its_start_does_not_report_attention(tmp_path: Path) -> None:
+    assert budget.reserve(tmp_path, "root", "one", LIMITS) is None
+    budget.observe(tmp_path, "root", "child-a", stopped=True)
+
+    state = _state(tmp_path)
+    assert state.get("status") != "needs_attention"
+    assert "without a dispatch reservation" not in (state.get("reason") or "")
+
+
+def test_a_stop_with_no_reservation_at_all_still_reports_attention(
+    tmp_path: Path,
+) -> None:
+    # The cure must not swallow the genuine case it was masking.
+    budget.observe(tmp_path, "root", "orphan", stopped=True)
+
+    state = _state(tmp_path)
+    assert state["status"] == "needs_attention"
+    assert "without a dispatch reservation" in state["reason"]
+
+
+def test_the_normal_start_then_stop_order_is_unchanged(tmp_path: Path) -> None:
+    assert budget.reserve(tmp_path, "root", "one", LIMITS) is None
+    budget.observe(tmp_path, "root", "child-a")
+    assert _rows(tmp_path)[0]["status"] == "active"
+    budget.observe(tmp_path, "root", "child-a", stopped=True)
+    assert _rows(tmp_path)[0]["status"] == "returned_unverified"


### PR DESCRIPTION
Two of the nine council residuals declared but not fixed when the child ledger shipped (#6046). Grouped because they are the same failure: a `reserved` row the ledger loses track of.

## 1 — the unstarted sweep fired inside the handshake window

`mandate_budget.reserve()` swept `reserved` rows older than `unstarted_ttl`, default
**60 s**. `context_bridge.ACKNOWLEDGE_SECONDS` — how long the supervisor waits for a
destination to claim its source — is **240 s**. Any concurrent `reserve()` under a
shared `NUZANTARA_MANDATE_ID` therefore swept a HEALTHY mid-handshake row to
`expired_unstarted`: the row left the `max_active` count (cap drift) and its later
accept found no reserved row to bind, recording *"observed without a dispatch
reservation"*.

Fixed by derivation, not by agreement: `ACKNOWLEDGE_SECONDS` now lives in
`mandate_budget.py` as the single source and `context_bridge.py` imports it. Two
independent literals drifted apart once; they can no longer.

## 2 — a stop that arrived before its start could never claim its reservation

`observe()` claimed a pending reservation only under `if bound is None and not
stopped`. Under reordered or missing hook delivery a `SubagentStop` can arrive
first — the row then stayed `reserved` while the child was recorded stopped, the
slot leaked until the sweep took it, and the ledger raised attention for a child
that had returned fine. The claim is no longer gated on the direction of the event.

This is the same ordering family as Blocker 1, which the Claude side fixed and the
ledger side kept.

## Neither cure widens what the ledger forgives

Stated because a fix in this area is easy to make silently permissive, and both
properties have their own test:

- a row genuinely older than the handshake **is still swept** (`test_a_row_older_than_the_handshake_is_still_swept`);
- a stop with no reservation at all **still reports attention** (`test_a_stop_with_no_reservation_at_all_still_reports_attention`);
- the normal start→stop order is unchanged (`test_the_normal_start_then_stop_order_is_unchanged`).

## Mutation-verified

7 regression cases. Restoring the 60 s default kills exactly
`test_a_row_younger_than_the_handshake_is_not_swept`; restoring `and not stopped`
kills exactly the two stop-before-start tests; neither mutant touches the others.
`pytest infra/codex-hooks/ -q` → **58 passed**.

## Bites

CONSUMER: the live ledger under `native_claude_child_probe.py --candidate`, which
copies these sources into a throwaway seat and drives a real child through
`reserve()` → `observe(start)` → `observe(stop)`.

That observation is deliberately NOT posted yet. Run today from a worktree on
`origin/main` it returns `transport_passed=false` for an unrelated reason — the
probe's own parent/child selection defect, cured in #6064 and not yet merged — so a
run made now would measure that defect, not this ledger. The Bites lands in this
thread once #6064 is on `main`, as a `--candidate` run exercising both cures, with
the reservation binding shown in the resulting ledger row. Reported before this PR
is called done, not after.

## Still open, not here

The remaining 6 residuals, in two further PRs: the Codex side (#10 missing
`active_ttl` so `suspect_zombie` never sweeps, #11 `child_hook` releasing after the
block instead of before) and the operator verbs (#5 `release()` during an in-flight
launch, #6 `TRANSIENT_FAILURES` classifying by exception type). Plus #12
(`needs_attention` latches) and #15 (the dead depth branch), which are signal
hygiene rather than binding correctness and do not belong in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRgCfZacYYdLR26BnfbMU4
