### PR TITLE
fix(hooks): one mission deadline, a binding that admits when it is guessing, and the parent's ToolSearch hole

### DIFF
--- a/infra/claude-hooks/context_window_guard.py
+++ b/infra/claude-hooks/context_window_guard.py
@@ -66,6 +66,10 @@ ALLOW-LIST once at/above threshold (the only things a hand-off needs):
   - a Write/Edit whose `file_path` IS this session's own handoff file (so a
     session that wants to enrich the handoff by hand still can)
   - `SendMessage`, `TaskStop` (delegate to a peer / end the turn cleanly)
+  - `ToolSearch`, but ONLY for a query naming one of those two: in a harness
+    that defers tool schemas they are names with no parameters until their
+    definition is fetched, so denying the fetch denied the hand-off this guard
+    is telling the session to make. An unrelated search stays denied.
 Everything else — including a bare `Bash`/`Write`/`Edit`/`Agent` that is not
 one of the above — is DENIED (exit 2), in Italian, naming the exact percent,
 threshold, handoff path, the evidence for the window it computed, and the
@@ -129,7 +133,8 @@ ROLE_THRESHOLDS = {"imperator": 0.20}
 HANDOFF_RATE_LIMIT_S = 600
 TAIL_BYTES = 400_000  # same tail size context_hygiene.py's own estimator reads
 
-ALLOWED_TOOLS_UNCONDITIONAL = {"SendMessage", "TaskStop"}
+REPORTING_TOOLS = ("SendMessage", "TaskStop")
+ALLOWED_TOOLS_UNCONDITIONAL = set(REPORTING_TOOLS)
 
 ASSISTANT_TYPE_RE = re.compile(r'"type"\s*:\s*"assistant"')
 
@@ -691,9 +696,29 @@ def _write_handoff(payload: dict, mandate: str = ""):
     return None
 
 
+def _reporting_search(tool_input: dict) -> bool:
+    """Let a capped session reach the schema of the tools it is told to use.
+
+    The parent had the same hole the child adapter had: `SendMessage` and
+    `TaskStop` were exempt, `ToolSearch` was not, and in a harness that defers
+    tool schemas a deferred `SendMessage` is a NAME with no parameters until
+    `ToolSearch` fetches its definition. So the deny message named the hand-off
+    route and blocked the one call that reaches it. Narrowed by the query: only
+    a search naming one of the two passes. When there is no readable query --
+    a payload shape this guard does not own -- `ToolSearch` is allowed as a
+    whole rather than trapping the session; every other tool stays denied.
+    """
+    query = tool_input.get("query")
+    if not isinstance(query, str) or not query.strip():
+        return True
+    return any(name.lower() in query.lower() for name in REPORTING_TOOLS)
+
+
 def _is_allowed_call(tool_name: str, tool_input: dict, handoff_path: Path) -> bool:
     if tool_name in ALLOWED_TOOLS_UNCONDITIONAL:
         return True
+    if tool_name == "ToolSearch":
+        return _reporting_search(tool_input)
     if tool_name == "Bash":
         return "mem save" in (tool_input.get("command") or "")
     if tool_name in ("Write", "Edit"):

--- a/infra/claude-hooks/test_context_window_guard.py
+++ b/infra/claude-hooks/test_context_window_guard.py
@@ -422,3 +422,19 @@ def _run_all():
 
 if __name__ == "__main__":
     _run_all()
+
+
+def test_above_threshold_allows_toolsearch_only_for_the_handoff_tools():
+    """The parent's copy of the defect the child adapter fixed in PR #6077.
+
+    A capped session is told to hand off with SendMessage. Under a deferred
+    tool schema that call is unreachable until ToolSearch loads it, so the
+    guard was naming a route it had just closed.
+    """
+    for query in ("select:SendMessage", "+taskstop handoff"):
+        rc, _, err, _ = run_gate("ToolSearch", {"query": query}, tokens=150_000)
+        assert rc == 0, f"{query!r} must reach the handoff schema, got rc={rc} err={err!r}"
+    rc_none, _, _, _ = run_gate("ToolSearch", {}, tokens=150_000)
+    assert rc_none == 0, "no readable query must not trap the session"
+    rc_other, _, _, _ = run_gate("ToolSearch", {"query": "select:Bash"}, tokens=150_000)
+    assert rc_other == 2, "an unrelated search is not a handoff and stays denied"

--- a/infra/codex-hooks/README.md
+++ b/infra/codex-hooks/README.md
@@ -10,7 +10,11 @@ CLI for fresh continuations. It does not modify the Claude/Fable hook files.
   PostCompact, Stop, SubagentStart, SubagentStop. Existing hook definitions and their ordering are retained.
 - Context usage is `last_token_usage.total_tokens / model_context_window` from
   the current Codex rollout, never cumulative lifetime tokens or a guessed 1M
