### PR TITLE
docs(agents): AGENTS.md becomes an index — 45 KB → 18 KB, Codex boot 45.9k → 41.9k

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,13 @@
-# AGENTS.md - Nuzantara Project Context for AI coding agents (Codex · Kimi · Gemini · …)
+# AGENTS.md — Nuzantara door for external AI coding agents (Codex · Kimi · Gemini · …)
 
 > Read by every AGENTS.md-standard agent: Codex CLI, **Kimi (kimi-code CLI + Kimi Desktop
 > work-mode, whose workspace is this repo)**, Antigravity/agy, and others. "Codex" below
 > generalizes to "you, the external agent" unless a rule names a specific tool.
+>
+> **This file is an INDEX, not a manual** (boot diet, 2026-09-10). What is below is what a
+> session must know BEFORE it reads anything else. Everything else moved — nothing was
+> deleted — into `docs/agents/` and the canonical docs named in the INDICE. Load a file when
+> the task needs it, not at boot.
 
 <!-- CANON:builder-contract -->
 
@@ -105,749 +110,59 @@ stays prepare-only. An undeclared mission is BLUE and the sentence above binds u
    one line and take the narrowest reading — do NOT invent adjacent work (this is aimed
    especially at K3's known over-proactivity).
 
-### Damar editorial publishing protocol (News Room + WR2)
-
-When an authenticated Zero or Damar session explicitly asks to publish a News Room article
-or WR2 carousel, load `.agents/skills/editorial-publishing/SKILL.md` and follow it end to end.
-These editorial decisions are mandatory and may never come from a UI or API default:
-
-- **News Room:** obtain an explicit destination (`Latest`, `Hero Main`, `Hero 2–5`, or
-  `Insight 1–3`) before sending any publish request. For a batch, require a common destination
-  or a complete article-to-position map; reject duplicate Hero/Insight slots.
-- **WR2 carousel:** show the exact caption, obtain approval of that caption, run the
-  `confirm=false` dry-run, and only after it succeeds ask for the final explicit publish act
-  before `confirm=true`. Editing the caption invalidates the dry-run.
-
-Report an opened article PR as **queued**, never published. Report **live** only after opening
-the public URL and verifying the expected title/content. A red artefact gate blocks publication;
-verbal confirmation never overrides it. “Mark as published” only records an external post and
-must never be represented as publishing to Instagram.
-
-## 0. Machine Identification (IMPORTANT)
-
-**You MUST identify which machine you are running on at session start.**
-
-**Three machines** exist on the local network (Tailscale tailnet `balizero`):
-
-| Machine    | User        | Hostname    | Role                                                              |
-| ---------- | ----------- | ----------- | ----------------------------------------------------------------- |
-| **Pro**    | `nuzantara` | `Nuzantara` | Workhorse — dev, DB, Qdrant, Ollama, 224 daemon, deploy (48GB)    |
-| **Mini**   | `nuzantara` | `Mini-Pro2` | Server H24 — Ollama dedicato, cron pesanti (24GB)                 |
-| **Air-M5** | `balizero`  | `Air-M5`    | **THIN-CLIENT dev** — editing + agenti; pesante → `ssh pro`       |
-
-**At every session start, run this check:**
-
-```bash
-echo "Machine: $(whoami)@$(hostname)" && \
-case "$(hostname)" in Nuzantara) OTHER=mini ;; Mini-Pro2) OTHER=pro ;; Air-M5) OTHER=pro ;; *) OTHER=pro ;; esac && \
-ssh -o ConnectTimeout=3 $OTHER 'echo "Peer: $(whoami)@$(hostname)"' 2>/dev/null || echo "Peer: UNREACHABLE" && \
-LOCAL_HEAD=$(git log --oneline -1 2>/dev/null) && \
-REMOTE_HEAD=$(ssh -o ConnectTimeout=3 $OTHER 'cd ~/nuzantara 2>/dev/null; git log --oneline -1' 2>/dev/null) && \
-if [ "$LOCAL_HEAD" = "$REMOTE_HEAD" ]; then echo "Git sync: OK ($LOCAL_HEAD)"; else echo "Git sync: OUT OF SYNC! Local=$LOCAL_HEAD Remote=$REMOTE_HEAD"; fi
-```
-
-This tells you:
-
-- `whoami=nuzantara`, `hostname=Nuzantara` → you are on **Pro** (workhorse)
-- `hostname=Mini-Pro2` → you are on **Mini** (server)
-- `whoami=balizero`, `hostname=Air-M5` → you are on **Air-M5** (**thin-client** — see §0.1 below, it changes everything)
-- Whether the peer machine is reachable, and whether both repos are on the same commit
-
-**Always prefix your first response with which machine you're on**, e.g. "[Pro]", "[Mini]", or "[Air-M5]".
-
-> ⚠️ **CRITICAL — peer-unreachable is NOT a license to go local.** On Air-M5 the peer is the **Pro**, and `ssh pro` is the *destination* for all heavy work, not just a git-sync peer. If the session-start git-sync check reports the peer "UNREACHABLE", that means **sync is unverified** — it does **NOT** mean "do the heavy task locally on M5 instead". Heavy work that needs the Pro still routes via `ssh pro`; if `ssh pro` itself fails, **STOP and tell the operator**, do not fall back to a local install. (This was the #1 failure mode in the M5 thin-client audit, 2026-06-02.)
-
-**SSH between machines:** `ssh mini` / `ssh pro` (from any node) — uses Tailscale. From Air-M5: `ssh pro` (alias for `nuzantara@100.107.22.111`).
-See `docs/PRO_AIR_CONNECTION.md` for full details.
+> Publishing mechanics for a News Room article or a WR2 carousel (destination, caption
+> dry-run, live verification): `docs/agents/editorial-publishing-protocol.md`.
 
 ---
 
-## 0.1. Air-M5 Thin-Client Routing Map (READ if `hostname=Air-M5`)
+## 0. Machine identification (IMPORTANT)
 
-**Air-M5 is a THIN-CLIENT.** You edit code, run agents, commit, and do light research **locally** on M5. Everything heavy — inference, vector DB, SQL, rendering, deploy, the 224-daemon fleet — **lives on the Pro** and is reached via `ssh pro` (or `ssh mini`). M5 deliberately does **not** have Ollama, Postgres, Qdrant, `fly`, or the daemon stack.
+**Identify your machine at session start and prefix your first response with it** — `[Pro]`,
+`[Mini]` or `[Air-M5]`. Three machines on the Tailscale tailnet `balizero`:
 
-### HARD RULE R1 — Heavy tools are NEVER installed on M5
+| Machine    | User        | Hostname    | Repo path             | Role                                                              |
+| ---------- | ----------- | ----------- | --------------------- | ----------------------------------------------------------------- |
+| **Pro**    | `nuzantara` | `Nuzantara` | `~/Desktop/nuzantara` | Workhorse — dev, DB, Qdrant, Ollama, daemon fleet, deploy (48GB)   |
+| **Mini**   | `nuzantara` | `Mini-Pro2` | `~/nuzantara`         | Server H24 — dedicated Ollama, heavy cron (24GB)                   |
+| **Air-M5** | `balizero`  | `Air-M5`    | `~/nuzantara`         | **THIN-CLIENT** — editing + agents; anything heavy → `ssh pro`     |
 
-Do **NOT** `brew install` / `ollama pull` / compile / `docker run` heavy tooling on M5 — **not even as an "option B" / alternative / fallback.** Route to the Pro.
+SSH between machines (Tailscale): `ssh pro` / `ssh mini` / `ssh air`. On M5 the paths
+`/Users/nuzantara/...` are DEAD — different user. Details: `docs/PRO_AIR_CONNECTION.md`.
 
-| Asked to… | ❌ WRONG (FAIL) | ✅ CORRECT |
-| --- | --- | --- |
-| use **ffmpeg** (video concat/render) | `brew install ffmpeg` on M5 | `ssh pro 'bash -lc "ffmpeg …"'` (Pro has the full ffmpeg) |
-| compile C/C++ (**cmake/make**) heavy build | build locally on M5 | `ssh pro` for the build; only trivial builds stay local |
-| **cloudflared** tunnel | install + launchd on M5 | tunnels live on Pro → `ssh pro` |
-| **ghostscript** / heavy PDF batch | `brew install ghostscript` on M5 | `ssh pro` for the processing |
-| **Playwright** mass scrape (100s of pages) | run headless chromium on M5 | `ssh pro` (heavy compute) |
-| compile **torch / CUDA / MPS** from source | build on M5 | `ssh pro`/`ssh mini` (M5 = thin) |
-| **docker** containers (>~1GB) | `docker run` on M5 | `ssh pro` |
+> ⚠️ **peer-unreachable is NOT a license to go local.** On Air-M5 the peer is the Pro, and
+> `ssh pro` is the *destination* for all heavy work, not merely a git-sync peer. "UNREACHABLE"
+> means sync is **unverified**; it does NOT mean "do the heavy task locally on M5 instead".
+> If `ssh pro` itself fails, **STOP and tell the operator** — never fall back to a local
+> install. (The #1 failure mode of the M5 thin-client audit, 2026-06-02.)
 
-> If a tool is genuinely lightweight (`jq`, `ripgrep`, `eza`, a pip dep in the local `.venv`) installing it on M5 is fine. The line is **heavy compute / persistent services**, which always belong on the Pro.
-
-### HARD RULE R2 — LLM models & Ollama: Pro/Mini only
-
-M5 has **no `ollama`** by design. Never `ollama pull` or `brew install ollama` on M5 — not even a smaller fallback model.
-
-| Asked to… | ✅ CORRECT |
-| --- | --- |
-| run/`pull` any model (`deepseek-r1`, `qwen3.5`, `qwen2.5vl`) | `ssh pro 'bash -lc "ollama run <model>"'` (Pro/Mini hold the models) |
-| OCR / vision (`qwen2.5vl`) | `ssh pro` — Ollama binds `127.0.0.1:11434`, **closed** to M5 |
-| embed batch (`bge-m3`) | `ssh pro` / `ssh mini` |
-
-Lightweight **cloud** LLM clients **are** fine on M5 (they're already set up): `agy` (Gemini), `codex`, `kimi` (`~/.kimi-code/bin/kimi`, armed M5+Pro+Mini), `nlm` (NotebookLM). Use them directly. (DeepSeek API RETIRED 2026-07-19 — never route to it; local `deepseek-r1:32b` Ollama weights on Pro/Mini are unrelated and stay.)
-
-### HARD RULE R3 — DB & vector store: exact access per service
-
-The DB and vectors live on the Pro. M5 reaches them — it does **NOT** install or replicate them.
-
-| Service | From M5 | Command / value |
-| --- | --- | --- |
-| **Qdrant** (local Pro mirror) | ✅ DIRECT via Tailscale (no tunnel, no auth) | `QDRANT_URL=http://100.107.22.111:6333` |
-| **Postgres dev** (`nuzantara_dev`) | tunnel (binds `127.0.0.1` on Pro) | `ssh -L 5432:localhost:5432 pro` → `DATABASE_URL=postgresql://nuzantara@localhost:5432/nuzantara_dev` |
-| **Fly prod PG proxy** | tunnel (binds `127.0.0.1:15432` on Pro) | `ssh -L 15432:localhost:15432 pro` |
-| **Ollama** | ❌ closed to M5 | `ssh pro 'bash -lc "ollama …"'` |
-
-Never `brew install postgres@17` / `docker run qdrant` on M5. Embedding model is **FROZEN** `text-embedding-3-small` (1536 dims, cloud) — do not swap `bge-m3` into the RAG vector path.
-
-### HARD RULE R4 — OSINT / WhatsApp data NEVER leaves the Pro (Symbiosis Law 2)
-
-The WhatsApp/OSINT mirror lives **only** in the Pro's local Postgres. M5 must **NEVER** copy, replicate, or sync it to disk.
-This is a raw-data movement boundary, not a blanket ban on LLMs processing authorized operational context. For every LLM in the system, Law 2 means: do not transcribe or persist client PII/OSINT in cleartext in outputs, memories, skills, logs, reports, alerts, prompts saved for reuse, or shared artifacts. Use IDs, hashes, placeholders, or redaction.
-
-- View it: dashboard `http://100.107.22.111:7790` (open in M5 browser) — read-only.
-- Raw SQL on OSINT: only via the dev tunnel (`ssh -L 5432:localhost:5432 pro`), querying the Pro's DB — never a local copy.
-- "Copy the WhatsApp DB to M5 for offline analysis" → **REFUSE.** (Law 2, non-negotiable.)
-
-### HARD RULE R5 — Deploy is Pro/CI-only; M5 has no `fly`
-
-M5 has **no `fly`/`flyctl`** and **no `~/nuzantara-deploy`** worktree. Never `brew install flyctl` on M5.
-
-- Canonical: commit in a worktree → push → `gh pr create` → green CI + review → **merge to `main`** triggers `.github/workflows/fly-deploy.yml` (gate→migrations→deploy→health→rollback). Vercel frontend auto-deploys on the same `main` push. Machine-independent — M5 needs no `fly`.
-- Manual/out-of-band deploy: **delegate** → `ssh pro 'bash -lc "cd ~/nuzantara-deploy && git pull --ff-only origin main && fly deploy --strategy rolling"'`.
-- `main` is **protected**: PR + CI + review required. Never `git push origin main` directly (from M5 *or* Pro).
-
-### HARD RULE R6 — Memory (MOS): always via `mem`, never the local file
-
-On M5 the local `~/.claude/memory.db` is a **0-byte decoy**. The real DB is on the Pro.
-
-- Search: `mem query "<term>"` (routes over SSH to the Pro's DB; falls back to grep on local `MEMORY*.md` if the Pro is unreachable — it does **not** silently fabricate).
-- Save: `mem save <type> "<text>" <importance>` (lands in the Pro's DB).
-- Never read the local `memory.db` directly, never write memory to a local `.codex/memories/` note, and **never present recalled context as if you ran a query** (anti-hallucination, CLAUDE.md §6).
-
-### HARD RULE R7 — Heavy render / NB studio / daemon fleet → Pro
-
-- WR2 hero images (FlowKit/Veo), WR3 video episodes, NotebookLM studio audio/video → **`ssh pro`** (the render pipelines and FlowKit live on the Pro). M5 dispatches and pulls results; it does not render locally.
-- The 212 `com.{nuzantara,balizero,cell,matagaruda}.*` LaunchAgents (224 jobs incl. cron, snapshot 2026-07-13 per `docs/AUTOMATIONS_REFERENCE.md`) are **production daemons** — they run on Pro/Mini only. Never load/install them on M5.
-
-### MCP servers from M5
-
-| MCP | On M5 | Note |
-| --- | --- | --- |
-| `notebooklm-mcp`, `nuzantara-fetch`, `playwright`, `ocr-tesseract` | ✅ local | work directly |
-| `nuzantara-mcp`, `nuzantara-mcp-advanced`, `github` | 🔧 light remote clients | need their small venv + env tokens |
-| `postgres-nuzantara` | ➡️ **route via Pro** | needs Fly proxy `:15432` + Keychain `nuzantara-postgres-readonly`, neither on M5 |
-| `ga4-analytics` | ⚠️ sovereignty | uses a **prod** service-account JSON — prefer Pro, or confirm with operator |
+Session-start check command, HARD RULES R1–R7 (what may never be installed on M5, where models,
+DB, vectors, deploy, memory and heavy render live), the MCP-from-M5 table and the git-sync
+architecture: **`docs/agents/m5-thin-client-routing.md`**.
 
 ---
 
-### Git Sync Architecture (updated 2026-05-25)
+## 0.5. Agent worktree discipline (L5.1, 2026-05-25) — MANDATORY
 
-Both machines work on `main` branch only. Sync is **automatic** via husky post-commit hooks:
+**Any session that mutates code in this repo works in a dedicated worktree, never in the main
+checkout.** 5+ Claude sessions, Codex and agy share one checkout; concurrent mutation produced
+32+ sibling-orphan stashes in 24h.
 
-- **Pro commits** → Mini auto-pulls (`git pull pro main --ff-only`)
-- **Mini commits** → Mini auto-pushes to Pro (`git push pro main`)
-- **GitHub** is updated by Pro only via `git push origin main`
+```bash
+python3 scripts/agent_start.py --lane <wr2|infra|backend-rag|ops|docs|…> --task-id <slug>
+# → WORKTREE_READY <repo>/.worktrees/<lane>-<task-id>
+cd <that path> && codex exec --sandbox workspace-write "…"
+```
 
-**Never** create an `air` or `mini` branch. **Never** push from Mini to `origin`. Log: `~/.openclaw/logs/git-sync.log`.
+`codex exec` inherits cwd from its spawner, so `cd` FIRST — spawning from the main checkout
+creates an orphan there. The Claude-side PreToolUse hooks do **not** bind you: the convention
+does. Kill switch, emergency/hotfix/cicatrix-fix only: `export AGENT_WORKTREE_ENFORCEMENT=false`.
+
+Wrong/right `codex exec` patterns, the active hooks, the L1 broker, the L2 lease registry and the
+L5.1 spec: **`docs/agents/worktree-discipline.md`** · `docs/runbooks/agent-worktree-broker.md`.
 
 ---
 
-## 0.5. Agent Worktree Discipline (L5.1, 2026-05-25)
-
-**MANDATORY for any Codex session that mutates code in this repo.**
-
-This repo is shared with 5+ Claude sessions + occasional Gemini agy on the same Pro machine. All processes default to `cwd=/Users/nuzantara/nuzantara` (main checkout). Concurrent file mutations have produced 32+ sibling-orphan stash in 24h. To prevent:
-
-### Before any mutation
-
-```bash
-# Create dedicated worktree
-python scripts/agent_start.py --lane <wr2|infra|backend-rag|ops|...> --task-id <slug>
-# Output: WORKTREE_READY /Users/nuzantara/nuzantara/.worktrees/<lane>-<task-id>
-cd <output-path>
-# Now spawn codex exec HERE, not in main checkout
-```
-
-### For codex exec invocations
-
-`codex exec` inherits cwd from spawner. Wrong pattern:
-
-```bash
-# Wrong (creates orphan in main):
-codex exec --sandbox workspace-write "fix bug X"
-```
-
-Right pattern:
-
-```bash
-WT=$(python scripts/agent_start.py --lane infra --task-id codex-bug-x | tail -1)
-cd "$WT" && codex exec --sandbox workspace-write "fix bug X"
-```
-
-### Hooks active
-
-PreToolUse hook `~/.claude/hooks/worktree_isolation.py` blocks Claude Code Bash git ops in main checkout. `~/.claude/hooks/worktree_file_write_check.py` blocks Claude Code Edit|Write|MultiEdit in main. These hooks are CLAUDE-SIDE only — Codex CLI runs in its own sandbox and is NOT subject to them. **Discipline relies on Codex authors following this convention manually.**
-
-### Kill switch
-
-```bash
-export AGENT_WORKTREE_ENFORCEMENT=false
-```
-
-Use only for emergency / hotfix / cicatrix-fix.
-
-### Reference
-
-- L1 broker: `docs/runbooks/agent-worktree-broker.md`
-- L2 lease: `docs/runbooks/redis-lease-registry.md`
-- L5.1 spec: `research/operations/specs/L5.1-agent-worktree-enforcement-2026-05-25.md`
-- Panel synthesis: `research/operations/specs/L5.1-panel-synthesis-2026-05-25.md`
-
----
-
-## 1. Project Overview
-
-**Name:** Nuzantara (Zantara)  
-**Version:** 5.2.0  
-**Type:** Production AI-powered business intelligence platform for Bali Zero  
-**URL:** https://kita.balizero.com
-
-### Architecture
-
-**Monorepo structure:**
-
-- `apps/mouth/` - Next.js frontend (Vercel)
-- `apps/backend-rag/` - Python FastAPI RAG backend (Fly.io)
-- `apps/admin-dashboard/` - Admin UI
-- `apps/webapp/` - Web application
-- `apps/bali-intel-scraper/` - Intelligence gathering
-- `apps/nuzantara-mcp/` - MCP server v2.1 (inspect the server for its live capability inventory)
-- `apps/nuzantara-mcp-advanced/` - Advanced MCP (Fly.io ops, diagnostics)
-- `apps/nuzantara-mcp-browser/` - Browser automation MCP
-- `apps/graph-engine/` - Graph processing engine
-- `apps/kbli-voice/` - KBLI voice interface
-- `apps/evaluator/` - Quality assurance
-- `apps/zantara-media/` - Editorial content system
-- `packages/core/` - Core libraries
-
-### Tech Stack
-
-- **Backend:** Python 3.11+, FastAPI. Live counts: `python3 scripts/docs_sync.py --json`
-- **Frontend:** Next.js, TypeScript, Tailwind CSS
-- **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)
-- **Infrastructure:** Fly.io (backend), Vercel (frontend)
-- **Knowledge Graph:** live counts are generated, not stored in this file
-- **Vector Collections:** canonical registry: `backend/core/collection_registry.py`; live counts: `python3 scripts/docs_sync.py --json`
-- **Embedding Model:** `text-embedding-3-small` (1536 dims) — **NEVER CHANGE**
-
-## 2. Agent Behavior Rules (IMPORTANT)
-
-**DO NOT ask the user to write code.** You are authorized to edit, write, and execute code directly.
-
-- Use `Edit`, `Write`, `Bash` without asking permission
-- `defaultMode: acceptEdits` means act first, ask if blocked
-- Only ask if you genuinely need user input (e.g., choosing between multiple valid approaches)
-- **NEVER** ask "should I write this?" or "do you want me to...?" — just do it
-
-**Exception:** Only ask for decisions on:
-
-- Architecture choices with trade-offs (use `AskUserQuestion`)
-- Production deployments (use risk/reversibility judgment)
-- Destructive operations (rm, git reset --hard, etc.)
-
-## 4. Golden Rules (ENFORCE STRICTLY)
-
-1. **Virtualenv Mandatory** - Never use system Python. Always activate venv first.
-2. **No Root Execution** - Use `PYTHONPATH=. python -m backend.module`, never run modules directly.
-3. **Path Discipline** - Absolute imports only: `from backend.core import config`, never relative.
-4. **Async First** - Use `httpx` for HTTP, never `requests`. All I/O must be async.
-5. **Type Hints Required** - Every function must have full type annotations.
-6. **No Hardcoded Secrets** - Use environment variables or secrets manager.
-7. **Data/Logic Separation** - Business logic separate from data access layer.
-8. **Clean Logging** - Use `logger`, never `print()` statements.
-9. **Quality Standards** - Tests, error handling, graceful degradation required.
-10. **Verify Sources** - Never presume, always verify against actual data sources.
-
-## 5. Development Commands
-
-### Backend (FastAPI)
-
-```bash
-# Activate virtualenv
-source venv/bin/activate  # or: . venv/bin/activate
-
-# Run backend locally
-cd apps/backend-rag
-PYTHONPATH=. python -m uvicorn backend.main:app --reload --port 8000
-
-# Run tests
-PYTHONPATH=. pytest tests/ -v
-PYTHONPATH=. pytest tests/test_specific.py::test_function -v
-
-# Type checking
-mypy backend/
-
-# Linting
-ruff check backend/
-ruff format backend/
-
-# Database migrations (custom SQL system — NOT Alembic)
-# Create: backend/db/migrations_v2/NNN_name.sql with mandatory `-- === ROLLBACK ===` marker
-PYTHONPATH=. python -m backend.db.migrate apply-all
-PYTHONPATH=. python -m backend.db.schema_audit
-```
-
-### Frontend (Next.js)
-
-```bash
-cd apps/mouth
-npm run dev        # Development server
-npm run build      # Production build
-npm run start      # Production server
-npm run lint       # ESLint
-npm run test       # Jest tests
-```
-
-### Deployment
-
-```bash
-# Backend to Fly.io
-fly deploy --config apps/backend-rag/fly.toml --app nuzantara-rag
-
-# Frontend to Vercel (auto-deploy on git push to main)
-vercel --prod
-```
-
-## 4. Critical Paths
-
-### Backend Structure
-
-```
-apps/backend-rag/
-├── backend/
-│   ├── app/              # FastAPI app
-│   │   ├── routers/      # API endpoints (live inventory: docs_sync.py --json)
-│   │   ├── services/     # App-level services (CRM, auth, metrics)
-│   │   ├── setup/        # app_factory, router_registration, service_initializer
-│   │   ├── dependencies.py  # ⚠️ Imported by ALL routers — test before deploy
-│   │   └── main.py       # Entrypoint (alias for main_cloud.py)
-│   ├── services/         # Core business logic
-│   ├── core/             # Config, security, logging
-│   ├── prompts/          # ⭐ Prompt Single Source of Truth (see below)
-│   ├── channels/         # 7 channels (whatsapp, telegram, instagram, etc.)
-│   ├── llm/              # LLM clients (Gemini, Ollama, OpenRouter)
-│   └── migrations/       # custom SQL (legacy 001→124 py; live v2 092→246 sql in backend/db/migrations_v2/)
-├── tests/                # Unit and integration tests
-├── .venv/                # ⚠️ ALWAYS .venv on Pro and Mini
-└── fly.toml
-```
-
-**IMPORTANT:** Routers in `backend/app/routers/`, NOT `backend/routers/`. Services in both `backend/services/` and `backend/app/services/`.
-
-### Prompt Architecture (Single Source of Truth)
-
-```
-backend/prompts/
-├── __init__.py              # Re-exports ZANTARA_MASTER_TEMPLATE, CREATOR_PERSONA, TEAM_PERSONA
-├── zantara_core.py          # ⭐ THE file — all prompt sections as composable constants
-├── channel_overlays.py      # Per-channel config (word limits, markdown, emoji)
-├── few_shot_examples.py     # Consolidated few-shot examples
-├── zantara_persona.py       # Backward compat wrapper → imports from zantara_core
-├── whatsapp_persona.py      # Dynamic builder for WhatsApp context → imports from zantara_core
-└── zantara_prompt_builder.py # Legacy builder → imports from zantara_core
-```
-
-**Rule:** To add/edit ANY Zantara prompt rule, edit ONLY `zantara_core.py`. All consumers import from it.
-
-**Sections in `zantara_core.py`:**
-`SECURITY_BOUNDARY` · `TOOL_USAGE_POLICY` · `SYSTEM_INSTRUCTIONS` · `KNOWLEDGE_GOVERNANCE` ·
-`LANGUAGE_PROTOCOL` · `GREETING_RULES` · `CITATION_RULES` · `INTERNAL_MONOLOGUE` ·
-`ESCALATION_PROTOCOL` · `CRASH_PROTOCOL` · `CLOSING_PHRASES` · `CREATOR_PERSONA` ·
-`TEAM_PERSONA` · `ZANTARA_MASTER_TEMPLATE`
-
-### Frontend Structure
-
-```
-apps/mouth/
-├── app/              # Next.js App Router
-├── components/       # React components
-├── lib/              # Utilities
-├── public/           # Static assets
-└── styles/           # Tailwind CSS
-```
-
-## 5. Domain-Specific Knowledge
-
-### KBLI (Indonesian Business Classification)
-
-**Storage:** Qdrant vector collection  
-**Format:** **FLAT payload structure**, NOT nested  
-**Fields:** `code`, `title_id`, `title_en`, `description`, `category`, `section`
-
-❌ **WRONG:**
-
-```json
-{
-  "code": "47911",
-  "details": {
-    "title": "...",
-    "description": "..."
-  }
-}
-```
-
-✅ **CORRECT:**
-
-```json
-{
-  "code": "47911",
-  "title_id": "Perdagangan Eceran...",
-  "title_en": "Retail Sale...",
-  "description": "...",
-  "category": "G",
-  "section": "Perdagangan"
-}
-```
-
-### Pricing System
-
-**CRITICAL:** All prices MUST come from `PricingTool`.  
-**Never:** Hardcode, guess, or cache prices outside the tool.  
-**Files:** Reference only `PRICING_REFERENCE.md` and `VISA_TYPES_REFERENCE.md`.
-
-### Evidence Scoring System
-
-Classification confidence thresholds:
-
-- **< 0.15:** `ABSTAIN` - Insufficient confidence, refuse to answer
-- **0.15 - 0.60:** `CAUTIOUS` - Provide answer with clear uncertainty disclaimer
-- **> 0.60:** `NORMAL` - Confident answer
-
-### Embedding Model
-
-**Model:** `text-embedding-3-small` (OpenAI)  
-**Dimensions:** 1536  
-**CRITICAL:** This model is FROZEN. Changing it would invalidate the existing vector index.
-**Never:** Switch to another model without explicit authorization and full re-indexing plan.
-
-## 6. MCP Servers
-
-**Primary:** `apps/nuzantara-mcp/` (v2.1, FastMCP, stdio transport)
-**Capabilities:**
-
-- **115 Tools** across 24 modules (CRM, portal, intel, content, analytics, knowledge, comms, drive, sheets, workflows, admin, health, google_bridge, journey, pricing, invoicing, compliance, memory, langsmith, legal, prime, federation, naga, heartbeat)
-- **10 Prompts** for guided workflows
-- **5 Resources** for knowledge base access
-- **8 Workflow Chains** for deterministic automation (daily_ops_autopilot, new_client_onboarding, practice_lifecycle_check, intel_pipeline, weekly_report, client_health_monitor, compliance_autopilot, journey_accelerator)
-
-**Additional MCP servers:**
-
-- `apps/nuzantara-mcp-advanced/` — Fly.io ops, deployment readiness, code search, diagnostics
-- `apps/nuzantara-mcp-browser/` — Browser automation
-
-## 7. Deployment Architecture
-
-### Production Stack
-
-- **Frontend:** Vercel (CDN, Edge Functions)
-- **Backend:** Fly.io `nuzantara-rag` (Asia region)
-- **Databases:**
-  - PostgreSQL: Fly.io managed
-  - Qdrant: Fly.io app
-  - Redis: Upstash or Fly.io
-
-### Environment Variables
-
-**Required:**
-
-- `OPENAI_API_KEY` - For embeddings
-- `DATABASE_URL` - PostgreSQL connection
-- `QDRANT_URL`, `QDRANT_API_KEY` - Vector DB
-- `REDIS_URL` - Cache
-- `JWT_SECRET` - Authentication
-- `FLY_API_TOKEN` - Deployment (CI/CD)
-
-## 8. Testing Strategy
-
-```bash
-# Unit tests (fast)
-PYTHONPATH=. pytest tests/unit/ -v
-
-# Integration tests (slower)
-PYTHONPATH=. pytest tests/integration/ -v
-
-# E2E tests (slowest)
-PYTHONPATH=. pytest tests/e2e/ -v
-
-# Coverage report
-PYTHONPATH=. pytest --cov=backend --cov-report=html tests/
-```
-
-**Standards:**
-
-- Unit tests: > 80% coverage
-- Critical paths: 100% coverage
-- All new features: tests required before merge
-
-## 9. Code Style & Patterns
-
-### Python (Backend)
-
-```python
-# Good: Async, typed, clean logging, persistent client
-from typing import Optional
-from backend.core.logging import logger
-
-async def fetch_kbli_data(code: str) -> Optional[dict]:
-    """Fetch KBLI data from Qdrant."""
-    try:
-        result = await qdrant.search(
-            collection_name="kbli",
-            query_vector=embedding,
-            limit=1
-        )
-        logger.info(f"KBLI search successful: {code}")
-        return result[0] if result else None
-    except Exception as e:
-        logger.error(f"KBLI search failed: {code}", exc_info=True)
-        raise
-```
-
-### TypeScript (Frontend)
-
-```typescript
-// Good: Type-safe, error handling
-interface KBLIResponse {
-  code: string;
-  title_en: string;
-  description: string;
-}
-
-async function fetchKBLI(code: string): Promise<KBLIResponse | null> {
-  try {
-    const response = await fetch(`/api/kbli/${code}`);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    return await response.json();
-  } catch (error) {
-    console.error("KBLI fetch failed:", error);
-    return null;
-  }
-}
-```
-
-## 10. Common Pitfalls
-
-❌ **AVOID:**
-
-- Running Python without virtualenv
-- Using `requests` instead of `httpx`
-- Nested payload structures in Qdrant
-- Hardcoded prices or visa info
-- `print()` debugging in production code
-- Relative imports
-- Blocking I/O operations
-- Missing type hints
-
-✅ **DO:**
-
-- Always activate venv first
-- Use `httpx` for all HTTP calls
-- Flat payloads in Qdrant
-- `PricingTool` for all pricing
-- `logger` for all logging
-- Absolute imports
-- Async/await everywhere
-- Full type annotations
-
-## 11. Language Protocol (Natural Language → Precise Engineering)
-
-The user writes in **colloquial Italian**. You must automatically translate intent into precise technical action.
-
-**Rules:**
-
-- Never ask "what do you mean?" — infer from codebase context
-- Short/vague prompt → deduce file, pattern, stack from existing code before acting
-- Italian colloquial → English technical internally, respond in Italian
-- If ambiguous between 2 interpretations, pick the most likely one and state your assumption in one line
-
-**Examples:**
-| User writes | You interpret as |
-|-------------|-----------------|
-| "aggiungi paginazione clienti" | Cursor-based pagination on `GET /clients`, follow existing router patterns, async SQLAlchemy, add tests |
-| "fixa il bug del login" | Search recent auth-related errors in routers/auth, identify root cause, fix with proper error handling |
-| "rendi più veloce la ricerca" | Profile the search endpoint, identify bottleneck (N+1, missing index, no cache), fix the actual cause |
-| "aggiungi un campo alla tabella" | SQL migration in `migrations_v2/` (with ROLLBACK marker) + model update + schema update + router update, in order |
-
-**Never** ask for clarification on standard dev tasks. Explore first, then act.
-
----
-
-## 11. Owner Information
-
-**Owner:** Zero (internal codename)  
-**Privacy:** Real name is PRIVATE, never reveal in client communications.  
-**Language:** Italian with owner, client's language with everyone else.
-
-## 12. Resources
-
-- **Architecture:** `docs/architecture.md`
-- **API Docs:** `http://localhost:8000/docs` (Swagger UI)
-- **Golden Rules:** This file + `AI_ONBOARDING.md`
-- **Pricing:** `PRICING_REFERENCE.md`
-- **Visa Info:** `VISA_TYPES_REFERENCE.md`
-
-### KBLI Navigator (Frontend)
-
-| Route             | Description                             |
-| ----------------- | --------------------------------------- |
-| `/kbli`           | KBLI 2025 Navigator homepage (Next.js)  |
-| `/kbli/[code]`    | KBLI code detail page (1,559 SSG pages) |
-| `/kbli-navigator` | **Redirect** → `/kbli` (permanent 301)  |
-| `/kbli-explorer`  | AI chat explorer (complementary)        |
-
----
-
-## 13. Pre-Deploy Checklist
-
-Before any production deployment:
-
-```bash
-# 1. Check for rogue AI changes
-git diff --name-only HEAD -- apps/backend-rag/backend/
-
-# 2. Test critical import chain (dependencies.py is imported by ALL routers)
-cd apps/backend-rag && source .venv/bin/activate
-python -c "from backend.app.dependencies import get_current_user; print('OK')"
-
-# 3. Run core KG tests (82 tests, <15s)
-PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q
-
-# 4. Deploy
-fly deploy --strategy rolling
-```
-
-**Test debt:** Cleaned 2026-03-20 (0 failed, 0 errors). Previously ~448 failures from rogue AI refactors — resolved by Windsurf cleanup. Details in `memory/session-2026-02-16-hotfix-and-tests.md`.
-
----
-
-**Last Updated:** 2026-08-10 (fleet topology, conductor-as-role, continuity ladder; was 2026-07-19)
-**Maintained by:** Bali Zero AI Team
-
----
-
-## 15. Anthropic API — Best Practices (Feb 2026)
-
-### Adaptive Thinking (OBBLIGATORIO su Opus 4.6 / Sonnet 4.6)
-
-`budget_tokens` è **deprecato** sui modelli 4.6. Usare sempre:
-
-```python
-# ✅ CORRETTO — adaptive thinking
-response = client.messages.create(
-    model="claude-sonnet-4-6",
-    max_tokens=8192,
-    thinking={"type": "adaptive"},
-    output_config={"effort": "medium"},  # "max" | "high" | "medium" | "low"
-    messages=[...]
-)
-
-# ❌ DEPRECATO — non usare su 4.6
-thinking={"type": "enabled", "budget_tokens": 10000}
-```
-
-- `effort="medium"` → raccomandato per workflow RAG/tool
-- `effort="high"` → default, per query complesse
-- `effort="max"` → solo per i problemi più difficili (solo Opus 4.6)
-- L'interleaved thinking (tra tool call) è **automatico** su Opus 4.6 con adaptive
-
-### Prompt Caching KBLI / Knowledge Base (-90% costo)
-
-Ogni volta che scrivi chiamate API che includono il knowledge base KBLI, system prompt largo,
-o definizioni di tool che non cambiano, usa `cache_control`:
-
-```python
-# ✅ System prompt con cache (risparmio 90% su letture successive)
-system=[
-    {
-        "type": "text",
-        "text": KBLI_SYSTEM_PROMPT_OR_KNOWLEDGE,
-        "cache_control": {"type": "ephemeral", "ttl": 3600}  # 1 ora per batch
-    }
-]
-
-# Monitoraggio cache
-print(response.usage.cache_read_input_tokens)     # token da cache
-print(response.usage.cache_creation_input_tokens)  # token scritti in cache
-```
-
-Prezzi Sonnet 4.6: scrittura 5min $3.75/MTok, scrittura 1h $6.00/MTok, **lettura $0.30/MTok**.
-Minimo cacheable: 1.024 token.
-
-### Batch API per elaborazioni massive (50% sconto)
-
-Per test suite, analisi bulk KBLI, valutazioni:
-
-```python
-# Stacking: Batch 50% off + cache reads 90% off = costi minimi
-batch = client.messages.batches.create(requests=[...])
-```
-
-### Tool Use — pattern corretti
-
-```python
-# Strict schema per produzione
-tools = [{"name": "...", "strict": True, "input_schema": {...}}]
-
-# Fine-grained streaming per tool con output grande
-tools = [{"name": "kbli_search", "eager_input_streaming": True, ...}]
-
-# Tool result caching per documenti grandi
-{"type": "tool_result", "content": [{"type": "text", "text": doc, "cache_control": {"type": "ephemeral"}}]}
-```
-
-### Modelli consigliati per Nuzantara
-
-| Uso                       | Modello                    | Perché                                       |
-| ------------------------- | -------------------------- | -------------------------------------------- |
-| RAG complesso, reasoning  | `claude-sonnet-4-6`         | Knowledge cutoff gen 2026, adaptive thinking |
-| Routing / classificazione | `claude-haiku-4-5-20251001` | $1/$5 MTok, velocissimo                      |
-| Task critici              | `claude-opus-4-6`           | 128K output, effort=max                      |
-| Spiegazioni KBLI          | `claude-haiku-4-5-20251001` | Già configurato in kbli_notebook.py          |
-
----
-
-## 16. Memory (MOS) — dove leggere la conoscenza di progetto
-
-La memoria di progetto (decisioni, scoperte, fatti, lessons) vive come file Markdown qui:
-
-- **Pro**: `~/.claude/projects/-Users-nuzantara-Desktop-nuzantara/memory/*.md` (388+ file)
-- **Air-M5**: `~/.claude/projects/-Users-balizero-Desktop-nuzantara/memory/*.md` (sincronizzati dal Pro via hub-daemon)
-- **Indice**: `MEMORY.md` nella stessa dir — leggi questo PRIMA per orientarti (1 riga per memory).
-
-Per interrogarla:
-
-- Comando `mem query "<termine>"` (FTS5 sul DB `memory.db`). Su **Pro** funziona diretto. Su **Air-M5** `mem` usa SSH-al-Pro per il DB ricco, con fallback grep sui `.md` locali se il Pro è irraggiungibile.
-- In alternativa (sempre disponibile, zero dipendenze): leggi i `.md` direttamente col path sopra, o `grep -rl "<termine>" <memory-dir>/*.md`.
-
-Codex NON carica la memory in automatico (a differenza di Claude che ha i SessionStart hook): leggi `MEMORY.md` + i `.md` rilevanti col path quando ti serve contesto storico del progetto.
-
-## 17. Fleet, Conductor & Continuity (2026-08-09)
-
-Binding roster + corrections: research/operations/2026-08-10-fleet-order-spec.md
-
-**SSOT files:** cloud fleet = `FLEET_TOPOLOGY.json` (repo root) · local Ollama = `MODEL_TOPOLOGY.json` (unchanged) · rationale + four-groups study = `research/operations/2026-08-09-quattro-gruppi-e-continuita.md` · roles roster = FLOTTA-LLM doc referenced there.
-
-**Full model roster × strengths × efforts: `MODEL_ROSTER.md`** — read it before choosing seats (Zero ruling 2026-08-14). Every conductor door (claude/codex/agy/kimi/qwen) reads `AGENTS.md`, so this is the shared denominator.
-
-### 17.1 Conductor is a ROLE, not a model
+## 17.1 Conductor is a ROLE, not a model
 
 - Zero may start the interactive session with **any frontier orchestrator**: Claude (Fable/Opus/Sonnet), Codex (Sol/Terra/Luna), agy/Antigravity, Kimi. Whoever conducts inherits the **same law**: this file, the harness (gears, Evidence Pack, verdicts), CLAUDE.md invariants. Same law, different door.
 - The conductor **orchestrates and dispatches** agents per `FLEET_TOPOLOGY.json` role chains, assembles the Evidence Pack, and prepares the mechanical ship path: PR → required checks → armed auto-merge → `fly-deploy.yml` on `main`. Arming is the act of the mission's release owner — an authorized Claude session on BLUE, the appointed Dux Sol session on ORANGE (RULED 2026-09-10); every other external conductor (Codex/agy/Kimi) prepares and hands over, it never arms (Builder Contract 5). **No conductor hand-merges around checks.**
@@ -856,24 +171,67 @@ Binding roster + corrections: research/operations/2026-08-10-fleet-order-spec.md
 - Client-facing outputs (quotes, comms) remain **Anthropic-interactive-only**. PII remains **local-only**. Legge 5 unchanged.
 - **REVIEW-È-INVOCABILE** (ruling Zero 2026-08-10, `research/operations/2026-08-10-fleet-order-spec.md` §3.2/§4): "serve review" is a dispatch instruction, never a parking state — "chi conduce non aspetta i grader: li convoca". The conductor invokes the grader per the role chains (§17.2 below / `FLEET_TOPOLOGY.json`) the moment a diff exists to judge; a PR is never parked on "waiting for review" without the grader having been dispatched.
 
-### 17.2 Continuity ladder — no line ever stops
 
-When a seat hits quota or dies, escalate IN ORDER and log each hop in the task evidence:
+Continuity ladder, account-lane mapping and spend order (§17.2–§17.4):
+**`docs/agents/fleet-continuity.md`**. Roster and seats: `MODEL_ROSTER.md` ·
+`FLEET_TOPOLOGY.json` · `docs/architecture/dual-consul/army-map.md`.
 
-1. **Rotate account, same model** (zero quality loss): Anthropic ×4 via OAuth profile swap (cswap-style), OpenAI ×2 via `CODEX_HOME=~/.codex-o2`.
-2. **Substitute model within the role** per `FLEET_TOPOLOGY.json` chain (builder: sonnet→codex→glm · refuter: sol→k3→gemini · grunt: haiku→local…).
-3. **Cross-family fallback**, marked `degraded_execution: true` in the Evidence Pack (the gate sees it).
-4. **Queue, never silent-stop**: chain fully dead → park in PENDING-ARMS with reason + timestamp.
+---
 
-**Carve-outs (special ladders):**
-- **Gear-3 harness gate (RULED 2026-08-20, supersedes the 2026-08-09 ruling):** **Opus 5 `effort=xhigh`**, rotating across ALL Anthropic accounts (AZ→A2→A3→A1). No fallback tier below it — Fable is out of the workflow, so there is no `gate_degraded: fable→opus` to record anymore. All Anthropic accounts dead → queue. Never pay per-token to unblock.
-- **WR2 on-disk content gate (RULED 2026-08-20):** **Opus 5 `effort=xhigh`** — was unconditionally Fable; no fallback either way, window dead → SUSPEND.
-- PII lanes = local models only → queue. Client-facing = Anthropic interactive only.
+## Language protocol and owner privacy
 
-### 17.3 Account-lane mapping (lanes with borrowing, not round-robin)
+- Zero writes **colloquial Italian**. Translate intent into precise technical action internally,
+  reply in Italian. Never ask "what do you mean?" — infer from the codebase. If two readings are
+  possible, take the narrowest, state the assumption in one line, and act.
+- **Owner:** Zero (internal codename). The real name is **PRIVATE** — never reveal it in client
+  communications. Italian with the owner, the client's language with everyone else.
+- Worked examples of the Italian→engineering mapping: `docs/agents/language-protocol.md`.
 
-Lanes are **home assignments, not fences**: each lane drains its home account first, then borrows automatically from the least-loaded other account — nothing sits idle, no line ever stops. Mapping (see `FLEET_TOPOLOGY.json` → `accounts`): **A1** antonellosiano interactive/architect · **A2** kaiser1987… subagents/build+Cowork · **A3** applevisionpro1987 cron/batch, **designated donor** (cron auto-pauses to free its window when the gate calls) · **AZ** zero (Team seat Premium) **gate primary** — the dedicated allowance for the final on-disk gate lives here (Opus 5 xhigh effort, RULED 2026-08-20; was Fable's dedicated weekly allowance) · **O1** antonellosiano (ChatGPT Pro) refuter-primary · **O2** zero (ChatGPT Pro) builders+refuter-backup.
+## Anti-hallucination, PII and secrets — one line each
 
-### 17.4 Spend order
+- **Anti-hallucination:** never cite the output of a tool you did not run in THIS turn, and never
+  build on a path you have not just verified on disk. → `docs/rules/operations.md` §6.
+- **PII is an OUTPUT boundary** (Builder Contract 4 · SYMBIOSIS Law 2 · UU PDP): processing under
+  an authorized lane is allowed, transcribing it is not — no cleartext client PII or OSINT in any
+  output, log, memory, report, alert or saved prompt. → `SYMBIOSIS.md`.
+- **Secrets:** never echo, print or commit a credential. `${VAR:+SET}` reports presence,
+  `${VAR:-default}` prints the value. → Builder Contract 3.
 
-Flat subscriptions → Token Plan credits → local. Anything per-token (incl. Google overage credits) requires Zero's explicit GO (CLAUDE.md §5). Note: §15 above is 4.6-era; for 5-family API gotchas (thinking on by default, `max_tokens` covers thinking+answer, no temperature knob, min-cacheable 512, tokenizer ≈+30%) see CLAUDE.md §«5-family» and the fleet research doc.
+---
+
+## INDICE — dove sta cosa
+
+> Moved, not deleted. Open a line's file only when the task needs it.
+
+**Moved out of this file on 2026-09-10 — all under `docs/agents/`:**
+
+- `m5-thin-client-routing.md` ← session-start check, HARD RULES R1–R7, MCP-from-M5, repo sync
+- `worktree-discipline.md` ← full §0.5: `codex exec` patterns, active hooks, broker/lease/spec
+- `editorial-publishing-protocol.md` ← News Room + WR2 publish protocol (Damar/Zero orders)
+- `project-overview.md` ← monorepo map, architecture, tech stack, frozen embedding model
+- `behavior-and-golden-rules.md` ← act-don't-ask rules + the 10 Golden Rules
+- `dev-commands.md` ← backend/frontend/deploy commands, testing, pre-deploy checklist
+- `critical-paths.md` ← backend tree, prompt SSOT (`zantara_core.py`), frontend tree
+- `domain-knowledge.md` ← KBLI flat payload, PricingTool rule, evidence scoring, resources
+- `mcp-and-deployment.md` ← MCP inventory, production stack, required env vars
+- `code-style.md` ← Python/TypeScript patterns, common pitfalls
+- `anthropic-api-practices.md` ← §15, 4.6-era (stale; the paid-endpoint ban still binds)
+- `memory-mos.md` ← where project memory lives, how to read it
+- `fleet-continuity.md` ← §17 SSOT files, continuity ladder, account lanes, spend order
+- `language-protocol.md` ← worked Italian→engineering examples
+
+**Canonical docs this door defers to:**
+
+- `SYMBIOSIS.md` ← the laws · `VADEMECUM.md` ← checklist before building · `INDEX.md` ← atlas
+- `docs/rules/operations.md` ← PR contract, autonomous ops, anti-hallucination, hooks, escalations
+- `docs/rules/RULINGS.md` ← every RULED decision, incl. PARABELLUM (2026-09-10) and routing bans
+- `.claude/skills/modus/SKILL.md` ← gears + battle-window doctrine; `PENDING-ARMS.md` ← parked work
+- `apps/backend-rag/CLAUDE.md` ← backend rules, data invariants, Postgres MCP, deploy lifecycle
+- `MODEL_ROSTER.md` ← models × efforts · `FLEET_TOPOLOGY.json` / `MODEL_TOPOLOGY.json` ← fleet SSOT
+- `docs/architecture/dual-consul/army-map.md` ← ranks, chain of communication, boot packets
+- `.claude/rules/cicatrix-superscar.md` ← the 10 scar families; body via `scar query "<theme>"`
+
+---
+
+**Maintained by:** Bali Zero AI Team.
+**Authoritative last update:** `git log -1 --format=%cd -- AGENTS.md` in the repo root.

--- a/docs/agents/anthropic-api-practices.md
+++ b/docs/agents/anthropic-api-practices.md
@@ -1,0 +1,85 @@
+# Anthropic API best practices (Feb 2026, 4.6 era — see the staleness note)
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+> **Stale by design:** this section is 4.6-era. For 5-family gotchas read `MODEL_ROSTER.md`
+> and the CLAUDE.md 5-family notes. Builder Contract §3 governs whether any of these calls
+> may be made at all: the paid per-token Anthropic endpoint is banned.
+
+### Adaptive Thinking (OBBLIGATORIO su Opus 4.6 / Sonnet 4.6)
+
+`budget_tokens` è **deprecato** sui modelli 4.6. Usare sempre:
+
+```python
+# ✅ CORRETTO — adaptive thinking
+response = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=8192,
+    thinking={"type": "adaptive"},
+    output_config={"effort": "medium"},  # "max" | "high" | "medium" | "low"
+    messages=[...]
+)
+
+# ❌ DEPRECATO — non usare su 4.6
+thinking={"type": "enabled", "budget_tokens": 10000}
+```
+
+- `effort="medium"` → raccomandato per workflow RAG/tool
+- `effort="high"` → default, per query complesse
+- `effort="max"` → solo per i problemi più difficili (solo Opus 4.6)
+- L'interleaved thinking (tra tool call) è **automatico** su Opus 4.6 con adaptive
+
+### Prompt Caching KBLI / Knowledge Base (-90% costo)
+
+Ogni volta che scrivi chiamate API che includono il knowledge base KBLI, system prompt largo,
+o definizioni di tool che non cambiano, usa `cache_control`:
+
+```python
+# ✅ System prompt con cache (risparmio 90% su letture successive)
+system=[
+    {
+        "type": "text",
+        "text": KBLI_SYSTEM_PROMPT_OR_KNOWLEDGE,
+        "cache_control": {"type": "ephemeral", "ttl": 3600}  # 1 ora per batch
+    }
+]
+
+# Monitoraggio cache
+print(response.usage.cache_read_input_tokens)     # token da cache
+print(response.usage.cache_creation_input_tokens)  # token scritti in cache
+```
+
+Prezzi Sonnet 4.6: scrittura 5min $3.75/MTok, scrittura 1h $6.00/MTok, **lettura $0.30/MTok**.
+Minimo cacheable: 1.024 token.
+
+### Batch API per elaborazioni massive (50% sconto)
+
+Per test suite, analisi bulk KBLI, valutazioni:
+
+```python
+# Stacking: Batch 50% off + cache reads 90% off = costi minimi
+batch = client.messages.batches.create(requests=[...])
+```
+
+### Tool Use — pattern corretti
+
+```python
+# Strict schema per produzione
+tools = [{"name": "...", "strict": True, "input_schema": {...}}]
+
+# Fine-grained streaming per tool con output grande
+tools = [{"name": "kbli_search", "eager_input_streaming": True, ...}]
+
+# Tool result caching per documenti grandi
+{"type": "tool_result", "content": [{"type": "text", "text": doc, "cache_control": {"type": "ephemeral"}}]}
+```
+
+### Modelli consigliati per Nuzantara
+
+| Uso                       | Modello                     | Perché                                       |
+| ------------------------- | --------------------------- | -------------------------------------------- |
+| RAG complesso, reasoning  | `claude-sonnet-4-6`         | Knowledge cutoff gen 2026, adaptive thinking |
+| Routing / classificazione | `claude-haiku-4-5-20251001` | $1/$5 MTok, velocissimo                      |
+| Task critici              | `claude-opus-4-6`           | 128K output, effort=max                      |
+| Spiegazioni KBLI          | `claude-haiku-4-5-20251001` | Già configurato in kbli_notebook.py          |
+
+---

--- a/docs/agents/behavior-and-golden-rules.md
+++ b/docs/agents/behavior-and-golden-rules.md
@@ -1,0 +1,31 @@
+# Agent behavior rules and golden rules
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+
+## 2. Agent Behavior Rules (IMPORTANT)
+
+**DO NOT ask the user to write code.** You are authorized to edit, write, and execute code directly.
+
+- Use `Edit`, `Write`, `Bash` without asking permission
+- `defaultMode: acceptEdits` means act first, ask if blocked
+- Only ask if you genuinely need user input (e.g., choosing between multiple valid approaches)
+- **NEVER** ask "should I write this?" or "do you want me to...?" — just do it
+
+**Exception:** Only ask for decisions on:
+
+- Architecture choices with trade-offs (use `AskUserQuestion`)
+- Production deployments (use risk/reversibility judgment)
+- Destructive operations (rm, git reset --hard, etc.)
+
+## 4. Golden Rules (ENFORCE STRICTLY)
+
+1. **Virtualenv Mandatory** - Never use system Python. Always activate venv first.
+2. **No Root Execution** - Use `PYTHONPATH=. python -m backend.module`, never run modules directly.
+3. **Path Discipline** - Absolute imports only: `from backend.core import config`, never relative.
+4. **Async First** - Use `httpx` for HTTP, never `requests`. All I/O must be async.
+5. **Type Hints Required** - Every function must have full type annotations.
+6. **No Hardcoded Secrets** - Use environment variables or secrets manager.
+7. **Data/Logic Separation** - Business logic separate from data access layer.
+8. **Clean Logging** - Use `logger`, never `print()` statements.
+9. **Quality Standards** - Tests, error handling, graceful degradation required.
+10. **Verify Sources** - Never presume, always verify against actual data sources.

--- a/docs/agents/code-style.md
+++ b/docs/agents/code-style.md
@@ -1,0 +1,73 @@
+# Code style, patterns and common pitfalls
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+
+## 9. Code Style & Patterns
+
+### Python (Backend)
+
+```python
+# Good: Async, typed, clean logging, persistent client
+from typing import Optional
+from backend.core.logging import logger
+
+async def fetch_kbli_data(code: str) -> Optional[dict]:
+    """Fetch KBLI data from Qdrant."""
+    try:
+        result = await qdrant.search(
+            collection_name="kbli",
+            query_vector=embedding,
+            limit=1
+        )
+        logger.info(f"KBLI search successful: {code}")
+        return result[0] if result else None
+    except Exception as e:
+        logger.error(f"KBLI search failed: {code}", exc_info=True)
+        raise
+```
+
+### TypeScript (Frontend)
+
+```typescript
+// Good: Type-safe, error handling
+interface KBLIResponse {
+  code: string;
+  title_en: string;
+  description: string;
+}
+
+async function fetchKBLI(code: string): Promise<KBLIResponse | null> {
+  try {
+    const response = await fetch(`/api/kbli/${code}`);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return await response.json();
+  } catch (error) {
+    console.error("KBLI fetch failed:", error);
+    return null;
+  }
+}
+```
+
+## 10. Common Pitfalls
+
+❌ **AVOID:**
+
+- Running Python without virtualenv
+- Using `requests` instead of `httpx`
+- Nested payload structures in Qdrant
+- Hardcoded prices or visa info
+- `print()` debugging in production code
+- Relative imports
+- Blocking I/O operations
+- Missing type hints
+
+✅ **DO:**
+
+- Always activate venv first
+- Use `httpx` for all HTTP calls
+- Flat payloads in Qdrant
+- `PricingTool` for all pricing
+- `logger` for all logging
+- Absolute imports
+- Async/await everywhere
+- Full type annotations

--- a/docs/agents/critical-paths.md
+++ b/docs/agents/critical-paths.md
@@ -1,0 +1,61 @@
+# Critical paths — backend, prompt architecture, frontend
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+
+## 4. Critical Paths
+
+### Backend Structure
+
+```
+apps/backend-rag/
+├── backend/
+│   ├── app/              # FastAPI app
+│   │   ├── routers/      # API endpoints (live inventory: docs_sync.py --json)
+│   │   ├── services/     # App-level services (CRM, auth, metrics)
+│   │   ├── setup/        # app_factory, router_registration, service_initializer
+│   │   ├── dependencies.py  # ⚠️ Imported by ALL routers — test before deploy
+│   │   └── main.py       # Entrypoint (alias for main_cloud.py)
+│   ├── services/         # Core business logic
+│   ├── core/             # Config, security, logging
+│   ├── prompts/          # ⭐ Prompt Single Source of Truth (see below)
+│   ├── channels/         # 7 channels (whatsapp, telegram, instagram, etc.)
+│   ├── llm/              # LLM clients (Gemini, Ollama, OpenRouter)
+│   └── migrations/       # custom SQL (legacy 001→124 py; live v2 092→246 sql in backend/db/migrations_v2/)
+├── tests/                # Unit and integration tests
+├── .venv/                # ⚠️ ALWAYS .venv on Pro and Mini
+└── fly.toml
+```
+
+**IMPORTANT:** Routers in `backend/app/routers/`, NOT `backend/routers/`. Services in both `backend/services/` and `backend/app/services/`.
+
+### Prompt Architecture (Single Source of Truth)
+
+```
+backend/prompts/
+├── __init__.py              # Re-exports ZANTARA_MASTER_TEMPLATE, CREATOR_PERSONA, TEAM_PERSONA
+├── zantara_core.py          # ⭐ THE file — all prompt sections as composable constants
+├── channel_overlays.py      # Per-channel config (word limits, markdown, emoji)
+├── few_shot_examples.py     # Consolidated few-shot examples
+├── zantara_persona.py       # Backward compat wrapper → imports from zantara_core
+├── whatsapp_persona.py      # Dynamic builder for WhatsApp context → imports from zantara_core
+└── zantara_prompt_builder.py # Legacy builder → imports from zantara_core
+```
+
+**Rule:** To add/edit ANY Zantara prompt rule, edit ONLY `zantara_core.py`. All consumers import from it.
+
+**Sections in `zantara_core.py`:**
+`SECURITY_BOUNDARY` · `TOOL_USAGE_POLICY` · `SYSTEM_INSTRUCTIONS` · `KNOWLEDGE_GOVERNANCE` ·
+`LANGUAGE_PROTOCOL` · `GREETING_RULES` · `CITATION_RULES` · `INTERNAL_MONOLOGUE` ·
+`ESCALATION_PROTOCOL` · `CRASH_PROTOCOL` · `CLOSING_PHRASES` · `CREATOR_PERSONA` ·
+`TEAM_PERSONA` · `ZANTARA_MASTER_TEMPLATE`
+
+### Frontend Structure
+
+```
+apps/mouth/
+├── app/              # Next.js App Router
+├── components/       # React components
+├── lib/              # Utilities
+├── public/           # Static assets
+└── styles/           # Tailwind CSS
+```

--- a/docs/agents/dev-commands.md
+++ b/docs/agents/dev-commands.md
@@ -1,0 +1,96 @@
+# Development commands, testing strategy and the pre-deploy checklist
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+
+## 5. Development Commands
+
+### Backend (FastAPI)
+
+```bash
+# Activate virtualenv
+source venv/bin/activate  # or: . venv/bin/activate
+
+# Run backend locally
+cd apps/backend-rag
+PYTHONPATH=. python -m uvicorn backend.main:app --reload --port 8000
+
+# Run tests
+PYTHONPATH=. pytest tests/ -v
+PYTHONPATH=. pytest tests/test_specific.py::test_function -v
+
+# Type checking
+mypy backend/
+
+# Linting
+ruff check backend/
+ruff format backend/
+
+# Database migrations (custom SQL system — NOT Alembic)
+# Create: backend/db/migrations_v2/NNN_name.sql with mandatory `-- === ROLLBACK ===` marker
+PYTHONPATH=. python -m backend.db.migrate apply-all
+PYTHONPATH=. python -m backend.db.schema_audit
+```
+
+### Frontend (Next.js)
+
+```bash
+cd apps/mouth
+npm run dev        # Development server
+npm run build      # Production build
+npm run start      # Production server
+npm run lint       # ESLint
+npm run test       # Jest tests
+```
+
+### Deployment
+
+```bash
+# Backend to Fly.io
+fly deploy --config apps/backend-rag/fly.toml --app nuzantara-rag
+
+# Frontend to Vercel (auto-deploy on git push to main)
+vercel --prod
+```
+
+## 8. Testing Strategy
+
+```bash
+# Unit tests (fast)
+PYTHONPATH=. pytest tests/unit/ -v
+
+# Integration tests (slower)
+PYTHONPATH=. pytest tests/integration/ -v
+
+# E2E tests (slowest)
+PYTHONPATH=. pytest tests/e2e/ -v
+
+# Coverage report
+PYTHONPATH=. pytest --cov=backend --cov-report=html tests/
+```
+
+**Standards:**
+
+- Unit tests: > 80% coverage
+- Critical paths: 100% coverage
+- All new features: tests required before merge
+
+## 13. Pre-Deploy Checklist
+
+Before any production deployment:
+
+```bash
+# 1. Check for rogue AI changes
+git diff --name-only HEAD -- apps/backend-rag/backend/
+
+# 2. Test critical import chain (dependencies.py is imported by ALL routers)
+cd apps/backend-rag && source .venv/bin/activate
+python -c "from backend.app.dependencies import get_current_user; print('OK')"
+
+# 3. Run core KG tests (82 tests, <15s)
+PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q
+
+# 4. Deploy
+fly deploy --strategy rolling
+```
+
+**Test debt:** Cleaned 2026-03-20 (0 failed, 0 errors). Previously ~448 failures from rogue AI refactors — resolved by Windsurf cleanup. Details in `memory/session-2026-02-16-hotfix-and-tests.md`.

--- a/docs/agents/domain-knowledge.md
+++ b/docs/agents/domain-knowledge.md
@@ -1,0 +1,76 @@
+# Domain knowledge — KBLI, pricing, evidence scoring, embeddings, resources
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+
+## 5. Domain-Specific Knowledge
+
+### KBLI (Indonesian Business Classification)
+
+**Storage:** Qdrant vector collection  
+**Format:** **FLAT payload structure**, NOT nested  
+**Fields:** `code`, `title_id`, `title_en`, `description`, `category`, `section`
+
+❌ **WRONG:**
+
+```json
+{
+  "code": "47911",
+  "details": {
+    "title": "...",
+    "description": "..."
+  }
+}
+```
+
+✅ **CORRECT:**
+
+```json
+{
+  "code": "47911",
+  "title_id": "Perdagangan Eceran...",
+  "title_en": "Retail Sale...",
+  "description": "...",
+  "category": "G",
+  "section": "Perdagangan"
+}
+```
+
+### Pricing System
+
+**CRITICAL:** All prices MUST come from `PricingTool`.  
+**Never:** Hardcode, guess, or cache prices outside the tool.  
+**Files:** Reference only `PRICING_REFERENCE.md` and `VISA_TYPES_REFERENCE.md`.
+
+### Evidence Scoring System
+
+Classification confidence thresholds:
+
+- **< 0.15:** `ABSTAIN` - Insufficient confidence, refuse to answer
+- **0.15 - 0.60:** `CAUTIOUS` - Provide answer with clear uncertainty disclaimer
+- **> 0.60:** `NORMAL` - Confident answer
+
+### Embedding Model
+
+**Model:** `text-embedding-3-small` (OpenAI)  
+**Dimensions:** 1536  
+**CRITICAL:** This model is FROZEN. Changing it would invalidate the existing vector index.
+**Never:** Switch to another model without explicit authorization and full re-indexing plan.
+
+## 12. Resources
+
+- **Architecture:** `docs/architecture.md`
+- **API Docs:** `http://localhost:8000/docs` (Swagger UI)
+- **Golden Rules:** This file + `AI_ONBOARDING.md`
+- **Pricing:** `PRICING_REFERENCE.md`
+- **Visa Info:** `VISA_TYPES_REFERENCE.md`
+
+### KBLI Navigator (Frontend)
+
+| Route             | Description                             |
+| ----------------- | --------------------------------------- |
+| `/kbli`           | KBLI 2025 Navigator homepage (Next.js)  |
+| `/kbli/[code]`    | KBLI code detail page (1,559 SSG pages) |
+| `/kbli-navigator` | **Redirect** → `/kbli` (permanent 301)  |
+| `/kbli-explorer`  | AI chat explorer (complementary)        |
+
+---

--- a/docs/agents/editorial-publishing-protocol.md
+++ b/docs/agents/editorial-publishing-protocol.md
@@ -1,0 +1,22 @@
+# Editorial publishing protocol (News Room + WR2) — external agents
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+> Binding on every external agent seat; `AGENTS.md` §0.0 item 2 (Legge 5) points here.
+
+### Damar editorial publishing protocol (News Room + WR2)
+
+When an authenticated Zero or Damar session explicitly asks to publish a News Room article
+or WR2 carousel, load `.agents/skills/editorial-publishing/SKILL.md` and follow it end to end.
+These editorial decisions are mandatory and may never come from a UI or API default:
+
+- **News Room:** obtain an explicit destination (`Latest`, `Hero Main`, `Hero 2–5`, or
+  `Insight 1–3`) before sending any publish request. For a batch, require a common destination
+  or a complete article-to-position map; reject duplicate Hero/Insight slots.
+- **WR2 carousel:** show the exact caption, obtain approval of that caption, run the
+  `confirm=false` dry-run, and only after it succeeds ask for the final explicit publish act
+  before `confirm=true`. Editing the caption invalidates the dry-run.
+
+Report an opened article PR as **queued**, never published. Report **live** only after opening
+the public URL and verifying the expected title/content. A red artefact gate blocks publication;
+verbal confirmation never overrides it. “Mark as published” only records an external post and
+must never be represented as publishing to Instagram.

--- a/docs/agents/fleet-continuity.md
+++ b/docs/agents/fleet-continuity.md
@@ -1,0 +1,33 @@
+# Fleet, conductor and continuity — ladder, account lanes, spend order
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+> §17.1 (conductor-is-a-role) stays in `AGENTS.md`: it carries the PARABELLUM door line.
+
+Binding roster + corrections: research/operations/2026-08-10-fleet-order-spec.md
+
+**SSOT files:** cloud fleet = `FLEET_TOPOLOGY.json` (repo root) · local Ollama = `MODEL_TOPOLOGY.json` (unchanged) · rationale + four-groups study = `research/operations/2026-08-09-quattro-gruppi-e-continuita.md` · roles roster = FLOTTA-LLM doc referenced there.
+
+**Full model roster × strengths × efforts: `MODEL_ROSTER.md`** — read it before choosing seats (Zero ruling 2026-08-14). Every conductor door (claude/codex/agy/kimi/qwen) reads `AGENTS.md`, so this is the shared denominator.
+
+### 17.2 Continuity ladder — no line ever stops
+
+When a seat hits quota or dies, escalate IN ORDER and log each hop in the task evidence:
+
+1. **Rotate account, same model** (zero quality loss): Anthropic ×4 via OAuth profile swap (cswap-style), OpenAI ×2 via `CODEX_HOME=~/.codex-o2`.
+2. **Substitute model within the role** per `FLEET_TOPOLOGY.json` chain (builder: sonnet→codex→glm · refuter: sol→k3→gemini · grunt: haiku→local…).
+3. **Cross-family fallback**, marked `degraded_execution: true` in the Evidence Pack (the gate sees it).
+4. **Queue, never silent-stop**: chain fully dead → park in PENDING-ARMS with reason + timestamp.
+
+**Carve-outs (special ladders):**
+
+- **Gear-3 harness gate (RULED 2026-08-20, supersedes the 2026-08-09 ruling):** **Opus 5 `effort=xhigh`**, rotating across ALL Anthropic accounts (AZ→A2→A3→A1). No fallback tier below it — Fable is out of the workflow, so there is no `gate_degraded: fable→opus` to record anymore. All Anthropic accounts dead → queue. Never pay per-token to unblock.
+- **WR2 on-disk content gate (RULED 2026-08-20):** **Opus 5 `effort=xhigh`** — was unconditionally Fable; no fallback either way, window dead → SUSPEND.
+- PII lanes = local models only → queue. Client-facing = Anthropic interactive only.
+
+### 17.3 Account-lane mapping (lanes with borrowing, not round-robin)
+
+Lanes are **home assignments, not fences**: each lane drains its home account first, then borrows automatically from the least-loaded other account — nothing sits idle, no line ever stops. Mapping (see `FLEET_TOPOLOGY.json` → `accounts`): **A1** antonellosiano interactive/architect · **A2** kaiser1987… subagents/build+Cowork · **A3** applevisionpro1987 cron/batch, **designated donor** (cron auto-pauses to free its window when the gate calls) · **AZ** zero (Team seat Premium) **gate primary** — the dedicated allowance for the final on-disk gate lives here (Opus 5 xhigh effort, RULED 2026-08-20; was Fable's dedicated weekly allowance) · **O1** antonellosiano (ChatGPT Pro) refuter-primary · **O2** zero (ChatGPT Pro) builders+refuter-backup.
+
+### 17.4 Spend order
+
+Flat subscriptions → Token Plan credits → local. Anything per-token (incl. Google overage credits) requires Zero's explicit GO (CLAUDE.md §5). Note: §15 above is 4.6-era; for 5-family API gotchas (thinking on by default, `max_tokens` covers thinking+answer, no temperature knob, min-cacheable 512, tokenizer ≈+30%) see CLAUDE.md §«5-family» and the fleet research doc.

--- a/docs/agents/language-protocol.md
+++ b/docs/agents/language-protocol.md
@@ -1,0 +1,28 @@
+# Language protocol — worked Italian→engineering examples
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+> `AGENTS.md` keeps the rule; the examples live here.
+
+## 11. Language Protocol (Natural Language → Precise Engineering)
+
+The user writes in **colloquial Italian**. You must automatically translate intent into precise technical action.
+
+**Rules:**
+
+- Never ask "what do you mean?" — infer from codebase context
+- Short/vague prompt → deduce file, pattern, stack from existing code before acting
+- Italian colloquial → English technical internally, respond in Italian
+- If ambiguous between 2 interpretations, pick the most likely one and state your assumption in one line
+
+**Examples:**
+
+| User writes                      | You interpret as                                                                                                  |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| "aggiungi paginazione clienti"   | Cursor-based pagination on `GET /clients`, follow existing router patterns, async SQLAlchemy, add tests           |
+| "fixa il bug del login"          | Search recent auth-related errors in routers/auth, identify root cause, fix with proper error handling            |
+| "rendi più veloce la ricerca"    | Profile the search endpoint, identify bottleneck (N+1, missing index, no cache), fix the actual cause             |
+| "aggiungi un campo alla tabella" | SQL migration in `migrations_v2/` (with ROLLBACK marker) + model update + schema update + router update, in order |
+
+**Never** ask for clarification on standard dev tasks. Explore first, then act.
+
+---

--- a/docs/agents/m5-thin-client-routing.md
+++ b/docs/agents/m5-thin-client-routing.md
@@ -1,0 +1,141 @@
+# Air-M5 thin-client routing map, machine check and git sync
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+> `AGENTS.md` §0 keeps the machine table and the prefix rule. The full session-start
+> check, hard rules R1-R7, the MCP-from-M5 table and the git-sync architecture live here.
+
+## Session-start machine check
+
+**Three machines** exist on the local network (Tailscale tailnet `balizero`). `AGENTS.md` §0
+carries the same table with the per-machine repo path added.
+
+| Machine    | User        | Hostname    | Role                                                           |
+| ---------- | ----------- | ----------- | -------------------------------------------------------------- |
+| **Pro**    | `nuzantara` | `Nuzantara` | Workhorse — dev, DB, Qdrant, Ollama, 224 daemon, deploy (48GB) |
+| **Mini**   | `nuzantara` | `Mini-Pro2` | Server H24 — Ollama dedicato, cron pesanti (24GB)              |
+| **Air-M5** | `balizero`  | `Air-M5`    | **THIN-CLIENT dev** — editing + agenti; pesante → `ssh pro`    |
+
+**At every session start, run this check:**
+
+```bash
+echo "Machine: $(whoami)@$(hostname)" && \
+case "$(hostname)" in Nuzantara) OTHER=mini ;; Mini-Pro2) OTHER=pro ;; Air-M5) OTHER=pro ;; *) OTHER=pro ;; esac && \
+ssh -o ConnectTimeout=3 $OTHER 'echo "Peer: $(whoami)@$(hostname)"' 2>/dev/null || echo "Peer: UNREACHABLE" && \
+LOCAL_HEAD=$(git log --oneline -1 2>/dev/null) && \
+REMOTE_HEAD=$(ssh -o ConnectTimeout=3 $OTHER 'cd ~/nuzantara 2>/dev/null; git log --oneline -1' 2>/dev/null) && \
+if [ "$LOCAL_HEAD" = "$REMOTE_HEAD" ]; then echo "Git sync: OK ($LOCAL_HEAD)"; else echo "Git sync: OUT OF SYNC! Local=$LOCAL_HEAD Remote=$REMOTE_HEAD"; fi
+```
+
+This tells you:
+
+- `whoami=nuzantara`, `hostname=Nuzantara` → you are on **Pro** (workhorse)
+- `hostname=Mini-Pro2` → you are on **Mini** (server)
+- `whoami=balizero`, `hostname=Air-M5` → you are on **Air-M5** (**thin-client** — see §0.1 below, it changes everything)
+- Whether the peer machine is reachable, and whether both repos are on the same commit
+
+**Always prefix your first response with which machine you're on**, e.g. "[Pro]", "[Mini]", or "[Air-M5]".
+
+> ⚠️ **CRITICAL — peer-unreachable is NOT a license to go local.** On Air-M5 the peer is the **Pro**, and `ssh pro` is the _destination_ for all heavy work, not just a git-sync peer. If the session-start git-sync check reports the peer "UNREACHABLE", that means **sync is unverified** — it does **NOT** mean "do the heavy task locally on M5 instead". Heavy work that needs the Pro still routes via `ssh pro`; if `ssh pro` itself fails, **STOP and tell the operator**, do not fall back to a local install. (This was the #1 failure mode in the M5 thin-client audit, 2026-06-02.)
+
+**SSH between machines:** `ssh mini` / `ssh pro` (from any node) — uses Tailscale. From Air-M5: `ssh pro` (alias for `nuzantara@100.107.22.111`).
+See `docs/PRO_AIR_CONNECTION.md` for full details.
+
+---
+
+## 0.1. Air-M5 Thin-Client Routing Map (READ if `hostname=Air-M5`)
+
+**Air-M5 is a THIN-CLIENT.** You edit code, run agents, commit, and do light research **locally** on M5. Everything heavy — inference, vector DB, SQL, rendering, deploy, the 224-daemon fleet — **lives on the Pro** and is reached via `ssh pro` (or `ssh mini`). M5 deliberately does **not** have Ollama, Postgres, Qdrant, `fly`, or the daemon stack.
+
+### HARD RULE R1 — Heavy tools are NEVER installed on M5
+
+Do **NOT** `brew install` / `ollama pull` / compile / `docker run` heavy tooling on M5 — **not even as an "option B" / alternative / fallback.** Route to the Pro.
+
+| Asked to…                                  | ❌ WRONG (FAIL)                  | ✅ CORRECT                                                |
+| ------------------------------------------ | -------------------------------- | --------------------------------------------------------- |
+| use **ffmpeg** (video concat/render)       | `brew install ffmpeg` on M5      | `ssh pro 'bash -lc "ffmpeg …"'` (Pro has the full ffmpeg) |
+| compile C/C++ (**cmake/make**) heavy build | build locally on M5              | `ssh pro` for the build; only trivial builds stay local   |
+| **cloudflared** tunnel                     | install + launchd on M5          | tunnels live on Pro → `ssh pro`                           |
+| **ghostscript** / heavy PDF batch          | `brew install ghostscript` on M5 | `ssh pro` for the processing                              |
+| **Playwright** mass scrape (100s of pages) | run headless chromium on M5      | `ssh pro` (heavy compute)                                 |
+| compile **torch / CUDA / MPS** from source | build on M5                      | `ssh pro`/`ssh mini` (M5 = thin)                          |
+| **docker** containers (>~1GB)              | `docker run` on M5               | `ssh pro`                                                 |
+
+> If a tool is genuinely lightweight (`jq`, `ripgrep`, `eza`, a pip dep in the local `.venv`) installing it on M5 is fine. The line is **heavy compute / persistent services**, which always belong on the Pro.
+
+### HARD RULE R2 — LLM models & Ollama: Pro/Mini only
+
+M5 has **no `ollama`** by design. Never `ollama pull` or `brew install ollama` on M5 — not even a smaller fallback model.
+
+| Asked to…                                                    | ✅ CORRECT                                                           |
+| ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| run/`pull` any model (`deepseek-r1`, `qwen3.5`, `qwen2.5vl`) | `ssh pro 'bash -lc "ollama run <model>"'` (Pro/Mini hold the models) |
+| OCR / vision (`qwen2.5vl`)                                   | `ssh pro` — Ollama binds `127.0.0.1:11434`, **closed** to M5         |
+| embed batch (`bge-m3`)                                       | `ssh pro` / `ssh mini`                                               |
+
+Lightweight **cloud** LLM clients **are** fine on M5 (they're already set up): `agy` (Gemini), `codex`, `kimi` (`~/.kimi-code/bin/kimi`, armed M5+Pro+Mini), `nlm` (NotebookLM). Use them directly. (DeepSeek API RETIRED 2026-07-19 — never route to it; local `deepseek-r1:32b` Ollama weights on Pro/Mini are unrelated and stay.)
+
+### HARD RULE R3 — DB & vector store: exact access per service
+
+The DB and vectors live on the Pro. M5 reaches them — it does **NOT** install or replicate them.
+
+| Service                            | From M5                                      | Command / value                                                                                       |
+| ---------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Qdrant** (local Pro mirror)      | ✅ DIRECT via Tailscale (no tunnel, no auth) | `QDRANT_URL=http://100.107.22.111:6333`                                                               |
+| **Postgres dev** (`nuzantara_dev`) | tunnel (binds `127.0.0.1` on Pro)            | `ssh -L 5432:localhost:5432 pro` → `DATABASE_URL=postgresql://nuzantara@localhost:5432/nuzantara_dev` |
+| **Fly prod PG proxy**              | tunnel (binds `127.0.0.1:15432` on Pro)      | `ssh -L 15432:localhost:15432 pro`                                                                    |
+| **Ollama**                         | ❌ closed to M5                              | `ssh pro 'bash -lc "ollama …"'`                                                                       |
+
+Never `brew install postgres@17` / `docker run qdrant` on M5. Embedding model is **FROZEN** `text-embedding-3-small` (1536 dims, cloud) — do not swap `bge-m3` into the RAG vector path.
+
+### HARD RULE R4 — OSINT / WhatsApp data NEVER leaves the Pro (Symbiosis Law 2)
+
+The WhatsApp/OSINT mirror lives **only** in the Pro's local Postgres. M5 must **NEVER** copy, replicate, or sync it to disk.
+This is a raw-data movement boundary, not a blanket ban on LLMs processing authorized operational context. For every LLM in the system, Law 2 means: do not transcribe or persist client PII/OSINT in cleartext in outputs, memories, skills, logs, reports, alerts, prompts saved for reuse, or shared artifacts. Use IDs, hashes, placeholders, or redaction.
+
+- View it: dashboard `http://100.107.22.111:7790` (open in M5 browser) — read-only.
+- Raw SQL on OSINT: only via the dev tunnel (`ssh -L 5432:localhost:5432 pro`), querying the Pro's DB — never a local copy.
+- "Copy the WhatsApp DB to M5 for offline analysis" → **REFUSE.** (Law 2, non-negotiable.)
+
+### HARD RULE R5 — Deploy is Pro/CI-only; M5 has no `fly`
+
+M5 has **no `fly`/`flyctl`** and **no `~/nuzantara-deploy`** worktree. Never `brew install flyctl` on M5.
+
+- Canonical: commit in a worktree → push → `gh pr create` → green CI + review → **merge to `main`** triggers `.github/workflows/fly-deploy.yml` (gate→migrations→deploy→health→rollback). Vercel frontend auto-deploys on the same `main` push. Machine-independent — M5 needs no `fly`.
+- Manual/out-of-band deploy: **delegate** → `ssh pro 'bash -lc "cd ~/nuzantara-deploy && git pull --ff-only origin main && fly deploy --strategy rolling"'`.
+- `main` is **protected**: PR + CI + review required. Never `git push origin main` directly (from M5 _or_ Pro).
+
+### HARD RULE R6 — Memory (MOS): always via `mem`, never the local file
+
+On M5 the local `~/.claude/memory.db` is a **0-byte decoy**. The real DB is on the Pro.
+
+- Search: `mem query "<term>"` (routes over SSH to the Pro's DB; falls back to grep on local `MEMORY*.md` if the Pro is unreachable — it does **not** silently fabricate).
+- Save: `mem save <type> "<text>" <importance>` (lands in the Pro's DB).
+- Never read the local `memory.db` directly, never write memory to a local `.codex/memories/` note, and **never present recalled context as if you ran a query** (anti-hallucination, CLAUDE.md §6).
+
+### HARD RULE R7 — Heavy render / NB studio / daemon fleet → Pro
+
+- WR2 hero images (FlowKit/Veo), WR3 video episodes, NotebookLM studio audio/video → **`ssh pro`** (the render pipelines and FlowKit live on the Pro). M5 dispatches and pulls results; it does not render locally.
+- The 212 `com.{nuzantara,balizero,cell,matagaruda}.*` LaunchAgents (224 jobs incl. cron, snapshot 2026-07-13 per `docs/AUTOMATIONS_REFERENCE.md`) are **production daemons** — they run on Pro/Mini only. Never load/install them on M5.
+
+### MCP servers from M5
+
+| MCP                                                                | On M5                   | Note                                                                             |
+| ------------------------------------------------------------------ | ----------------------- | -------------------------------------------------------------------------------- |
+| `notebooklm-mcp`, `nuzantara-fetch`, `playwright`, `ocr-tesseract` | ✅ local                | work directly                                                                    |
+| `nuzantara-mcp`, `nuzantara-mcp-advanced`, `github`                | 🔧 light remote clients | need their small venv + env tokens                                               |
+| `postgres-nuzantara`                                               | ➡️ **route via Pro**    | needs Fly proxy `:15432` + Keychain `nuzantara-postgres-readonly`, neither on M5 |
+| `ga4-analytics`                                                    | ⚠️ sovereignty          | uses a **prod** service-account JSON — prefer Pro, or confirm with operator      |
+
+---
+
+### Git Sync Architecture (updated 2026-05-25)
+
+Both machines work on `main` branch only. Sync is **automatic** via husky post-commit hooks:
+
+- **Pro commits** → Mini auto-pulls (`git pull pro main --ff-only`)
+- **Mini commits** → Mini auto-pushes to Pro (`git push pro main`)
+- **GitHub** is updated by Pro only via `git push origin main`
+
+**Never** create an `air` or `mini` branch. **Never** push from Mini to `origin`. Log: `~/.openclaw/logs/git-sync.log`.
+
+---

--- a/docs/agents/mcp-and-deployment.md
+++ b/docs/agents/mcp-and-deployment.md
@@ -1,0 +1,40 @@
+# MCP servers and deployment architecture
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+
+## 6. MCP Servers
+
+**Primary:** `apps/nuzantara-mcp/` (v2.1, FastMCP, stdio transport)
+**Capabilities:**
+
+- **115 Tools** across 24 modules (CRM, portal, intel, content, analytics, knowledge, comms, drive, sheets, workflows, admin, health, google_bridge, journey, pricing, invoicing, compliance, memory, langsmith, legal, prime, federation, naga, heartbeat)
+- **10 Prompts** for guided workflows
+- **5 Resources** for knowledge base access
+- **8 Workflow Chains** for deterministic automation (daily_ops_autopilot, new_client_onboarding, practice_lifecycle_check, intel_pipeline, weekly_report, client_health_monitor, compliance_autopilot, journey_accelerator)
+
+**Additional MCP servers:**
+
+- `apps/nuzantara-mcp-advanced/` — Fly.io ops, deployment readiness, code search, diagnostics
+- `apps/nuzantara-mcp-browser/` — Browser automation
+
+## 7. Deployment Architecture
+
+### Production Stack
+
+- **Frontend:** Vercel (CDN, Edge Functions)
+- **Backend:** Fly.io `nuzantara-rag` (Asia region)
+- **Databases:**
+  - PostgreSQL: Fly.io managed
+  - Qdrant: Fly.io app
+  - Redis: Upstash or Fly.io
+
+### Environment Variables
+
+**Required:**
+
+- `OPENAI_API_KEY` - For embeddings
+- `DATABASE_URL` - PostgreSQL connection
+- `QDRANT_URL`, `QDRANT_API_KEY` - Vector DB
+- `REDIS_URL` - Cache
+- `JWT_SECRET` - Authentication
+- `FLY_API_TOKEN` - Deployment (CI/CD)

--- a/docs/agents/memory-mos.md
+++ b/docs/agents/memory-mos.md
@@ -1,0 +1,16 @@
+# Memory (MOS) — where project knowledge lives, for external agents
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+
+La memoria di progetto (decisioni, scoperte, fatti, lessons) vive come file Markdown qui:
+
+- **Pro**: `~/.claude/projects/-Users-nuzantara-Desktop-nuzantara/memory/*.md` (388+ file)
+- **Air-M5**: `~/.claude/projects/-Users-balizero-Desktop-nuzantara/memory/*.md` (sincronizzati dal Pro via hub-daemon)
+- **Indice**: `MEMORY.md` nella stessa dir — leggi questo PRIMA per orientarti (1 riga per memory).
+
+Per interrogarla:
+
+- Comando `mem query "<termine>"` (FTS5 sul DB `memory.db`). Su **Pro** funziona diretto. Su **Air-M5** `mem` usa SSH-al-Pro per il DB ricco, con fallback grep sui `.md` locali se il Pro è irraggiungibile.
+- In alternativa (sempre disponibile, zero dipendenze): leggi i `.md` direttamente col path sopra, o `grep -rl "<termine>" <memory-dir>/*.md`.
+
+Codex NON carica la memory in automatico (a differenza di Claude che ha i SessionStart hook): leggi `MEMORY.md` + i `.md` rilevanti col path quando ti serve contesto storico del progetto.

--- a/docs/agents/project-overview.md
+++ b/docs/agents/project-overview.md
@@ -1,0 +1,36 @@
+# Project overview, architecture and tech stack
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+
+**Name:** Nuzantara (Zantara)  
+**Version:** 5.2.0  
+**Type:** Production AI-powered business intelligence platform for Bali Zero  
+**URL:** https://kita.balizero.com
+
+### Architecture
+
+**Monorepo structure:**
+
+- `apps/mouth/` - Next.js frontend (Vercel)
+- `apps/backend-rag/` - Python FastAPI RAG backend (Fly.io)
+- `apps/admin-dashboard/` - Admin UI
+- `apps/webapp/` - Web application
+- `apps/bali-intel-scraper/` - Intelligence gathering
+- `apps/nuzantara-mcp/` - MCP server v2.1 (inspect the server for its live capability inventory)
+- `apps/nuzantara-mcp-advanced/` - Advanced MCP (Fly.io ops, diagnostics)
+- `apps/nuzantara-mcp-browser/` - Browser automation MCP
+- `apps/graph-engine/` - Graph processing engine
+- `apps/kbli-voice/` - KBLI voice interface
+- `apps/evaluator/` - Quality assurance
+- `apps/zantara-media/` - Editorial content system
+- `packages/core/` - Core libraries
+
+### Tech Stack
+
+- **Backend:** Python 3.11+, FastAPI. Live counts: `python3 scripts/docs_sync.py --json`
+- **Frontend:** Next.js, TypeScript, Tailwind CSS
+- **Databases:** PostgreSQL (relational), Qdrant (vector), Redis (cache)
+- **Infrastructure:** Fly.io (backend), Vercel (frontend)
+- **Knowledge Graph:** live counts are generated, not stored in this file
+- **Vector Collections:** canonical registry: `backend/core/collection_registry.py`; live counts: `python3 scripts/docs_sync.py --json`
+- **Embedding Model:** `text-embedding-3-small` (1536 dims) — **NEVER CHANGE**

--- a/docs/agents/worktree-discipline.md
+++ b/docs/agents/worktree-discipline.md
@@ -1,0 +1,55 @@
+# Agent worktree discipline — full detail (L5.1, 2026-05-25)
+
+> Moved out of `AGENTS.md` on 2026-09-10 (boot diet). Substance unchanged.
+> `AGENTS.md` §0.5 keeps the mandatory rule, the broker command and the kill switch.
+
+**MANDATORY for any Codex session that mutates code in this repo.**
+
+This repo is shared with 5+ Claude sessions + occasional Gemini agy on the same Pro machine. All processes default to `cwd=/Users/nuzantara/nuzantara` (main checkout). Concurrent file mutations have produced 32+ sibling-orphan stash in 24h. To prevent:
+
+### Before any mutation
+
+```bash
+# Create dedicated worktree
+python scripts/agent_start.py --lane <wr2|infra|backend-rag|ops|...> --task-id <slug>
+# Output: WORKTREE_READY /Users/nuzantara/nuzantara/.worktrees/<lane>-<task-id>
+cd <output-path>
+# Now spawn codex exec HERE, not in main checkout
+```
+
+### For codex exec invocations
+
+`codex exec` inherits cwd from spawner. Wrong pattern:
+
+```bash
+# Wrong (creates orphan in main):
+codex exec --sandbox workspace-write "fix bug X"
+```
+
+Right pattern:
+
+```bash
+WT=$(python scripts/agent_start.py --lane infra --task-id codex-bug-x | tail -1)
+cd "$WT" && codex exec --sandbox workspace-write "fix bug X"
+```
+
+### Hooks active
+
+PreToolUse hook `~/.claude/hooks/worktree_isolation.py` blocks Claude Code Bash git ops in main checkout. `~/.claude/hooks/worktree_file_write_check.py` blocks Claude Code Edit|Write|MultiEdit in main. These hooks are CLAUDE-SIDE only — Codex CLI runs in its own sandbox and is NOT subject to them. **Discipline relies on Codex authors following this convention manually.**
+
+### Kill switch
+
+```bash
+export AGENT_WORKTREE_ENFORCEMENT=false
+```
+
+Use only for emergency / hotfix / cicatrix-fix.
+
+### Reference
+
+- L1 broker: `docs/runbooks/agent-worktree-broker.md`
+- L2 lease: `docs/runbooks/redis-lease-registry.md`
+- L5.1 spec: `research/operations/specs/L5.1-agent-worktree-enforcement-2026-05-25.md`
+- Panel synthesis: `research/operations/specs/L5.1-panel-synthesis-2026-05-25.md`
+
+---

--- a/evidence/brief.yml
+++ b/evidence/brief.yml
@@ -1,108 +1,100 @@
-task_id: vercel-prod-live-diff
+task_id: agents-md-index-diet
 gear: 2
 l_level: L2
 gate_class: opus
 # Floor computed for this diff: `python3 scripts/evidence_pack_lint.py --print-floor
-# --changed-files-file ... --numstat-file ...` returns 2 via the SIZE term alone — 4
-# changed files (apps/mouth/vercel.json, scripts/ci/vercel_ignore_build_step.sh,
-# scripts/ci/vercel_should_build.sh, scripts/tests/test_vercel_should_build.sh),
-# +322/-98 (net 224 lines). No hot-zone path (`--print-floor` without --numstat-file
-# returns 1). Gear 2 declared to match the floor exactly; no pack is required below
-# Gear 3.
+# --changed-files-file ... --numstat-file ...` returns 2, source `size`. 15 changed
+# files (AGENTS.md + 14 new docs/agents/*.md), +889/-738 — churn 1,627, over the
+# SIZE_GEAR2_THRESHOLD of 400 and under the SIZE_GEAR3_THRESHOLD of 1,828. No
+# hot-zone path: `--print-floor` without --numstat-file returns 1, source `none`.
+# Gear 2 is declared to match the floor exactly; no pack is required below Gear 3.
+# The churn is almost entirely MOVES — 738 of the 738 deletions are AGENTS.md
+# sections re-created verbatim under docs/agents/ — so net is +148 lines, well under
+# the 400-line PR ceiling. The PARABELLUM Dux additionally commissions an independent
+# Opus 5 gate outside this contribution chain; that review is arranged out-of-band and
+# is not declared here as Gear 3, which would require a full Evidence Pack this
+# mandate did not scope.
 objective: >-
-  Change the Vercel Ignored Build Step for the `mouth` project so a PRODUCTION
-  deployment skips when `git diff <live> HEAD` touches no bundle path (apps/mouth/**,
-  packages/**, root package.json/package-lock.json, vercel.json), where `live` is the
-  commit production is actually serving right now, read from
-  https://kita.balizero.com/api/health's `.commit` field — the same probe the Frontend
-  Live Sentinel and mini.vercel_autopromote already trust. Preview deployments keep the
-  existing merge-base rule untouched. The Ignored Build Step pointer moves out of the
-  Vercel dashboard field and into apps/mouth/vercel.json as `ignoreCommand`, with the
-  dashboard field kept only as a fallback. Measured on main: 301 commits in the last 7
-  days, 79 of which touch a bundle path — so production builds are expected to drop
-  from roughly 35/day to roughly 11/day, ~1,000 build-minutes/week, ~$60/month at
-  $0.014/build-minute.
+  Turn AGENTS.md — the door every external agent boots on (Codex CLI, Kimi, agy) — from
+  a 45,724-byte / 880-line manual into an 18,101-byte / 237-line index, mirroring the
+  CLAUDE.md diet of 2026-09-04. Keep in the door: the CANON:builder-contract block
+  byte-identical, the §0.0 external-agent contract with the PARABELLUM narrowing,
+  machine identification with a per-machine repo-path column, §0.5 worktree discipline,
+  §17.1 conductor-is-a-role including the door line #6076 added, the language and
+  owner-privacy rules, and one line each for anti-hallucination, PII and secrets. Move
+  fourteen sections verbatim into docs/agents/, one file per former section, each
+  replaced by a single index line under "INDICE — dove sta cosa". PARABELLUM lane 3,
+  staff room §4 item 6, astra-r1.md §A "Boot diet".
 constraints:
   - >-
-    Fail OPEN everywhere a signal is missing or ambiguous: probe unreachable, no
-    `.commit` field in the health response, live sha unknown or not fetchable, or
-    live == HEAD all resolve to BUILD. The only unacceptable failure mode is a SKIP
-    when a BUILD was actually needed — a false BUILD only costs build-minutes, a
-    false SKIP ships nothing.
+    The block between the <!-- CANON:builder-contract --> markers is compared BY MACHINE
+    across CLAUDE.md, AGENTS.md, GEMINI.md and QWEN.md by
+    scripts/proprioception.py's door_canon_parity probe. Not one character may change.
+    It is spliced from the original by byte range, never retyped.
   - >-
-    The script exits only 0 (BUILD) or 1 (SKIP) — any other exit code is a Vercel
-    deployment ERROR, not a third outcome, and must not happen by construction.
+    MOVE, never delete. Every section that leaves AGENTS.md is re-created verbatim under
+    docs/agents/ with a header stating it moved on 2026-09-10 and that its substance is
+    unchanged. Every RULED/RULING block keeps its substance wherever it lands.
   - >-
-    Never log a fetch URL or raw git stderr — either may carry credentials (e.g. a
-    token embedded in a private remote URL) and Vercel build logs are not a secrets
-    boundary.
+    The boot numbers are MEASURED on both ends from the Codex context bridge's own state
+    file, never estimated from byte counts. A byte-count-derived saving would have
+    hidden the truncation this PR found.
   - >-
-    No production environment variable is touched, no manual deploy, no
-    `vercel --prod` — this PR only changes the Ignored Build Step's own decision
-    script and its wiring in apps/mouth/vercel.json.
-  - >-
-    The comparison base is deliberately NOT `VERCEL_GIT_PREVIOUS_SHA` — that is the
-    previous DEPLOYMENT ATTEMPT, not the previous deployment that actually shipped,
-    and strands superseded frontend commits under a skipped-build streak (the
-    2026-08-15..18 freeze, #4309, was caused by exactly this). It is also
-    deliberately NOT `HEAD^` — the merge queue pushes batches of up to 4 squash
-    commits at once and Vercel deploys the tip, so `HEAD^..HEAD` can hide a
-    frontend-touching commit earlier in the same batch.
+    Lane 2 (harness) is in flight on infra/ — this PR touches no file under infra/.
 acceptance:
   - text: >-
-      A1: WHEN scripts/tests/test_vercel_should_build.sh runs on macOS and on
-      ubuntu-24.04 SHALL pass 48/48.
-    probe: scripts/tests/test_vercel_should_build.sh
+      A1: WHEN `python3 scripts/proprioception.py --probe door_canon_parity --json` runs
+      on this branch SHALL report RECONCILED with 0 diverged, proving the canon block is
+      still byte-identical across all four doors.
+    probe: python3 scripts/proprioception.py --probe door_canon_parity --json
   - text: >-
-      A2: WHERE the corpus header's mutation-kill census is read SHALL show every
-      mutation killed — always-build (4), base=VERCEL_GIT_PREVIOUS_SHA (4),
-      base=HEAD^ (8), probe-failure-treated-as-SKIP (4), positional-grep-extraction
-      (1) — with none surviving.
-    probe: scripts/tests/test_vercel_should_build.sh
+      A2: WHEN the 487 substantive lines of the old AGENTS.md are each searched for in
+      the new AGENTS.md plus docs/agents/ SHALL find all but 12, and those 12 SHALL be
+      only section headings promoted to file titles, the two machine-table intro
+      sentences, the two owner-privacy lines (both rewritten into the compressed
+      sections) and the stale "Last Updated" footer replaced by a `git log -1` pointer.
+    probe: normalised line-by-line coverage check over `git show 781c9c9b59:AGENTS.md`
   - text: >-
-      A3: WHEN scripts/ci/vercel_should_build.sh dry-runs against the real probe on
-      origin/main SHALL emit SKIP for the 14 docs-only commits after live commit
-      882ac94, and SHALL emit BUILD when re-run from an older, bundle-touching
-      frontend commit.
-    probe: scripts/ci/vercel_should_build.sh
+      A3: WHEN `python3 scripts/docs_sync.py` runs SHALL print "DOCSYNC OK (no changes)"
+      — AGENTS.md is not a DOCSYNC-counted surface (scripts/docs_sync.py lines 39-56).
+    probe: python3 scripts/docs_sync.py
   - text: >-
-      A4 Bites: WHEN this PR merges and the first docs-only commit lands on main
-      SHALL appear in `GET /v6/deployments?target=production` as CANCELED with
-      "should-build: production: comparing HEAD against live ... -> SKIP" in its
-      build log, WHILE kita.balizero.com/api/health keeps serving the newest
-      bundle-relevant commit AND the Frontend Live Sentinel stays green.
+      A4 Bites: WHEN a Codex session boots in this repo SHALL consume 41,882 of its
+      258,400-token window against 45,886 on the base commit, read as the first-turn
+      `used` from ~/.codex/state/nuzantara-context/<sid>.json, AND its transcript SHALL
+      contain the PARABELLUM door line that the base commit's boot did not.
     probe: >-
-      curl https://kita.balizero.com/api/health ; vercel deployments list --target
-      production
+      echo "reply pong" | CODEX_CONTEXT_ROLE=builder codex exec -s read-only
+      --skip-git-repo-check -m gpt-5.6-terra - ; then read the bridge state for that sid
 assumptions:
   - text: >-
-      kita.balizero.com/api/health exposes the live commit as a JSON `.commit`
-      field.
+      The old AGENTS.md was silently truncated at Codex's 32 KB project-doc cap, so
+      13,003 bytes — lines 673-880, including all of §17 and the PARABELLUM door line
+      merged the same day in #6076 — never reached the model.
     status: verified
     probe: >-
-      curl -s https://kita.balizero.com/api/health -> verified 2026-09-10:
-      {"status":"ok","commit":"882ac94..."}
+      replay of the before-boot transcript (sid 01a08802) — its copy of AGENTS.md stops
+      at byte ~32,721, line 672 of 880; the after-boot transcript (sid 01a0880a)
+      contains the door line
   - text: >-
-      GitHub will serve any reachable commit sha to a shallow fetch, including one
-      not on the default branch tip.
+      `project_doc_max_bytes` is unset on M5, so Codex's 32 KB default applies.
     status: verified
-    probe: git fetch --depth=1 origin <live-sha> against this repo, exit 0
+    probe: grep -n "project_doc" ~/.codex/config.toml -> no match, exit 1
   - text: >-
-      mini.vercel_autopromote promotes a READY build to production within ~2
-      minutes of it finishing.
+      The same 32 KB cap applies on Pro and Mini, so the truncation was fleet-wide and
+      not an M5-only artefact.
     status: unverified
     probe: >-
-      observe a production promotion timestamp minus its build-finished timestamp
-      over the next 5 promotions; a dead organ degrades to build-every-commit
-      (fail-open), never to a stale site, so this assumption bounds cost, not
-      correctness.
+      run the same boot on Pro and Mini and replay their transcripts; parked as a
+      PENDING-ARMS row, it bounds how widely the finding generalises, not whether this
+      diet is correct
   - text: >-
-      Adversarial review (Claude Sonnet, spalla-review) found no blocking issue;
-      three suggestions were applied — JSON-parser extraction of the live commit
-      (node/python3/grep fallback chain), a `timeout` wrapper on both production
-      fetches, and a corpus parity check between FRONTEND_RE, BUNDLE_PATHS and the
-      Frontend Live Sentinel's own paths.
+      The <=10% acceptance target cannot be reached by this concern alone — AGENTS.md is
+      now roughly 4.5k of a 41.9k boot, and the remainder is ~/.codex/AGENTS.md
+      (18,642 bytes), the skills catalog and the base tool definitions.
     status: verified
-    probe: scripts/tests/test_vercel_should_build.sh
+    probe: >-
+      measured boot 41,882/258,400 = 16.21% after the diet; the global door and the
+      skills catalog are a separate PR by the mandate
 appetite:
   wall_clock_hours: 2


### PR DESCRIPTION
## What

`AGENTS.md` — the door every external agent boots on (Codex CLI, Kimi, agy) — becomes an
**index**, mirroring the `CLAUDE.md` diet of 2026-09-04. PARABELLUM lane 3, staff room §4
item 6, `astra-r1.md` §A "Boot diet".

**Kept in the door, verbatim where the mandate says verbatim:** the `<!-- CANON:builder-contract -->`
block (byte-identical — `door_canon_parity` stays RECONCILED), §0.0 external-agent contract with
the PARABELLUM narrowing, machine identification with a per-machine repo-path column, §0.5
worktree discipline, §17.1 conductor-is-a-role **including the door line #6076 added**, the
language/owner-privacy rules, and one line each for anti-hallucination, PII and secrets.

**Moved, not deleted:** fourteen sections into `docs/agents/`, one file per former section, each
carrying a "moved on 2026-09-10, substance unchanged" header. `AGENTS.md` replaces each with one
`- <file> ← <what it holds>` line under "INDICE — dove sta cosa".

A line-by-line coverage check over the 487 substantive lines of the old file finds 12 absent.
All 12 are section headings promoted to file titles, the two machine-table intro sentences
rewritten into the compressed §0, the two owner-privacy lines rewritten into the compressed
language section, or the stale `**Last Updated:** 2026-08-10` footer, replaced by a
`git log -1 --format=%cd -- AGENTS.md` pointer exactly as `CLAUDE.md` does.

## Why — and the finding that makes it more than a diet

The old file was **silently truncated at 32,768 bytes**. Replaying the before-boot transcript
shows its copy of `AGENTS.md` stops at byte **32,768 exactly** — line 676 of 880, mid-§11 and
mid-UTF-8-sequence. Lines 677-880, **12,957 bytes, 28% of the file**, never reached the model.
(Corrected by the independent gate on 099374d032: my first pass reported ~32,721 / line 672 /
13,003 bytes, approximated from a line-level probe rather than measured. Those three figures
are wrong; these are the byte-exact ones.)

That dropped region held §15, §16 and the whole of §17, **including §17.1 conductor-is-a-role and
the PARABELLUM door line merged the same day in #6076**. The door line existed in the file and was
armed in no Codex context: cicatrix family **#2, Esiste ≠ Armato**. No truncation marker is
emitted, so nothing surfaced it. The after-boot transcript contains the door line.

## Numbers

| | `AGENTS.md` bytes | lines | Codex boot `used` | of 258,400 window |
|---|---|---|---|---|
| before (`781c9c9b59`, main checkout) | 45,724 | 880 | 45,886 | 17.76% |
| after (this branch, worktree) | 18,101 | 237 | 41,882 | 16.21% |

Method: `echo "reply pong" \| CODEX_CONTEXT_ROLE=builder codex exec -s read-only --skip-git-repo-check -m gpt-5.6-terra -`,
then the first-turn `used`/`window` from `~/.codex/state/nuzantara-context/<sid>.json`.
Sessions `01a08802-7d5e-71e3-a1f2-eaf16560d4fc` (before) and
`01a0880a-309a-7202-be5d-8da9a88693be` (after).

**The ≤10% acceptance target is NOT reached, and cannot be reached by this concern alone.**
Both boot transcripts were replayed to measure what actually fills the window, rather than
inferring it from file sizes:

| Boot block | before (chars / ~tok) | after (chars / ~tok) |
|---|---|---|
| `AGENTS.md` instructions (global **+** repo, one block) | 50,893 / ~12,723 | 36,512 / ~9,128 |
| memory-folder guidance | 16,769 / ~4,192 | unchanged |
| `<skills_instructions>` | 22,248 / ~5,562 | unchanged |
| recommended plugins, apps, team preamble, bridge note | ~7,000 / ~1,800 | unchanged |
| tool definitions + harness prompt | remainder | remainder |

The single instructions block holds **both** doors concatenated. Before: 18,642 B of
`~/.codex/AGENTS.md` plus the 32,768 B of a repo file the cap had already cut. After: the same
18,642 B plus this file's 18,101 B. **`~/.codex/AGENTS.md` is now 51% of the remaining door
cost** and is the next lever, alongside the memory-folder guidance (~4.2k) and the skills
instructions (~5.6k). `project_doc_max_bytes` is unset in `~/.codex/config.toml`, and the
32,768-byte boundary is **measured, not documented** — the official Codex config reference
states no default for it. Two profile files on M5,
`~/.codex/nuzantara-core.config.toml` and `~/.codex/nuzantara-research.config.toml`, do set it
to 65,536, each with the comment "Raise project_doc_max_bytes as a stopgap while AGENTS.md is
still large" — but neither was ever in force, because `~/.codex/config.toml` carries no
`[profiles]` block. The stopgap for this exact problem existed on disk and was never armed
either. All three are a **separate PR**, per the mandate.

## Also on Astra's target

Astra asked ≤6 KB. The honest floor is higher: the three blocks the mandate keeps verbatim —
canon (4,706 B), §0.0 (2,979 B), §17.1 (2,963 B) — are 10,648 B on their own. The remaining
7,453 B is the compressed machine/worktree/language sections and the INDICE. Reaching 6 KB means
relaxing one of the three KEEP items, which is a doctrine decision, not a formatting one.

## Size

+889 / −738, **net +148 lines** — under the 400 ceiling despite moving ~700 lines, because the
moves cancel. `evidence_pack_lint.py --print-floor` returns 1 with source `none`: `AGENTS.md` is
not in a machine-enforced hot zone. The Dux declared it one by judgment, so this PR is treated as
Gear-3 floor and an independent Opus 5 gate outside the contribution chain is commissioned
separately.

## Checks run locally

- `python3 scripts/proprioception.py --probe door_canon_parity --json` → **RECONCILED**, 0 diverged, before and after the commit.
- `python3 scripts/docs_sync.py` → **DOCSYNC OK (no changes)**. `AGENTS.md` is not a DOCSYNC surface (`scripts/docs_sync.py` lines 39-56).
- Husky pre-commit: prettier, secret scan, off-limits guard, Python lint → all passed. Prettier reformatted 6 of the moved files (table padding, `*em*`→`_em_`); the coverage check above normalises those and still finds zero substantive loss.
- Husky pre-push → passed.
- No repo link-checker workflow exists for `docs/`; `pr-size-taxonomy.yml` is advisory-only by its own header, and `token-lint.yml` is scoped to `apps/mouth`.

## Siblings

`gh pr list --state open --search "AGENTS.md"` returned only #6079 (doctrine follow-up) and #5819
(draft), neither touching `AGENTS.md`. No open PR changes this file or `docs/agents/`. Lane 2
(harness, `infra/`) is untouched here.

## PENDING-ARMS — leftovers this PR does not close

| Item | Why parked |
|---|---|
| Boot ≤10% of window | Needs the global `~/.codex/AGENTS.md` (18,642 B) and the skills catalog, both outside this concern. Separate PR. |
| `project_doc_max_bytes` | Unset in `~/.codex/config.toml`; the 32,768-byte cut is measured, not a documented default. Two profile files set 65,536 but are inert — no `[profiles]` block loads them. Wiring them, or a lint that fails when a door exceeds the measured cap, is its own change. Parity across Pro/Mini not measured here. |
| Same diet for `GEMINI.md` / `QWEN.md` | Both carry the canon block; their own sizes were not measured in this lane. |

## Correction after the first CI run — the floor is 2, and the brief now says so

`Harness floor recompute` went red on the first run and **the red lives in this diff**, so it is
cured here rather than in a follow-up: the check demands an `evidence/brief.yml` declaring
`gear >= floor`, and only a commit on this branch can supply one for this branch's own diff.
Auto-merge was never disarmed.

The size term of `compute_floor()` reads **churn**, `sum(added + deleted)`, not add-minus-delete.
This PR is 889 + 738 = **1,627 churn** — over `SIZE_GEAR2_THRESHOLD` (400), under
`SIZE_GEAR3_THRESHOLD` (1,828). Floor **2**, source `size`.

The "Size" section above reported floor 1 because the pre-push check passed `--net-lines 148`
instead of `--numstat-file`. Those are different inputs: `--net-lines` feeds `compute_ceiling()`'s
"is this diff small" question, while the size term only ever reads the numstat blob. Rerun with
`--numstat-file` it returns `2` / `size`, matching CI exactly. Treat that earlier line as the
measurement error it was — the net-line figure (+148) and the ceiling conclusion are unaffected.

`evidence/brief.yml` now declares **gear 2**, matching the floor, following the precedent of the
`vercel-prod-live-diff` brief this file inherited: a size-term-only floor takes no Evidence Pack
below Gear 3. The independent Opus 5 gate the PARABELLUM Dux commissions for this lane is
arranged out-of-band and is deliberately **not** declared here as Gear 3, which would additionally
require a full pack this mandate did not scope. If the Dux wants the gate to be merge-blocking,
that is a one-line change to `gear:` plus a pack, and their call.

Bites: the CONSUMER is the next Codex session that boots in this repo, and the observation is its
first-turn `used` read from `~/.codex/state/nuzantara-context/<sid>.json` — 45,886 on
`781c9c9b59` against 41,882 on this branch, both taken with the command above, plus the
before/after transcripts showing the PARABELLUM door line absent then present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PbxbVJmdaaEnWEPCrsHQv



