### PR TITLE
fix(a11y): give the KBLI search combobox its roles and active-descendant wiring

### DIFF
--- a/apps/mouth/src/components/kbli/KBLISearch.a11y-combobox.test.tsx
+++ b/apps/mouth/src/components/kbli/KBLISearch.a11y-combobox.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { KBLISearch } from "./KBLISearch";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
+
+const search = vi.fn();
+vi.mock("@/lib/api/kbli.api", () => ({
+  kbliApi: { search: (q: string) => search(q) },
+  apiPmaStatusLabel: () => "Open",
+  isApiPmaVerdictVerified: () => true,
+}));
+vi.mock("@/lib/analytics", () => ({ trackKBLISearch: vi.fn() }));
+
+const RESULTS = [
+  {
+    code: "56101",
+    title: "Restoran",
+    description: "Restaurants",
+    risk_category: "MR",
+  },
+  {
+    code: "55130",
+    title: "Villa",
+    description: "Villas",
+    risk_category: "MT",
+  },
+];
+
+/** Type a term and wait for the dropdown the debounced search opens. */
+async function openDropdown() {
+  const input = screen.getByRole("combobox");
+  fireEvent.change(input, { target: { value: "rest" } });
+  await screen.findAllByRole("option", {}, { timeout: 2000 });
+  return input;
+}
+
+describe("KBLISearch combobox semantics", () => {
+  beforeEach(() => {
+    push.mockReset();
+    search.mockReset();
+    search.mockResolvedValue(RESULTS);
+  });
+
+  it("exposes the input as a collapsed combobox before any search", () => {
+    render(<KBLISearch />);
+    const input = screen.getByRole("combobox");
+
+    expect(input).toHaveAttribute("aria-expanded", "false");
+    expect(input).toHaveAttribute("aria-autocomplete", "list");
+    expect(input).toHaveAttribute("aria-controls");
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("expands into a listbox of options, wired to the input by id", async () => {
+    render(<KBLISearch />);
+    const input = await openDropdown();
+
+    const listbox = screen.getByRole("listbox");
+    expect(input).toHaveAttribute("aria-expanded", "true");
+    expect(input.getAttribute("aria-controls")).toBe(listbox.id);
+    expect(screen.getAllByRole("option")).toHaveLength(RESULTS.length);
+  });
+
+  // The whole point of the PR: arrow keys already moved the highlight, but
+  // nothing announced it. aria-activedescendant is what makes it perceivable.
+  it("points aria-activedescendant at the row the arrow keys highlight", async () => {
+    render(<KBLISearch />);
+    const input = await openDropdown();
+    const [first, second] = screen.getAllByRole("option");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    await waitFor(() =>
+      expect(input).toHaveAttribute("aria-activedescendant", first.id),
+    );
+    expect(first).toHaveAttribute("aria-selected", "true");
+    expect(second).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    await waitFor(() =>
+      expect(input).toHaveAttribute("aria-activedescendant", second.id),
+    );
+    expect(first).toHaveAttribute("aria-selected", "false");
+    expect(second).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("keeps focus on the input while the highlight moves", async () => {
+    render(<KBLISearch />);
+    const input = await openDropdown();
+    input.focus();
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    await waitFor(() => expect(input).toHaveAttribute("aria-activedescendant"));
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("announces the result count in a polite live region", async () => {
+    render(<KBLISearch />);
+    await openDropdown();
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent(`${RESULTS.length} KBLI codes found`);
+  });
+
+  // Two instances on one page (hero + inline) must not share a listbox id, or
+  // every aria reference on the second one resolves to the first one's rows.
+  it("gives each rendered instance its own listbox id", () => {
+    render(
+      <>
+        <KBLISearch />
+        <KBLISearch />
+      </>,
+    );
+    const [a, b] = screen.getAllByRole("combobox");
+    expect(a.getAttribute("aria-controls")).not.toBe(
+      b.getAttribute("aria-controls"),
+    );
+  });
+});

--- a/apps/mouth/src/components/kbli/KBLISearch.quick-filters.test.tsx
+++ b/apps/mouth/src/components/kbli/KBLISearch.quick-filters.test.tsx
@@ -31,7 +31,7 @@ describe("KBLISearch quick filters", () => {
 
   it("writes the chip term into the search input", () => {
     render(<KBLISearch quickFilters={FILTERS} />);
-    const input = screen.getByRole("textbox") as HTMLInputElement;
+    const input = screen.getByRole("combobox") as HTMLInputElement;
     expect(input.value).toBe("");
 
     fireEvent.click(screen.getByRole("button", { name: "Search Restaurant" }));
@@ -50,7 +50,7 @@ describe("KBLISearch quick filters", () => {
 
   it("replaces a previous term instead of appending to it", () => {
     render(<KBLISearch quickFilters={FILTERS} />);
-    const input = screen.getByRole("textbox") as HTMLInputElement;
+    const input = screen.getByRole("combobox") as HTMLInputElement;
 
     fireEvent.change(input, { target: { value: "villa" } });
     fireEvent.click(screen.getByRole("button", { name: "Search Tech" }));

--- a/apps/mouth/src/components/kbli/KBLISearch.tsx
+++ b/apps/mouth/src/components/kbli/KBLISearch.tsx
@@ -45,6 +45,11 @@ export function KBLISearch({
   const router = useRouter();
   const containerRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  // useId, not a literal: this component is rendered more than once per page
+  // (hero + inline), and two listboxes sharing an id would make every
+  // aria-controls / aria-activedescendant reference point at the first one.
+  const listboxId = React.useId();
+  const optionId = (index: number) => `${listboxId}-option-${index}`;
 
   // Sync initialQuery on mount only (URL ?q= pre-fill).
   // Not in dep array — intentional: user can freely edit after mount.
@@ -164,6 +169,11 @@ export function KBLISearch({
     }
   };
 
+  // The dropdown shows for results OR for the error banner, and the listbox
+  // node lives inside it in both cases — so aria-controls resolves whenever
+  // aria-expanded is true.
+  const isDropdownOpen = isOpen && (results.length > 0 || Boolean(searchError));
+
   return (
     <div ref={containerRef} className={cn("relative w-full", className)}>
       <div className="relative group">
@@ -183,6 +193,13 @@ export function KBLISearch({
           onFocus={() => query.length >= 2 && setIsOpen(true)}
           placeholder={placeholder}
           aria-label={placeholder || "Search KBLI"}
+          role="combobox"
+          aria-expanded={isDropdownOpen}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={
+            activeIndex >= 0 ? optionId(activeIndex) : undefined
+          }
           className={cn(
             "w-full pl-12 pr-10 py-4 bg-white/[0.04] backdrop-blur-xl border border-white/[0.08] rounded-2xl text-white placeholder-zinc-400",
             "shadow-[0_4px_20px_rgba(0,0,0,0.3),inset_0_1px_0_rgba(255,255,255,0.04)]",
@@ -200,6 +217,12 @@ export function KBLISearch({
             <X className="w-4 h-4" />
           </button>
         )}
+      </div>
+
+      <div className="sr-only" role="status" aria-live="polite">
+        {isDropdownOpen && results.length > 0
+          ? `${results.length} KBLI codes found`
+          : ""}
       </div>
 
       {quickFilters && quickFilters.length > 0 && (
@@ -228,7 +251,7 @@ export function KBLISearch({
       )}
 
       {/* Results dropdown — also shown when there is a search error */}
-      {isOpen && (results.length > 0 || searchError) && (
+      {isDropdownOpen && (
         <div className="absolute z-50 w-full mt-2 bg-[#1c1c1f]/95 backdrop-blur-2xl border border-white/[0.08] rounded-xl shadow-[0_16px_48px_rgba(0,0,0,0.5)] overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200">
           {/* Error banner — shown above results when search fails */}
           {searchError && (
@@ -237,10 +260,18 @@ export function KBLISearch({
               <span className="text-amber-300">{searchError}</span>
             </div>
           )}
-          <div className="max-h-[400px] overflow-y-auto">
+          <div
+            id={listboxId}
+            role="listbox"
+            aria-label="KBLI search results"
+            className="max-h-[400px] overflow-y-auto"
+          >
             {results.map((result, index) => (
               <button
                 key={result.code}
+                id={optionId(index)}
+                role="option"
+                aria-selected={index === activeIndex}
                 onClick={() => handleSelect(result.code)}
                 onMouseEnter={() => setActiveIndex(index)}
                 className={cn(


### PR DESCRIPTION
## Problem

`apps/mouth/src/components/kbli/KBLISearch.tsx` implements the active-descendant
combobox pattern **entirely visually**. `activeIndex` (`:43`) moves with the arrow
keys (`handleKeyDown`), `Enter` selects the highlighted row, and the row restyles
(`index === activeIndex`). None of that is exposed to assistive technology: the file
carried **zero `role=` attributes**, therefore zero `role="combobox"` /
`"listbox"` / `"option"` and zero `aria-expanded` / `aria-controls` /
`aria-activedescendant` / `aria-autocomplete` / `aria-selected`.

For a screen reader user: typing never announces that a result list appeared, and
arrow up/down moves a highlight they cannot perceive. This is **WCAG 4.1.2 Name,
Role, Value** — not 1.4.3 Contrast.

## Change

Standard APG active-descendant wiring, nothing more:

| Element | Added |
|---|---|
| input (`:177`–`:189`) | `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-autocomplete="list"`, `aria-activedescendant` |
| scroll container (`max-h-[400px] overflow-y-auto`) | `role="listbox"` + `id` + `aria-label` |
| each result row (`<button>`) | `role="option"`, `id`, `aria-selected` |
| new node after the input | `sr-only` `role="status"` `aria-live="polite"` carrying the result count |

Ids come from `React.useId()`, not a literal: this component renders more than once
per page (hero + inline), and a shared id would make every `aria-controls` /
`aria-activedescendant` on the second instance resolve to the first one's rows. A
test asserts that.

The existing `isOpen && (results.length > 0 || searchError)` gate is extracted to a
named `isDropdownOpen`, reused by the markup and by `aria-expanded`, so the listbox
node exists whenever `aria-expanded` is true and `aria-controls` always resolves.

## Raw Observations

Measured in this session, base `origin/main` = `ed07dda54c`.

Per-pattern counts on the changed file, separate calls, `git --no-pager grep -c`:

```
role=                    4    (was 0)   # combobox, status, listbox, option
aria-activedescendant    2    (was 0)   # 1 JSX attribute + 1 comment line — grep -c counts LINES
dc2626                   3    (was 3)   # SCOPE CONTROL — unchanged
```

Positive control for the counting tool, same file, own call: `className` → 31.

Scope control, stronger form — the staged diff itself:

```
git diff --cached -U0 | grep -E '^[+-]' | grep -c 'dc2626\|D01033'   →   0
```

**Zero colour lines are added or removed by this PR.** The three `#dc2626`
occurrences (`:189` focus ring, `:253` badge, `:282` active chevron) do fail AA as
text, and that is deliberately left alone — fixing it reopens the
semantic-vs-decorative question and collides with the brand-red decision. Separate PR.

`sr-only` availability was verified rather than assumed: Tailwind v4 (CSS-first, no
`tailwind.config.*`), `sr-only` already used in 10+ files across `apps/mouth`, and
the class is present in the built CSS:

```
apps/mouth/.next/static/css/ae0c99f6b808b8f9.css
.sr-only{clip-path:inset(50%);white-space:nowrap;border-width:0;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden}
```

SSR markup from a local `next dev` on `/kbli` confirms the attributes reach the
rendered HTML: `role="combobox"` ×1, `aria-autocomplete="list"` ×1,
`aria-controls="_R_h9bmt5rimlb_"` (the `useId` value), `role="status"` ×1,
`class="sr-only"` ×1.

## Regression caught

The input is no longer an implicit `textbox`. Two `screen.getByRole("textbox")`
queries in the pre-existing `KBLISearch.quick-filters.test.tsx` would have gone red
on this change; they move to `getByRole("combobox")`. That file is otherwise untouched.

## Tests

New suite `KBLISearch.a11y-combobox.test.tsx` (vitest + jsdom), 6 assertions:
collapsed-state attributes, listbox/option wiring by id, `aria-activedescendant`
following the arrow keys across two rows with `aria-selected` flipping, focus staying
on the input while the highlight moves, the polite live region carrying the count,
and per-instance id uniqueness.

Guilt **and** innocence, both measured:

```
new suite vs origin/main's component   →  Test Files 1 failed | Tests 6 failed (6)
new suite vs this PR's component       →  Test Files 1 passed | Tests 6 passed (6)
both KBLISearch suites, this PR        →  Test Files 2 passed | Tests 11 passed (11)
```

## Gates

```
npm run build -w apps/mouth   →  green (PUBLIC_LOGIN_BUNDLE_OK: 8 assets, no internal API prefixes)
npm run lint  -w apps/mouth   →  0 errors, 177 warnings  — identical to today's baseline
npx prettier --check <3 files> →  All matched files use Prettier code style
tsc --noEmit (pre-commit)     →  clean
```

Lint is exactly the 0/177 baseline: this change adds no warning.

## Not measured — stated plainly

- **Playwright was not run locally.** Any e2e assertion touching the search input's
  role is the most likely thing to go red in CI, and I am not claiming it passes.
- **No live-browser keyboard run.** The Chrome extension refused `localhost` /
  `127.0.0.1` (two attempts, tab landed on `about:blank`), so the DOM-inspector check
  of `aria-activedescendant` mutating under real arrow keys was **not** performed in
  a browser. The jsdom suite above covers the same claim — `fireEvent.keyDown` →
  attribute equals the first option's id, then the second's — but it is jsdom, not a
  screen reader, and no actual AT (VoiceOver/NVDA) was used.
- No axe/Lighthouse run.

## Scope

Zero visual change. Zero keyboard-behaviour change — `handleKeyDown`, `handleSelect`
and the debounced search path are byte-identical. Zero colour change.
`apps/mouth/src/app/kbli/page.tsx` is untouched (held by open PR #6092).
Nothing under `packages/core/**`.

## CI source parity

Zero new `source="..."` lines (`git diff --cached -U0 | grep '^+' | grep -c 'source="'` → 0).
The `LeadSource` enum is untouched. Zero backend change.

Bites: `apps/mouth/src/components/kbli/KBLISearch.a11y-combobox.test.tsx` — it ships
in this PR and is the consumer. It fails 6/6 against `origin/main`'s component and
passes 6/6 against this one; the arrow-key assertion reads `aria-activedescendant`
off the rendered input, so a future edit that drops the wiring turns it red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182kQxzbDmB825Cpg2iutZN
