### PR TITLE
fix(codex-hooks): needs_attention never cleared, and the one limit that ignored strict

### DIFF
--- a/infra/codex-hooks/mandate_budget.py
+++ b/infra/codex-hooks/mandate_budget.py
@@ -32,6 +32,39 @@ ACKNOWLEDGE_SECONDS = 240
 ACTIVE_TTL_SECONDS = 1800
 
 
+def _attend(state: dict[str, Any], reason: str, key: str) -> None:
+    """Raise the live attention flag AND keep the history.
+
+    Every writer went through `state["status"] = "needs_attention"` directly and
+    nothing ever cleared it, so a child that later returned cleanly left its alarm
+    standing and the attention report accumulated resolved alarms — the same
+    signal pollution R1 was written to stop, one level up. The live flag is now
+    derived from a KEY that a later contradicting observation can supersede; the
+    ledger keeps every raise in `attention_history` regardless.
+    """
+    state["status"] = "needs_attention"
+    state["reason"] = reason
+    state["attention_key"] = key
+    state.setdefault("attention_history", []).append(
+        {"reason": reason, "key": key, "at": time.time()}
+    )
+
+
+def _resolve(state: dict[str, Any], *keys: str) -> None:
+    """Supersede the live flag when an observation contradicts the raise.
+
+    Only the named keys are cleared: an alarm this observation says nothing about
+    must survive. The history is never rewritten — the alarm happened.
+    """
+    if state.get("status") == "needs_attention" and state.get("attention_key") in keys:
+        state.pop("status", None)
+        state.pop("reason", None)
+        resolved = state.pop("attention_key", None)
+        state.setdefault("attention_history", []).append(
+            {"resolved": resolved, "at": time.time()}
+        )
+
+
 @contextmanager
 def ledger(root: Path, mandate: str) -> Iterator[dict[str, Any]]:
     root.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -74,7 +107,11 @@ def reserve(
         )
         state["max_active"] = limits.get("max_active", 3)
         if not tool_id:
-            state["status"] = "needs_attention"
+            _attend(
+                state,
+                "Native dispatch identity is UNKNOWN; return to the coordinator.",
+                "dispatch_identity_unknown",
+            )
             return "Native dispatch identity is UNKNOWN; return to the coordinator."
         key = hashlib.sha256(tool_id.encode()).hexdigest()
         if key in reservations:
