### PR TITLE
chore(regulatory): daily delta 2026-09-10 — no new regs

### DIFF
--- a/research/regulatory/2026-09-10-delta.json
+++ b/research/regulatory/2026-09-10-delta.json
@@ -1,0 +1,121 @@
+{
+  "run_at": "2026-09-10T07:05:01+08:00",
+  "today": "2026-09-10",
+  "yesterday_seen_count": 24,
+  "yesterday_file_used": "2026-09-09-delta.json",
+  "new_today_count": 0,
+  "partial": true,
+  "unreachable_sources": [
+    {
+      "url": "https://www.hukumonline.com/berita/",
+      "reason": "http_403",
+      "note": "Cloudflare challenge (HTTP 403), persisted after 1 retry with Mozilla UA"
+    },
+    {
+      "url": "https://ortax.org/news",
+      "reason": "empty_shell",
+      "note": "HTTP 200 but body is soft-404 \"Artikel tidak ditemukan\""
+    },
+    {
+      "url": "https://muc.co.id/article",
+      "reason": "http_403",
+      "note": "HTTP 403, persisted after 1 retry with Mozilla UA"
+    },
+    {
+      "url": "https://ikpi.or.id/articles",
+      "reason": "empty_shell",
+      "note": "HTTP 200 Nuxt SPA shell, \"Menampilkan 0 berita & artikel / Memuat artikel perpajakan...\", zero static entries rendered"
+    },
+    {
+      "url": "https://peraturan.go.id/rss",
+      "reason": "http_404",
+      "note": "RSS endpoint not found"
+    },
+    {
+      "url": "https://jdih.kemenkeu.go.id/peraturan",
+      "reason": "timeout",
+      "note": "connection failed (curl exit 1, HTTP 000), persisted after 1 retry"
+    }
+  ],
+  "sources_checked_no_delta": [
+    {
+      "url": "https://news.ddtc.co.id/",
+      "reason": "checked_no_new",
+      "note": "All Sep 2026 entries reference PMK 55/2026 (already in seen_citations); no new verbatim citation"
+    },
+    {
+      "url": "https://peraturan.go.id",
+      "reason": "outside_window",
+      "note": "Newest entries Permenkeu 66/2026, Permenkop 5/2026, Permen PMI 9/2026, Permenaker 12/2026 (all already seen); dated 24-31 Aug 2026, predate 48h window"
+    },
+    {
+      "url": "https://peraturan.bpk.go.id/Search?type=PerundangUndangan&jenis=PMK&tahun=2026",
+      "reason": "outside_window",
+      "note": "Newest entries PP 31/PP 30/PP 27/PP 24/PP 23/2026 and UU 5/UU 4/UU 3/UU 1/2026, all dated 1-4 months ago (\"berlaku mulai sebulan/2-4 bulan yang lalu\"); predate 48h window"
+    },
+    {
+      "url": "https://www.imigrasi.go.id",
+      "reason": "checked_no_new",
+      "note": "Siaran Pers dated 1 and 9 Sep 2026 are enforcement/operational news (WNA detensi, patroli pengawasan), not new regulations; no Permenimigrasi/Permenkumham citation found"
+    },
+    {
+      "url": "https://www.pajak.go.id/peraturan",
+      "reason": "outside_window",
+      "note": "Newest entry KEP-185/PJ/2026 (bencana alam NTT tax admin policy) dated 2026-09-02, predates 48h window"
+    },
+    {
+      "url": "https://jdih.kemnaker.go.id/peraturan",
+      "reason": "checked_no_new",
+      "note": "Listing/filter menu only, no dated Permenaker entry newer than already-seen items rendered"
+    }
+  ],
+  "nb_query_errors": [
+    {
+      "nb": "NB-INTEL-Regulation — Daily Regulatory Intelligence",
+      "reason": "auth_expired",
+      "note": "nlm auth expired (needs manual nlm login), confirmed live via nlm notebook list"
+    },
+    {
+      "nb": "NB-INTEL-Press — Daily Press Intelligence",
+      "reason": "auth_expired",
+      "note": "nlm auth expired (needs manual nlm login)"
+    },
+    {
+      "nb": "NB-INTEL-Immigration — Daily Immigration Intelligence",
+      "reason": "auth_expired",
+      "note": "nlm auth expired (needs manual nlm login)"
+    },
+    {
+      "nb": "NB-INTEL-Tax — Daily Tax/Fiscal Intelligence",
+      "reason": "auth_expired",
+      "note": "nlm auth expired (needs manual nlm login)"
+    }
+  ],
+  "deltas": [],
+  "seen_citations": [
+    "PMK Nomor 28 Tahun 2026",
+    "PMK Nomor 40 Tahun 2026",
+    "PMK Nomor 41 Tahun 2026",
+    "PMK Nomor 42 Tahun 2026",
+    "PMK Nomor 43 Tahun 2026",
+    "PMK Nomor 44 Tahun 2026",
+    "PMK Nomor 55 Tahun 2026",
+    "PMK Nomor 57 Tahun 2026",
+    "PMK Nomor 61 Tahun 2026",
+    "PP Nomor 20 Tahun 2026",
+    "PP Nomor 24 Tahun 2026",
+    "Peraturan Direktur Jenderal Pajak Nomor PER-8/PJ/2026",
+    "Peraturan Menteri Hukum Nomor 13 Tahun 2026",
+    "Permen PMK/Badan PMI Nomor 5 Tahun 2026",
+    "Permenaker No. 12 Tahun 2026; BN 2026 (598)",
+    "Permenaker Nomor 7 Tahun 2026",
+    "Permenaker Nomor 8 Tahun 2026",
+    "Permenaker Nomor 9 Tahun 2026",
+    "Permenkes Nomor 6 Tahun 2026",
+    "Perpres Nomor 26 Tahun 2026",
+    "Perpres Nomor 27 Tahun 2026",
+    "Perpres Nomor 3 Tahun 2026",
+    "UU Nomor 4 Tahun 2026",
+    "UU Nomor 5 Tahun 2026"
+  ]
+}


