### PR TITLE
fix(a11y): lift /kbli secondary text to zinc-400 so it passes AA on the dark surface

### DIFF
--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -122,7 +122,7 @@ export default async function KBLIHomePage({
               </p>
 
               {/* Inline stats */}
-              <p className="mt-3 text-sm text-zinc-500 tracking-wide">
+              <p className="mt-3 text-sm text-zinc-400 tracking-wide">
                 {codeCount} codes&ensp;&middot;&ensp;22
                 sectors&ensp;&middot;&ensp;PMA rules
               </p>
@@ -220,7 +220,7 @@ export default async function KBLIHomePage({
               <div className="text-2xl sm:text-3xl font-extrabold text-white tracking-tight">
                 {t.num}
               </div>
-              <div className="mt-1 text-[10px] font-bold uppercase tracking-[0.12em] text-zinc-500">
+              <div className="mt-1 text-[10px] font-bold uppercase tracking-[0.12em] text-zinc-400">
                 {t.label}
               </div>
             </div>

--- a/apps/mouth/src/components/kbli/KBLIPersonaDoors.tsx
+++ b/apps/mouth/src/components/kbli/KBLIPersonaDoors.tsx
@@ -39,7 +39,7 @@ function handleDoorClick(door: KBLIDoor): void {
 export function KBLIPersonaDoors() {
   return (
     <div className="mt-8 mb-0">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500 mb-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-400 mb-4">
         Where do you want to begin?
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
@@ -54,7 +54,7 @@ export function KBLIPersonaDoors() {
             <div className="text-[14px] font-semibold text-zinc-100 mb-1">
               {label}
             </div>
-            <div className="text-[12px] leading-relaxed text-zinc-500">
+            <div className="text-[12px] leading-relaxed text-zinc-400">
               {subtext}
             </div>
           </a>

--- a/apps/mouth/src/components/kbli/KBLISearch.tsx
+++ b/apps/mouth/src/components/kbli/KBLISearch.tsx
@@ -204,7 +204,7 @@ export function KBLISearch({
 
       {quickFilters && quickFilters.length > 0 && (
         <div className="mt-4 flex flex-wrap items-center gap-2 justify-center lg:justify-start">
-          <span className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mr-2">
+          <span className="text-xs font-semibold text-zinc-400 uppercase tracking-wider mr-2">
             Quick:
           </span>
           {quickFilters.map((filter) => (

--- a/apps/mouth/src/components/kbli/ZantaraChat.tsx
+++ b/apps/mouth/src/components/kbli/ZantaraChat.tsx
@@ -135,7 +135,7 @@ export function ZantaraChat({
         </div>
         {codeContext && (
           <div className="ml-auto flex flex-col items-end">
-            <span className="text-[10px] text-zinc-500 uppercase tracking-wider">
+            <span className="text-[10px] text-zinc-400 uppercase tracking-wider">
               Context
             </span>
             <span className="text-xs font-semibold text-zinc-300 bg-white/5 px-2 py-0.5 rounded-md border border-white/10">


### PR DESCRIPTION
Lift six secondary-text nodes on /kbli from `text-zinc-500` to `text-zinc-400` so they clear the WCAG AA 4.5:1 threshold on the dark surface.

# Insight

`text-zinc-500` on /kbli's dark backgrounds is a genuine AA failure for normal-size text, not a stylistic preference. Measured on the live deployment, the computed colour `oklch(0.552 0.016 285.938)` sits at **3.81:1** against the page ground `rgb(20,20,22)` and **3.09:1** against the card ground `rgb(29,39,59)`. Both fall under the 4.5:1 bar of WCAG 2.x SC 1.4.3, and the affected nodes render at 10–14px, so the large-text 3:1 exemption does not apply to any of them.

The next step on the zinc ramp fixes it with no other change: `zinc-400` (`#a1a1aa`) measures **7.18:1** on `#141416` and **5.83:1** on `#1d273b` — passing on both grounds with headroom, while staying a step below the `zinc-100`/`zinc-300` used for primary text, so the visual hierarchy is preserved rather than flattened.

# Studio

## Source / Reference

- WCAG 2.x SC 1.4.3 Contrast (Minimum), normal text threshold 4.5:1.
- Live measurement of /kbli taken 10 Sep 2026: `x-vercel-cache: MISS`, `age: 0`, deployment `dpl_DcEykC5zr7oJmAaiUXAB2NDXfzNW`, served commit `8d743ab7c3`. 10 elements carrying `.text-zinc-500`, computed backgrounds `rgb(20,20,22)` and `rgb(29,39,59)` plus an `rgba(255,255,255,0.03)` overlay.
- Contrast tool sanity-checked against the black/white control pair, which returned the expected 21.00.
- Branch base: `origin/main` at `ed07dda54c`.

## Methodology

1. Enumerated every `text-zinc-500` occurrence on `origin/main` across the four files that /kbli renders, before editing anything.
2. Changed only the colour token on the six lines that carry **text**, leaving every other byte of each `className` untouched.
3. Ran the three real gates — `npm run build -w apps/mouth`, `npm run lint -w apps/mouth`, `npx prettier --check` on the four files.
4. Reverted the build-regenerated `apps/mouth/public/llms-full.txt` before staging, and staged the four source files by name rather than with `git add .`.
5. Confirmed the change reaches the compiled artifact, not just the source.
6. Tested this branch for merge conflicts against the three open PRs that touch the same files.

## Raw Observations

Pre-edit enumeration on `origin/main` returned exactly 7 lines — page.tsx:125, page.tsx:223, KBLIPersonaDoors.tsx:42, KBLIPersonaDoors.tsx:57, KBLISearch.tsx:198, KBLISearch.tsx:207, ZantaraChat.tsx:138 — matching the expected inventory. Positive control on the same pathspec (`className` in KBLIPersonaDoors.tsx) returned 7, so the pathspec resolves.

Closing greps on the staged change:

| Check | Expected | Measured |
|---|---|---|
| `text-zinc-500` remaining in the four files | 1 | **1** (only KBLISearch.tsx:198) |
| `^[-+].*text-zinc-` lines in the staged diff | 12 | **12** |
| `#[0-9a-fA-F]{6}` lines in the staged diff | 0 | **0** |

Gates:

| Gate | Result |
|---|---|
| `npm run build -w apps/mouth` | exit 0 — compiled in 4.3min, TypeScript clean, 1766/1766 static pages |
| `npm run lint -w apps/mouth` | exit 0 — **0 errors / 177 warnings**, exactly the stated baseline |
| `npx prettier --check` (4 files) | exit 0 — all matched files use Prettier code style |
| pre-commit hooks (incl. `tsc --noEmit`) | all checks passed |

Test search: `zinc-500` across `apps/mouth/src/**/*.test.*` and `apps/mouth/e2e/**` returned **zero** hits, so no assertion locks the old token and no test needed updating. Positive control on the same globs: `className` matched **52** files, confirming the globs resolve rather than silently matching nothing. Playwright was not run locally, so e2e behaviour is **unmeasured**, not verified.

Compiled-artifact check: all six new class strings appear in `apps/mouth/.next`, and the old string `mt-3 text-sm text-zinc-500 tracking-wide` has **zero** occurrences anywhere in the build output. The untouched icon button's `hover:bg-white/[0.08] text-zinc-500` is still present, as intended.

Conflict test against the three open PRs sharing these files (this git is 2.37.1, which predates `merge-tree --write-tree`, so the legacy three-argument form was used):

| Branch | PR | Conflict hunks |
|---|---|---|
| `sancho/kbli-brand-red` | #6092 | 0 |
| `sancho/kbli-a11y-combobox` | #6093 | 0 |
| `sancho/kbli-a11y-chatlog` | #6094 | 0 |

The detector was positively controlled: against #6093, `KBLISearch.tsx` reports "changed in both" and still merges with zero conflict markers, so the zero is a real clean merge and not an empty comparison.

## Reasoning Path

The failure is a colour-token choice, so the minimal correct fix is a token change, not a layout or markup change — which is also what keeps this PR to one concern. `zinc-400` was chosen over a custom value because it is the adjacent step already in use elsewhere in the design system: it clears AA on both measured grounds and needs no new token, so `packages/core` tokens stay untouched.

KBLISearch.tsx:198 was deliberately excluded. It is an icon-only clear button, so it is governed by SC 1.4.11 Non-text Contrast at a 3:1 threshold — a different criterion with a different bar, and therefore a different PR. Folding it in here would mix two success criteria under one claim.

Red brand colours were likewise left alone: they belong to #6092. Roles and ARIA belong to #6093 and #6094.

## Risk / Implication

Low. The change is six colour tokens with no structural, behavioural, or API surface. The realistic risk is aesthetic rather than functional: secondary text becomes brighter, which slightly compresses the perceived distance between it and the `zinc-100`/`zinc-300` primary text. The hierarchy is preserved on paper — `zinc-400` remains two steps below `zinc-100` — but that is a judgement the rendered page has to settle, which is why the aesthetic gate below is the owner's and not this session's.

The three open PRs touching these files merge cleanly today. That is a measurement of the current tips, not a guarantee: if any of them is rebased or force-pushed, the test should be re-run before this one lands.

# Recommendation

Merge after the aesthetic gate passes. The accessibility case is measured and unambiguous, the gates are green, and the change is confined to the smallest edit that fixes it.

# Next Action

Aesthetic gate — **owner's call, not this session's**: screenshot local `next dev` /kbli before/after at 390px and 1280px, covering the hero block (page.tsx:125), the persona doors, and the trust bar, and confirm the heading/secondary hierarchy still reads correctly. Pass/fail is written by the owner.

Bites: CONSUMER is the compiled /kbli route bundle `apps/mouth/.next/server/app/kbli/page.js`, produced by `npm run build -w apps/mouth` in this branch (exit 0). Observation proving the change is in force: that bundle contains `mt-3 text-sm text-zinc-400 tracking-wide`, and the pre-change string `mt-3 text-sm text-zinc-500 tracking-wide` has zero occurrences anywhere under `apps/mouth/.next`. The build ships in this PR; nothing here is deferred to a future job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2BWNqHXKjYQoW94Ua6fkK
