### PR TITLE
fix(fly-cost-guard): cpu_kind is a finding and a missing billable field is an inventory error, never a 0

### DIFF
--- a/scripts/fly_cost_guard.py
+++ b/scripts/fly_cost_guard.py
@@ -3,20 +3,23 @@
 
 Fly exposes no supported billing API, so spend is guarded by INVENTORY: machine
 count, started machine count, started memory and started CPUs (the compute cost
-drivers), provisioned volume GB and dedicated IPv4s across the expected apps.
+drivers), CPU kind (a performance CPU costs ~4x a shared one at equal core
+count), provisioned volume GB and dedicated IPv4s across the expected apps.
 Any finding makes the process exit non-zero so the workflow run goes RED — a
 `::warning::` that leaves the job green is a guard that cannot sound (cicatrix
 #2, Esiste≠Armato: the previous inline version had breached thresholds for
 weeks and every run was "success").
 
-The guard fails CLOSED on what it cannot read: a started machine whose memory
-or CPU count is missing from flyctl's JSON, a volume without a size, or a
+The guard fails CLOSED on what it cannot read: a machine whose config, guest,
+state, memory, CPU count or CPU kind is missing from flyctl's JSON, a volume
+without a size, an IP without a type, a status without a machine list, or a
 flyctl call that errors, is a finding — never a silent 0 that reads as savings.
 
 Usage:
     fly_cost_guard.py                       # live: shells out to flyctl
     fly_cost_guard.py --inventory-json f    # offline: evaluate a captured inventory
-    fly_cost_guard.py --dump-inventory f    # live: also write the inventory (fixture capture)
+    fly_cost_guard.py --dump-inventory      # live: print the inventory, no verdict
+                                            # (fixture capture: redirect stdout)
 
 Thresholds come from env (MAX_*), matching the workflow's `env:` block, or from
 the --max-* flags. The report/alert lines are appended to $GITHUB_OUTPUT when
@@ -32,7 +35,14 @@ import subprocess
 import sys
 from typing import Any
 
+# bites-observable — an `observe:` line may point at this script. Its arguments
+# are integer ceilings, app names, a JSON path it only READS (--inventory-json)
+# and a bare flag that prints to stdout (--dump-inventory): none can name a
+# program to run (the only subprocess is the fixed `flyctl` on PATH), a file to
+# write, or a database to reach. Keep it that way, or drop this marker.
+
 DEFAULT_EXPECTED_APPS = "nuzantara-rag,nuzantara-postgres"
+SHARED_CPU_KIND = "shared"
 
 # Measured live 2026-09-10 (fly machine list / volumes list / ips list):
 #   nuzantara-rag      4 machines (api 3072MB/2cpu, rag 2048MB/2cpu, drive
@@ -40,10 +50,13 @@ DEFAULT_EXPECTED_APPS = "nuzantara-rag,nuzantara-postgres"
 #                      0 dedicated IPv4
 #   nuzantara-postgres 3 machines x 2048MB/2cpu, 3x25GB volumes (77 GB total
 #                      with the two 1 GB rag volumes), 0 dedicated IPv4
+#   all 7 machines shared-cpu (re-probed 2026-09-09T19:45Z)
 # Ceilings sit AT today's footprint: one more machine, one started standby, one
 # extra GB of RAM, one extra shared CPU (a shared-cpu-4x upgrade keeps the RAM
 # figure and doubles the compute bill), one extended volume or one paid IPv4
