### PR TITLE
fix(a11y): give the /kbli chat surface a live region and named controls

### DIFF
--- a/apps/mouth/src/components/kbli/ZantaraChat.a11y.test.tsx
+++ b/apps/mouth/src/components/kbli/ZantaraChat.a11y.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ZantaraChat } from "./ZantaraChat";
+
+// next/dynamic pulls react-markdown in lazily; under jsdom we only need a
+// passthrough so the component tree mounts.
+vi.mock("next/dynamic", () => ({
+  default: () =>
+    function Markdown({ children }: { children?: React.ReactNode }) {
+      return <>{children}</>;
+    },
+}));
+vi.mock("@/lib/analytics", () => ({ trackKBLIChatQuestion: vi.fn() }));
+
+describe("ZantaraChat accessibility surface", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("exposes the message list as a named polite log, before any message", () => {
+    render(<ZantaraChat />);
+
+    const log = screen.getByRole("log", {
+      name: "Conversation with Zantara AI",
+    });
+    expect(log).toHaveAttribute("aria-live", "polite");
+  });
+
+  // The typing indicator is three bouncing dots and nothing else — zero text.
+  // role="status" on a node with no text announces nothing, so the dots are
+  // aria-hidden and an sr-only string carries the state.
+  it("announces the typing indicator instead of showing silent dots", async () => {
+    let release: (v: unknown) => void = () => {};
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    render(<ZantaraChat />);
+    const box = screen.getByRole("textbox", { name: "Chat with Zantara AI" });
+    fireEvent.change(box, { target: { value: "what is 56101" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    const status = await screen.findByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent("Zantara is typing");
+
+    release({ ok: true, json: async () => ({ answer: "ok" }) });
+    await waitFor(() =>
+      expect(screen.queryByRole("status")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("keeps a programmatic name on the icon-only send control", () => {
+    render(<ZantaraChat />);
+    expect(
+      screen.getByRole("button", { name: "Send message" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a programmatic name on the chat input", () => {
+    render(<ZantaraChat />);
+    expect(
+      screen.getByRole("textbox", { name: "Chat with Zantara AI" }),
+    ).toBeInTheDocument();
+  });
+
+  it("names each suggestion chip from its visible text", () => {
+    render(<ZantaraChat suggestions={["Capital rules", "Risk level"]} />);
+    expect(
+      screen.getByRole("button", { name: "Capital rules" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Risk level" }),
+    ).toBeInTheDocument();
+  });
+
+  it("puts the opener inside the log so it is announced with the thread", () => {
+    render(<ZantaraChat opener="Ask me about this code." />);
+    const log = screen.getByRole("log", {
+      name: "Conversation with Zantara AI",
+    });
+    expect(log).toHaveTextContent("Ask me about this code.");
+  });
+});

--- a/apps/mouth/src/components/kbli/ZantaraChat.tsx
+++ b/apps/mouth/src/components/kbli/ZantaraChat.tsx
@@ -148,6 +148,9 @@ export function ZantaraChat({
       {/* Messages Area */}
       <div
         ref={messagesBoxRef}
+        role="log"
+        aria-live="polite"
+        aria-label="Conversation with Zantara AI"
         className="relative z-10 max-h-96 min-h-[300px] space-y-5 overflow-y-auto p-5 scrollbar-thin scrollbar-thumb-white/10 scrollbar-track-transparent"
       >
         {opener && messages.length === 0 && (
@@ -191,13 +194,21 @@ export function ZantaraChat({
         ))}
 
         {loading && (
-          <div className="flex justify-start animate-fade-in-up">
-            <div className="shrink-0 mr-3 mt-1">
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex justify-start animate-fade-in-up"
+          >
+            <span className="sr-only">Zantara is typing…</span>
+            <div aria-hidden="true" className="shrink-0 mr-3 mt-1">
               <div className="flex items-center justify-center w-6 h-6 rounded-full bg-accent-warm/20 border border-accent-warm/30 shadow-[0_0_10px_rgba(212,132,90,0.2)]">
                 <Loader2 className="h-3 w-3 text-accent-warm animate-spin" />
               </div>
             </div>
-            <div className="max-w-[85%] rounded-2xl rounded-tl-sm bg-transparent px-2 py-3">
+            <div
+              aria-hidden="true"
+              className="max-w-[85%] rounded-2xl rounded-tl-sm bg-transparent px-2 py-3"
+            >
               <div className="flex space-x-1">
                 <div
                   className="w-1.5 h-1.5 bg-accent-warm/60 rounded-full animate-bounce"


### PR DESCRIPTION
## Problem

`apps/mouth/src/components/kbli/ZantaraChat.tsx` streams a whole conversation into
a plain `<div>`. On `origin/main` the file carries **zero `role=` attributes**
(measured, not assumed), so:

- nothing tells assistive technology that the message list is a region that updates
  on its own — an answer arriving from the backend is announced to nobody;
- the "typing" state is three bouncing dots (`:193`–`:217`) with **zero text
  content**, so it is invisible in both directions: no visual-only user loses it, no
  screen-reader user ever gets it.

WCAG 4.1.2 Name, Role, Value and 4.1.3 Status Messages.

## What reading the file falsified

The brief assumed the two `<button>` elements and the chat input needed programmatic
names. Reading `sed -n '1,273p'` shows they **already have them**, and those two
`aria-` hits are exactly the 2 the pattern probe counted:

| Element | Line | State on `origin/main` |
|---|---|---|
| suggestion chips | `:226` | named by **visible text** `{s}` — already fine |
| send control (icon-only `<Send/>`) | `:261` | `aria-label="Send message"` — already fine |
| chat input (`<textarea>`) | `:242` | `aria-label="Chat with Zantara AI"` — already fine |

Those three are left **byte-identical**. They are now covered by tests rather than
rewritten. Introducing a second labelling style over a correct one would have been
churn, and the brief explicitly warned against a third convention.

## Change

| Node | Added |
|---|---|
| message list (`:149`, `ref={messagesBoxRef}`) | `role="log"`, `aria-live="polite"`, `aria-label="Conversation with Zantara AI"` |
| typing indicator (`:193`) | `role="status"`, `aria-live="polite"`, `<span className="sr-only">Zantara is typing…</span>` |
| spinner avatar + dot row | `aria-hidden="true"` |

Two design points that are not cosmetic:

1. The log node is **always mounted** — `min-h-[300px]` keeps it on screen even with
   zero messages. A live region has to exist in the DOM *before* its content changes
   to be announced reliably; one that appears together with its first content is not.
2. `role="status"` on a node with no text announces **nothing**. That is why the dots
   are `aria-hidden` and an `sr-only` string carries the state, rather than the role
   being bolted onto silent decoration.

`sr-only` is measured, not assumed — it was confirmed present in the built CSS on
PR #6093 (Tailwind v4, CSS-first, no `tailwind.config.*`).

## Raw Observations

Base `origin/main` = `ed07dda54c`. `grep -c` counts **LINES**; the `role=` figure is
also given as occurrences via `grep -o | wc -l`, and the two agree.

Per-pattern, separate calls, same file:

```
                 origin/main   this branch
role=                 0            2       (log, status)   [occurrences: 2]
aria-                 2            7
aria-live             0            2
sr-only               0            1
<button               2            2       (unchanged — already named)
<label                0            0
file length         273          284 lines
```

Positive control for the counting tool, own call: `className` → **38** on
`origin/main`. That matches the cloud session's independently measured 38 exactly —
two sources, same number — and rises to 39 here only because the `sr-only` span adds
a line.

Closing colour control, run exactly as briefed (includes context lines):

```
git diff --cached | grep -c 'dc2626\|D01033\|#[0-9a-fA-F]\{6\}'                    → 0
git diff --cached -U0 | grep -E '^[+-]' | grep -v '^[+-][+-]' | grep -c '…same…'   → 0
```

**Zero colour lines**, in changed lines and in surrounding context alike.

## Blast radius — the #6093 lesson, applied

Changing an ARIA role is an API change visible to tests. Checked before editing:

```
git --no-pager grep -rn 'getByRole|findByRole|getAllByRole|queryByRole' -- apps/mouth/src/components/kbli
git --no-pager grep -rn 'ZantaraChat' -- apps/mouth/src
```

Result: **zero** tests query this component, and no test file for it existed at all.
Furthermore `log` and `status` land on plain `<div>`s, which have **no implicit
role** — nothing is being replaced, only added. This is materially unlike #6093,
where `role="combobox"` displaced the input's implicit `textbox` and broke two live
assertions. No deviation was required here.

`PrimeZantaraChat.tsx` is a separate component and is untouched.

## Tests

New suite `ZantaraChat.a11y.test.tsx` (vitest + jsdom), 6 assertions: the named
polite log present before any message; the typing indicator announced as
`role="status"` with its `sr-only` text while a request is in flight and gone after
it resolves; the icon-only send control's name; the input's name; each chip named
from visible text; the opener sitting inside the log.

Guilt and innocence, both measured, and the split reported as it actually is:

```
new suite vs origin/main's component   →  Tests 3 failed | 3 passed (6)
new suite vs this branch's component   →  Tests 6 passed (6)
```

The 3 that fail against `origin/main` are the log region, the typing announcement and
the opener-inside-log. The 3 that pass on both are deliberate **guards over
already-correct behaviour** (the two names and the chip names) — they prove nothing
about this diff and are not claimed to; they exist so a later edit cannot silently
strip the labels the file already earned. Reporting this as "6/6 red" would have been
false.

## Gates

Bare exit codes, not softened:

```
npm run build -w apps/mouth                    → RC=0   (PUBLIC_LOGIN_BUNDLE_OK: 8 assets)
npm run lint  -w apps/mouth                    → 0 errors, 177 warnings
npx prettier --check <ZantaraChat.tsx, test>   → RC=0   "All matched files use Prettier code style"
tsc --noEmit (pre-commit)                      → clean
vitest ZantaraChat.a11y.test.tsx               → 6 passed (6)
```

Lint is **exactly** the 0/177 baseline — delta 0 errors, 0 warnings. This change adds
no warning.

## Not measured — stated plainly

- **Playwright was not run locally.** Any new e2e assertion is the likeliest thing to
  go red in CI and is not claimed to pass. The existing `e2e/chat/*.spec.ts` files
  target a different chat surface, not this component, but that was read, not run.
- **No screen reader was used.** jsdom asserts the attributes and the text; it does
  not prove VoiceOver or NVDA actually speaks the log update. No axe or Lighthouse run.
- The `.worktrees/`-scanning half of the "vitest not measured" label still stands
  unmeasured: one test name can surface from a different branch.
- Local gates are not the real gate. CI is.

## Deliberately deferred

The message list is a scrollable region with no keyboard focus (`tabIndex` absent),
so a keyboard-only user cannot scroll it — a genuine WCAG 2.1.1 gap. Adding
`tabIndex={0}` is the standard fix but **adds a tab stop**, a user-visible change to
keyboard order that deserves its own decision rather than riding along in an
attribute-only PR. Flagged here rather than done silently. Likewise the suggestion
chip row has no group name; separate, smaller concern.

## Scope

Zero visual change. Zero behaviour change — `sendMessage`, the scroll effect, the
Enter/Shift+Enter handler and the fetch path are byte-identical. Zero colour change.
Untouched: `apps/mouth/src/app/kbli/page.tsx` (PR #6092), `KBLISearch.tsx` (PR #6093),
`KBLISectorBrowser.tsx`, `KBLIPersonaDoors.tsx`, `packages/core/**`, the KBLI data
model and `/api/kbli/*`. `apps/mouth/public/llms-full.txt` was regenerated by the
build and reverted with `git checkout --` before staging; the working tree shows only
the two intended files.

Zero new `source="..."` lines; the `LeadSource` enum is untouched; zero backend change.

Bites: `apps/mouth/src/components/kbli/ZantaraChat.a11y.test.tsx` — it ships in this
PR and is the consumer. It fails 3/6 against `origin/main`'s component and passes 6/6
against this one; the typing-indicator assertion drives a real in-flight request and
reads `role="status"` plus its `sr-only` text off the rendered tree, so an edit that
drops the live region or re-silences the dots turns it red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182kQxzbDmB825Cpg2iutZN
