### PR TITLE
fix(hooks): a capped child could not report, and the native child ignored the policy wall

### DIFF
--- a/infra/claude-hooks/child_workflow.py
+++ b/infra/claude-hooks/child_workflow.py
@@ -48,6 +48,59 @@ CONTRACT = (
     "and deadline; do not reset those budgets when replacing a child."
 )
 
+REPORTING_TOOLS = ("SendMessage", "TaskStop")
+
+
+def reporting_exempt(payload: dict[str, Any]) -> bool:
+    """Tools a capped child may still call, because they ARE the return path.
+
+    SendMessage and TaskStop were already exempt; ToolSearch was not. In a
+    harness that defers tool schemas, a deferred SendMessage is a NAME with no
+    parameters until ToolSearch fetches its definition, so denying ToolSearch
+    denied the report itself while the deny text told the child to report. The
+    exemption is narrowed BY THE QUERY whenever the hook can read one: only a
+    search naming SendMessage or TaskStop passes, and an unrelated search stays
+    denied like any other tool. When the payload carries no readable query --
+    a payload shape this hook does not own -- ToolSearch is exempted AS A WHOLE
+    rather than trapping the child in an unreportable cap; the denial counter
+    and the ledger still record that the cap fired.
+    """
+    tool = payload.get("tool_name")
+    if tool in REPORTING_TOOLS:
+        return True
+    if tool != "ToolSearch":
+        return False
+    query = (payload.get("tool_input") or {}).get("query")
+    if not isinstance(query, str) or not query.strip():
+        return True
+    return any(name.lower() in query.lower() for name in REPORTING_TOOLS)
+
+
+def budget_denial(state: dict[str, Any], mandate: str) -> str:
+    """Name the counter that fired, never only the contract.
+
+    The old denial recited CONTRACT and stopped: the child learned it was over
+    budget without learning WHICH budget, by how much, or under whose mandate,
+    so it could not report the number upward and the transcript could not be
+    audited after the fact. Every field here is one the coordinator asks for.
+    """
+    return (
+        "Child context budget reached: counter="
+        + str(state.get("budget_reason") or "UNKNOWN")
+        + " used="
+        + str(state.get("budget_used", "UNKNOWN"))
+        + " limit="
+        + str(state.get("budget_limit", "UNKNOWN"))
+        + " role="
+        + str(state.get("role") or "builder")
+        + " mandate="
+        + (mandate or "UNKNOWN")
+        + ". Required next action: send the checkpoint and the remaining work to the "
+        "parent with SendMessage, then TaskStop; ToolSearch stays available only to "
+        "load those two schemas. No other tool is granted. "
+        + CONTRACT
+    )
+
 
 def child_identity(payload: dict[str, Any]) -> tuple[str, str] | None:
     # Same detection as orchestrate_gate, but Stop's transcript is explicitly the parent.
@@ -128,9 +181,10 @@ def context_guard(payload: dict[str, Any], guard: dict[str, Any]) -> int | None:
     key, transcript = identity
     import child_context
 
+    mandate = mandate_id(payload, guard)
     lease_error = budget_observe(
         budget_dir(),
-        mandate_id(payload, guard),
+        mandate,
         str(payload.get("agent_id") or "UNKNOWN"),
         transcript=transcript or None,
     )
@@ -138,7 +192,7 @@ def context_guard(payload: dict[str, Any], guard: dict[str, Any]) -> int | None:
         sys.stderr.write(
             lease_error + "; return an incomplete checkpoint to the parent.\n"
         )
-        return 0 if payload.get("tool_name") in ("SendMessage", "TaskStop") else 2
+        return 0 if reporting_exempt(payload) else 2
     if payload.get("tool_name") in ("Agent", "Task"):
         sys.stderr.write(
             "Child delegation depth reached. Return remaining work to the parent.\n"
@@ -187,18 +241,33 @@ def context_guard(payload: dict[str, Any], guard: dict[str, Any]) -> int | None:
             else child_context.FALLBACK_TOKENS
         )
         over = state["used"] is not None and state["used"] >= state["token_limit"]
