### PR TITLE
fix(codex-hooks): release() ignored the invariant its own docstring declared, and one token stood for three failures

### DIFF
--- a/infra/codex-hooks/context_bridge.py
+++ b/infra/codex-hooks/context_bridge.py
@@ -39,8 +39,31 @@ POLL_SECONDS = 1
 MANDATE_SECONDS = 3600
 # Launch failures the next Stop may retry on its own (bounded by MAX_LAUNCH_ATTEMPTS).
 TRANSIENT_FAILURES = frozenset(
-    {"continuation_not_confirmed", "TimeoutError", "RuntimeError", "destination_failed"}
+    {
+        "continuation_not_confirmed",
+        "TimeoutError",
+        "destination_failed",
+        "destination_exited",
+    }
 )
+
+# Three different causes were raised as bare RuntimeError, so `type(exc).__name__`
+# collapsed them into one token and every consumer downstream — frozen_reason() and
+# the Stop handler — had to decide retry policy from a class name that could mean
+# any of them. The message is the only place the cause survives, so it is mapped
+# to a STABLE code here, at the point it is still known. Codes outside
+# TRANSIENT_FAILURES are terminal: a launch whose ownership changed, or one the
+# operator cancelled, must not be retried by the next Stop.
+FAILURE_CODES = {
+    "launch ownership changed": "launch_ownership_changed",
+    "continuation cancelled": "continuation_cancelled",
+    "owned destination exited without completion": "destination_exited",
+}
+
+
+def failure_code(exc: BaseException) -> str:
+    """A stable code for a failure, falling back to the exception type name."""
+    return FAILURE_CODES.get(str(exc), type(exc).__name__)
 SELF = Path(__file__).resolve()
 EVENTS = (
     "SessionStart",
@@ -1131,7 +1154,7 @@ def continue_session(sid: str) -> None:
             latest.update(
                 rollover="needs_attention",
                 completion_status="needs_attention",
-                failure=type(exc).__name__,
+                failure=failure_code(exc),
             )
             save(path, latest)
     finally:
@@ -1183,6 +1206,15 @@ def release(sid: str) -> dict[str, Any]:
     with locked(sid) as (path, state):
         if state.get("rollover") not in ("needs_attention", "requested"):
             raise ValueError("release applies to a parked (needs_attention/requested) source")
+        # The docstring above has always declared this; the code did not enforce it.
+        # Popping launch_nonce under a live supervisor makes it raise "launch
+        # ownership changed", which rewrites rollover=needs_attention OVER the
+        # released state and re-freezes the source the operator just unfroze.
+        if supervisor_alive(state):
+            raise ValueError(
+                "a launch is still in flight for this source: cancel it first, so "
+                "the supervisor records its own verdict instead of racing this write"
+            )
         state["released"] = {
             "from": state.get("rollover"),
             "failure": state.get("failure"),

--- a/infra/codex-hooks/test_operator_verbs.py
+++ b/infra/codex-hooks/test_operator_verbs.py
@@ -1,0 +1,109 @@
+"""The last two council residuals, both on the operator path.
+
+  * release() did not refuse while a launch was in flight, although its own
+    docstring declared that it must: popping launch_nonce makes the live
+    supervisor raise "launch ownership changed", which rewrites
+    rollover=needs_attention OVER the released state and re-freezes the source.
+  * three different causes were raised as bare RuntimeError, so the except
+    recorded `type(exc).__name__` and collapsed them into one token; retry policy
+    downstream then could not tell "the destination exited" (worth retrying) from
+    "the operator cancelled" (never).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import context_bridge as bridge
+from test_context_bridge import setup, token  # noqa: F401
+
+
+# --- residual: release() during an in-flight launch ------------------------
+
+
+def _park(sid: str, **extra) -> None:
+    bridge.save(
+        bridge.state_path(sid),
+        {"session_id": sid, "rollover": "needs_attention", **extra},
+    )
+
+
+def test_release_refuses_while_a_launch_is_in_flight(setup: tuple) -> None:
+    sid = "src-in-flight"
+    # os.getpid() is alive by construction: this is a launch still running.
+    _park(sid, supervisor_pid=os.getpid(), launch_nonce="nonce-1")
+
+    with pytest.raises(ValueError, match="still in flight"):
+        bridge.release(sid)
+
+    # The state must be untouched — no half-release.
+    state = bridge.load(bridge.state_path(sid))
+    assert state["rollover"] == "needs_attention"
+    assert state["launch_nonce"] == "nonce-1"
+    assert "released" not in state
+
+
+def test_release_proceeds_once_the_supervisor_has_finished(setup: tuple) -> None:
+    sid = "src-finished"
+    _park(
+        sid,
+        supervisor_pid=os.getpid(),
+        supervisor_finished=True,
+        launch_nonce="nonce-2",
+    )
+
+    assert bridge.release(sid) == {"released": True}
+    state = bridge.load(bridge.state_path(sid))
+    assert state["released"]["from"] == "needs_attention"
+    assert "launch_nonce" not in state
+    assert "rollover" not in state
+
+
+def test_release_still_refuses_a_source_that_is_not_parked(setup: tuple) -> None:
+    sid = "src-live"
+    bridge.save(bridge.state_path(sid), {"session_id": sid, "rollover": "starting"})
+    with pytest.raises(ValueError, match="parked"):
+        bridge.release(sid)
+
+
+# --- residual: failure classified by exception type ------------------------
+
+
+def test_the_three_runtime_causes_get_distinct_codes() -> None:
+    codes = {
+        bridge.failure_code(RuntimeError("launch ownership changed")),
+        bridge.failure_code(RuntimeError("continuation cancelled")),
+        bridge.failure_code(RuntimeError("owned destination exited without completion")),
+    }
+    assert len(codes) == 3, "all three collapsed into one token again"
+
+
+def test_an_exited_destination_stays_retryable() -> None:
+    code = bridge.failure_code(
+        RuntimeError("owned destination exited without completion")
+    )
+    assert code in bridge.TRANSIENT_FAILURES
+
+
+def test_a_cancelled_or_reowned_launch_is_terminal() -> None:
+    # Retrying either of these is what the single RuntimeError token used to do.
+    assert bridge.failure_code(RuntimeError("continuation cancelled")) not in (
+        bridge.TRANSIENT_FAILURES
+    )
+    assert bridge.failure_code(RuntimeError("launch ownership changed")) not in (
+        bridge.TRANSIENT_FAILURES
+    )
+
+
+def test_an_unmapped_failure_falls_back_to_its_type_name() -> None:
+    assert bridge.failure_code(TimeoutError("slow")) == "TimeoutError"
+    assert bridge.failure_code(TimeoutError("slow")) in bridge.TRANSIENT_FAILURES
+    # And an unclassified RuntimeError is NOT retried blindly any more.
+    assert bridge.failure_code(RuntimeError("something new")) == "RuntimeError"
+    assert "RuntimeError" not in bridge.TRANSIENT_FAILURES


### PR DESCRIPTION
The last two council residuals from #6046, both on the operator path. Both were carried at PLAUSIBLE status; both turned out to be real when read.

## 1 — `release()` ignored the invariant its own docstring declares

The docstring has always said *"A launch still in flight must be cancelled first,
so the supervisor records its own verdict instead of racing this write."* The code
checked only that `rollover` was parked. With a live supervisor it went ahead and
popped `launch_nonce` — which makes that supervisor raise "launch ownership changed"
and rewrite `rollover=needs_attention` OVER the released state, re-freezing the
source the operator had just unfrozen.

A docstring that states a rule the code does not enforce is worse than no docstring:
it makes the next reader trust a guarantee that is not there. `release()` now refuses
while `supervisor_alive()` — a helper that already existed in this same file — and
leaves the state completely untouched when it refuses (no half-release, pinned).

## 2 — one token stood for three different failures

`continue_session`'s except recorded `type(exc).__name__`. Three causes are raised
as bare `RuntimeError`:

- `launch ownership changed`
- `continuation cancelled`
- `owned destination exited without completion`

so all three arrived downstream as the single string `"RuntimeError"`, and both
consumers — `frozen_reason()` and the `Stop` handler — had to set retry policy from
a class name that could mean any of them. `failure_code()` now maps the message to a
stable code at the point the cause is still known.

> **A note on the residual's own wording:** it said the except "classifies by
> exception TYPE". Reading the code, the except does not reference
> `TRANSIENT_FAILURES` at all — it discards the cause, and the classification happens
> downstream at `frozen_reason():400` and in the `Stop` handler. The defect is real;
> the fix belongs where the information is lost, not where it is consumed.

### Behaviour change — this is the risk in the diff

`"RuntimeError"` is **no longer in `TRANSIENT_FAILURES`**:

| cause | before | after |
|---|---|---|
| destination exited without completing | retried | retried, as `destination_exited` |
| launch ownership changed | retried | **terminal** |
| continuation cancelled | retried | **terminal** |
| any unmapped `RuntimeError` | retried | **terminal**, falls back to type name |
| `TimeoutError`, `continuation_not_confirmed` | retried | unchanged |

Retrying a launch whose ownership changed, or one the operator explicitly
cancelled, is what the single token used to make the next `Stop` do. Stopping that
is the point of the residual rather than a side effect of it — but it does mean an
unclassified `RuntimeError` now parks instead of retrying, which is a real change in
behaviour and not a refactor.

## Mutation-verified

7 regression cases. Removing the `supervisor_alive` guard kills exactly the
in-flight test; reverting `failure_code` to the type name kills exactly the two
classification tests. `pytest infra/codex-hooks/ -q` → **82 passed**.

## Bites

CONSUMER: the operator verb itself. After merge, from a detached worktree on
`origin/main`: park a source with a live supervisor pid and show `release()`
refusing with the state intact, then the same source releasing once the supervisor
is finished — plus the three codes coming out distinct and landing on the right side
of `TRANSIENT_FAILURES`. Posted in this thread before the work is called done.

## This closes the council residuals

With #6064, #6067, #6072 and #6074, all nine declared residuals from #6046 are now
cured, each with its own mutation-verified test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRgCfZacYYdLR26BnfbMU4
