### PR TITLE
fix(portal): the client portal is the client persona on every host, not only on my.

### DIFF
--- a/apps/mouth/src/app/__tests__/portal-theme-persona.test.ts
+++ b/apps/mouth/src/app/__tests__/portal-theme-persona.test.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The pre-paint persona script is a STRING inside layout.tsx, so nothing type-
+ * checks it and no render test reaches it — it runs before React exists. This
+ * suite extracts the real string and EXECUTES it against a stubbed document,
+ * location and localStorage, so the assertions are about behaviour rather than
+ * about the source text happening to contain a substring.
+ *
+ * Guarded defect (measured live 2026-09-10): persona was derived from the
+ * hostname alone, so `/portal/login-upgraded` served from anything that is not
+ * literally `my.` rendered with the editorial NIGHT palette — dark on
+ * 127.0.0.1, cream on production, for byte-identical code. The authenticated
+ * portal pinned operative-light in its own CSS and so looked correct, which is
+ * what kept the split hidden: only the unauthenticated screens diverged.
+ */
+
+const layoutSource = readFileSync(join(__dirname, "..", "layout.tsx"), "utf8");
+
+function extractThemeInitScript(): string {
+  const match = layoutSource.match(/const themeInitScript = `([\s\S]*?)`;/);
+  if (!match) {
+    throw new Error(
+      "themeInitScript not found in layout.tsx — the persona script was renamed or reshaped; update this test rather than deleting it.",
+    );
+  }
+  return match[1];
+}
+
+function runPersonaScript(options: {
+  host: string;
+  path: string;
+  stored?: string | null;
+}): { product?: string; theme?: string } {
+  const dataset: Record<string, string> = {};
+  const localStorage = {
+    getItem: (key: string) =>
+      key === "bz-theme" ? (options.stored ?? null) : null,
+  };
+  const location = { hostname: options.host, pathname: options.path };
+  const document = { documentElement: { dataset } };
+
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  new Function(
+    "localStorage",
+    "location",
+    "document",
+    extractThemeInitScript(),
+  )(localStorage, location, document);
+
+  return { product: dataset.product, theme: dataset.theme };
+}
+
+describe("pre-paint persona script", () => {
+  describe("GUILT — the portal is the client persona on ANY host", () => {
+    it.each([
+      ["127.0.0.1", "/portal"],
+      ["127.0.0.1", "/portal/login-upgraded"],
+      ["localhost", "/portal/magic-link"],
+      ["localhost", "/portal/register"],
+      ["mouth-git-main-nuzantara-2026.vercel.app", "/portal/vault"],
+    ])(
+      "serves operative-light for %s%s (this failed before the path check)",
+      (host, path) => {
+        expect(runPersonaScript({ host, path })).toEqual({
+          product: "my",
+          theme: "operative-light",
+        });
+      },
+    );
+  });
+
+  describe("INNOCENCE — every other persona is untouched", () => {
+    it("keeps production my.balizero.com on operative-light", () => {
+      expect(
+        runPersonaScript({ host: "my.balizero.com", path: "/portal" }),
+      ).toEqual({ product: "my", theme: "operative-light" });
+    });
+
+    it("keeps the public editorial site dark-by-design", () => {
+      expect(
+        runPersonaScript({ host: "balizero.com", path: "/blog/anything" }),
+      ).toEqual({ product: "editorial", theme: "editorial" });
+    });
+
+    it("does not turn a non-portal path on a plain host into the portal", () => {
+      expect(
+        runPersonaScript({ host: "127.0.0.1", path: "/portal-news" }),
+      ).toEqual({ product: "editorial", theme: "editorial" });
+    });
+
+    it("keeps kita on its day mode", () => {
+      expect(
+        runPersonaScript({ host: "kita.balizero.com", path: "/clients" }),
+      ).toEqual({ product: "kita", theme: "operative-light" });
+    });
+
+    it("keeps prime on operative-dark — the 3D maps are designed for it", () => {
+      expect(
+        runPersonaScript({ host: "prime.balizero.com", path: "/" }),
+      ).toEqual({ product: "kita", theme: "operative-dark" });
+    });
+  });
+
+  describe("the client's own choice still wins over the default", () => {
+    it("honours a stored dark preference inside the portal", () => {
+      expect(
+        runPersonaScript({
+          host: "my.balizero.com",
+          path: "/portal",
+          stored: "dark",
+        }),
+      ).toEqual({ product: "my", theme: "operative-dark" });
+    });
+
+    it("honours a stored light preference inside the portal", () => {
+      expect(
+        runPersonaScript({
+          host: "127.0.0.1",
+          path: "/portal",
+          stored: "light",
+        }),
+      ).toEqual({ product: "my", theme: "operative-light" });
+    });
+  });
+
+  it("falls back to editorial when the environment throws", () => {
+    const dataset: Record<string, string> = {};
+    const throwingStorage = {
+      getItem: () => {
+        throw new Error("localStorage blocked");
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+    new Function(
+      "localStorage",
+      "location",
+      "document",
+      extractThemeInitScript(),
+    )(
+      throwingStorage,
+      { hostname: "my.balizero.com", pathname: "/portal" },
+      { documentElement: { dataset } },
+    );
+    expect(dataset).toEqual({ product: "editorial", theme: "editorial" });
+  });
+});

--- a/apps/mouth/src/app/layout.tsx
+++ b/apps/mouth/src/app/layout.tsx
@@ -20,13 +20,26 @@ import "./globals.css";
 
 // Pre-paint theme script — persona-aware, sets data-theme before React hydrates
 // to prevent FOUC. Design 2026-04-17-v2-subdomain-rollout §3 (L1/L2/L3 persona).
-// Precedence: localStorage('bz-theme') > hostname persona > editorial default.
+// Precedence: localStorage('bz-theme') > PATH persona > hostname persona > editorial.
+//   /portal/**                    → operative-light (client portal, ANY host)
 //   kita.                         → operative-light (workspace day mode)
 //   prime.                        → operative-dark (3D workspace)
 //   my., zantara.                 → operative-light (client self-service)
 //   balizero, visa., tax., /kbli  → editorial (public funnel)
+//
+// WHY THE PATH IS CHECKED BEFORE THE HOST (measured 2026-09-10, Zero ruling):
+// persona used to be derived from the hostname ALONE, so every environment that
+// is not literally `my.` served the client portal with the editorial NIGHT
+// palette — the login screen at /portal/login-upgraded rendered dark on
+// 127.0.0.1 while production rendered it cream, and the authenticated area
+// rendered light in both because its own CSS pins operative-light. That is a
+// persona the deploy target decides, which is exactly the class of drift that
+// makes local QA disagree with production. `/portal` IS the client persona
+// wherever it is served, so the path is now the stronger signal. The client's
+// own ThemeToggle (components/ui/ThemeToggle, mounted in PortalHeader) still
+// wins over both — this fixes the DEFAULT, it does not remove the choice.
 // Must be inline; next/script strategy="beforeInteractive" is insufficient in App Router.
-const themeInitScript = `(function(){try{var stored=localStorage.getItem('bz-theme');var host=location.hostname;var isKita=host.indexOf('kita.')===0;var isPrime=host.indexOf('prime.')===0;var isMy=host.indexOf('my.')===0||host.indexOf('zantara.')===0;var product=(isKita||isPrime)?'kita':isMy?'my':'editorial';var t=stored;if(product!=='editorial'){if(t==='light')t='operative-light';if(t==='dark')t='operative-dark';}if(!t){if(isKita||isMy)t='operative-light';else if(isPrime)t='operative-dark';else t='editorial';}document.documentElement.dataset.product=product;document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.product='editorial';document.documentElement.dataset.theme='editorial';}})();`;
+const themeInitScript = `(function(){try{var stored=localStorage.getItem('bz-theme');var host=location.hostname;var path=location.pathname;var isKita=host.indexOf('kita.')===0;var isPrime=host.indexOf('prime.')===0;var isPortalPath=path==='/portal'||path.lastIndexOf('/portal/',0)===0;var isMy=isPortalPath||host.indexOf('my.')===0||host.indexOf('zantara.')===0;var product=isPortalPath?'my':(isKita||isPrime)?'kita':isMy?'my':'editorial';var t=stored;if(product!=='editorial'){if(t==='light')t='operative-light';if(t==='dark')t='operative-dark';}if(!t){if(isKita||isMy)t='operative-light';else if(isPrime)t='operative-dark';else t='editorial';}document.documentElement.dataset.product=product;document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.product='editorial';document.documentElement.dataset.theme='editorial';}})();`;
 
 export const viewport: Viewport = {
   width: "device-width",


### PR DESCRIPTION
## What was measured

The pre-paint persona script in `apps/mouth/src/app/layout.tsx` derived `data-theme` from the **hostname alone**. Every environment that is not literally `my.` therefore served the client portal with the editorial NIGHT palette.

Measured in a real browser, same commit, same URL `/portal/login-upgraded`:

| Where | product | theme | body background |
|---|---|---|---|
| `127.0.0.1` (origin/main) | `editorial` | `editorial` | `rgb(29, 39, 59)` — dark navy |
| `127.0.0.1` (this branch) | `my` | `operative-light` | `rgb(244, 241, 234)` — cream |

Same code, two different products, decided by the deploy target.

## Why it stayed hidden

Only the **unauthenticated** screens diverge. The authenticated area pins `operative-light` in its own CSS, so a walkthrough of the portal proper looks correct while login, magic-link, register and forgot-password render the night variant. The login page already ships a complete `[data-theme="operative-light"]` day treatment — it was never being switched on.

## The change

`/portal` IS the client persona wherever it is served, so the path is now the stronger signal and is read before the host. Two lines of the inline script, plus the comment that explains why.

The client's own `ThemeToggle` (mounted in `PortalHeader`) still wins over both. This changes the DEFAULT; it does not remove the choice.

## The test is load-bearing

`portal-theme-persona.test.ts` extracts the real script string from `layout.tsx` and EXECUTES it against a stubbed `document`/`location`/`localStorage`, so the assertions are about behaviour, not about source text containing a substring.

Proven non-vacuous by reverting the two changed lines: **6 of 13 go red**. The five innocence controls stay green in BOTH states — production `my.`, the editorial site, `/portal-news` as a non-portal path, kita day mode, and prime `operative-dark`.

## Bites

A client opening the portal login screen on any host consumes the cream day palette — measured in a live browser on this branch (`product=my theme=operative-light bodyBg=rgb(244,241,234)`) against origin/main at the same URL (`product=editorial theme=editorial bodyBg=rgb(29,39,59)`).

## Scope

Portal only, per the owner's ruling of 2026-09-10. `kita`, `prime` and the public editorial site are untouched — prime stays `operative-dark` by design, since the 3D maps are built for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfDZPdTt1ajymVzJnaQEQT