### PR TITLE
feat(crm): give the workspace a portal-access control, and make the status it reads true

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_portal_integration.py
+++ b/apps/backend-rag/backend/app/routers/crm_portal_integration.py
@@ -25,6 +25,7 @@ from backend.app.utils.crm_utils import verify_client_access
 from backend.app.utils.logging_utils import get_logger
 from backend.app.utils.service_accounts import is_human_team_member
 from backend.services.portal._rbac import ClientContext
+from backend.services.portal.portal_profile_service import PLACEHOLDER_PIN_HASH
 
 if TYPE_CHECKING:
     from backend.services.portal import InviteService, PortalService
@@ -163,17 +164,38 @@ async def get_portal_status(
     async with db_pool.acquire() as conn:
         await verify_client_access(client_id, current_user, conn, allow_assigned=True)
 
-        # Check for portal user
+        # Check for portal user.
+        #
+        # `portal_access = true` alone is NOT portal access — superscar #2,
+        # Esiste != Armato. `PortalProfileService.ensure_portal_profile()` runs
+        # as a background task on every client creation that carries an email
+        # and inserts the row with `portal_access = true` and
+        # PLACEHOLDER_PIN_HASH, a hash that no PIN can ever match. Measured on
+        # production 2026-09-10: of 532 active client rows with
+        # `portal_access = true`, **448 carry that placeholder and can never log
+        # in** — 84% — and only 9 have ever logged in at all. Without the
+        # pin_hash predicate this endpoint answers "has portal access" for all
+        # 448, so the workspace shows "Portal active" for a client who was never
+        # invited and hides the control that would invite them.
+        #
+        # Compared by EQUALITY against the constant, not by a substring of it
+        # (superscar #3): a guard on an entity is an entity test.
+        #
+        # `last_login` is also read from the real column here. It used to be
+        # `tm.created_at as last_login`, so every "last signed in" the CRM
+        # displayed was in fact the date the record was created.
         portal_user = await conn.fetchrow(
             """
-            SELECT tm.id, tm.email, tm.created_at as last_login
+            SELECT tm.id, tm.email, tm.last_login
             FROM team_members tm
             WHERE tm.linked_client_id = $1
               AND tm.role = 'client'
               AND tm.active = true
               AND tm.portal_access = true
+              AND tm.pin_hash IS DISTINCT FROM $2
             """,
             client_id,
+            PLACEHOLDER_PIN_HASH,
         )
 
         # Check for pending invitation

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_crm_portal_status_placeholder.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_crm_portal_status_placeholder.py
@@ -1,0 +1,174 @@
+"""Guilt/innocence for crm_portal_integration.py::get_portal_status.
+
+Two defects, one query, both measured live on 2026-09-10.
+
+DEFECT 1 — `portal_access = true` was treated as portal access.
+`PortalProfileService.ensure_portal_profile()` runs as a background task on
+every client creation that carries an email, and inserts the row with
+`portal_access = true` and PLACEHOLDER_PIN_HASH — a hash no PIN can ever match.
+Measured on production: of 532 active client rows with `portal_access = true`,
+**448 carry that placeholder and can never log in** (84%), and only 9 have ever
+logged in at all. So this endpoint answered "has portal access" for 448 clients
+who were never invited, and the workspace consequently showed "Portal active"
+and HID the control that would have invited them. The invite path was therefore
+unreachable for the common case: a client created with an email already on file.
+
+DEFECT 2 — `SELECT tm.created_at as last_login` aliased the creation date to
+the last-login field, so every "Last signed in ..." the CRM displayed was in
+fact "record created on ...". Measured on the same client: the API returned
+04:02:25 (created_at) while the real `last_login` was 04:03:00, 35 seconds
+later.
+
+These tests assert on the QUERY, because the whole behaviour lives in SQL: the
+row is either filtered out by the database or it is not. The live behavioural
+proof is recorded in the PR — client 5, carrying `portal_access = true` and the
+placeholder, flipped from `has_portal_access: true` to `false`, while client 4,
+carrying real bcrypt credentials, stayed `true` AND began reporting the real
+`last_login` instead of `created_at`.
+
+Reverting either line of the cure turns these red.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend.app.routers.crm_portal_integration import get_portal_status
+from backend.services.portal.portal_profile_service import PLACEHOLDER_PIN_HASH
+
+
+class _RecordingConnection:
+    """Captures every query and its bind parameters, returns no rows."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetchrow(self, query: str, *args: Any) -> None:
+        self.calls.append((query, args))
+        return None
+
+    async def fetchval(self, query: str, *args: Any) -> None:
+        self.calls.append((query, args))
+        return None
+
+
+class _Acquire:
+    def __init__(self, conn: _RecordingConnection) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> _RecordingConnection:
+        return self._conn
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class _Pool:
+    def __init__(self, conn: _RecordingConnection) -> None:
+        self._conn = conn
+
+    def acquire(self) -> _Acquire:
+        return _Acquire(self._conn)
+
+
+async def _run_status(monkeypatch: pytest.MonkeyPatch) -> _RecordingConnection:
+    conn = _RecordingConnection()
+
+    async def _allow_access(*_: object, **__: object) -> tuple[bool, str | None]:
+        return True, "consultant@balizero.com"
+
+    monkeypatch.setattr(
+        "backend.app.routers.crm_portal_integration.verify_client_access",
+        _allow_access,
+    )
+
+    await get_portal_status(
+        client_id=4,
+        current_user={"email": "consultant@balizero.com", "role": "Consultant"},
+        db_pool=_Pool(conn),  # type: ignore[arg-type]
+    )
+    return conn
+
+
+def _portal_user_query(conn: _RecordingConnection) -> tuple[str, tuple[Any, ...]]:
+    for query, args in conn.calls:
+        if "team_members" in query:
+            return query, args
+    raise AssertionError(
+        "no query against team_members was issued — the portal-user lookup "
+        "was renamed or removed; update this test rather than deleting it.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_placeholder_account_is_excluded_from_portal_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GUILT: a provisioned-but-unusable account must not count as access."""
+    conn = await _run_status(monkeypatch)
+    query, args = _portal_user_query(conn)
+
+    assert "pin_hash" in query, (
+        "the portal-user lookup no longer filters on pin_hash, so the 448 "
+        "production rows carrying PLACEHOLDER_PIN_HASH would read as "
+        "'has portal access' again"
+    )
+    assert PLACEHOLDER_PIN_HASH in args, (
+        "the placeholder hash must be passed as a bind PARAMETER and compared "
+        "by equality — an entity test, not a substring of it (superscar #3)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_last_login_is_read_from_the_last_login_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GUILT: the creation date must never be dressed up as a sign-in."""
+    conn = await _run_status(monkeypatch)
+    query, _ = _portal_user_query(conn)
+
+    assert "created_at as last_login" not in query.lower(), (
+        "created_at is being aliased to last_login again — the CRM would "
+        "report a sign-in date for a client who has never signed in"
+    )
+    assert "tm.last_login" in query
+
+
+@pytest.mark.asyncio
+async def test_pending_invitation_lookup_is_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INNOCENCE: the invitation branch must keep working unchanged."""
+    conn = await _run_status(monkeypatch)
+
+    invite_queries = [q for q, _ in conn.calls if "client_invitations" in q]
+    assert invite_queries, "the pending-invitation lookup disappeared"
+    invite_query = invite_queries[0]
+    assert "used_at IS NULL" in invite_query
+    assert "expires_at > NOW()" in invite_query
+
+
+@pytest.mark.asyncio
+async def test_access_check_still_runs_before_any_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INNOCENCE: RBAC must not have been bypassed while editing the query."""
+    calls: list[int] = []
+
+    async def _record_access(client_id: int, *_: object, **__: object):
+        calls.append(client_id)
+        return True, "consultant@balizero.com"
+
+    monkeypatch.setattr(
+        "backend.app.routers.crm_portal_integration.verify_client_access",
+        _record_access,
+    )
+    conn = _RecordingConnection()
+    await get_portal_status(
+        client_id=7,
+        current_user={"email": "consultant@balizero.com", "role": "Consultant"},
+        db_pool=_Pool(conn),  # type: ignore[arg-type]
+    )
+    assert calls == [7]

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.test.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * PortalAccess — the first caller the invitation endpoints have ever had.
+ *
+ * `POST /api/crm/portal/clients/{id}/invite` shipped months ago with NO caller
+ * anywhere in apps/mouth: it could only be reached by hand-crafting an HTTP
+ * request with a team JWT. Measured on production 2026-09-10, the last portal
+ * invitation and the last client portal login are both dated 2026-07-10 —
+ * consultants had no way to send one. So this component's contract is not
+ * cosmetic, and the tests below are about which BUTTON a consultant is shown,
+ * because each wrong branch has its own real-world cost:
+ *
+ *   - inviting a client who already has access  -> a confusing second email
+ *   - inviting on a FAILED status read          -> a duplicate invitation
+ *   - inviting with no email on file            -> a guaranteed 400
+ *   - a bare "failed" toast on the 403          -> the consultant hunts logs
+ *     for the assigned-owner rule the backend already stated
+ *
+ * The failed-read case is the one worth stating plainly: an error must NOT
+ * degrade into the "no portal access yet" branch, because that branch offers
+ * the invite button. Failing open there is how a client gets invited twice.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PortalAccess } from "./PortalAccess";
+import { api } from "@/lib/api";
+import { toast } from "sonner";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    crm: {
+      getPortalStatus: vi.fn(),
+      sendPortalInvite: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const NO_ACCESS = {
+  has_portal_access: false,
+  portal_user_id: null,
+  portal_email: null,
+  last_login: null,
+  pending_invite: false,
+  invite_expires_at: null,
+};
+
+const PENDING = {
+  ...NO_ACCESS,
+  pending_invite: true,
+  invite_expires_at: "2026-09-13T00:00:00Z",
+};
+
+const ACTIVE = {
+  has_portal_access: true,
+  portal_user_id: 12,
+  portal_email: "client@example.com",
+  last_login: "2026-09-01T00:00:00Z",
+  pending_invite: false,
+  invite_expires_at: null,
+};
+
+function renderPanel(email: string | null = "client@example.com") {
+  return render(
+    <PortalAccess
+      clientId={4}
+      clientName="Pilot Invitee"
+      clientEmail={email}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.crm.getPortalStatus).mockReset();
+  vi.mocked(api.crm.sendPortalInvite).mockReset();
+  vi.mocked(toast.success).mockReset();
+  vi.mocked(toast.error).mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PortalAccess", () => {
+  it("offers the invite button when the client has no portal access", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(NO_ACCESS);
+    renderPanel();
+
+    const button = await screen.findByRole("button", {
+      name: /invite to portal/i,
+    });
+    expect(button).toBeEnabled();
+  });
+
+  it("sends the invitation and confirms it by name", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(NO_ACCESS);
+    vi.mocked(api.crm.sendPortalInvite).mockResolvedValue({
+      emailSent: true,
+      emailError: null,
+    });
+    renderPanel();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /invite to portal/i }),
+    );
+
+    await waitFor(() =>
+      expect(api.crm.sendPortalInvite).toHaveBeenCalledWith(
+        4,
+        "client@example.com",
+      ),
+    );
+    expect(toast.success).toHaveBeenCalledWith(
+      "Portal invitation emailed to Pilot Invitee",
+    );
+    // The status is re-read so the panel does not keep offering "Invite"
+    // after the invitation exists.
+    expect(vi.mocked(api.crm.getPortalStatus).mock.calls.length).toBe(2);
+  });
+
+  it("does NOT claim success when the invitation was minted but the email failed", async () => {
+    // The failure the pilot actually risks: the row exists, the consultant is
+    // told "sent", and the client waits for a link that never arrives.
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(NO_ACCESS);
+    vi.mocked(api.crm.sendPortalInvite).mockResolvedValue({
+      emailSent: false,
+      emailError: "Brevo rejected the recipient",
+    });
+    renderPanel();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /invite to portal/i }),
+    );
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toMatch(/did NOT go out/i);
+    expect(vi.mocked(toast.error).mock.calls[0][1]).toMatchObject({
+      description: "Brevo rejected the recipient",
+    });
+  });
+
+  it("never exposes the invite token — the email is its only channel", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(NO_ACCESS);
+    vi.mocked(api.crm.sendPortalInvite).mockResolvedValue({
+      emailSent: true,
+      emailError: null,
+    });
+    const { container } = renderPanel();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /invite to portal/i }),
+    );
+    await waitFor(() => expect(api.crm.sendPortalInvite).toHaveBeenCalled());
+
+    expect(container.textContent).not.toMatch(/token|invite_url|\/register\?/i);
+  });
+
+  it("explains the assigned-owner rule instead of a bare failure on 403", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(NO_ACCESS);
+    vi.mocked(api.crm.sendPortalInvite).mockRejectedValue(
+      new Error("403 Forbidden"),
+    );
+    renderPanel();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /invite to portal/i }),
+    );
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(vi.mocked(toast.error).mock.calls[0][1]).toMatchObject({
+      description: expect.stringContaining("assigned to this client"),
+    });
+  });
+
+  it("passes a non-permission error through verbatim", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(NO_ACCESS);
+    vi.mocked(api.crm.sendPortalInvite).mockRejectedValue(
+      new Error("Client has no email address"),
+    );
+    renderPanel();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /invite to portal/i }),
+    );
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(vi.mocked(toast.error).mock.calls[0][1]).toMatchObject({
+      description: "Client has no email address",
+    });
+  });
+
+  it("offers resend, not invite, while an invitation is pending", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(PENDING);
+    renderPanel();
+
+    expect(await screen.findByText(/invitation pending/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /send again/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /invite to portal/i }),
+    ).toBeNull();
+  });
+
+  it("offers no invitation at all once the portal is active", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(ACTIVE);
+    renderPanel();
+
+    expect(await screen.findByText(/portal active/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /invite|send again/i }),
+    ).toBeNull();
+  });
+
+  it("does NOT fall back to the invite button when the status read fails", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockRejectedValue(new Error("boom"));
+    renderPanel();
+
+    expect(
+      await screen.findByText(/portal status unavailable/i),
+    ).toBeInTheDocument();
+    // The whole point: a failed read must not look like "no access yet",
+    // because that branch would invite the client a second time.
+    expect(
+      screen.queryByRole("button", { name: /invite to portal/i }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("cannot invite a client with no email on file", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(NO_ACCESS);
+    renderPanel(null);
+
+    const button = await screen.findByRole("button", {
+      name: /invite to portal/i,
+    });
+    expect(button).toBeDisabled();
+    expect(screen.getByText(/no email address on file/i)).toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import { KeyRound, MailCheck, Clock, ShieldAlert, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import type { PortalAccessStatus } from "@/lib/api/crm/crm.types";
+
+/**
+ * Portal access control for the client-detail page.
+ *
+ * WHY THIS EXISTS: the invitation endpoints have shipped for months with NO
+ * caller anywhere in the workspace — `POST /api/crm/portal/clients/{id}/invite`
+ * could only be reached by hand-crafting an HTTP request with a team JWT. The
+ * consequence measured on production 2026-09-10: the last portal invitation and
+ * the last client portal login are both dated 2026-07-10, because no consultant
+ * had a way to send one. This panel is that missing caller.
+ *
+ * The raw invite token is never available here on purpose: the backend strips
+ * `token` and `invite_url` at the router boundary because the Brevo email is
+ * their only legitimate channel. So this component can report that an invite
+ * was sent, never what it contained.
+ */
+export function PortalAccess({
+  clientId,
+  clientName,
+  clientEmail,
+}: {
+  clientId: number;
+  clientName: string;
+  clientEmail?: string | null;
+}) {
+  const [status, setStatus] = useState<PortalAccessStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSending, setIsSending] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const next = await api.crm.getPortalStatus(clientId);
+      setStatus(next);
+      setLoadFailed(false);
+    } catch {
+      // A failed status read must not present as "no portal access" — that
+      // would invite a consultant to send a duplicate invitation to a client
+      // who already has one. Show the failure instead.
+      setLoadFailed(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [clientId]);
+
+  useEffect(() => {
+    void loadStatus();
+  }, [loadStatus]);
+
+  const handleInvite = async () => {
+    if (!clientEmail) return;
+    setIsSending(true);
+    try {
+      const { emailSent, emailError } = await api.crm.sendPortalInvite(
+        clientId,
+        clientEmail,
+      );
+      if (emailSent) {
+        toast.success(`Portal invitation emailed to ${clientName}`);
+      } else {
+        // The invitation row EXISTS but the mail did not leave, so the client
+        // is waiting for a link that will never arrive. Reporting this as a
+        // success is how a pilot dies quietly.
+        toast.error("Invitation created, but the email did NOT go out", {
+          description:
+            emailError ??
+            "The mail service rejected it. Resend once it is back, or send the client a magic link.",
+        });
+      }
+      await loadStatus();
+    } catch (err) {
+      const message = (err as Error).message;
+      // The assigned-owner rule is the single most likely refusal here, and a
+      // generic "failed" toast would send the consultant hunting through logs
+      // for a permission rule the backend already stated.
+      const isForbidden = /403|forbidden|permission/i.test(message);
+      toast.error("Could not send the invitation", {
+        description: isForbidden
+          ? "Only the team member assigned to this client (or an admin) can invite them."
+          : message,
+      });
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const formatDate = (value: string | null) =>
+    value
+      ? new Date(value).toLocaleDateString(undefined, {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+        })
+      : null;
+
+  return (
+    <div className="bz-product-panel overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--bz-border)]">
+        <div className="flex items-center gap-2">
+          <KeyRound className="w-4 h-4 text-[var(--bz-accent)]" />
+          <h3 className="text-sm font-medium text-[var(--bz-text-1)]">
+            Client Portal Access
+          </h3>
+        </div>
+        <span className="text-xs text-[var(--bz-text-2)]">my.balizero.com</span>
+      </div>
+
+      <div className="px-4 py-4">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-4">
+            <div className="w-5 h-5 border-2 border-[var(--bz-accent)] border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : loadFailed ? (
+          <div className="flex items-start gap-2">
+            <ShieldAlert className="w-4 h-4 text-[var(--bz-text-2)] mt-0.5 shrink-0" />
+            <div>
+              <p className="text-sm text-[var(--bz-text-1)]">
+                Portal status unavailable
+              </p>
+              <p className="text-xs text-[var(--bz-text-2)] mt-1">
+                Not sending an invitation blind — retry before inviting, so this
+                client does not receive a second one.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setIsLoading(true);
+                  void loadStatus();
+                }}
+                className="mt-2"
+              >
+                Retry
+              </Button>
+            </div>
+          </div>
+        ) : status?.has_portal_access ? (
+          <div className="flex items-start gap-2">
+            <MailCheck className="w-4 h-4 text-[var(--bz-accent)] mt-0.5 shrink-0" />
+            <div>
+              <p className="text-sm text-[var(--bz-text-1)]">
+                Portal active
+                {status.portal_email ? ` — ${status.portal_email}` : ""}
+              </p>
+              <p className="text-xs text-[var(--bz-text-2)] mt-1">
+                {status.last_login
+                  ? `Last signed in ${formatDate(status.last_login)}`
+                  : "Registered, but has never signed in yet"}
+              </p>
+            </div>
+          </div>
+        ) : status?.pending_invite ? (
+          <div className="flex items-start gap-2">
+            <Clock className="w-4 h-4 text-[var(--bz-text-2)] mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm text-[var(--bz-text-1)]">
+                Invitation pending
+              </p>
+              <p className="text-xs text-[var(--bz-text-2)] mt-1">
+                {status.invite_expires_at
+                  ? `Expires ${formatDate(status.invite_expires_at)}. `
+                  : ""}
+                Not registered yet.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleInvite}
+                disabled={isSending}
+                className="mt-2 gap-1"
+              >
+                <Send className="w-3.5 h-3.5" />
+                {isSending ? "Sending..." : "Send again"}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-start gap-2">
+            <KeyRound className="w-4 h-4 text-[var(--bz-text-2)] mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm text-[var(--bz-text-1)]">
+                No portal access yet
+              </p>
+              <p className="text-xs text-[var(--bz-text-2)] mt-1">
+                {clientEmail
+                  ? `Emails an invitation to ${clientEmail}, where they choose their own PIN.`
+                  : "This client has no email address on file, so there is nowhere to send the invitation."}
+              </p>
+              <Button
+                size="sm"
+                onClick={handleInvite}
+                disabled={isSending || !clientEmail}
+                className="mt-2 gap-1"
+              >
+                <Send className="w-3.5 h-3.5" />
+                {isSending ? "Sending..." : "Invite to portal"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mouth/src/app/(workspace)/clients/[id]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/page.tsx
@@ -58,6 +58,7 @@ import { CompanyTab } from "./components/CompanyTab";
 import { TaxTab } from "./components/TaxTab";
 import { TimelineTab } from "./components/TimelineTab";
 import { WaTimelineTab } from "./components/WaTimelineTab";
+import { PortalAccess } from "./components/PortalAccess";
 import { PortalMessages } from "./components/PortalMessages";
 import { BusinessStoryPanel } from "./components/BusinessStoryPanel";
 import { EditClientModal } from "./components/modals/EditClientModal";
@@ -893,6 +894,11 @@ export default function ClientDetailPage() {
             maps={businessStoryQuery.data ?? []}
             isLoading={businessStoryQuery.isLoading}
             error={businessStoryError}
+          />
+          <PortalAccess
+            clientId={clientId}
+            clientName={client.full_name}
+            clientEmail={client.email}
           />
           <PortalMessages clientId={clientId} clientName={client.full_name} />
         </>

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -22,6 +22,7 @@ import type {
   ClientCompanyLink,
   CompanyDocument,
   TaxRecord,
+  PortalAccessStatus,
   PortalMessageThread,
   PassportOcrResult,
   TaxCompanyPilotKey,
@@ -1380,6 +1381,63 @@ export class CrmApi {
       method: "POST",
       body: JSON.stringify(data),
     });
+  }
+
+  // ============================================================================
+  // Portal Access (invitation to my.balizero.com)
+  // ============================================================================
+
+  /**
+   * Does this client have portal access yet, and is an invite already pending?
+   * Read-only: RBAC requires the caller to be the client's assigned team
+   * member, its creator, or a CRM admin.
+   */
+  async getPortalStatus(clientId: number): Promise<PortalAccessStatus> {
+    const resp = await this.client.request<{
+      success: boolean;
+      data: PortalAccessStatus;
+    }>(`/api/crm/portal/clients/${clientId}/status`);
+    return resp.data;
+  }
+
+  /**
+   * Mint a portal invitation and mail it to the client through Brevo.
+   *
+   * DELIBERATELY calls `/api/portal/invite/send` rather than the
+   * namespace-matching `/api/crm/portal/clients/{id}/invite`. Both mint the
+   * same invitation through the same InviteService, but only this one reports
+   * `email_sent` / `email_error`; the CRM-namespace twin answers a flat
+   * `{success: true}` whether or not the mail actually left. Since the whole
+   * point of this control is that a consultant knows the client can now get in,
+   * a UI that says "sent" when nothing was sent is the failure mode worth
+   * paying one namespace inconsistency to avoid.
+   *
+   * `email` is required by this endpoint (the CRM twin defaults it from
+   * `clients.email`), so callers pass the client's own address.
+   *
+   * The raw invite token is never in the response: the backend strips `token`
+   * and `invite_url` at the router boundary because the email is their only
+   * legitimate channel.
+   *
+   * Expect 403 when the caller is not the client's assigned team member.
+   */
+  async sendPortalInvite(
+    clientId: number,
+    email: string,
+  ): Promise<{ emailSent: boolean; emailError: string | null }> {
+    const resp = await this.client.request<{
+      success: boolean;
+      message: string;
+      email_sent: boolean;
+      email_error: string | null;
+    }>(`/api/portal/invite/send`, {
+      method: "POST",
+      body: JSON.stringify({ client_id: clientId, email }),
+    });
+    return {
+      emailSent: Boolean(resp.email_sent),
+      emailError: resp.email_error ?? null,
+    };
   }
 
   // ============================================================================

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -1004,6 +1004,23 @@ export interface SearchFilters {
 }
 
 // Portal Messages (team ↔ client bridge)
+/**
+ * Whether a client can reach my.balizero.com yet, and if not, whether an
+ * invitation is already in flight. Returned by
+ * GET /api/crm/portal/clients/{id}/status.
+ * Backend: apps/backend-rag/backend/app/routers/crm_portal_integration.py
+ * (PortalStatusResponse). The three states are mutually exclusive:
+ * portal access granted, invite pending, or neither.
+ */
+export interface PortalAccessStatus {
+  has_portal_access: boolean;
+  portal_user_id: number | null;
+  portal_email: string | null;
+  last_login: string | null;
+  pending_invite: boolean;
+  invite_expires_at: string | null;
+}
+
 export interface PortalMessageThread {
   id: number;
   subject?: string;

--- a/evidence/2026-09/agent-air-m5-frontend-kita-portal-invite-cdebe01f/brief.yml
+++ b/evidence/2026-09/agent-air-m5-frontend-kita-portal-invite-cdebe01f/brief.yml
@@ -1,0 +1,78 @@
+task_id: kita-portal-invite
+gear: 2
+l_level: L2
+gate_class: opus
+objective: >-
+  Give a consultant in kita.balizero.com a control that invites a client to
+  my.balizero.com, and make the portal status that control reads TRUE — the
+  status endpoint answered "has portal access" for 448 active clients whose
+  PIN hash is the placeholder no PIN can match, and aliased created_at onto
+  last_login. Both defects would have hidden the invite button from exactly
+  the clients that need it, so they are cured in the same diff as the caller.
+constraints:
+  - >-
+    Scope is the CRM client page (PortalAccess panel + its wiring) and the
+    portal-status/last-login lookup in crm_portal_integration.py. No change to
+    the invitation minting service or to the portal app itself.
+  - >-
+    The placeholder hash is matched by EQUALITY against the constant, never as
+    a substring (superscar #3, guard-over-match).
+  - >-
+    Local verification only against a database carrying the production schema;
+    the local backend's internal-email endpoint is pointed at a dead address so
+    no real mail can leave a dev machine.
+  - No client PII in the diff, the tests, the PR body or this brief.
+acceptance:
+  - text: >-
+      WHEN a client's portal profile carries the placeholder PIN hash, the
+      status endpoint SHALL report has_portal_access=false so the panel offers
+      the invitation; WHEN the client holds real credentials it SHALL still
+      report true.
+    probe: >-
+      backend/tests/unit/app/routers/test_crm_portal_status_placeholder.py
+  - text: >-
+      The status endpoint SHALL return the real last_login column, never
+      created_at wearing its name.
+    probe: >-
+      backend/tests/unit/app/routers/test_crm_portal_status_placeholder.py
+  - text: >-
+      The panel SHALL render four distinct branches (active / pending / not
+      invited / status-read failed), SHALL surface a minted-but-not-emailed
+      result as a failure rather than a success, and SHALL never place the
+      invitation token in the DOM.
+    probe: >-
+      npx vitest run "src/app/(workspace)/clients/[id]/components/PortalAccess.test.tsx"
+consumer_map:
+  - >-
+    A consultant opening a client in kita.balizero.com consumes the new
+    "Client Portal Access" panel and sends the invitation from it — observed
+    live in a browser as an Executive Consultant: the panel offered "Invite to
+    portal", the click returned email_sent=false with the mail endpoint
+    deliberately dead, the UI showed the NOT-sent state, a client_invitations
+    row appeared and a reload flipped the panel to "Invitation pending".
+  - >-
+    The CRM client page's existing "Last signed in" line consumes the corrected
+    last_login and stops displaying the record's creation date.
+risks:
+  - >-
+    ~448 clients will stop claiming "Portal active" in the CRM. That is the
+    correction, not a regression, but it is visible to the whole team at once.
+  - >-
+    The panel calls /api/portal/invite/send rather than its namespace-matching
+    CRM twin, because only that endpoint reports email_sent/email_error. One
+    namespace inconsistency, taken deliberately.
+  - >-
+    Email delivery itself is unproven on production — it was verified only in
+    its failure branch locally. First real send is a pilot observation.
+assumptions:
+  - text: >-
+      PLACEHOLDER_PIN_HASH remains the single sentinel written by
+      ensure_portal_profile; a second sentinel shape would escape the equality
+      check.
+    status: verified
+    probe: grep for PLACEHOLDER_PIN_HASH assignments in the portal profile service
+grader: >-
+  Independent verification by the session, generator != grader; CI gates plus a
+  live browser round on the assigned-consultant role.
+budget: Existing subscription only; no paid per-token API calls.
+pii: none


### PR DESCRIPTION
## The measurement that started this

| Production, measured 2026-09-10 | |
|---|---|
| Last portal invitation sent | 2026-07-10 |
| Last client portal login | 2026-07-10 |
| Callers of the invite endpoints in `apps/mouth` | **zero** |

The invitation endpoints have shipped for months and could only be reached by hand-crafting an HTTP request with a team JWT. No consultant had a button. This PR is that missing caller — plus the two bugs found while building it, which would have made the button useless.

## Defect 1 — `portal_access = true` is not portal access

Superscar #2, Esiste != Armato. `PortalProfileService.ensure_portal_profile()` runs as a background task on **every** client creation carrying an email, inserting the row with `portal_access = true` and `PLACEHOLDER_PIN_HASH` — a hash no PIN can ever match.

| Active client rows on production | count |
|---|---|
| `portal_access = true` | 532 |
| …of which carry the placeholder and **can never log in** | **448** |
| …of which hold real credentials | 84 |
| …that have ever logged in at all | 9 |

So the status endpoint answered "has portal access" for 448 clients who were never invited. The new panel would have rendered "Portal active" and **hidden the invite button for exactly the clients who need it** — the common case, since a client created with an email on file is provisioned within a second.

The lookup now excludes the placeholder, compared by **equality against the constant**, not a substring of it (superscar #3).

## Defect 2 — the creation date was dressed up as a sign-in

`SELECT tm.created_at as last_login` literally aliased one column onto the other, so every "Last signed in …" the CRM has ever displayed was "record created on …". Measured on one client: the API returned `04:02:25` (`created_at`) while the real `last_login` was `04:03:00`, 35 seconds later.

## Proven live, one client each way

| Client | Before | After |
|---|---|---|
| 5 — created through the normal CRM flow, placeholder hash | `has_portal_access: true` | `false` → invite button appears |
| 4 — genuinely registered through the invite chain | `true`, `last_login` = created_at | `true`, `last_login` = the real column |

One guilt case, one innocence case, both measured against a database carrying the production schema.

## Two deliberate design calls

**The panel calls `/api/portal/invite/send`, not the namespace-matching CRM twin.** Both mint the same invitation through the same service, but only that one reports `email_sent` / `email_error`. A control that says "sent" when the mail never left is the failure this pilot actually risks. One namespace inconsistency is worth avoiding it.

**A failed STATUS read does not degrade into "no access yet".** That branch offers the invite button, so failing open there is how a client gets invited twice. It shows the failure and a retry instead.

## Tests, proven non-vacuous

Reverting the cure turns the two backend guilt tests red while the two innocence tests — pending-invitation lookup and RBAC ordering — stay green in both states. Frontend: 10 cases across the four panel branches, including the minted-but-not-emailed toast and an assertion that the invite token never reaches the DOM.

## Bites

A consultant opening a client in kita.balizero.com consumes the new "Client Portal Access" panel and sends the invitation from it. Observed in a live browser as the assigned Executive Consultant, the same role Krisna holds: the panel offered "Invite to portal"; the click returned `{"email_sent": false, "email_error": "All connection attempts failed"}` with the mail endpoint deliberately pointed at a dead address; the UI showed **"Invitation created, but the email did NOT go out"** rather than a success toast; a `client_invitations` row appeared; a reload flipped the panel to "Invitation pending".

## Note for reviewers

This touches `apps/backend-rag`, so merging it deploys. The visible change for the team is that ~448 clients stop claiming "Portal active" — that is the correction, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfDZPdTt1ajymVzJnaQEQT