-# turns the run red.
+# turns the run red. CPU kind has no ceiling: any machine that is not
+# shared-cpu is a finding on its own, because a performance CPU at the SAME
+# core count is invisible to every other counter.
 DEFAULT_LIMITS: dict[str, int] = {
     "machines": 7,
     "started_machines": 6,
@@ -63,6 +76,10 @@ LIMIT_ENV = {
 }
 
 
+class InventoryShapeError(ValueError):
+    """flyctl's JSON lacks a field the guard bills on — a finding, never a 0."""
+
+
 def fly_json(*args: str) -> Any:
     result = subprocess.run(
         ["flyctl", *args, "--json"],
@@ -73,10 +90,15 @@ def fly_json(*args: str) -> Any:
     return json.loads(result.stdout)
 
 
+def _require(container: Any, key: str, where: str) -> Any:
+    """The field must be present and non-null; anything else names itself."""
+    if not isinstance(container, dict) or container.get(key) is None:
+        raise InventoryShapeError(f"missing {key} on {where}")
+    return container[key]
+
+
 def _int_or_none(value: Any) -> int | None:
-    """A missing or unparsable field stays None so evaluate() can name it."""
-    if value is None:
-        return None
+    """An unparsable field stays None so evaluate() can name it."""
     try:
         return int(value)
     except (TypeError, ValueError):
@@ -84,16 +106,38 @@ def _int_or_none(value: Any) -> int | None:
 
 
 def _machine_row(machine: dict[str, Any]) -> dict[str, Any]:
-    config = machine.get("config") or {}
-    guest = config.get("guest") or {}
+    where = f"machine {machine.get('id')}"
+    config = _require(machine, "config", where)
+    guest = _require(config, "guest", where)
     metadata = config.get("metadata") or {}
     return {
         "id": machine.get("id"),
-        "state": machine.get("state"),
-        "memory_mb": _int_or_none(guest.get("memory_mb")),
-        "cpus": _int_or_none(guest.get("cpus")),
+        "state": _require(machine, "state", where),
+        "memory_mb": _int_or_none(_require(guest, "memory_mb", where)),
+        "cpus": _int_or_none(_require(guest, "cpus", where)),
+        "cpu_kind": _require(guest, "cpu_kind", where),
         "group": metadata.get("fly_process_group"),
     }
+
+
+def _volume_row(volume: dict[str, Any]) -> dict[str, Any]:
+    where = f"volume {volume.get('id')}"
+    return {
+        "id": volume.get("id"),
+        "size_gb": _int_or_none(_require(volume, "size_gb", where)),
+    }
+
+
+def _ip_row(ip: dict[str, Any]) -> dict[str, Any]:
+    # Type is "v4" for a paid dedicated IPv4, "shared_v4" for the free one.
+    return {"type": _require(ip, "Type", f"ip {ip.get('ID')}")}
+
+
+def _named(app: str, resource: str, exc: Exception) -> str:
+    text = f"{app}:{resource}:{type(exc).__name__}"
+    if isinstance(exc, InventoryShapeError):
+        text += f":{exc}"
+    return text
 
 
 def collect_inventory() -> dict[str, Any]:
@@ -103,36 +147,38 @@ def collect_inventory() -> dict[str, Any]:
     FINDING (inventory errors), not a silent "0 machines" that reads as savings.
     The same holds for the app listing itself: when it fails, every expected app
     is reported missing and the error is named, instead of a traceback that
-    leaves the Telegram step with no report.
+    leaves the Telegram step with no report. A shape error (a billable field
+    missing from the JSON) drops that app's listing for that resource WHOLE and
+    names the field, so the report cannot quietly under-count.
     """
     inventory: dict[str, Any] = {"apps": {}, "errors": []}
     try:
         apps = fly_json("apps", "list")
     except Exception as exc:  # noqa: BLE001 — a failed listing is a finding
-        inventory["errors"].append(f"apps:list:{type(exc).__name__}")
+        inventory["errors"].append(_named("apps", "list", exc))
         return inventory
     app_names = sorted({app.get("Name") or app.get("ID") for app in apps} - {None})
     for app in app_names:
         entry: dict[str, Any] = {"machines": [], "volumes": [], "ips": []}
         try:
             status = fly_json("status", "--app", app)
-            entry["machines"] = [_machine_row(m) for m in status.get("Machines") or []]
-        except Exception as exc:  # noqa: BLE001 — flyctl/JSON failures are findings
-            inventory["errors"].append(f"{app}:status:{type(exc).__name__}")
+            machines = _require(status, "Machines", f"status of {app}")
+            entry["machines"] = [_machine_row(m) for m in machines]
+        except Exception as exc:  # noqa: BLE001 — flyctl/JSON/shape failures are findings
+            entry["machines"] = []
+            inventory["errors"].append(_named(app, "status", exc))
         try:
-            volumes = fly_json("volumes", "list", "--app", app)
             entry["volumes"] = [
-                {"id": v.get("id"), "size_gb": _int_or_none(v.get("size_gb"))}
-                for v in volumes
+                _volume_row(v) for v in fly_json("volumes", "list", "--app", app)
             ]
         except Exception as exc:  # noqa: BLE001
-            inventory["errors"].append(f"{app}:volumes:{type(exc).__name__}")
+            entry["volumes"] = []
+            inventory["errors"].append(_named(app, "volumes", exc))
         try:
-            addresses = fly_json("ips", "list", "--app", app)
-            # Type is "v4" for a paid dedicated IPv4, "shared_v4" for the free one.
-            entry["ips"] = [{"type": ip.get("Type")} for ip in addresses]
+            entry["ips"] = [_ip_row(ip) for ip in fly_json("ips", "list", "--app", app)]
         except Exception as exc:  # noqa: BLE001
-            inventory["errors"].append(f"{app}:ips:{type(exc).__name__}")
+            entry["ips"] = []
+            inventory["errors"].append(_named(app, "ips", exc))
         inventory["apps"][app] = entry
     return inventory
 
@@ -147,10 +193,17 @@ def evaluate(
     app_names = set(apps)
     machine_count = started_count = started_memory_mb = started_cpus = 0
     volume_gb = dedicated_ipv4 = 0
+    started_cpus_by_kind: dict[str, int] = {}
+    non_shared: list[str] = []
     errors = list(inventory.get("errors") or [])
     for app, entry in apps.items():
         for m in entry.get("machines") or []:
             machine_count += 1
+            kind = m.get("cpu_kind")
+            # None counts: a machine whose kind cannot be read is not shared-cpu
+            # until proven so — the kind is what a same-core-count upgrade changes.
+            if kind != SHARED_CPU_KIND:
+                non_shared.append(f"{m.get('id')}:{kind}")
             if m.get("state") != "started":
                 continue
             started_count += 1
@@ -166,6 +219,10 @@ def evaluate(
                     started_memory_mb += value
                 else:
                     started_cpus += value
+                    label = kind if isinstance(kind, str) else "unknown"
+                    started_cpus_by_kind[label] = (
+                        started_cpus_by_kind.get(label, 0) + value
+                    )
         for v in entry.get("volumes") or []:
             size = v.get("size_gb")
             if not isinstance(size, int) or size <= 0:
@@ -181,6 +238,8 @@ def evaluate(
         findings.append("unexpected apps=" + ",".join(unexpected_apps))
     if missing_apps:
         findings.append("missing apps=" + ",".join(missing_apps))
+    if non_shared:
+        findings.append("non-shared cpu=" + ",".join(non_shared))
     if machine_count > limits["machines"]:
         findings.append(f"machines {machine_count}>{limits['machines']}")
     if started_count > limits["started_machines"]:
@@ -200,11 +259,12 @@ def evaluate(
     if errors:
         findings.append("inventory errors=" + ",".join(errors))
 
+    kinds = ",".join(f"{k}={n}" for k, n in sorted(started_cpus_by_kind.items()))
     report = (
         f"Apps: {len(app_names)} | Machines: {started_count}/{machine_count} started "
         f"(limit {limits['started_machines']}/{limits['machines']}) | "
         f"Started RAM: {started_memory_mb} MB (limit {limits['started_memory_mb']}) | "
-        f"Started CPUs: {started_cpus} (limit {limits['started_cpus']}) | "
+        f"Started CPUs: {started_cpus} (limit {limits['started_cpus']}) [{kinds}] | "
         f"Volumes: {volume_gb} GB (limit {limits['volume_gb']}) | "
         f"Dedicated IPv4: {dedicated_ipv4} (limit {limits['dedicated_ipv4']})"
     )
@@ -232,7 +292,9 @@ def main(argv: list[str] | None = None) -> int:
         "--inventory-json", help="evaluate this captured inventory instead of flyctl"
     )
     parser.add_argument(
-        "--dump-inventory", help="write the live inventory to this path"
+        "--dump-inventory",
+        action="store_true",
+        help="print the inventory JSON to stdout and exit 0 without judging it",
     )
     parser.add_argument(
         "--expected-apps",
@@ -260,10 +322,9 @@ def main(argv: list[str] | None = None) -> int:
             inventory = json.load(handle)
     else:
         inventory = collect_inventory()
-        if args.dump_inventory:
-            with open(args.dump_inventory, "w", encoding="utf-8") as handle:
-                json.dump(inventory, handle, indent=2, sort_keys=True)
-                handle.write("\n")
+    if args.dump_inventory:
+        print(json.dumps(inventory, indent=2, sort_keys=True))
+        return 0
 
     report, findings = evaluate(inventory, expected, limits)
     alert = "\n".join(findings)

--- a/scripts/tests/fixtures/fly_inventory_2026-09-10.json
+++ b/scripts/tests/fixtures/fly_inventory_2026-09-10.json
@@ -8,6 +8,7 @@
       ],
       "machines": [
         {
+          "cpu_kind": "shared",
           "cpus": 2,
           "group": "app",
           "id": "78113d4f67d938",
@@ -15,6 +16,7 @@
           "state": "started"
         },
         {
+          "cpu_kind": "shared",
           "cpus": 2,
           "group": "app",
           "id": "5683e090f3d228",
@@ -22,6 +24,7 @@
           "state": "started"
         },
         {
+          "cpu_kind": "shared",
           "cpus": 2,
           "group": "app",
           "id": "0801696b541568",
@@ -58,6 +61,7 @@
       ],
       "machines": [
         {
+          "cpu_kind": "shared",
           "cpus": 2,
           "group": "api",
           "id": "7817d92c4117d8",
@@ -65,6 +69,7 @@
           "state": "started"
         },
         {
+          "cpu_kind": "shared",
           "cpus": 1,
           "group": "drive",
           "id": "48ee717b736948",
@@ -72,6 +77,7 @@
           "state": "stopped"
         },
         {
+          "cpu_kind": "shared",
           "cpus": 1,
           "group": "drive",
           "id": "2874974fe6e158",
@@ -79,6 +85,7 @@
           "state": "started"
         },
         {
+          "cpu_kind": "shared",
           "cpus": 2,
           "group": "rag",
           "id": "1781e5eda03438",

--- a/scripts/tests/test_fly_cost_guard.py
+++ b/scripts/tests/test_fly_cost_guard.py
@@ -59,18 +59,50 @@ def test_live_fixture_is_innocent_under_workflow_ceilings() -> None:
     assert findings == []
     assert report.startswith("Apps: 2 | Machines: 6/7 started (limit 6/7)")
     assert "Started RAM: 12288 MB (limit 12288)" in report
-    assert "Started CPUs: 11 (limit 11)" in report
+    assert "Started CPUs: 11 (limit 11) [shared=11]" in report
     assert "Volumes: 77 GB (limit 77)" in report
     assert "Dedicated IPv4: 0 (limit 0)" in report
+    assert all(
+        m["cpu_kind"] == "shared"
+        for entry in _inventory()["apps"].values()
+        for m in entry["machines"]
+    ), "the live fixture must carry cpu_kind on every machine"
 
 
 def test_one_more_machine_is_guilty() -> None:
     inv = _inventory()
     inv["apps"]["nuzantara-rag"]["machines"].append(
-        {"id": "extra", "state": "stopped", "memory_mb": 256, "cpus": 1, "group": "api"}
+        {
+            "id": "extra",
+            "state": "stopped",
+            "memory_mb": 256,
+            "cpus": 1,
+            "cpu_kind": "shared",
+            "group": "api",
+        }
     )
     _, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
     assert findings == ["machines 8>7"]
+
+
+def test_performance_cpu_is_guilty() -> None:
+    """A performance CPU at the SAME core count breaches no counter — it is a
+    finding on its own. Guilt: switch the rag machine's kind; then strip the
+    kind entirely (None is not shared until proven so). Innocence is the live
+    fixture above: 7/7 shared, no finding."""
+    inv = _inventory()
+    rag = next(
+        m for m in inv["apps"]["nuzantara-rag"]["machines"] if m["group"] == "rag"
+    )
+    rag["cpu_kind"] = "performance"
+    report, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == ["non-shared cpu=1781e5eda03438:performance"]
+    assert "Started CPUs: 11 (limit 11) [performance=2,shared=9]" in report
+
+    del rag["cpu_kind"]
+    report, findings = fly_cost_guard.evaluate(inv, EXPECTED, _workflow_limits())
+    assert findings == ["non-shared cpu=1781e5eda03438:None"]
+    assert "[shared=9,unknown=2]" in report
 
 
 def test_started_standby_is_guilty_on_count_and_memory() -> None:
@@ -235,12 +267,19 @@ elif args[0] == "status":
     }
     data = {"Machines": [
         {"id": f"{app}-{i}", "state": state,
-         "config": {"guest": {"memory_mb": 2048, "cpus": 2}, "metadata": {"fly_process_group": "app"}}}
+         "config": {"guest": {"memory_mb": 2048, "cpus": 2, "cpu_kind": "shared"},
+                    "metadata": {"fly_process_group": "app"}}}
         for i, state in enumerate(counts[app])
     ]}
+    for machine in data["Machines"]:
+        if machine["id"] == os.environ.get("FAKE_FLYCTL_DROP_MEMORY_MB_ON"):
+            del machine["config"]["guest"]["memory_mb"]
 elif args[:2] == ["volumes", "list"]:
     sizes = {"nuzantara-rag": [1, 1], "nuzantara-postgres": [25, 25], "fly-builder-legacy": [50]}
     data = [{"id": f"vol{i}", "size_gb": size} for i, size in enumerate(sizes[app])]
+    for volume in data:
+        if f"{app}:{volume['id']}" == os.environ.get("FAKE_FLYCTL_DROP_SIZE_GB_ON"):
+            del volume["size_gb"]
 elif args[:2] == ["ips", "list"]:
     data = [{"Type": "v4"}, {"Type": "shared_v4"}] if app == "nuzantara-rag" else []
 else:
@@ -267,20 +306,16 @@ def test_collection_through_a_fake_flyctl_replaying_the_observed_json_shapes(
     and a paid one as "v4".
     """
     _install_fake_flyctl(tmp_path)
-    dump = tmp_path / "inventory.json"
-    result = _run(
-        ["--dump-inventory", str(dump)],
-        {
-            "PATH": f"{tmp_path}:{os.environ['PATH']}",
-            "MAX_TOTAL_MACHINES": "6",
-            "MAX_TOTAL_VOLUME_GB": "60",
-        },
-        tmp_path,
-    )
+    env = {
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "MAX_TOTAL_MACHINES": "6",
+        "MAX_TOTAL_VOLUME_GB": "60",
+    }
+    result = _run([], env, tmp_path)
     assert result.returncode == 1
     assert "Apps: 3 | Machines: 5/7 started" in result.stdout
     assert "Started RAM: 10240 MB" in result.stdout
-    assert "Started CPUs: 10 (limit 11)" in result.stdout
+    assert "Started CPUs: 10 (limit 11) [shared=10]" in result.stdout
     assert "Volumes: 102 GB" in result.stdout
     for finding in (
         "unexpected apps=fly-builder-legacy",
@@ -289,12 +324,51 @@ def test_collection_through_a_fake_flyctl_replaying_the_observed_json_shapes(
         "dedicated IPv4 1>0",
     ):
         assert finding in result.stdout
-    captured = json.loads(dump.read_text(encoding="utf-8"))
+    # `--dump-inventory` is a bare flag: the inventory goes to stdout and the
+    # run does not judge (exit 0 on the same guilty footprint), so the script's
+    # argument surface never names a file to write (bites-observable marker).
+    dump = _run(["--dump-inventory"], env, tmp_path)
+    assert dump.returncode == 0, dump.stderr
+    captured = json.loads(dump.stdout)
+    assert "::error::" not in dump.stdout
     assert captured["apps"]["nuzantara-rag"]["ips"] == [
         {"type": "v4"},
         {"type": "shared_v4"},
     ]
+    assert captured["apps"]["nuzantara-rag"]["machines"][0]["cpu_kind"] == "shared"
     assert captured["errors"] == []
+
+
+def test_missing_billable_field_is_an_inventory_error_not_zero(tmp_path: Path) -> None:
+    """flyctl JSON without a field the guard bills on drops that app's listing
+    for that resource WHOLE and names the field — never a 0 that reads as
+    savings. Guilt: no memory_mb on a started Postgres machine, no size_gb on
+    a rag volume. Innocence: the untouched fake above records no error."""
+    _install_fake_flyctl(tmp_path)
+    env = {
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "FAKE_FLYCTL_DROP_MEMORY_MB_ON": "nuzantara-postgres-0",
+        "FAKE_FLYCTL_DROP_SIZE_GB_ON": "nuzantara-rag:vol0",
+    }
+    result = _run([], env, tmp_path)
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert (
+        "nuzantara-postgres:status:InventoryShapeError:"
+        "missing memory_mb on machine nuzantara-postgres-0" in result.stdout
+    )
+    assert (
+        "nuzantara-rag:volumes:InventoryShapeError:missing size_gb on volume vol0"
+        in result.stdout
+    )
+    # rag 4 machines (3 started) + legacy 1 stopped; the 2 pg machines are gone.
+    assert "Machines: 3/5 started" in result.stdout
+    # pg 25+25 + legacy 50; the two 1 GB rag volumes are gone.
+    assert "Volumes: 100 GB" in result.stdout
+    captured = json.loads(_run(["--dump-inventory"], env, tmp_path).stdout)
+    assert captured["apps"]["nuzantara-postgres"]["machines"] == []
+    assert captured["apps"]["nuzantara-rag"]["volumes"] == []
+    assert len(captured["errors"]) == 2
 
 
 def test_failed_app_listing_is_a_finding_with_a_report(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

Two residual risks declared in #6044's Gear-3 pack (`evidence/2026-09/agent-nuzantara-infra-fly-cost-guard-04548498/`) and tracked as an open ledger row (#6059): the weekly guard did not collect `cpu_kind`, so a performance-CPU switch at equal core count (~4x compute bill, every counter unchanged) was invisible; and a `Machines`, `Type` or `size_gb` key missing from flyctl's JSON read as "nothing" instead of a finding.

## What (one concern: the guard fails closed on kind and shape)

- `collect_inventory()` fails CLOSED through `_require`: `config`, `guest`, `state`, `memory_mb`, `cpus`, `cpu_kind` on every machine, `Machines` on the status, `size_gb` on every volume, `Type` on every IP. A shape error drops that app's listing for that resource whole and is recorded as `<app>:<resource>:InventoryShapeError:missing <key> on <where>` under `inventory errors=`.
- `evaluate()` adds the finding `non-shared cpu=<id>:<kind>` for any machine whose `cpu_kind` is not `shared` (`None` counts) and reports started CPUs by kind: `Started CPUs: 11 (limit 11) [shared=11]`.
- `--dump-inventory` is now a BARE flag that prints the inventory JSON to stdout and exits 0 without judging, so the argument surface names no file to write; the script carries the `bites-observable` marker (`scripts/ci/bites_parse.py::_guard_observable_script`).
- Fixture `scripts/tests/fixtures/fly_inventory_2026-09-10.json` recaptured LIVE on Pro 2026-09-09T19:45Z with `--dump-inventory` (read-only flyctl): 7/7 machines `shared`; the only diff is the new field (+7 lines).
- `.github/workflows/cron-fly-cost-alert.yml` runs the script bare and is untouched (harness floor 1, `evidence_pack_lint.py --print-floor`).

## Guilt / innocence

`scripts/tests/test_fly_cost_guard.py` — 17 tests, all green locally with the backend venv (`pytest scripts/tests/test_fly_cost_guard.py scripts/tests/test_fly_workflow_guards.py scripts/tests/test_bites_parse.py -p no:cacheprovider`: 146 passed):
- innocence: the recaptured fixture → 0 findings, exit 0, report `Started CPUs: 11 (limit 11) [shared=11]`; the fake-flyctl replay records no error.
- guilt: `test_performance_cpu_is_guilty` — rag machine `1781e5eda03438` set to `performance` → `["non-shared cpu=1781e5eda03438:performance"]`, kind deleted → `["non-shared cpu=1781e5eda03438:None"]`; `test_missing_billable_field_is_an_inventory_error_not_zero` — fake flyctl drops `memory_mb` on a started Postgres machine and `size_gb` on a rag volume → exit 1, no traceback, both `InventoryShapeError:missing …` lines named, `Machines: 3/5 started`, `Volumes: 100 GB`, dump shows the two listings empty and exactly 2 errors.

Bites: consumer = the scheduled `cron - fly cost alert` run (Mon 01:00 UTC, bare `python3 scripts/fly_cost_guard.py`) and its Telegram report; observation = run on Pro before opening: `python3 scripts/fly_cost_guard.py --inventory-json scripts/tests/fixtures/fly_inventory_2026-09-10.json` exits 0 and a copy of the fixture with one `cpu_kind: performance` exits 1 under the shipped defaults with `::error::Fly resource guard: non-shared cpu=1781e5eda03438:performance`; after merge the same two commands from a checkout of `main`, and the next scheduled run's report line carries `[shared=11]`.

Closes the ledger row opened in #6059 (a `closed` row follows as a ledger-only PR from fresh main once this is merged and proven on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
