### PR TITLE
fix(codex-hooks): the Codex side had no zombie detection at all, and released its slot after the block instead of before

### DIFF
--- a/infra/codex-hooks/context_bridge.py
+++ b/infra/codex-hooks/context_bridge.py
@@ -549,6 +549,13 @@ def child_hook(
             + ' with JSON {"objective":"...","next_action":"return to parent","remaining":["..."],"risks":[]}.'
         )
         if event in ("SubagentStop", "Stop"):
+            # Release BEFORE judging. The block path below returns early, and the
+            # release used to sit after this whole `with`, so a first BLOCKED
+            # SubagentStop skipped it entirely and the reservation stayed active
+            # until the harness's second Stop. This is exactly the ordering the
+            # Claude side fixed for Blocker 1 (stop_lifecycle releases and pauses
+            # before any verification); the Codex side kept the old one.
+            budget_observe(state_dir() / "mandates", mandate, sid, stopped=True)
             state.update(
                 transport_status="stopped",
                 claimed_complete=state.get("checkpoint", {}).get("remaining") == [],
@@ -575,8 +582,6 @@ def child_hook(
             return context_output(event, message, deny=True)
         if event == "SubagentStart":
             return context_output(event, message)
-    if event in ("SubagentStop", "Stop"):
-        budget_observe(state_dir() / "mandates", mandate, sid, stopped=True)
     return {}
 
 

--- a/infra/codex-hooks/install.py
+++ b/infra/codex-hooks/install.py
@@ -16,6 +16,7 @@ import sys
 import time
 from pathlib import Path
 
+import mandate_budget
 from context_bridge import EVENTS, VERSION, digest, load, save
 from rpc import RPC
 
@@ -76,7 +77,15 @@ def install(seat: Path, roots: list[str], trust: bool = False) -> dict:
     policy.setdefault("max_hops", 3)
     policy.setdefault(
         "child_limits",
-        {"max_attempts": 24, "max_active": 3, "max_depth": 1, "max_seconds": 3600},
+        {
+            "max_attempts": 24,
+            "max_active": 3,
+            "max_depth": 1,
+            "max_seconds": 3600,
+            # Declared, not inherited: the Claude adapter passes the same value and
+            # the asymmetry was silent until the council named it.
+            "active_ttl": mandate_budget.ACTIVE_TTL_SECONDS,
+        },
     )
     save(seat / "nuzantara-context-policy.json", policy)
     # Only the current seat is selected for this subprocess. Credentials stay put.

--- a/infra/codex-hooks/mandate_budget.py
+++ b/infra/codex-hooks/mandate_budget.py
@@ -22,6 +22,15 @@ from typing import Any, Iterator
 # reservation".
 ACKNOWLEDGE_SECONDS = 240
 
+# How long an ACTIVE row may go silent before the sweep may call it a suspect
+# zombie. The Claude adapter has always passed this explicitly (child_workflow.py
+# active_ttl=1800); install.py's Codex default carried no such key, and the sweep
+# below was gated on `limits.get("active_ttl")` — so on the Codex side the sweep
+# never ran at all and a SIGKILLed supervisor pinned its slot until max_attempts.
+# A default here cures the policies already on disk, which an install-time-only
+# fix would not: none of the three live seats has the key.
+ACTIVE_TTL_SECONDS = 1800
+
 
 @contextmanager
 def ledger(root: Path, mandate: str) -> Iterator[dict[str, Any]]:
@@ -75,9 +84,10 @@ def reserve(
                 "created"
             ] > limits.get("unstarted_ttl", ACKNOWLEDGE_SECONDS):
                 row["status"] = "expired_unstarted"
-            elif row["status"] == "active" and limits.get("active_ttl"):
+            elif row["status"] == "active":
+                active_ttl = limits.get("active_ttl", ACTIVE_TTL_SECONDS)
                 heartbeat = max(row.get("heartbeat", row["created"]), row["created"])
-                if time.time() - heartbeat < limits["active_ttl"]:
+                if time.time() - heartbeat < active_ttl:
                     continue
                 child_row = state.get("children", {}).get(row.get("child"), {})
                 try:
@@ -91,7 +101,7 @@ def reserve(
                     )
                     continue
                 last_activity = max(modified, heartbeat)
-                if time.time() - last_activity >= limits["active_ttl"]:
+                if time.time() - last_activity >= active_ttl:
                     row.update(status="suspect_zombie", suspected_at=time.time())
                     state.update(
                         status="needs_attention",

--- a/infra/codex-hooks/test_codex_side_release_and_sweep.py
+++ b/infra/codex-hooks/test_codex_side_release_and_sweep.py
@@ -1,0 +1,168 @@
+"""Two council residuals on the Codex side of the child ledger.
+
+  * install.py's default child_limits carried no `active_ttl`, and the sweep was
+    gated on the key being present — so the Codex side had NO zombie detection at
+    all and a SIGKILLed supervisor pinned its slot until max_attempts. The Claude
+    adapter has always passed active_ttl=1800; the asymmetry was undeclared.
+  * child_hook released the ledger slot only AFTER the block path returned, so a
+    first BLOCKED SubagentStop skipped the release until the harness's second
+    Stop. This is the ordering the Claude side fixed for Blocker 1.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import context_bridge as bridge
+import mandate_budget as budget
+from test_child_lifecycle import child_transcript
+from test_context_bridge import setup, token  # noqa: F401
+
+LIMITS_WITHOUT_TTL = {
+    "max_attempts": 24,
+    "max_active": 3,
+    "max_depth": 1,
+    "max_seconds": 3600,
+}
+
+
+def _state(root: Path, mandate: str = "root") -> dict:
+    return json.loads(
+        (root / (hashlib.sha256(mandate.encode()).hexdigest() + ".json")).read_text()
+    )
+
+
+# --- residual: the Codex side had no zombie detection ----------------------
+
+
+def test_the_sweep_runs_even_when_the_policy_omits_active_ttl(tmp_path: Path) -> None:
+    # Exactly install.py's shipped default before this PR: no active_ttl key.
+    assert budget.reserve(tmp_path, "root", "one", LIMITS_WITHOUT_TTL) is None
+    budget.observe(tmp_path, "root", "child-a")
+
+    state = _state(tmp_path)
+    silent = time.time() - (budget.ACTIVE_TTL_SECONDS + 60)
+    for row in state["reservations"].values():
+        row["created"] = row["heartbeat"] = silent
+    state["children"]["child-a"]["transcript_path"] = str(tmp_path / "gone.jsonl")
+    (tmp_path / (hashlib.sha256(b"root").hexdigest() + ".json")).write_text(
+        json.dumps(state)
+    )
+
+    budget.reserve(tmp_path, "root", "two", LIMITS_WITHOUT_TTL)
+    after = _state(tmp_path)
+    # Missing transcript cannot establish silence, so the row is RETAINED and the
+    # ledger asks for reconciliation — it must never be silently deleted (D1).
+    assert after["status"] == "needs_attention"
+    assert "UNKNOWN" in after["reason"] or "silent" in after["reason"]
+
+
+def test_a_silent_transcript_becomes_suspect_zombie_without_an_explicit_ttl(
+    tmp_path: Path,
+) -> None:
+    assert budget.reserve(tmp_path, "root", "one", LIMITS_WITHOUT_TTL) is None
+    transcript = tmp_path / "child.jsonl"
+    transcript.write_text("{}\n")
+    budget.observe(tmp_path, "root", "child-a", transcript=str(transcript))
+
+    state = _state(tmp_path)
+    silent = time.time() - (budget.ACTIVE_TTL_SECONDS + 600)
+    for row in state["reservations"].values():
+        row["created"] = row["heartbeat"] = silent
+    (tmp_path / (hashlib.sha256(b"root").hexdigest() + ".json")).write_text(
+        json.dumps(state)
+    )
+    import os
+
+    os.utime(transcript, (silent, silent))
+
+    budget.reserve(tmp_path, "root", "two", LIMITS_WITHOUT_TTL)
+    rows = list(_state(tmp_path)["reservations"].values())
+    assert any(r["status"] == "suspect_zombie" for r in rows)
+    # Never deleted, only stopped from counting.
+    assert len(rows) == 2
+
+
+def test_an_explicit_active_ttl_still_wins(tmp_path: Path) -> None:
+    limits = dict(LIMITS_WITHOUT_TTL, active_ttl=1)
+    assert budget.reserve(tmp_path, "root", "one", limits) is None
+    budget.observe(tmp_path, "root", "child-a")
+    state = _state(tmp_path)
+    for row in state["reservations"].values():
+        row["created"] = row["heartbeat"] = time.time() - 10
+    (tmp_path / (hashlib.sha256(b"root").hexdigest() + ".json")).write_text(
+        json.dumps(state)
+    )
+    budget.reserve(tmp_path, "root", "two", limits)
+    # active_ttl=1 is far shorter than the default: the sweep must have looked.
+    assert _state(tmp_path)["status"] == "needs_attention"
+
+
+def test_installed_policy_declares_active_ttl() -> None:
+    import install
+
+    source = Path(install.__file__).read_text()
+    assert '"active_ttl": mandate_budget.ACTIVE_TTL_SECONDS' in source
+
+
+# --- residual: release after block instead of before -----------------------
+
+
+def test_a_blocked_stop_releases_the_ledger_slot_before_it_blocks(
+    setup: tuple,
+) -> None:
+    _, log, e = setup
+    child = "child-session-release"
+    child_transcript(log, child, e["session_id"])
+    bridge.hook({**e, "agent_id": child, "hook_event_name": "SubagentStart"})
+    with log.open("a") as out:
+        out.write(
+            json.dumps(
+                {
+                    "timestamp": "new",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "model_context_window": 1000,
+                            "last_token_usage": {"total_tokens": 500},
+                        },
+                    },
+                }
+            )
+            + "\n"
+        )
+    pre = {**e, "hook_event_name": "PreToolUse", "tool_name": "Bash"}
+    for _ in range(3):
+        assert bridge.hook(pre)["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    stop = {
+        **e,
+        "agent_id": child,
+        "hook_event_name": "SubagentStop",
+        "agent_transcript_path": str(log),
+    }
+    with patch.object(
+        bridge, "launch", side_effect=AssertionError("child must never launch")
+    ):
+        # FIRST stop, and it BLOCKS — the slot must already be released.
+        assert bridge.hook(stop)["decision"] == "block"
+
+    ledger = bridge.state_dir() / "mandates"
+    children = {
+        cid: row
+        for state_file in ledger.glob("*.json")
+        for cid, row in json.loads(state_file.read_text()).get("children", {}).items()
+    }
+    assert children, "the stop must have reached the ledger at all"
+    assert children[child]["transport"] == "stopped", (
+        "a blocked stop left the child recorded as started: the release ran "
+        "after the block path returned instead of before it"
+    )


### PR DESCRIPTION
The last two council residuals from #6046 that concern the Codex adapter.

## 1 — the Codex side had NO zombie detection at all

`mandate_budget`'s suspect_zombie sweep was gated on `limits.get("active_ttl")`
being present, and `install.py`'s default Codex `child_limits` carried no such key.
So the sweep never ran on the Codex side and a SIGKILLed supervisor pinned its slot
until `max_attempts`. The Claude adapter has always passed `active_ttl=1800`
explicitly (`child_workflow.py:119`); the asymmetry was undeclared.

**Cured in the sweep, not only in the installer.** The council named both shapes;
an installer-only fix would leave every seat already on disk uncured, and none of
the three live seats has the key — measured this turn, M5/Pro/Mini policies all
carry `{max_attempts, max_active, max_depth, max_seconds}` and nothing else. A
default in `mandate_budget` cures them without a reinstall; `install.py` now
declares it too, derived from the same constant so the two cannot drift.

**The sweep still never deletes.** Worth stating because widening a sweep is how
you lose rows: a silent row becomes `suspect_zombie` and stops counting toward
`max_active` (D1), and a row whose transcript is MISSING stays retained with
"liveness UNKNOWN" rather than being convicted — cannot-verify is not a verdict.
Both properties have their own test.

## 2 — release after the block instead of before

`child_hook` called `budget_observe(stopped=True)` after the whole `with locked()`
block, but the incomplete/UNKNOWN path `return`s a `{"decision": "block"}` from
inside it. A first BLOCKED SubagentStop therefore skipped the release entirely and
the child stayed recorded as `started` until the harness's second Stop.

This is precisely the ordering the Claude side fixed for Blocker 1 — `stop_lifecycle`
releases and pauses before any verification — and the Codex side kept the old one.
The release now happens on entry to the stop branch, before any judgement.

## Mutation-verified

5 regression cases. Restoring the key-gated sweep kills exactly the two sweep tests;
moving the release back after the block kills exactly the ordering test; neither
mutant touches the others. `pytest infra/codex-hooks/ -q` → **68 passed**.

## Bites

CONSUMER: the live Codex seat policy on M5, Pro and Mini, plus the ledger the
adapter writes.

Observation to make after merge, from a detached worktree on `origin/main`:
the sweep default is what cures the seats that already exist, so the observable is
that a policy WITHOUT `active_ttl` — which is what all three seats have right now —
now reaches the sweep. I will show the three live policies still lacking the key and
the merged `mandate_budget` reaching the sweep for exactly that shape, plus
`install.py` writing the key on a fresh install. Reported in this thread before the
work is called done.

## Remaining residuals after this PR

Two of the nine, both signal hygiene rather than correctness, deliberately not
bundled here: #12 (`needs_attention` latches — nothing clears the status once the
condition resolves, so the attention report accumulates resolved alarms) and #15
(the unguarded depth branch, dead code whose ownership overlaps the adapter-level
structural guard). #5 and #6 (operator-verb `release()` during an in-flight launch,
and `TRANSIENT_FAILURES` classifying by exception type) remain PLAUSIBLE-status
residuals on the operator path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRgCfZacYYdLR26BnfbMU4