### PR DESCRIPTION
Daily regulatory-watcher run for 2026-09-10 WITA, executed inline (one-shot print-mode, no backgrounding per incident 2026-07-05).

**Summary**: `new_today_count: 0` — no new regulations affecting Bali Zero service lines detected in the 48h window (2026-09-08 → 2026-09-10). No Telegram alert sent (per spec: no ping on zero count).

**Step 2 (NB-INTEL)**: all 4 NBs failed with `auth_expired` (confirmed live via `nlm notebook list`) — consistent with the account-wide auth expiry tracked since 2026-09-06. `partial: true` set per spec's "All NBs fail" failure mode.

**Step 3 (web cross-check)**: primary sources — hukumonline 403 (Cloudflare, persisted after retry), ortax.org empty_shell (soft-404), muc.co.id 403 (persisted after retry), ikpi.or.id/articles empty_shell (Nuxt SPA, 0 rendered items — same defect as 2026-09-07, still unresolved on their end). ddtc.co.id readable, but all Sep 2026 articles reference PMK 55/2026 (already in `seen_citations`).

Fell through to backup gov sources (primary yielded <3 deltas): peraturan.go.id (newest entries outside 48h window, already seen), peraturan.bpk.go.id (newest PP/UU entries 1-4 months old), imigrasi.go.id (only enforcement/operational press releases, no new regulation), pajak.go.id (KEP-185/PJ/2026 dated 2026-09-02, outside window), jdih.kemenkeu.go.id (connection timeout, persisted after retry), jdih.kemnaker.go.id (menu/filter only, no new dated Permenaker).

`seen_citations` carried forward unchanged (24 items) from 2026-09-09.

🤖 Generated with [Claude Code](https://claude.com/claude-code)