@@ -88,6 +125,10 @@ def reserve(
                 active_ttl = limits.get("active_ttl", ACTIVE_TTL_SECONDS)
                 heartbeat = max(row.get("heartbeat", row["created"]), row["created"])
                 if time.time() - heartbeat < active_ttl:
+                    # A row heartbeating inside its TTL contradicts an earlier
+                    # "liveness UNKNOWN" on this ledger: the slot is demonstrably
+                    # alive, so the alarm must not outlive the doubt.
+                    _resolve(state, "liveness_unknown")
                     continue
                 child_row = state.get("children", {}).get(row.get("child"), {})
                 try:
@@ -95,17 +136,19 @@ def reserve(
                     modified = transcript.stat().st_mtime
                 except (KeyError, OSError):
                     # Missing evidence cannot establish transcript silence.
-                    state.update(
-                        status="needs_attention",
-                        reason="Child transcript liveness UNKNOWN; slot retained",
+                    _attend(
+                        state,
+                        "Child transcript liveness UNKNOWN; slot retained",
+                        "liveness_unknown",
                     )
                     continue
                 last_activity = max(modified, heartbeat)
                 if time.time() - last_activity >= active_ttl:
                     row.update(status="suspect_zombie", suspected_at=time.time())
-                    state.update(
-                        status="needs_attention",
-                        reason="Child transcript silent; suspect_zombie slot requires reconciliation",
+                    _attend(
+                        state,
+                        "Child transcript silent; suspect_zombie slot requires reconciliation",
+                        "suspect_zombie",
                     )
         child = None
         if target:
@@ -130,7 +173,7 @@ def reserve(
                 )
             )
             if child is None:
-                state.update(status="needs_attention", reason="Resume target UNKNOWN")
+                _attend(state, "Resume target UNKNOWN", "resume_target_unknown")
         active = {
             r.get("child", key)
             for key, r in reservations.items()
@@ -140,7 +183,13 @@ def reserve(
         strict = limits.get("strict", True)
         if time.time() >= state["deadline"] and strict:
             reason = "Mandate deadline reached"
-        elif depth > limits.get("max_depth", 1):
+        elif depth > limits.get("max_depth", 1) and strict:
+            # Gated like its four siblings. It was the only limit in this chain
+            # enforced under interactive_observation too — an asymmetry nobody
+            # chose: the structural depth rule is already enforced by the adapter
+            # ABOVE this ledger, so an ungated copy here duplicated a decision it
+            # does not own and would have denied an interactive caller that the
+            # other four limits let through.
             reason = "Mandate child depth reached"
         elif len(reservations) >= limits.get("max_attempts", 24) and strict:
             reason = "Mandate total dispatch attempts reached"
@@ -151,7 +200,7 @@ def reserve(
         ):
             reason = "Mandate concurrent dispatch limit reached"
         if reason:
-            state.update(status="needs_attention", reason=reason)
+            _attend(state, reason, "mandate_limit")
             return (
                 reason
                 + "; return the remaining work. Do not reset the budget with a replacement."
@@ -170,9 +219,11 @@ def reserve(
             or len(reservations) > limits.get("max_attempts", 24)
             or (len(active) >= limits.get("max_active", 3) and child not in active)
         ):
-            state.update(
-                status="needs_attention",
-                reason="Interactive session counters exceed one mandate budget; declare an explicit autonomous mandate for enforced total limits.",
+            _attend(
+                state,
+                "Interactive session counters exceed one mandate budget; declare an "
+                "explicit autonomous mandate for enforced total limits.",
+                "interactive_counters",
             )
     return None
 
@@ -241,13 +292,18 @@ def observe(
                     and child not in active
                     and len(active) >= state.get("max_active", 3)
                 ):
-                    state.update(
-                        status="needs_attention",
-                        reason="Child lease cannot resume: concurrent dispatch limit reached",
+                    _attend(
+                        state,
+                        "Child lease cannot resume: concurrent dispatch limit reached",
+                        "lease_cannot_resume",
                     )
                     return state["reason"]
             bound["status"] = "returned_unverified" if stopped else "active"
             bound["heartbeat"] = time.time()
+            # This child DID have a reservation and its lease DID resume, which is
+            # exactly what those two alarms claimed was untrue. Any other alarm
+            # (a mandate limit, an unknown resume target) is untouched.
+            _resolve(state, "observed_without_reservation", "lease_cannot_resume")
             # One child may have multiple resume reservations. Refresh them all.
             for row in reservations.values():
                 if row.get("child") == child:
@@ -257,6 +313,9 @@ def observe(
                     if row.get("child") == child:
                         row["status"] = "returned_unverified"
         else:
-            state["status"] = "needs_attention"
-            state["reason"] = "Child observed without a dispatch reservation"
+            _attend(
+                state,
+                "Child observed without a dispatch reservation",
+                "observed_without_reservation",
+            )
     return None

--- a/infra/codex-hooks/test_attention_latch_and_depth_gate.py
+++ b/infra/codex-hooks/test_attention_latch_and_depth_gate.py
@@ -1,0 +1,123 @@
+"""Two council residuals about signals the ledger raises but never revises.
+
+  * `needs_attention` latched: eight writers set it, nothing ever cleared it, so a
+    child that later returned cleanly left its alarm standing and the attention
+    report accumulated resolved alarms — the same signal pollution R1 was written
+    to stop, one level up.
+  * the `depth > max_depth` branch was the only limit in reserve()'s chain NOT
+    gated on `strict`, so it denied interactive callers that the other four let
+    through, duplicating a structural rule the adapter already enforces above it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import mandate_budget as budget
+
+LIMITS = {"max_active": 4, "max_attempts": 8, "max_seconds": 600, "max_depth": 1}
+
+
+def _state(root: Path, mandate: str = "root") -> dict:
+    return json.loads(
+        (root / (hashlib.sha256(mandate.encode()).hexdigest() + ".json")).read_text()
+    )
+
+
+def _write(root: Path, state: dict, mandate: str = "root") -> None:
+    (root / (hashlib.sha256(mandate.encode()).hexdigest() + ".json")).write_text(
+        json.dumps(state)
+    )
+
+
+# --- residual: needs_attention latches -------------------------------------
+
+
+def test_an_alarm_is_superseded_when_the_child_turns_out_to_have_a_reservation(
+    tmp_path: Path,
+) -> None:
+    # Raise it the way the live path does: a stop with no reservation at all.
+    budget.observe(tmp_path, "root", "orphan", stopped=True)
+    assert _state(tmp_path)["status"] == "needs_attention"
+
+    # Now the same ledger sees a properly reserved child return.
+    assert budget.reserve(tmp_path, "root", "one", LIMITS) is None
+    budget.observe(tmp_path, "root", "child-a")
+
+    state = _state(tmp_path)
+    assert state.get("status") != "needs_attention"
+    assert state.get("reason") is None
+
+
+def test_the_history_keeps_the_alarm_that_was_superseded(tmp_path: Path) -> None:
+    budget.observe(tmp_path, "root", "orphan", stopped=True)
+    assert budget.reserve(tmp_path, "root", "one", LIMITS) is None
+    budget.observe(tmp_path, "root", "child-a")
+
+    history = _state(tmp_path)["attention_history"]
+    assert any(h.get("key") == "observed_without_reservation" for h in history), (
+        "the alarm must survive in the ledger even though the live flag cleared"
+    )
+    assert any(h.get("resolved") == "observed_without_reservation" for h in history)
+
+
+def test_an_unrelated_alarm_is_not_cleared(tmp_path: Path) -> None:
+    # A mandate-limit alarm says nothing about reservations; a clean child return
+    # must NOT silence it.
+    limits = dict(LIMITS, max_attempts=1)
+    assert budget.reserve(tmp_path, "root", "one", limits) is None
+    assert budget.reserve(tmp_path, "root", "two", limits) is not None
+    assert _state(tmp_path)["attention_key"] == "mandate_limit"
+
+    budget.observe(tmp_path, "root", "child-a")
+    state = _state(tmp_path)
+    assert state["status"] == "needs_attention"
+    assert state["attention_key"] == "mandate_limit"
+
+
+def test_a_live_heartbeat_supersedes_a_liveness_unknown_alarm(tmp_path: Path) -> None:
+    assert budget.reserve(tmp_path, "root", "one", LIMITS) is None
+    budget.observe(tmp_path, "root", "child-a")
+    state = _state(tmp_path)
+    state["status"] = "needs_attention"
+    state["reason"] = "Child transcript liveness UNKNOWN; slot retained"
+    state["attention_key"] = "liveness_unknown"
+    _write(tmp_path, state)
+
+    # The row is heartbeating well inside its TTL: the doubt is contradicted.
+    budget.reserve(tmp_path, "root", "two", LIMITS)
+    assert _state(tmp_path).get("status") != "needs_attention"
+
+
+# --- residual: the ungated depth branch ------------------------------------
+
+
+def test_depth_denies_under_a_strict_mandate(tmp_path: Path) -> None:
+    verdict = budget.reserve(
+        tmp_path, "root", "deep", dict(LIMITS, strict=True), depth=2
+    )
+    assert verdict is not None
+    assert "depth" in verdict
+
+
+def test_depth_does_not_deny_an_interactive_session(tmp_path: Path) -> None:
+    # The other four limits in this chain are gated on strict; this one was not.
+    assert (
+        budget.reserve(tmp_path, "root", "deep", dict(LIMITS, strict=False), depth=2)
+        is None
+    )
+
+
+def test_depth_within_the_limit_is_untouched_either_way(tmp_path: Path) -> None:
+    assert (
+        budget.reserve(tmp_path, "a", "ok", dict(LIMITS, strict=True), depth=1) is None
+    )
+    assert (
+        budget.reserve(tmp_path, "b", "ok", dict(LIMITS, strict=False), depth=1) is None
+    )


### PR DESCRIPTION
Two council residuals about signals the ledger raises but never revises.

## 1 — `needs_attention` latched

Eight writers set it in `mandate_budget.py`; **nothing anywhere cleared it**. A child
that later returned cleanly left its alarm standing, so the attention report — the
operator's only signal — accumulated resolved alarms. R1 narrowed the *trigger*; the
*latch* was untouched, which is the same signal pollution R1 exists to stop, one
level up.

Every raise now goes through `_attend()`, recording a stable key and appending to
`attention_history`. `_resolve()` supersedes the LIVE flag only for keys an
observation actually contradicts:

| observation | supersedes |
|---|---|
| a child binds its reservation | `observed_without_reservation`, `lease_cannot_resume` |
| a row heartbeats inside its TTL | `liveness_unknown` |

**Over-clearing is how this fix fails, so it has its own test.** A mandate-limit
alarm says nothing about reservations and must survive a clean child return
(`test_an_unrelated_alarm_is_not_cleared`). The history is never rewritten — the
alarm happened; only the live flag moves.

## 2 — the one limit that ignored `strict`

`reserve()`'s chain has five limits. Four are gated on `strict`; `depth > max_depth`
was not, so it denied interactive callers that deadline, `max_attempts` and
`max_active` all let through.

The council offered "remove it, or gate it like its four siblings". **Gated, not
removed**: removing it drops a defence if the adapter above ever changes, whereas
gating makes it consistent. Stated plainly, gating *weakens* the non-strict case —
which is why both sides are pinned (`test_depth_denies_under_a_strict_mandate`,
`test_depth_does_not_deny_an_interactive_session`). The structural depth rule is
enforced by the adapter ABOVE this ledger; the ungated copy was duplicating a
decision it does not own.

## Mutation-verified

7 regression cases, 3 mutants:

| mutant | kills |
|---|---|
| `_resolve` disabled (latch returns) | exactly the 3 supersession tests |
| `_resolve` clears ANY key (over-clear) | exactly the unrelated-alarm test |
| `depth` un-gated again | exactly the interactive test |

`pytest infra/codex-hooks/ -q` → **75 passed**.

## Bites

CONSUMER: the attention report's live flag, i.e. `state["status"]` in the ledger
under `~/.claude/state/child-mandates/`. Observation after merge, driven from a
detached worktree on `origin/main`: raise a real alarm through the live path, then
have the same ledger see a properly reserved child return, and show `status` gone
from the live state while the raise survives in `attention_history`. Posted in this
thread before the work is called done.

## Last residuals after this PR

#5 and #6, both PLAUSIBLE-status and both on the operator path in
`context_bridge.py`: `release()` does not refuse while a launch is in flight
(its own docstring declares the invariant that the code does not enforce), and
`continue_session`'s except records `type(exc).__name__`, discarding the cause so
the two consumers downstream — `frozen_reason()` and the `Stop` handler — must guess
from a class name. In the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRgCfZacYYdLR26BnfbMU4