-        state["time_budget_exceeded"] = (
+        # Child ACTIVE TIME, measured and reported here. It is not the mission
+        # deadline: `mandate_budget` owns that one, and conflating them would let
+        # a fresh child inherit an expired wall or a stale mandate outlive itself.
+        elapsed = (
             state.get("budget_elapsed", 0) + time.time() - state["budget_started_at"]
-            >= child_context.MAX_SECONDS
         )
+        state["time_budget_exceeded"] = elapsed >= child_context.MAX_SECONDS
         if state["pretool_count"] > child_context.MAX_TOOL_CALLS:
-            state["budget_reason"] = "tool_calls"
+            state.update(
+                budget_reason="tool_calls",
+                budget_used=state["pretool_count"],
+                budget_limit=child_context.MAX_TOOL_CALLS,
+            )
             over = True
         elif state["time_budget_exceeded"]:
-            state["budget_reason"] = "elapsed_time"
+            state.update(
+                budget_reason="elapsed_time",
+                budget_used=round(elapsed),
+                budget_limit=child_context.MAX_SECONDS,
+            )
             over = True
         elif over:
-            state["budget_reason"] = "context_tokens"
+            state.update(
+                budget_reason="context_tokens",
+                budget_used=state["used"],
+                budget_limit=state["token_limit"],
+            )
         if over:
             state.update(
                 status="needs_attention",
@@ -207,17 +276,9 @@ def context_guard(payload: dict[str, Any], guard: dict[str, Any]) -> int | None:
             )
             if strict:
                 state["return_required"] = True
-        if (
-            strict
-            and state.get("return_required")
-            and tool not in ("SendMessage", "TaskStop")
-        ):
+        if strict and state.get("return_required") and not reporting_exempt(payload):
             state["denials"] = state.get("denials", 0) + 1
-            sys.stderr.write(
-                "Child context budget reached. Return a checkpoint and remaining work to the parent. "
-                + CONTRACT
-                + "\n"
-            )
+            sys.stderr.write(budget_denial(state, mandate) + "\n")
             return 2  # Repeated denials never grant normal tools.
         warnings = []
         if state["measurement"] == "UNKNOWN":

--- a/infra/claude-hooks/test_child_review_regressions.py
+++ b/infra/claude-hooks/test_child_review_regressions.py
@@ -294,3 +294,44 @@ def test_installer_canary_retargets_existing_adapter_without_changing_timeout() 
         hook["command"] == "python /tmp/candidate/child_workflow.py context"
         and hook["timeout"] == 17
     )
