### PR TITLE
style(kbli): repaint decorative hero red to brand accent #D01033

### DIFF
--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -71,7 +71,7 @@ export default async function KBLIHomePage({
           <div
             className="hidden lg:block absolute top-[-15%] left-[10%] w-[500px] h-[500px] rounded-full opacity-[0.06] blur-[120px]"
             style={{
-              background: "radial-gradient(circle, #dc2626, transparent)",
+              background: "radial-gradient(circle, #D01033, transparent)",
             }}
           />
           <div
@@ -83,7 +83,7 @@ export default async function KBLIHomePage({
           <div
             className="hidden lg:block absolute bottom-[-15%] right-[-5%] w-[350px] h-[350px] rounded-full opacity-[0.05] blur-[100px]"
             style={{
-              background: "radial-gradient(circle, #dc2626, transparent)",
+              background: "radial-gradient(circle, #D01033, transparent)",
             }}
           />
 
@@ -130,7 +130,7 @@ export default async function KBLIHomePage({
               {/* CTA — glassmorphism button */}
               <Link
                 href="#search"
-                className="mt-8 inline-flex items-center gap-2 rounded-xl bg-white/[0.06] backdrop-blur-md border border-white/[0.1] px-7 py-3.5 text-sm font-bold text-white shadow-[0_4px_20px_rgba(0,0,0,0.3),inset_0_1px_0_rgba(255,255,255,0.06)] transition-all duration-300 hover:bg-[#dc2626]/90 hover:border-[#dc2626]/60 hover:shadow-[0_0_40px_rgba(220,38,38,0.3)] active:scale-[0.98]"
+                className="mt-8 inline-flex items-center gap-2 rounded-xl bg-white/[0.06] backdrop-blur-md border border-white/[0.1] px-7 py-3.5 text-sm font-bold text-white shadow-[0_4px_20px_rgba(0,0,0,0.3),inset_0_1px_0_rgba(255,255,255,0.06)] transition-all duration-300 hover:bg-[#D01033]/90 hover:border-[#D01033]/60 hover:shadow-[0_0_40px_rgba(208,16,51,0.3)] active:scale-[0.98]"
               >
                 Explore All KBLI Sectors &rarr;
               </Link>
@@ -143,7 +143,7 @@ export default async function KBLIHomePage({
                 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[320px] h-[320px] blur-[80px] pointer-events-none"
                 style={{
                   background:
-                    "radial-gradient(circle, rgba(220,38,38,0.06), transparent 70%)",
+                    "radial-gradient(circle, rgba(208,16,51,0.06), transparent 70%)",
                 }}
               />
               <div
@@ -153,7 +153,7 @@ export default async function KBLIHomePage({
                     "perspective(1000px) rotateY(-12deg) rotateX(4deg) rotate(-3deg)",
                   transformStyle: "preserve-3d",
                   filter:
-                    "drop-shadow(0 40px 60px rgba(0,0,0,0.6)) drop-shadow(0 0 30px rgba(220,38,38,0.08))",
+                    "drop-shadow(0 40px 60px rgba(0,0,0,0.6)) drop-shadow(0 0 30px rgba(208,16,51,0.08))",
                 }}
               >
                 {/* Tablet frame — glassmorphism */}


### PR DESCRIPTION
Aligns the /kbli hero and CTA decorative red with the brand action red already
used on the homepage and blog surfaces.

# Insight
The /kbli hero red was orphaned three ways: it is not the surface's own accent
(--kbli-accent #d4845a), not the design-system primitive (--color-red-500
#ff2d4c), and not the brand action red (#D01033). It was a bare #dc2626 whose
only namesake in the codebase is --kbli-pma-closed / --kbli-risk-high, two
tokens whose meaning is "PMA closed" and "high risk" — semantics that have
nothing to do with hero decoration.

# Studio

## Source / Reference
Decision by Subhi, 9 Sep 2026: decorative red on the /kbli hero and CTA uses the
existing brand accent #D01033, not a new token.

## Methodology
Measured on origin/main 221483bf with explicit pathspecs, counts taken before
any truncation, and a separate positive control for every zero. Note the base
moved: the task was written against 98bcd2b2 and every count below was re-taken
on the current tip.

## Raw Observations
- `#dc2626` in apps/mouth/src/app/kbli/page.tsx: 3 lines / 4 occurrences
  (:74, :86 ambient orbs; :133 CTA hover, two occurrences on one line).
  Positive control, same file, separate call: `export default` -> 1 line.
- `220, ?38, ?38` in the same file: 3 lines (:133, :146, :156). 220,38,38 is
  dc,26,26 — the same red in rgb form.
- `D01033` across apps + packages: 13 lines, case-sensitive and
  case-insensitive alike. Six are value assignments (merahPutihDayVars.ts
  :133 :139 :140 :142 :143; rumahVars.ts :58); the rest are docstrings and
  e2e/studio references. Positive control, same scope, separate call:
  `ff2d4c` -> 17 lines case-insensitive, 15 case-sensitive.
- packages/core/tokens/primitives.css:15 `--color-red-500: #ff2d4c`;
  packages/core/tokens/semantic.css:72 `--cta-primary-bg: var(--color-red-500)`.
- rumahVars.ts:56, verbatim: "Scoped here so only homepage + blog pages".
- `--kbli-accent` is already taken: kbli-theme.css:19 `#d4845a`, matched on 17
  lines in kbli/[code]/page.tsx.

## Reasoning Path
Binding the surface to var(--cta-primary-bg) would render #ff2d4c, because /kbli
carries its own layout and theme and sits outside the RUMAH_VARS wrapper scope.
Naming a new --kbli-* token collides with an accent system that already exists.
Writing the literal matches how the repo stores this same red on the two
surfaces that already use it, and it is exactly what the decision asked for.

## Risk / Implication
Visual change on one route, decorative elements only. No token definition moves,
so no other surface shifts. The two semantic #dc2626 tokens keep their value and
their meaning.

# Recommendation
Merge as an atomic surface repaint. The remaining /kbli colour debt — #141416
and the three undifferentiated #dc2626 sites in KBLISearch.tsx — stays out of
this PR by design and keeps its own rows.

# Next Action
Decide the #141416 token name (open decision 1), then measure whether the
KBLISearch.tsx reds are risk semantics or decoration.

Bites: CONSUMER is the /kbli route in apps/mouth. Observation on this branch:
`git grep -c 'dc2626' -- apps/mouth/src/app/kbli/page.tsx` -> 0 and
`git grep -c -E '220, ?38, ?38'` on the same file -> 0, with the same probe
returning 4 on apps/mouth/src/styles/kbli-theme.css as positive control; and
`npm run build -w apps/mouth` compiles the route through to
PUBLIC_LOGIN_BUNDLE_OK. Post-merge the live check is the rendered hero colour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oKrXqwDHSvhkMXWiUJF1j