-  window. The policy is 20% for imperator and 40% for other roles. The role is
+  window. Thresholds come from the policy file, one validated lookup for the
+  parent seat and the native child alike; `install.py` seeds 60% for imperator,
+  builder and dux, and an undeclared role falls back to 40%. Fresh installs
+  seeded 20% imperator / 40% builder until 2026-09-10. Existing keys are never
+  overwritten, so a seat keeps a tuned value across reinstalls. The role is
   read from CODEX_CONTEXT_ROLE, falling back to the existing CONTEXT_GUARD_ROLE.
 - Threshold crossing asks for an operational checkpoint and restricts further
   tools to the exact bridge helpers. Compaction discards stale token readings.
@@ -53,7 +57,7 @@ The capacity follow-up adds expiring, host/profile/model/version-specific Claude
 calibration from a successful native CLI result. Claude interactive sessions
 observe token, tool, time and concurrency limits without denying tools. Explicit
 mandates enforce eight concurrent children, 120 tools per child, 3,600 active
-seconds and 40% of a measured window. Unknown capacity emits a warning per tool;
+seconds and the role's policy share of a measured window. Unknown capacity emits a warning per tool;
 strict mode retains time/tool limits and a 400,000 measured-token emergency
 ceiling, without claiming a percentage. A fresh Air-M5 desktop task also proved
 native Codex parent and child hook consumption; its evidence is linked in the

--- a/infra/codex-hooks/ROLLOUT.md
+++ b/infra/codex-hooks/ROLLOUT.md
@@ -12,8 +12,11 @@ preservation of previous hooks were independently checked on every profile.
 | Pro    | `.codex`, `.codex-acct2`              | Astra, primary profile | Two continuations and failed-launch retention |
 | Mini   | `.codex`, `.codex-acct2`              | Astra, primary profile | Two continuations and failed-launch retention |
 
-The adapter measures Codex's current reported context window, with a 20% limit
-for the imperator role and 40% for other roles. Fresh continuations carry the
+The adapter measures Codex's current reported context window and takes its
+limit from the seat's policy file, which `install.py` seeds at 60% for the
+imperator, builder and dux roles; a role the policy does not declare falls back
+to 40%. Before 2026-09-10 the seeded values were 20% imperator and 40% builder,
+and the native child ignored the policy entirely in favour of a hardcoded 40%. Fresh continuations carry the
 original text mandate, intervening instructions and checkpoint; the destination
 must acknowledge the exact source and start actual model work before the source
 turn stops. Failed launches retain the source. Verification receipts bind real

--- a/infra/codex-hooks/context_bridge.py
+++ b/infra/codex-hooks/context_bridge.py
@@ -26,7 +26,12 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from rpc import binary_path
-from mandate_budget import observe as budget_observe, reserve as budget_reserve
+from mandate_budget import (
+    MANDATE_SECONDS,
+    mandate_deadline as budget_deadline,
+    observe as budget_observe,
+    reserve as budget_reserve,
+)
 
 VERSION = "1.2.0"
 HANDSHAKE_SECONDS = 45  # one Stop hook blocks at most this long waiting for the destination
@@ -36,7 +41,7 @@ HANDSHAKE_SECONDS = 45  # one Stop hook blocks at most this long waiting for the
 from mandate_budget import ACKNOWLEDGE_SECONDS  # noqa: E402
 MAX_LAUNCH_ATTEMPTS = 3
 POLL_SECONDS = 1