+
+
+def test_capped_child_names_the_counter_and_keeps_its_report_path(
+    event: dict, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """The deny must be readable, and the report path must survive the deny.
+
+    Two defects in one gesture: the denial recited the contract without naming
+    which counter fired or by how much, and it denied `ToolSearch` -- so in a
+    harness that defers tool schemas, the child was told to SendMessage while
+    the only way to load SendMessage's schema was blocked.
+    """
+    monkeypatch.setenv("NUZANTARA_MANDATE_ID", "strict-mandate-42")
+    path = Path(event["transcript_path"])
+    guard = {"_read_tail": lambda _: path.read_text()}
+    key, _ = child.child_identity(event)
+    with child.child_state(key) as (_, state):
+        state["pretool_count"] = ctx.MAX_TOOL_CALLS
+    assert child.context_guard(event, guard) == 2
+    denial = capsys.readouterr().err
+    for field in (
+        "counter=tool_calls",
+        "used=" + str(ctx.MAX_TOOL_CALLS + 1),
+        "limit=" + str(ctx.MAX_TOOL_CALLS),
+        "role=builder",
+        "mandate=strict-mandate-42",
+        "SendMessage",
+        "TaskStop",
+    ):
+        assert field in denial, field
+    with child.child_state(key) as (_, state):
+        assert state["budget_used"] == ctx.MAX_TOOL_CALLS + 1
+        assert state["budget_limit"] == ctx.MAX_TOOL_CALLS
+    search = {**event, "tool_name": "ToolSearch"}
+    # Readable query naming a report tool: allowed. No query at all: allowed as a
+    # whole rather than trapping the child. Any other query: denied like the rest.
+    assert child.context_guard({**search, "tool_input": {"query": "select:SendMessage"}}, guard) == 0
+    assert child.context_guard({**search, "tool_input": {"query": "+taskstop return"}}, guard) == 0
+    assert child.context_guard(search, guard) == 0
+    assert child.context_guard({**search, "tool_input": {"query": "select:Bash"}}, guard) == 2
+    assert child.context_guard({**event, "tool_name": "SendMessage"}, guard) == 0

--- a/infra/codex-hooks/context_bridge.py
+++ b/infra/codex-hooks/context_bridge.py
@@ -455,8 +455,26 @@ def native_child(payload: dict[str, Any]) -> tuple[str, str, str] | None:
     return None
 
 
+def threshold(policy: dict[str, Any], role: str) -> float:
+    """The ONE validated threshold lookup, parent seat and native child alike.
+
+    The native child hardcoded 0.4 while the parent read `thresholds` from the
+    policy, so raising the wall on the three hosts moved the parent and left
+    every child it dispatched at the old number -- a policy that was law for one
+    topology only, and invisible because both numbers were plausible. A role the
+    policy does not declare still falls back to 0.4: the fallback stays the
+    conservative one, and `install.py` is what declares `dux`.
+    """
+    fraction = policy.get("thresholds", {}).get(role, 0.4)
+    if not isinstance(fraction, (float, int)) or not 0 < fraction < 1:
+        raise ValueError("invalid threshold")
+    return float(fraction)
+
+
 def child_hook(
-    payload: dict[str, Any], identity: tuple[str, str, str]
+    payload: dict[str, Any],
+    identity: tuple[str, str, str],
+    policy: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     sid, parent, transcript = identity
     event = payload["hook_event_name"]
@@ -533,7 +551,9 @@ def child_hook(
         state["measurement"] = (
             "observed" if state.get("window") and state.get("observed") else "UNKNOWN"
         )
-        if state.get("used", 0) >= state.get("window", float("inf")) * 0.4:
+        if state.get("used", 0) >= state.get("window", float("inf")) * threshold(
+            policy or {}, state["role"]
+        ):
             state["return_required"] = True
         message = (
             "Native child "
@@ -597,7 +617,7 @@ def hook(payload: dict[str, Any]) -> dict[str, Any]:
         return {}
     child = native_child(payload)
     if child:
-        return child_hook(payload, child)
+        return child_hook(payload, child, policy)
     source_id = os.environ.get("CODEX_CONTEXT_FROM_SESSION")
     if (
         source_id
@@ -724,9 +744,7 @@ def hook(payload: dict[str, Any]) -> dict[str, Any]:
             state.pop("rollover", None)
             save(path, state)
             return context_output(event, instructions(sid))
-        fraction = policy.get("thresholds", {}).get(state.get("role", "builder"), 0.4)
-        if not isinstance(fraction, (float, int)) or not 0 < fraction < 1:
-            raise ValueError("invalid threshold")
+        fraction = threshold(policy, state.get("role", "builder"))
         over = state.get("used", 0) >= state.get("window", float("inf")) * fraction
         over = over and state.get("observed") != state.get("ignore_observed")
         over = over and not state.get("threshold_released")

--- a/infra/codex-hooks/install.py
+++ b/infra/codex-hooks/install.py
@@ -21,6 +21,26 @@ from context_bridge import EVENTS, VERSION, digest, load, save
 from rpc import RPC
 
 
+THRESHOLD_DEFAULTS = {"imperator": 0.6, "builder": 0.6, "dux": 0.6}
+
+
+def merge_thresholds(policy: dict) -> dict:
+    """Fill missing role thresholds per KEY, never per dict.
+
+    `policy.setdefault("thresholds", {...})` added nothing to a host that had
+    ever been installed, so a role introduced later could never reach an
+    existing seat: the three live policies carried `imperator`/`builder` and
+    would have carried no `dux` forever, and the seat would have silently used
+    the conservative 0.4 fallback while the doctrine said 0.6. Each key is
+    filled only when ABSENT, so an operator's tuned value survives every
+    reinstall -- the same reason the imperator regression still pins 0.2.
+    """
+    thresholds = policy.setdefault("thresholds", {})
+    for role, default in THRESHOLD_DEFAULTS.items():
+        thresholds.setdefault(role, default)
+    return thresholds
+
+
 def install(seat: Path, roots: list[str], trust: bool = False) -> dict:
     seat = seat.expanduser().resolve()
     seat.mkdir(parents=True, exist_ok=True)
@@ -73,7 +93,7 @@ def install(seat: Path, roots: list[str], trust: bool = False) -> dict:
     save(hooks_file, config)
     policy = load(seat / "nuzantara-context-policy.json")
     policy.update(version=VERSION, enabled=True, roots=roots)
-    policy.setdefault("thresholds", {"imperator": 0.2, "builder": 0.4})
+    merge_thresholds(policy)
     policy.setdefault("max_hops", 3)
     policy.setdefault(
         "child_limits",

--- a/infra/codex-hooks/test_child_lifecycle.py
+++ b/infra/codex-hooks/test_child_lifecycle.py
@@ -611,3 +611,82 @@ def test_broken_router_preserves_parent_and_child_never_jumps(tmp_path: Path) ->
         assert run.returncode == expected and "Traceback" not in run.stderr
         if child:
             assert "no parent jump" in run.stderr
+
+
+def test_native_child_threshold_follows_the_policy_not_a_literal(
+    setup: tuple,
+) -> None:
+    """The child read 0.4 from its own source while the parent read the policy.
+
+    Raising the wall on the three hosts moved the parent seat and left every
+    native child it dispatched at the old number. At 500/1000 under a declared
+    builder 0.6 the child must keep working; the hardcoded literal returned it.
+    """
+    _, log, e = setup
+    seat = bridge.codex_home()
+    policy = bridge.load(seat / "nuzantara-context-policy.json")
+    policy["thresholds"] = {"imperator": 0.6, "builder": 0.6, "dux": 0.6}
+    bridge.save(seat / "nuzantara-context-policy.json", policy)
+    assert bridge.threshold(policy, "builder") == 0.6
+    assert bridge.threshold(policy, "dux") == 0.6
+    # An undeclared role keeps the conservative fallback; install.py declares it.
+    assert bridge.threshold({}, "dux") == 0.4
+    child = "child-session-123"
+    child_transcript(log, child, e["session_id"])
+    bridge.hook({**e, "agent_id": child, "hook_event_name": "SubagentStart"})
+    with log.open("a") as out:
+        out.write(
+            json.dumps(
+                {
+                    "timestamp": "new",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "model_context_window": 1000,
+                            "last_token_usage": {"total_tokens": 500},
+                        },
+                    },
+                }
+            )
+            + "\n"
+        )
+    bridge.hook(
+        {**e, "agent_id": child, "hook_event_name": "PreToolUse", "tool_name": "Read"}
+    )
+    state = bridge.load(bridge.state_path(child))
+    assert state["role"] == "builder" and state["used"] == 500 and state["window"] == 1000
+    assert not state.get("return_required")
+
+
+def test_dux_role_resolves_to_its_declared_threshold(
+    setup: tuple, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`dux` was undeclared, so a Dux seat silently ran at the 0.4 fallback."""
+    _, log, e = setup
+    monkeypatch.setenv("CODEX_CONTEXT_ROLE", "DUX")
+    seat = bridge.codex_home()
+    policy = bridge.load(seat / "nuzantara-context-policy.json")
+    policy["thresholds"] = {"imperator": 0.6, "builder": 0.6, "dux": 0.6}
+    bridge.save(seat / "nuzantara-context-policy.json", policy)
+    e = {**e, "session_id": "dux-session-123"}
+    bridge.hook(e)
+    assert bridge.load(bridge.state_path("dux-session-123"))["role"] == "dux"
+    pre = {**e, "hook_event_name": "PreToolUse", "tool_name": "Bash"}
+    token(log, 500, 1000)
+    assert bridge.hook(pre) == {}
+    token(log, 601, 1000)
+    assert bridge.hook(pre)["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_installer_adds_dux_without_overwriting_a_tuned_threshold() -> None:
+    """A seat installed before `dux` existed must still receive it."""
+    from install import THRESHOLD_DEFAULTS, merge_thresholds
+
+    existing = {"thresholds": {"imperator": 0.2, "builder": 0.4}}
+    assert merge_thresholds(existing) == {
+        "imperator": 0.2,
+        "builder": 0.4,
+        "dux": 0.6,
+    }
+    assert merge_thresholds({}) == THRESHOLD_DEFAULTS

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -996,6 +996,24 @@
       "repo": "infra/codex-hooks/mandate_budget.py",
       "machines": ["all"],
       "_note": "Shared root ledger for the Claude and Codex child adapters; exact source bytes copied, no launcher."
+    },
+    {
+      "live": "~/.codex/hooks/nuzantara-context/context_bridge.py",
+      "repo": "infra/codex-hooks/context_bridge.py",
+      "machines": ["all"],
+      "_note": "CODEX_HOME half of the child adapter, undeclared from birth until 2026-09-10 (PARABELLUM \u00a74.7): the Claude copies under ~/.claude/hooks/ were declared and the Codex ones were not, so lint_home_fork.py reported clean over the seat that actually enforces the Codex context wall \u2014 superscar #1 and W107, census the producers not the one that bit you. Installed by infra/codex-hooks/install.py, which copies the exact source bytes into $CODEX_HOME/hooks/nuzantara-context/. Expect DRIFT on each host between this PR merging and the installer being re-run there; that is the pair doing its job, not a regression."
+    },
+    {
+      "live": "~/.codex/hooks/nuzantara-context/rpc.py",
+      "repo": "infra/codex-hooks/rpc.py",
+      "machines": ["all"],
+      "_note": "CODEX_HOME half of the child adapter, undeclared from birth until 2026-09-10 (PARABELLUM \u00a74.7): the Claude copies under ~/.claude/hooks/ were declared and the Codex ones were not, so lint_home_fork.py reported clean over the seat that actually enforces the Codex context wall \u2014 superscar #1 and W107, census the producers not the one that bit you. Installed by infra/codex-hooks/install.py, which copies the exact source bytes into $CODEX_HOME/hooks/nuzantara-context/. Expect DRIFT on each host between this PR merging and the installer being re-run there; that is the pair doing its job, not a regression."
+    },
+    {
+      "live": "~/.codex/hooks/nuzantara-context/mandate_budget.py",
+      "repo": "infra/codex-hooks/mandate_budget.py",
+      "machines": ["all"],
+      "_note": "CODEX_HOME half of the child adapter, undeclared from birth until 2026-09-10 (PARABELLUM \u00a74.7): the Claude copies under ~/.claude/hooks/ were declared and the Codex ones were not, so lint_home_fork.py reported clean over the seat that actually enforces the Codex context wall \u2014 superscar #1 and W107, census the producers not the one that bit you. Installed by infra/codex-hooks/install.py, which copies the exact source bytes into $CODEX_HOME/hooks/nuzantara-context/. Expect DRIFT on each host between this PR merging and the installer being re-run there; that is the pair doing its job, not a regression."
     }
   ],
   "allow": [


### PR DESCRIPTION
## What

PARABELLUM §4 harness set, part A of two. Three defects in the child harness, each of which made a limit lie about what it was enforcing.

**1 — Reporting (§4.1).** `infra/claude-hooks/child_workflow.py` exempted `SendMessage` and `TaskStop` from the post-budget deny but not `ToolSearch`. In a harness that defers tool schemas, a deferred `SendMessage` is a NAME with no parameters until `ToolSearch` fetches its definition — so the deny told the child to report through a tool it had just made unreachable. `ToolSearch` is now exempt, **narrowed by the query** whenever the hook can read one: only a search naming `SendMessage` or `TaskStop` passes, an unrelated search stays denied like any other tool, and a payload carrying no readable query exempts `ToolSearch` as a whole rather than trapping the child. The reason is written in the `reporting_exempt()` docstring. Both facts are in the deny path too: the denial now names counter, used/limit, role, mandate id and the one action still allowed, instead of reciting `CONTRACT` and stopping.

**2 — Thresholds (§4.2).** `infra/codex-hooks/context_bridge.py` read `thresholds` from the policy for the parent seat and hardcoded `0.4` for the native child (`:533`), so Zero raising the wall to 0.6 on the three hosts at 04:20 moved the parent and left every child it dispatched at the old number. Both paths now go through one validated `threshold()` lookup. An undeclared role still falls back to 0.4 exactly as today — `install.py` is what declares `dux`.

**The fresh-install defaults change too, and that is a behaviour change I under-described in the first version of this body.** `install.py` used to seed a brand-new seat with `{imperator: 0.2, builder: 0.4}`. It now seeds `{imperator: 0.6, builder: 0.6, dux: 0.6}`. So a seat installed after this merges starts at the wall Zero ruled tonight instead of at the old one, without anybody having to remember to edit its policy afterwards. That is the intent, but it IS a default change and it belongs in the summary rather than only in the diff.

The second half is the merge shape: `install.py` now fills the thresholds map **per key** instead of per dict. `setdefault("thresholds", {...})` added nothing to a host that had ever been installed, so a role introduced later could never reach an existing seat. Filling per key means an operator's tuned value is never overwritten — and **the test that carries that guarantee is the new `test_installer_adds_dux_without_overwriting_a_tuned_threshold`**, which calls `merge_thresholds` on a seat holding `{imperator: 0.2, builder: 0.4}` and asserts both survive while `dux: 0.6` arrives. An earlier version of this body credited `test_existing_imperator_role_uses_twenty_percent` with that guarantee. That was wrong: that test writes a policy by hand and exercises the BRIDGE's threshold lookup, never `install.py`. It is left untouched because it is still a correct test of the lookup, not because it proves anything about the installer.

**3 — Installation parity (§4.7, partial).** The Claude copies of the child adapter were declared in `infra/home-fork/declared-pairs.json` and the CODEX_HOME copies were not, so `lint_home_fork.py` reported clean over the three files that actually enforce the Codex context wall. Superscar #1, and W107: census the producers, not the one that bit you.

## Bites:

**Consumer 1 — the pytest regressions.** `python3 -m pytest infra/claude-hooks infra/codex-hooks -q` on this HEAD: **293 passed, 1 failed**. The failure is `test_host_boundary_carveout.py::test_carveouts_are_writable_and_control_plane_is_not`, which does not touch any file in this diff and **reproduces identically on an unmodified checkout of `origin/main`** on M5 — see "Leftovers" below. Four new regressions. **Three of them are red against the code this PR replaces; the fourth is not, and the gate was right to catch me claiming otherwise** — see row 11:

- `test_capped_child_names_the_counter_and_keeps_its_report_path` — a capped child is denied `Read`, the stderr carries `counter=tool_calls used=121 limit=120 role=builder mandate=strict-mandate-42`, `ToolSearch` passes with `select:SendMessage`, passes with no query at all, and is still denied with `select:Bash`.
- `test_native_child_threshold_follows_the_policy_not_a_literal` — a child at 500/1000 under a declared `builder: 0.6` keeps working; the old literal `0.4` returned it.
- `test_dux_role_resolves_to_its_declared_threshold` — `CODEX_CONTEXT_ROLE=DUX` resolves to role `dux`, passes at 500/1000 and denies at 601/1000. **This one does not discriminate.** With `dux` absent the fallback is 0.4 and 601/1000 denies just the same, so the assertion cannot fail on the code this PR replaces. What it does prove is that the role RESOLVES and that a declared `dux` threshold is honoured; making it discriminate is condition 3, owed in the follow-up.
- `test_installer_adds_dux_without_overwriting_a_tuned_threshold` — a seat carrying `{imperator: 0.2, builder: 0.4}` receives `dux: 0.6` and keeps both tuned values.

**Consumer 2 — the HOME-fork lint over the three newly declared pairs, re-run after #6074 merged.** `python3 scripts/lint_home_fork.py --check --config infra/home-fork/declared-pairs.json` on M5: `177 declared pair(s)`, `clean — 39 live copy/copies match their repo twin`, exit 0. That green is against the M5 CHECKOUT, which is deliberately left stale, so on its own it proves only that nothing regressed.

The pairs earn their keep when arbitrated against `origin/main`, and there they immediately name a drift that was invisible while they were undeclared:

| CODEX_HOME file | live on M5 | `origin/main` | verdict |
|---|---|---|---|
| `context_bridge.py` | `62041ac9…` | `270d6920…` | DRIFT |
| `rpc.py` | `5bbf5850…` | `5bbf5850…` | match |
| `mandate_budget.py` | `a31df830…` | `5414833c…` | DRIFT |

The live Codex adapter on M5 is behind by at least two merged PRs — #6072's zombie detection and #6074's attention latch — and nothing could see it, because these were exactly the files `lint_home_fork.py` was not looking at. That is superscar #1 paying out on the day it was declared. The install after this merge closes all three.

**Consumer 3 — post-merge md5 parity and the native child probe on M5, Pro and Mini.** Owned by this session, reported on this PR after merge: `md5` repo == live for every changed file, plus `python3 infra/codex-hooks/native_claude_child_probe.py --model sonnet --parent-model claude-opus-5` (the default haiku/haiku invocation cannot pass — parent==child, known).

## Follow-up PR: the deadline semantics (§4.3, item C), spec first

Item C is not in this PR. Its ten-line contract is frozen here and goes into the `mandate_budget.py` module docstring in the follow-up, before the code:

1. There is ONE mission deadline. It belongs to the root mandate, not to a session, a child or a continuation.
2. `mandate_budget.reserve()` and the `context_bridge.py` continuation supervisor read that same `mandate_deadline`; neither computes its own.
3. `created + max_seconds` stops being a deadline source. `max_seconds` becomes the DEFAULT used only to derive the deadline when the root mandate is first opened.
4. A continuation inherits `mandate_deadline` unchanged. A continuation can never manufacture a later one.
5. Renewal is explicit: a coordinator call/flag, never a side effect of dispatching, resuming or replacing.
6. Every renewal is appended to the ledger with who, when, the previous deadline and the new one. The history is never rewritten.
7. Spent attempts, depth, concurrency and token counters are NEVER reset by a renewal. Only the wall clock moves.
8. An expired deadline suspends the mandate; it does not silently extend, and it does not deny the reporting path.
9. Child ACTIVE TIME (`child_context.MAX_SECONDS`, measured in `child_workflow.py`) is a separate counter, measured and reported separately, never conflated with the mission deadline. This PR already labels it as such in code.
10. A deny naming `deadline` carries the deadline, the now, and who may renew it — the same reporting rule as every other counter here.

Item D (bind `observe()` to the returned native child identity, `UNKNOWN` when uncertain) ships in that same follow-up, because it lands in the same function.

## Deviations and leftovers (PENDING-ARMS rows, owner: this session)

| # | Observation | Why it is not closed here | Closing evidence |
|---|---|---|---|
| 1 | **Items C and D are deferred to a second PR.** | `infra/codex-hooks/mandate_budget.py` is already being rewritten by open PR #6074 (`agent/air-m5/infra/attention-latch`, armed), which replaces the exact `reserve()` deny block and `observe()` binding that C and D land in. Racing it would have guaranteed a conflict; the Builder Contract says serialize. | PR #6074 merges, then the follow-up opens from a fresh `origin/main`. |
| 2 | ~~PR #6074 is armed but stuck on CodeQL.~~ **CLOSED, and the claim was MINE and WRONG.** #6074 is MERGED. Its `CodeQL Analysis (python)` job (run 34400463918, job 102631202287) started 2026-09-09T20:21:57Z and completed 2026-09-09T20:29:00Z — **7 minutes, success**. | I read `20:21:57Z` against today's WITA date and concluded "stuck for eight hours". It was twenty minutes old. UTC 2026-09-09T20:2x is WITA 2026-09-10T04:2x — the same evening, not the previous one. Recorded here rather than deleted, because a timezone slip that manufactures an incident is worth one line in the scar record. | Done: #6074 merged, and I have posted the correction on #6074 too. |
| 3 | **`.codex/hooks.json` was NOT fixed. It is blocked three ways, and the third one is the harness working.** | (a) It is **gitignored** — `.gitignore:185` matches `.codex/`, confirmed with `git check-ignore -v` — so no PR can carry it. (b) It exists on **M5 only**: `~/Desktop/nuzantara/.codex/hooks.json` and `~/nuzantara/.codex/hooks.json` are both absent on Pro and Mini, checked over ssh. It is a 2026-06-06 M5 leftover, not a fleet mechanism; the real Codex hook config is `$CODEX_HOME/hooks.json`, which is correct on M5 and already carries the bridge on every event. (c) It lives in the MAIN checkout, so `worktree_isolation.py` denies an agent session writing it — correctly, and I did not use the documented `AGENT_WORKTREE_ENFORCEMENT=false` escape to get around it. | Operator or a session holding the main checkout applies the string below. |
| 4 | **Correction to the mandate's premise on that path.** `/Users/balizero/Desktop/nuzantara` is **not dead on M5** — it is a symlink to `/Users/balizero/nuzantara` (`ls -ld`), and `.codex/hooks/codex-spalla-trigger.sh` is itself a symlink into `.claude/hooks/`. The hardcoded path resolves on M5 today; it would be wrong on Pro and Mini because of the USER segment rather than `Desktop/`, and on those two hosts the file does not exist to be wrong. | Recorded so the next session does not re-derive it. | — |
| 5 | **"The spalla matcher fires natively" is NOT proven here.** The Codex binary carries `hook.scope` / `hook.source` telemetry fields and both `hooks.json` and `hooks/hooks.json` literals, which is consistent with a project scope but does not establish that `<repo-root>/.codex/hooks.json` is loaded at all. | Proving it needs a live native Codex session, which is the orange mission's job. | First orange mission, per staff room §7.3. |
| 6 | **Pre-existing local test failure, unrelated to this diff.** `test_host_boundary_carveout` reports `rc=0` where it wants `rc=2` for `~/.claude/hooks/orchestrate_gate.py`, `~/.claude/settings.json` and `~/.claude/CLAUDE.md`. It fails identically on an unmodified `origin/main` checkout on M5, and #6074 passed the same CI check on this base, so it is M5-local, not a CI regression. Worth a look: it is the control-plane write guard reporting ALLOW. | Out of this lane's perimeter. | Own investigation. |
| 7 | **No independent Gear-3 final gate was commissioned by this session.** This Dux runs as a child seat: `Agent` is denied by its own `child_workflow.py` with `Child delegation depth reached`. | The harness is enforcing exactly the rule this PR is about. | The coordinator commissions the fresh `opus` gate session, outside this chain, which checks out this HEAD, runs the suite itself, reads the diff by content and posts `scripts/harness_fable_gate.py`. |

| 8 | ~~The 0.6 wall reached the PRIMARY Codex profile only.~~ **CLOSED BY OBSERVATION.** Zero ordered the secondaries to 0.6 ("metti gli imperatori al 60%", 04:20 WITA); the imperator window applied it and I re-measured every policy file myself afterwards. All seven now read `{imperator: 0.6, builder: 0.6}`: M5 `~/.codex`, `~/.codex-o2`, `~/.codex-acct2`; Pro `~/.codex`, `~/.codex-acct2`; Mini `~/.codex`, `~/.codex-acct2`. **`~/.codex-o2` is M5-only** — it does not exist on Pro or Mini, and nothing was written there. Backups `nuzantara-context-policy.json.bak-fable-6060-20260910` sit beside the four files that changed; the three already at 0.6 have none, correctly. | The finding stands as measured: before Zero's order the secondaries really were at 0.2/0.4 while the seat anyone checks was at 0.6. Superscar #2 in its exact shape. | Closed. `install.py` will add `dux: 0.6` to all seven and preserve every 0.6 already there. |
| 9 | **Only the PRIMARY profile's CODEX_HOME files are declared.** The three new pairs cover `~/.codex/hooks/nuzantara-context/`; `~/.codex-o2` and `~/.codex-acct2` hold their own copies of the same three files, still undeclared, so the lint remains blind on 3 of 3 M5 seats' worth of secondaries. | Adding them needs per-machine entries (M5 has an extra profile) and the branch is frozen: auto-merge is armed, so nothing more is pushed here. | Follow-up PR, alongside items C and D. |

| 10 | **The PARENT seat has the same ToolSearch omission this PR fixes for the child, and it survives this merge.** Census of every surviving `SendMessage`/`TaskStop` allowlist on the Claude side after this branch lands, run on the branch itself: `context_window_guard.py:132` declares `ALLOWED_TOOLS_UNCONDITIONAL = {"SendMessage", "TaskStop"}`, `:695` is its single use site (`if tool_name in ALLOWED_TOOLS_UNCONDITIONAL`), and `:68` is the docstring that publishes that pair as the contract. `child_workflow.py`'s two occurrences are the ones this PR cures, now `REPORTING_TOOLS` at `:51`. The Codex side reaches its report through a different mechanism (the exempt checkpoint helper), so it is not a fourth copy of this literal. | Same defect one level up: a PARENT at its context wall is told to hand off via SendMessage while the discovery a deferred SendMessage needs is not exempt. It is in scope for record §4.1, but not in this diff, and the branch is frozen — auto-merge is armed and nothing more is pushed here. | Follow-up PR. |
| 11 | **Gate conditions 1 and 3 are owed as code and docs, not body text.** Condition 1: `infra/codex-hooks/README.md:12-14` and `:56`, and `ROLLOUT.md:15-16`, still recite the thresholds `install.py` no longer writes. Condition 3: `test_dux_role_resolves_to_its_declared_threshold` does not DISCRIMINATE — `dux` absent falls back to 0.4 and `dux: 0.6` both deny at 601/1000, so the test passes against the code it was meant to catch, and the "four regressions, each red against the code this PR replaces" claim above is true of three of them, not four. | The branch is frozen. | **Closing observation: the follow-up PR merged.** It carries conditions 1 and 3, the parent-side exemption in row 10, and PARABELLUM items C and D. |

### The exact replacement string for row 3, proven on M5

The obvious `rev-parse --show-toplevel` form is WRONG for this fleet: inside a worktree it returns the worktree root, which carries no `.codex/`. Use the common dir, which resolves to the main checkout from either place and hardcodes no user, no host and no `Desktop/` segment:

```sh
"$(dirname "$(git -C "$PWD" rev-parse --path-format=absolute --git-common-dir)")/.codex/hooks/codex-spalla-trigger.sh"
```

Proven from both origins on M5, each resolving to `/Users/balizero/nuzantara/.codex/hooks/codex-spalla-trigger.sh` with `test -x` true:

| Invoked from | `--show-toplevel` | `--git-common-dir` |
|---|---|---|
| main checkout | correct | correct |
| `.worktrees/infra-parabellum-harness-reporting-thresholds` | resolves into the worktree, file absent | correct |

Back up with a `.bak-2026-09-10` sibling before writing, and note this only matters if Codex loads a project-scope hooks file at all — which is row 5, still unproven.

## Sibling check (2026-09-10, before open)

`gh pr list --state open --search "codex-hooks OR claude-hooks OR child_workflow"`: #6074 (`mandate_budget.py` — serialized, row 1), #6054 (`scripts/proprioception.py`, no overlap), #5860 (DRAFT, `worktree_file_write_check.py`, no overlap). No open PR touches `child_workflow.py`, `context_bridge.py`, `install.py` or `declared-pairs.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PbxbVJmdaaEnWEPCrsHQv