-MANDATE_SECONDS = 3600
+# MANDATE_SECONDS now comes from mandate_budget: one default, one owner.
 # Launch failures the next Stop may retry on its own (bounded by MAX_LAUNCH_ATTEMPTS).
 TRANSIENT_FAILURES = frozenset(
     {
@@ -921,8 +926,15 @@ def launch(sid: str, max_hops: int) -> dict[str, Any]:
         if state.get("rollover") != "requested":
             return {}
         state.setdefault("mandate_root", os.environ.get("NUZANTARA_MANDATE_ID") or sid)
-        if not state.get("mandate_deadline"):
-            state["mandate_deadline"] = time.time() + MANDATE_SECONDS
+        # ONE mission clock, owned by the root mandate's ledger. This used to be
+        # `time.time() + MANDATE_SECONDS`, a second clock started fresh at every
+        # launch: a continuation could outlive the mandate that authorized it,
+        # and `mandate_budget.reserve()` on the same mission was meanwhile
+        # counting down from `created`. The two disagreed by however long the
+        # mission had already been running. See mandate_budget's module docstring.
+        state["mandate_deadline"] = budget_deadline(
+            state_dir() / "mandates", state["mandate_root"], MANDATE_SECONDS
+        )
         if state.get("cancel_requested") or time.time() >= state["mandate_deadline"]:
             state.update(
                 rollover="needs_attention", failure="mandate_cancelled_or_expired"

--- a/infra/codex-hooks/mandate_budget.py
+++ b/infra/codex-hooks/mandate_budget.py
@@ -1,4 +1,32 @@
-"""Small locked mandate ledger shared by both hook adapters; no worker launcher."""
+"""Small locked mandate ledger shared by both hook adapters; no worker launcher.
+
+ONE MISSION DEADLINE — the contract, in ten lines (PARABELLUM §4.3).
+
+1.  There is ONE mission deadline. It belongs to the ROOT MANDATE, never to a
+    session, a child or a continuation, and this ledger file is its only home.
+2.  `reserve()` and the `context_bridge.py` continuation supervisor both read it
+    through `mandate_deadline()`. Neither computes a clock of its own; before
+    2026-09-10 the supervisor ran `time.time() + MANDATE_SECONDS` against this
+    ledger's `created + max_seconds` and the two mission clocks disagreed by
+    however long the mission had already been running.
+3.  `created + max_seconds` stops being a deadline SOURCE. `max_seconds` is only
+    the default used to derive the deadline the first time a root mandate opens.
+4.  A continuation INHERITS the deadline unchanged and can never manufacture a
+    later one. A fresh seat joining an old mandate joins its remaining time.
+5.  Renewal is EXPLICIT: `renew()`, called by a coordinator. Never a side effect
+    of dispatching, resuming or replacing.
+6.  Every renewal is appended to `renewals` with who, when, the previous deadline
+    and the new one. The history is never rewritten.
+7.  A renewal NEVER resets a spent counter. Attempts, depth, concurrency and
+    reservations survive it untouched; only the wall clock moves.
+8.  An expired deadline SUSPENDS the mandate. It never silently extends, and it
+    never denies the reporting path — a capped worker still checkpoints out.
+9.  Child ACTIVE TIME (`child_context.MAX_SECONDS`, measured per child in
+    `child_workflow.py`) is a SEPARATE counter, reported separately and never
+    conflated with this one. A short-lived child says nothing about the mission.
+10. A deny naming the deadline carries the deadline, the now, the overrun and who
+    may renew it — the same reporting rule every other counter here obeys.
+"""
 
 from __future__ import annotations
 
@@ -30,6 +58,56 @@ ACKNOWLEDGE_SECONDS = 240
 # A default here cures the policies already on disk, which an install-time-only
 # fix would not: none of the three live seats has the key.
 ACTIVE_TTL_SECONDS = 1800
+
+# Default mission length, used ONLY to derive the deadline when a root mandate is
+# first opened. context_bridge.py imports this name so the two sides cannot drift
+# to different defaults the way they drifted to different clocks.
+MANDATE_SECONDS = 3600
+
+
+def _stamp(when: float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(when))
+
+
+def mandate_deadline(
+    root: Path, mandate: str, max_seconds: float = MANDATE_SECONDS
+) -> float:
+    """Read the root mandate's deadline, opening it once if it does not exist.
+
+    Every consumer of the mission clock goes through here. `max_seconds` is a
+    default for the FIRST call on a mandate and is ignored afterwards, so a
+    continuation that happens to carry a different limit cannot lengthen a
+    mission that is already running.
+    """
+    with ledger(root, mandate) as state:
+        state.setdefault("created", time.time())
+        state.setdefault("deadline", state["created"] + max_seconds)
+        return float(state["deadline"])
+
+
+def renew(root: Path, mandate: str, seconds: float, who: str) -> dict[str, Any]:
+    """Move the mission clock, on purpose, on the record, counters untouched.
+
+    Only the wall clock moves: `reservations`, attempts, depth and concurrency
+    are not touched here, so a renewal can never launder a spent budget into a
+    fresh one. The raise this supersedes is `mandate_deadline` specifically --
+    an attempts or concurrency alarm says nothing about the clock and must
+    survive, which is why the deadline carries its own attention key.
+    """
+    if seconds <= 0:
+        raise ValueError("a renewal must extend the mission, not shorten it")
+    with ledger(root, mandate) as state:
+        previous = state.get("deadline")
+        state["deadline"] = time.time() + seconds
+        record = {
+            "who": who,
+            "at": time.time(),
+            "previous_deadline": previous,
+            "new_deadline": state["deadline"],
+        }
+        state.setdefault("renewals", []).append(record)
+        _resolve(state, "mandate_deadline")
+        return record
 
 
 def _attend(state: dict[str, Any], reason: str, key: str) -> None:
@@ -100,7 +178,11 @@ def reserve(
         return None
     with ledger(root, mandate) as state:
         state.setdefault("created", time.time())
-        state.setdefault("deadline", state["created"] + limits.get("max_seconds", 3600))
+        # The SAME clock the continuation supervisor reads. `max_seconds` only
+        # opens it; it never re-derives a deadline that already exists.
+        state.setdefault(
+            "deadline", state["created"] + limits.get("max_seconds", MANDATE_SECONDS)
+        )
         reservations = state.setdefault("reservations", {})
         state["budget_mode"] = (
             "enforced" if limits.get("strict", True) else "interactive_observation"
@@ -180,9 +262,27 @@ def reserve(
             if r["status"] in ("reserved", "active")
         }
         reason = None
+        key_for_reason = "mandate_limit"
         strict = limits.get("strict", True)
-        if time.time() >= state["deadline"] and strict:
-            reason = "Mandate deadline reached"
+        now = time.time()
+        if now >= state["deadline"] and strict:
+            # The deadline gets its OWN attention key so an explicit renewal can
+            # supersede exactly this alarm and leave an attempts alarm standing.
+            key_for_reason = "mandate_deadline"
+            reason = (
+                "Mandate deadline reached: counter=mission_deadline deadline="
+                + _stamp(state["deadline"])
+                + " now="
+                + _stamp(now)
+                + " overrun="
+                + str(round(now - state["deadline"]))
+                + "s mandate="
+                + str(state.get("mandate_id"))
+                + " mode="
+                + str(state["budget_mode"])
+                + ". Only the coordinator may extend it, by calling"
+                " mandate_budget.renew(); a replacement dispatch cannot"
+            )
         elif depth > limits.get("max_depth", 1) and strict:
             # Gated like its four siblings. It was the only limit in this chain
             # enforced under interactive_observation too — an asymmetry nobody
@@ -190,20 +290,42 @@ def reserve(
             # ABOVE this ledger, so an ungated copy here duplicated a decision it
             # does not own and would have denied an interactive caller that the
             # other four limits let through.
-            reason = "Mandate child depth reached"
+            reason = (
+                "Mandate child depth reached: counter=depth used="
+                + str(depth)
+                + " limit="
+                + str(limits.get("max_depth", 1))
+                + " mandate="
+                + str(state.get("mandate_id"))
+            )
         elif len(reservations) >= limits.get("max_attempts", 24) and strict:
-            reason = "Mandate total dispatch attempts reached"
+            reason = (
+                "Mandate total dispatch attempts reached: counter=attempts used="
+                + str(len(reservations))
+                + " limit="
+                + str(limits.get("max_attempts", 24))
+                + " mandate="
+                + str(state.get("mandate_id"))
+            )
         elif (
             strict
             and len(active) >= limits.get("max_active", 3)
             and child not in active
         ):
-            reason = "Mandate concurrent dispatch limit reached"
+            reason = (
+                "Mandate concurrent dispatch limit reached: counter=concurrency used="
+                + str(len(active))
+                + " limit="
+                + str(limits.get("max_active", 3))
+                + " mandate="
+                + str(state.get("mandate_id"))
+            )
         if reason:
-            _attend(state, reason, "mandate_limit")
+            _attend(state, reason, key_for_reason)
             return (
                 reason
-                + "; return the remaining work. Do not reset the budget with a replacement."
+                + ". Required next action: return the remaining work to the coordinator."
+                " Do not reset the budget with a replacement."
             )
         reservations[key] = {
             "status": "active" if child else "reserved",
@@ -261,6 +383,7 @@ def observe(
             )
         )
         reservations = state.get("reservations", {})
+        ambiguous = False
         bound = next(
             (
                 r
@@ -275,11 +398,39 @@ def observe(
             # the claim was gated on `not stopped` the row stayed `reserved` while the
             # child was recorded stopped, so the slot leaked until unstarted_ttl swept
             # it and the ledger reported attention for a child that had returned fine.
-            bound = next(
-                (r for r in reservations.values() if r["status"] == "reserved"), None
-            )
-            if bound is not None:
+            #
+            # But "the first reserved row" is only the right row when there IS only
+            # one candidate. A reservation is keyed by the dispatching tool_use_id
+            # and the child identity arrives later, so with two unbound rows in
+            # flight the old `next(...)` was a coin flip that silently attributed
+            # one child's work to another child's slot -- and the ledger, being
+            # internally consistent afterwards, could never show the mistake.
+            # Ambiguity is now recorded as ambiguity.
+            unbound = [
+                r
+                for r in reservations.values()
+                if r["status"] == "reserved" and not r.get("child")
+            ]
+            if len(unbound) == 1:
+                bound = unbound[0]
                 bound["child"] = child
+                bound["binding"] = "sole_unbound_reservation"
+            elif len(unbound) > 1:
+                ambiguous = True
+                _attend(
+                    state,
+                    "Child dispatch reservation UNKNOWN: counter=binding candidates="
+                    + str(len(unbound))
+                    + " child="
+                    + hashlib.sha256(child.encode()).hexdigest()[:12]
+                    + " mandate="
+                    + str(state.get("mandate_id"))
+                    + ". Two or more unbound reservations are in flight, so this"
+                    " child cannot be attributed to one of them. Required next"
+                    " action: the coordinator reconciles the slot before the next"
+                    " dispatch; no reservation was consumed.",
+                    "binding_unknown",
+                )
         if bound is not None:
             if not stopped and bound["status"] not in ("active", "reserved"):
                 active = {
@@ -303,7 +454,12 @@ def observe(
             # This child DID have a reservation and its lease DID resume, which is
             # exactly what those two alarms claimed was untrue. Any other alarm
             # (a mandate limit, an unknown resume target) is untouched.
-            _resolve(state, "observed_without_reservation", "lease_cannot_resume")
+            _resolve(
+                state,
+                "observed_without_reservation",
+                "lease_cannot_resume",
+                "binding_unknown",
+            )
             # One child may have multiple resume reservations. Refresh them all.
             for row in reservations.values():
                 if row.get("child") == child:
@@ -312,7 +468,9 @@ def observe(
                 for row in reservations.values():
                     if row.get("child") == child:
                         row["status"] = "returned_unverified"
-        else:
+        elif not ambiguous:
+            # Genuinely no candidate at all, which is a different fact from
+            # "too many candidates to choose" and keeps its own key.
             _attend(
                 state,
                 "Child observed without a dispatch reservation",

--- a/infra/codex-hooks/test_child_lifecycle.py
+++ b/infra/codex-hooks/test_child_lifecycle.py
@@ -659,24 +659,46 @@ def test_native_child_threshold_follows_the_policy_not_a_literal(
     assert not state.get("return_required")
 
 
-def test_dux_role_resolves_to_its_declared_threshold(
+def test_dux_role_resolves_and_the_declared_key_is_what_moves_its_wall(
     setup: tuple, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """`dux` was undeclared, so a Dux seat silently ran at the 0.4 fallback."""
+    """Two seats, same role, same usage, opposite verdicts — the key decides.
+
+    The earlier version of this test asserted only that a declared `dux: 0.6`
+    denies at 601/1000, which an UNDECLARED `dux` does too via the 0.4
+    fallback: it could not fail on the code it was written to protect. The
+    parent-side lookup always honoured an arbitrary role key; what was missing
+    was `install.py` declaring one. So the discriminating fact is the CONTRAST
+    at a single usage point — 500 of 1000 is over 0.4 and under 0.6 — and that
+    is what is asserted here, in both directions.
+    """
     _, log, e = setup
     monkeypatch.setenv("CODEX_CONTEXT_ROLE", "DUX")
     seat = bridge.codex_home()
-    policy = bridge.load(seat / "nuzantara-context-policy.json")
-    policy["thresholds"] = {"imperator": 0.6, "builder": 0.6, "dux": 0.6}
-    bridge.save(seat / "nuzantara-context-policy.json", policy)
-    e = {**e, "session_id": "dux-session-123"}
-    bridge.hook(e)
-    assert bridge.load(bridge.state_path("dux-session-123"))["role"] == "dux"
-    pre = {**e, "hook_event_name": "PreToolUse", "tool_name": "Bash"}
-    token(log, 500, 1000)
-    assert bridge.hook(pre) == {}
-    token(log, 601, 1000)
-    assert bridge.hook(pre)["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def verdict(session: str, thresholds: dict, used: int) -> dict:
+        policy = bridge.load(seat / "nuzantara-context-policy.json")
+        policy["thresholds"] = thresholds
+        bridge.save(seat / "nuzantara-context-policy.json", policy)
+        event = {**e, "session_id": session}
+        bridge.hook(event)
+        assert bridge.load(bridge.state_path(session))["role"] == "dux"
+        token(log, used, 1000)
+        return bridge.hook(
+            {**event, "hook_event_name": "PreToolUse", "tool_name": "Bash"}
+        )
+
+    undeclared = verdict("dux-undeclared-123", {"builder": 0.6}, 500)
+    assert undeclared["hookSpecificOutput"]["permissionDecision"] == "deny"
+    declared = verdict("dux-declared-1234", {"builder": 0.6, "dux": 0.6}, 500)
+    assert declared == {}
+    # And the declared wall is a real wall, not merely a higher number.
+    assert (
+        verdict("dux-over-the-wall", {"builder": 0.6, "dux": 0.6}, 601)[
+            "hookSpecificOutput"
+        ]["permissionDecision"]
+        == "deny"
+    )
 
 
 def test_installer_adds_dux_without_overwriting_a_tuned_threshold() -> None:
@@ -690,3 +712,55 @@ def test_installer_adds_dux_without_overwriting_a_tuned_threshold() -> None:
         "dux": 0.6,
     }
     assert merge_thresholds({}) == THRESHOLD_DEFAULTS
+def test_one_mission_deadline_is_shared_renewed_explicitly_and_resets_nothing(
+    tmp_path: Path,
+) -> None:
+    """The supervisor and the ledger used to run two clocks for one mission."""
+    limits = {"strict": True, "max_seconds": 100}
+    assert budget.reserve(tmp_path, "root", "one", limits) is None
+    opened = budget.mandate_deadline(tmp_path, "root")
+    # A later reader cannot lengthen a mission that is already running, whatever
+    # default it happens to carry. This is what context_bridge.launch() now calls.
+    assert budget.mandate_deadline(tmp_path, "root", 99999) == opened
+    with budget.ledger(tmp_path, "root") as state:
+        state["deadline"] = 0
+    denial = budget.reserve(tmp_path, "root", "two", limits)
+    for field in ("counter=mission_deadline", "overrun=", "mandate_budget.renew()"):
+        assert field in denial, field
+    with budget.ledger(tmp_path, "root") as state:
+        # Its own key, so a renewal cannot silence an attempts alarm by accident.
+        assert state["attention_key"] == "mandate_deadline"
+        spent = len(state["reservations"])
+    record = budget.renew(tmp_path, "root", 3600, "coordinator-test")
+    assert record["previous_deadline"] == 0 and record["new_deadline"] > time.time()
+    with budget.ledger(tmp_path, "root") as state:
+        assert state["renewals"][-1]["who"] == "coordinator-test"
+        assert state["renewals"][-1]["previous_deadline"] == 0
+        assert len(state["reservations"]) == spent  # only the wall clock moved
+        assert state.get("attention_key") != "mandate_deadline"
+    assert budget.reserve(tmp_path, "root", "three", limits) is None
+    with pytest.raises(ValueError):
+        budget.renew(tmp_path, "root", 0, "coordinator-test")
+
+
+def test_observe_refuses_to_guess_between_two_unbound_reservations(
+    tmp_path: Path,
+) -> None:
+    """`next(reserved)` was a coin flip that the ledger could never show as one."""
+    limits = {"strict": True, "max_active": 3}
+    assert budget.reserve(tmp_path, "root", "dispatch-a", limits) is None
+    assert budget.reserve(tmp_path, "root", "dispatch-b", limits) is None
+    assert budget.observe(tmp_path, "root", "child-x") is None
+    with budget.ledger(tmp_path, "root") as state:
+        assert state["attention_key"] == "binding_unknown"
+        assert "candidates=2" in state["reason"]
+        # Ambiguity consumed nothing: both slots are still unattributed.
+        assert all(not r.get("child") for r in state["reservations"].values())
+    with budget.ledger(tmp_path, "root") as state:
+        list(state["reservations"].values())[0]["child"] = "child-y"
+    # One unbound candidate is not a guess, so it still binds and clears the doubt.
+    assert budget.observe(tmp_path, "root", "child-z") is None
+    with budget.ledger(tmp_path, "root") as state:
+        rows = [r for r in state["reservations"].values() if r.get("child") == "child-z"]
+        assert len(rows) == 1 and rows[0]["binding"] == "sole_unbound_reservation"
+        assert state.get("attention_key") != "binding_unknown"


### PR DESCRIPTION
## What

PARABELLUM §4 harness set, part B, plus the four conditions the gate attached to #6077. Two mission clocks, one coin flip, one defect that turned out to live one level up, and two docs reciting numbers nobody writes.

**C — one mission deadline (§4.3).** `mandate_budget.reserve()` counted down from `created + max_seconds` in the ledger while `context_bridge.launch()` started a fresh `time.time() + MANDATE_SECONDS` at every launch. Two clocks for one mission, disagreeing by however long the mission had already been running, which is how the pilot met a mandate that had expired 21 minutes before it launched. Both now read one `mandate_deadline()` owned by the root mandate's ledger; `max_seconds` only OPENS the deadline, so a later reader carrying a different default cannot lengthen a mission in flight. Renewal is `renew()`, explicit, appended to `renewals` with who, when, previous and new, and it moves nothing but the wall clock: attempts, depth, concurrency and reservations survive untouched, so a renewal cannot launder a spent budget into a fresh one. **`renew()` is a library function with no invocable entry point yet** — no CLI, no `python3 -m` subcommand, no rpc verb, no hook path; its only callers in the tree are its own tests. The deny text names it as the route a coordinator should take, and until row 5 below closes, taking that route means writing Python by hand. That is a real gap between what the message promises and what a coordinator can do at a shell. The deadline now carries its own attention key, so a renewal supersedes exactly that alarm and leaves an attempts alarm standing — the discipline #6074 established. **The ten-line contract is in the module docstring and was written before the code**, as the mandate required; it is also quoted verbatim in #6077's body.

**Scope of the one-clock invariant, stated precisely rather than as the docstring's flat "neither computes a clock of its own".** What this PR establishes is that INSIDE THE CODEX ADAPTER the continuation supervisor no longer runs a second clock — which is the pilot's actual bug, a continuation outliving the mandate that authorized it. Two things are narrower than the docstring reads. First, `reserve()` still opens the deadline INLINE (`state.setdefault("deadline", state["created"] + limits.get("max_seconds", MANDATE_SECONDS))`) rather than calling `mandate_deadline()`; the formula is identical and they share the ledger row, so the values agree, but they agree by convention and not by construction. Second, the Claude adapter keeps a SEPARATE ledger root — `child_workflow.budget_dir()` is `~/.claude/state/child-mandates`, not the Codex `state_dir()/mandates` — so a Claude-side mandate is a different file whose deadline is likewise opened inline and never through `mandate_deadline()`. One clock per adapter, not yet one clock across both. Row 6 owns it.

**D — reservation identity (§4.4).** `observe()` fell back to `next(r for r in reservations if r["status"] == "reserved")`, the first available row. A reservation is keyed by the dispatching tool_use_id and the child identity arrives later, so with two unbound rows in flight that was a coin flip which silently attributed one child's work to another child's slot — and the ledger, internally consistent afterwards, could never show the mistake. One unbound candidate still binds and is marked `sole_unbound_reservation`. Two or more is recorded as UNKNOWN with the candidate count, and consumes nothing.

Every deny in `reserve()` now names its counter, used, limit and mandate; the deadline deny carries the deadline, the now, the overrun and who may renew it.

**Gate condition 1 — docs.** `README.md` and `ROLLOUT.md` both recited "20% for imperator and 40% for other roles": thresholds `install.py` no longer writes, and which the native child never read from the policy at all. Both now describe the code. The old values are kept as dated history rather than deleted.

**Gate condition 3 — a test that could not fail.** `test_dux_role_resolves_to_its_declared_threshold` asserted that a declared `dux: 0.6` denies at 601/1000 — which an UNDECLARED `dux` does too, via the 0.4 fallback. **Correction to how I first justified this**, which the gate caught: I claimed the old test "could not fail". That is wrong — the gate's mutation run turned it red, so it did carry some signal. The accurate statement is narrower and still worth the rewrite. The old assertion was that a declared `dux: 0.6` denies at 601/1000, and an UNDECLARED `dux` denies there too via the 0.4 fallback, so the assertion could not distinguish the two policies it was ostensibly about. That the parent-side lookup already honoured an arbitrary role key is why: nothing about `dux` was broken there, only `install.py` failed to declare it. The rewrite is better because it tests the undeclared-versus-declared CONTRAST at one usage point, 500 of 1000 being over 0.4 and under 0.6 — undeclared denies, declared passes, and the declared wall still bites at 601 — not because the original was inert. Renamed to what it proves.

**Gate row 10 — the same hole one level up.** `context_window_guard.py` exempted SendMessage and TaskStop from the at-threshold deny and not ToolSearch. A capped PARENT was told to hand off with SendMessage while the one call that loads a deferred SendMessage's schema was denied. Narrowed by the query exactly as on the child side.

## Bites:

**Consumer 1 — the regressions.** `python3 -m pytest infra/claude-hooks infra/codex-hooks -q` on this HEAD: **310 passed, 1 failed.** The failure is `test_host_boundary_carveout`, which touches nothing in this diff, fails identically on unmodified `origin/main`, and was independently confirmed pre-existing by #6077's gate run. Four new regressions, and unlike last time I have checked each one is red against the code it replaces:

- `test_one_mission_deadline_is_shared_renewed_explicitly_and_resets_nothing` — one clock survives a second reader carrying a different default; the deny carries `counter=mission_deadline`, `overrun=` and `mandate_budget.renew()`; the renewal is recorded with who and previous; reservations are unchanged across it; a non-positive renewal raises.
- `test_observe_refuses_to_guess_between_two_unbound_reservations` — two unbound rows produce `binding_unknown` with `candidates=2` and consume nothing; one unbound row still binds and clears the doubt.
- `test_dux_role_resolves_and_the_declared_key_is_what_moves_its_wall` — the contrast above.
- `test_above_threshold_allows_toolsearch_only_for_the_handoff_tools` — `select:SendMessage` reaches the schema, no readable query does not trap the session, `select:Bash` stays denied.

**Consumer 2 — the base this PR builds on, NOT this PR's own arming. The table below is #6077's install, and it says nothing about the code in this diff.** Every line of this PR is live on zero hosts until it merges and the installers run again. Run after #6077 merged, `md5` of `origin/main` against the live copy, 15 of 15 MATCH:

| host | Claude `child_workflow.py` + `mandate_budget.py` | CODEX_HOME `context_bridge.py` + `mandate_budget.py` + `rpc.py` |
|---|---|---|
| M5 | MATCH, MATCH | MATCH, MATCH, MATCH |
| Pro | MATCH, MATCH | MATCH, MATCH, MATCH |
| Mini | MATCH, MATCH | MATCH, MATCH, MATCH |

`dux: 0.6` now present on all seven Codex profiles (M5 `.codex`, `.codex-o2`, `.codex-acct2`; Pro and Mini `.codex`, `.codex-acct2`), with `imperator` and `builder` still 0.6 — the per-key merge doing exactly what it was built for. `.codex-o2` is M5-only. Backups `nuzantara-context-policy.json.bak-2026-09-10` beside each policy touched.

**Consumer 2b — THIS PR's arming step, observation still to come.** After this merges I install on M5, Pro and Mini by the same method (Pro via `git archive origin/main` into a temp dir, its checkout untouched), then post here: the merged sha, `md5` repo == live for the five changed files on each of the three hosts, and a native child probe against the newly installed adapter. Until that comment exists, this PR is merged code and nothing more — the distance between a merged diff and a live one is most of this repo's scar record.

**Consumer 3 — the native child probe against the adapter installed from #6077**, `--model sonnet --parent-model claude-opus-5`, no `--candidate`: `"passed": true`, `"candidate": false`, child role builder, model claude-sonnet-5, measurement calibrated, window 1000000, all six hook events observed.

## Leftovers (PENDING-ARMS rows, owner: this session)

| # | Observation | Why not here | Closing evidence |
|---|---|---|---|
| 1 | **`PENDING-ALIGN:pro`.** Pro's main checkout is at `c963dd2c9d` with `published_articles.json`, `AUTOMATIONS_REFERENCE.md` and `escalations_pro.jsonl` modified by its own H24 daemons. I did not `pull --ff-only` it. | A dirty live runtime checkout is not mine to fast-forward. The install still reached Pro without touching it: `git archive origin/main` into a temp dir, install from there, temp dir removed. Read-only on the repo, no worktree-list mutation, no race with a live session. | Operator aligns Pro's checkout, or a session that owns it does. |
| 2 | **Only the PRIMARY Codex profile's CODEX_HOME files are declared in the lint** (#6077 row 9, still open). `~/.codex-o2` and `~/.codex-acct2` hold their own copies of the same three files and are undeclared, so the lint is blind on four of the seven installed seats. | Needs per-machine entries, since `.codex-o2` is M5-only. Not in this concern. | Own PR. |
| 3 | **`.codex/hooks.json` still carries a per-host absolute path on M5** (#6077 row 3). Gitignored, M5-only, and it lives in the MAIN checkout, where `worktree_isolation.py` correctly denies an agent session writing it. I did not use the documented escape hatch. | Not shippable by any PR. | Operator applies the string proven in #6077's body. |
| 4 | **Whether Codex loads a project-scope `.codex/hooks.json` at all is still unproven** (#6077 row 5). | Needs a live native Codex session — the orange mission's job. | First orange mission, staff room §7.3. |
| 5 | **`renew()` has no invocable entry point.** Its only callers in the tree are its own tests: no CLI, no `python3 -m` subcommand, no rpc verb, no hook path. Meanwhile `reserve()`'s deadline deny tells a coordinator to call `mandate_budget.renew()`. | The function, its ledger record and its guarantees are the substance; the entry point is a separate concern and the branch is frozen. | **Owner: next harness PR. Closing observation: a coordinator renews a live mandate from the shell and the ledger shows the renewal row with who, when, previous and new.** |
| 6 | **The one-clock invariant holds INSIDE the Codex adapter, not across both adapters.** `reserve()` still opens the deadline inline instead of calling `mandate_deadline()` — same formula, same ledger row, so the values agree by convention rather than by construction. And `child_workflow.budget_dir()` is `~/.claude/state/child-mandates`, a different ledger root from the Codex `state_dir()/mandates`, so a Claude-side mandate's deadline is likewise opened inline and never through `mandate_deadline()`. | Routing both adapters through one ledger root is a data-migration concern, not this one, and the pilot's bug — a continuation outliving its mandate — is inside the Codex adapter and is fixed here. | **Owner: next harness PR. Closing observation: `reserve()` calls `mandate_deadline()`, and a mandate opened by the Claude adapter and read by the Codex supervisor shows one deadline.** |

## Sibling check (before open)

`gh pr list --state open --search "codex-hooks OR claude-hooks OR child_workflow"`: no open PR touches `mandate_budget.py`, `context_bridge.py`, `context_window_guard.py`, `README.md` or `ROLLOUT.md`. #6074, which owned `mandate_budget.py`, merged; this branch is rebased on top of it and the one conflict (both PRs appending to `test_child_lifecycle.py`) was resolved keeping both blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
