### PR TITLE
fix(pro): reap a stale .git/index.lock that stalls the main-checkout puller

### DIFF
--- a/scripts/pro/pro-git-pull.sh
+++ b/scripts/pro/pro-git-pull.sh
@@ -70,6 +70,7 @@ LOG_FILE="${PRO_GIT_PULL_LOG:-$HOME/logs/pro-git-pull.log}"
 LOCK_DIR="${PRO_GIT_PULL_LOCK:-/tmp/pro-git-pull.lock.d}"
 BACKUP_ROOT="${PRO_GIT_PULL_BACKUP_ROOT:-$HOME/.git-pull-collision-backup}"
 LOCK_STALE_SECONDS=1800
+INDEX_LOCK_STALE_SECONDS="${PRO_GIT_PULL_INDEX_LOCK_STALE_SECONDS:-1800}"
 
 # Pro-authoritative runtime-state files — the SAME SSOT the worktree_isolation hook reads
 # (infra/claude-hooks/runtime_state_allowlist.json). On a collision these are kept LOCAL,
@@ -132,6 +133,62 @@ for e in d.get("entries", []):
     if p and isinstance(m, list) and ("pro" in m or "all" in m):
         print(p)
 PY
+}
+
+# A git process that crashes or is SIGKILLed mid-index-write leaves `.git/index.lock`
+# behind. Every later tick then dies inside an index-touching command — resolve_collisions'
+# `git checkout HEAD --`, or the ff itself — and git's generic "Another git process seems to
+# be running" text was logged under this script's "file/dir conflict" line, a misleading
+# message that hid the real cause for 20h / 77 ticks / 46 commits on 2026-09-10 (lock born
+# 00:00:17, zero bytes, no holder). Nothing self-heals it: an orphaned lock has no owner to
+# reap it, so the puller retries forever against a condition that never changes.
+#
+# Stealing a lock a LIVE git holds would corrupt that git's index write, so BOTH conditions
+# must hold before we touch it: (a) no process has the file open, and (b) it is older than
+# INDEX_LOCK_STALE_SECONDS (>= 2 puller ticks). Either alone is unsafe — the holder test
+# alone races a git that has not opened the lock yet in this instant, and age alone would
+# kill a genuinely long-running `git checkout`. If lsof is unavailable the holder test
+# cannot be MADE, so we do not steal: config/tooling gaps must fail toward "don't touch",
+# never toward "clobber" (the same rule _runtime_state_paths follows for a corrupt
+# allowlist). The lock is copied to the backup root before removal — a non-empty index.lock
+# can carry a partially-written index — so this deletes nothing unrecoverably.
+#
+# Returns 0 = safe to proceed, 1 = caller must skip this tick (everything left untouched).
+clear_stale_git_index_lock() {
+  local lock now mtime age holder ts dest
+  lock="$(git rev-parse --git-path index.lock 2>/dev/null)"
+  [ -n "$lock" ] || lock=".git/index.lock"
+  [ -e "$lock" ] || return 0
+
+  now=$(date +%s)
+  mtime=$(stat -f %m "$lock" 2>/dev/null || echo "$now")
+  age=$(( now - mtime ))
+  if [ "$age" -le "$INDEX_LOCK_STALE_SECONDS" ]; then
+    log "index.lock present, only ${age}s old — a live git may hold it; skip tick"
+    return 1
+  fi
+
+  if ! command -v lsof >/dev/null 2>&1; then
+    log "  ERROR: index.lock is ${age}s old but lsof is unavailable — cannot prove it unheld; skip tick (fail-safe)"
+    telegram_alert "index-lock-no-lsof" \
+      "Pro pull: stale .git/index.lock (${age}s old) but lsof is missing, so the no-holder test cannot run and it was NOT stolen. Sync stays stalled until an operator clears it."
+    return 1
+  fi
+  holder="$(lsof -t "$lock" 2>/dev/null)"
+  if [ -n "$holder" ]; then
+    log "index.lock is ${age}s old but PID(s) '$holder' still hold it — not stealing; skip tick"
+    return 1
+  fi
+
+  ts="$(date '+%Y%m%d-%H%M%S')-$$"
+  dest="$BACKUP_ROOT/stale-index-lock-$ts"
+  mkdir -p "$dest" 2>>"$LOG_FILE" || { log "  ERROR: mkdir $dest for index.lock backup"; return 1; }
+  cp -p "$lock" "$dest/index.lock" 2>>"$LOG_FILE" || { log "  ERROR: index.lock backup cp failed — not stealing (fail-safe)"; return 1; }
+  rm -f "$lock" 2>>"$LOG_FILE" || { log "  ERROR: index.lock removal failed"; return 1; }
+  log "Stole stale .git/index.lock (age ${age}s, no holder) -> $dest/index.lock"
+  telegram_alert "index-lock-stale" \
+    "Pro pull: removed a stale .git/index.lock (${age}s old, no process holding it) that was blocking every sync tick. Backup: ${dest}. A git process crashed or was killed mid-index-write."
+  return 0
 }
 
 # Atomic single-instance lock via mkdir (POSIX-atomic). Steals a lock older than
@@ -302,10 +359,18 @@ trap 'exit 130' INT
 trap 'exit 129' HUP
 
 cd "$REPO" 2>/dev/null || { log "FATAL: $REPO not found"; exit 1; }
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-/usr/bin:/bin}"
+# /usr/sbin is on this PATH for lsof (clear_stale_git_index_lock's holder test); launchd
+# hands this job a minimal PATH, and without lsof that test fails closed and stalls sync.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:${PATH:-/usr/bin:/bin}"
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 if [ "$BRANCH" != "main" ]; then log "On branch '$BRANCH' (not main), skip"; exit 0; fi
+
+# Before ANY index-touching command (resolve_collisions' checkout, the ff): an orphaned
+# index.lock makes every one of them fail. exit 0, not 1 — a lock a live git legitimately
+# holds is transient and retries next tick, and the pathological cases (stale-but-unverifiable)
+# have already raised their own alert. This mirrors the fetch-failed path's convention.
+clear_stale_git_index_lock || exit 0
 
 if ! git fetch --quiet origin main 2>>"$LOG_FILE"; then
   log "git fetch origin failed (network?), skip"

--- a/scripts/pro/pro-git-pull.sh
+++ b/scripts/pro/pro-git-pull.sh
@@ -135,6 +135,20 @@ for e in d.get("entries", []):
 PY
 }
 
+# File mtime in epoch seconds, portable across the two stats this repo's CI and its target
+# host actually run: GNU (`stat -c %Y`, ubuntu-latest, where the antidotes job executes the
+# suite) and BSD (`stat -f %m`, Pro/M5), with python3 — already a hard dep via tg_notify.py —
+# as the last resort. Prints NOTHING on total failure, deliberately: the caller must treat an
+# unknown mtime as "do not touch". A `|| echo $(date +%s)` fallback would be WORSE than an
+# error, because every lock would then measure 0s old and the steal would never fire — the
+# failure would be silent and indistinguishable from a healthy repo, which is exactly the
+# invisible-stall class this whole function exists to end.
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null \
+    || stat -f %m "$1" 2>/dev/null \
+    || python3 -c 'import os,sys;print(int(os.stat(sys.argv[1]).st_mtime))' "$1" 2>/dev/null
+}
+
 # A git process that crashes or is SIGKILLed mid-index-write leaves `.git/index.lock`
 # behind. Every later tick then dies inside an index-touching command — resolve_collisions'
 # `git checkout HEAD --`, or the ff itself — and git's generic "Another git process seems to
@@ -161,7 +175,11 @@ clear_stale_git_index_lock() {
   [ -e "$lock" ] || return 0
 
   now=$(date +%s)
-  mtime=$(stat -f %m "$lock" 2>/dev/null || echo "$now")
+  mtime="$(file_mtime "$lock")"
+  if [ -z "$mtime" ]; then
+    log "  ERROR: cannot read index.lock mtime (no usable stat/python3) — skip tick (fail-safe)"
+    return 1
+  fi
   age=$(( now - mtime ))
   if [ "$age" -le "$INDEX_LOCK_STALE_SECONDS" ]; then
     log "index.lock present, only ${age}s old — a live git may hold it; skip tick"

--- a/scripts/pro/test_pro_git_pull.sh
+++ b/scripts/pro/test_pro_git_pull.sh
@@ -72,6 +72,14 @@ write_allowlist() {
     printf ']}\n'; } > "$out"
 }
 
+# Backdate a file by 2h, portably. The obvious spellings are each half-portable — BSD touch
+# wants an absolute stamp its own date builds, GNU touch takes a relative phrase and rejects
+# the BSD date flag outright — and this suite runs on BOTH (ubuntu-latest in the antidotes
+# job, macOS on Pro and M5). python3 sidesteps the split; it is already a hard dep here.
+backdate_2h() {
+  python3 -c 'import os,sys,time; t=time.time()-7200; os.utime(sys.argv[1],(t,t))' "$1"
+}
+
 echo "=== pro-git-pull adversarial suite ==="
 
 # ── A: clean behind → ff, no backup ──
@@ -291,7 +299,7 @@ rm -rf "$SANDBOX"
 echo "[J1] stale unheld index.lock → stolen, ff succeeds"
 setup_case J1; advance_origin "docs/j1.md" "hello"; git -C "$LOCAL" fetch -q origin main
 : > "$LOCAL/.git/index.lock" || fatal "J1 lock create"
-touch -t "$(date -v-2H '+%Y%m%d%H%M')" "$LOCAL/.git/index.lock" || fatal "J1 backdate"
+backdate_2h "$LOCAL/.git/index.lock" || fatal "J1 backdate"
 RC=$(run_puller); eq_ne "$RC" "0" "J1 rc=0"
 eq_ne "$(head_of)" "$(remote_head)" "J1 HEAD advanced past the stale lock"
 [ ! -e "$LOCAL/.git/index.lock" ] && ok "J1 stale lock removed" || bad "J1 stale lock survived"
@@ -314,17 +322,27 @@ rm -rf "$SANDBOX"
 echo "[J3] old-but-held index.lock → not stolen (holder test is load-bearing)"
 setup_case J3; advance_origin "docs/j3.md" "hello"; git -C "$LOCAL" fetch -q origin main
 : > "$LOCAL/.git/index.lock" || fatal "J3 lock create"
-touch -t "$(date -v-2H '+%Y%m%d%H%M')" "$LOCAL/.git/index.lock" || fatal "J3 backdate"
-sleep 30 9>"$LOCAL/.git/index.lock" & HOLDER=$!
-sleep 1
-if lsof -t "$LOCAL/.git/index.lock" >/dev/null 2>&1; then
-  RC=$(run_puller); eq_ne "$RC" "0" "J3 rc=0"
-  ne_ne "$(head_of)" "$(remote_head)" "J3 HEAD did NOT move"
-  [ -e "$LOCAL/.git/index.lock" ] && ok "J3 held lock preserved" || bad "J3 stole a lock a live process held!"
+backdate_2h "$LOCAL/.git/index.lock" || fatal "J3 backdate"
+if command -v lsof >/dev/null 2>&1; then
+  sleep 30 9>"$LOCAL/.git/index.lock" & HOLDER=$!
+  sleep 1
+  if lsof -t "$LOCAL/.git/index.lock" >/dev/null 2>&1; then
+    RC=$(run_puller); eq_ne "$RC" "0" "J3 rc=0"
+    ne_ne "$(head_of)" "$(remote_head)" "J3 HEAD did NOT move"
+    [ -e "$LOCAL/.git/index.lock" ] && ok "J3 held lock preserved" || bad "J3 stole a lock a live process held!"
+  else
+    bad "J3 fixture: holder process did not register with lsof (case did not run)"
+  fi
+  kill "$HOLDER" 2>/dev/null; wait "$HOLDER" 2>/dev/null
 else
-  bad "J3 fixture: holder process did not register with lsof (case did not run)"
+  # No lsof on this host (some CI images ship without it). The holder test cannot be
+  # ISOLATED here, so asserting "lock preserved" would pass for the wrong reason. Assert the
+  # function's no-lsof REFUSAL path instead: same observable outcome, but a claim this
+  # environment can actually earn.
+  RC=$(run_puller); eq_ne "$RC" "0" "J3 rc=0 (no lsof on this host, refusal path)"
+  ne_ne "$(head_of)" "$(remote_head)" "J3 HEAD did NOT move (no-lsof refusal)"
+  [ -e "$LOCAL/.git/index.lock" ] && ok "J3 lock preserved without a holder test" || bad "J3 stole a lock with no way to check for a holder!"
 fi
-kill "$HOLDER" 2>/dev/null; wait "$HOLDER" 2>/dev/null
 rm -rf "$SANDBOX"
 
 echo "=== $PASS passed, $FAIL failed ==="

--- a/scripts/pro/test_pro_git_pull.sh
+++ b/scripts/pro/test_pro_git_pull.sh
@@ -285,5 +285,47 @@ eq_ne "$(head_of)" "$(remote_head)" "I5 HEAD advanced"
 [ "$(cat "$LOCAL/escalations.jsonl")" = 'e-local' ] && ok "I5 file#2 kept local" || bad "I5 file#2 reset (multi-file restore missed one!)"
 rm -rf "$SANDBOX"
 
+# ── J1: STALE unheld .git/index.lock → stolen (backed up), ff succeeds ──
+# The 2026-09-10 outage in one case: an orphaned lock blocked 77 consecutive ticks because
+# nothing reaps a lock whose owner died. Backdated 2h so it is past INDEX_LOCK_STALE_SECONDS.
+echo "[J1] stale unheld index.lock → stolen, ff succeeds"
+setup_case J1; advance_origin "docs/j1.md" "hello"; git -C "$LOCAL" fetch -q origin main
+: > "$LOCAL/.git/index.lock" || fatal "J1 lock create"
+touch -t "$(date -v-2H '+%Y%m%d%H%M')" "$LOCAL/.git/index.lock" || fatal "J1 backdate"
+RC=$(run_puller); eq_ne "$RC" "0" "J1 rc=0"
+eq_ne "$(head_of)" "$(remote_head)" "J1 HEAD advanced past the stale lock"
+[ ! -e "$LOCAL/.git/index.lock" ] && ok "J1 stale lock removed" || bad "J1 stale lock survived"
+ls "$SANDBOX"/backup/stale-index-lock-* >/dev/null 2>&1 && ok "J1 lock backed up (recoverable)" || bad "J1 no lock backup"
+rm -rf "$SANDBOX"
+
+# ── J2: FRESH index.lock → tick skipped, lock untouched, HEAD unmoved ──
+# A young lock is presumed to belong to a live git; stealing it would corrupt that write.
+echo "[J2] fresh index.lock → skip tick, lock preserved"
+setup_case J2; advance_origin "docs/j2.md" "hello"; git -C "$LOCAL" fetch -q origin main
+: > "$LOCAL/.git/index.lock" || fatal "J2 lock create"
+RC=$(run_puller); eq_ne "$RC" "0" "J2 rc=0 (transient skip, not an error)"
+ne_ne "$(head_of)" "$(remote_head)" "J2 HEAD did NOT move"
+[ -e "$LOCAL/.git/index.lock" ] && ok "J2 fresh lock preserved" || bad "J2 fresh lock stolen (would corrupt a live git!)"
+rm -rf "$SANDBOX"
+
+# ── J3: OLD lock but a LIVE process holds it → NOT stolen ──
+# The sharp one: age alone must never authorise the steal. Only the holder test separates
+# this case from J1, so a regression that drops lsof fails here and nowhere else.
+echo "[J3] old-but-held index.lock → not stolen (holder test is load-bearing)"
+setup_case J3; advance_origin "docs/j3.md" "hello"; git -C "$LOCAL" fetch -q origin main
+: > "$LOCAL/.git/index.lock" || fatal "J3 lock create"
+touch -t "$(date -v-2H '+%Y%m%d%H%M')" "$LOCAL/.git/index.lock" || fatal "J3 backdate"
+sleep 30 9>"$LOCAL/.git/index.lock" & HOLDER=$!
+sleep 1
+if lsof -t "$LOCAL/.git/index.lock" >/dev/null 2>&1; then
+  RC=$(run_puller); eq_ne "$RC" "0" "J3 rc=0"
+  ne_ne "$(head_of)" "$(remote_head)" "J3 HEAD did NOT move"
+  [ -e "$LOCAL/.git/index.lock" ] && ok "J3 held lock preserved" || bad "J3 stole a lock a live process held!"
+else
+  bad "J3 fixture: holder process did not register with lsof (case did not run)"
+fi
+kill "$HOLDER" 2>/dev/null; wait "$HOLDER" 2>/dev/null
+rm -rf "$SANDBOX"
+
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Cause

A git process killed mid-index-write leaves `.git/index.lock` behind. Nothing reaps an orphaned lock, so every subsequent tick of the 15-minute Pro puller died inside an index-touching command (`resolve_collisions`' `git checkout HEAD --`, or the fast-forward itself) and logged git's generic "Another git process seems to be running" under this script's `file/dir conflict` line — a message that named the wrong cause.

Observed tonight on Pro: a zero-byte lock born 2026-09-10 00:00:17, no holder, blocked 77 consecutive ticks over 20 hours. The main checkout sat 46 commits behind `origin/main` while `launchctl list` reported `com.nuzantara.git-pull-main.15min` at exit 0 the whole time. Scar #2, Esiste != Armato: the job existed, ran, and did nothing.

The three tracked files that are always dirty on Pro (`published_articles.json`, `AUTOMATIONS_REFERENCE.md`, `escalations_pro.jsonl`) were **not** the cause. They are dirty by design — declared in `infra/claude-hooks/runtime_state_allowlist.json` and already kept-local across the ff by this puller. This PR does not touch that contract.

## Change

`clear_stale_git_index_lock()` runs right after the branch guard, before any index-touching command. It steals the lock only when **both** conditions hold:

- no process has the file open (`lsof`), and
- it is older than `INDEX_LOCK_STALE_SECONDS` (default 1800s, two full ticks).

Either test alone is unsafe. The holder test alone races a git that has not opened the lock yet in that instant; age alone would kill a genuinely long-running `git checkout`. When `lsof` is unavailable the holder test cannot be *made*, so the tick skips and alerts instead of clobbering — the same fail-toward-"don't touch" rule `_runtime_state_paths` already applies to a corrupt allowlist. The lock is copied to the backup root before removal, because a non-empty `index.lock` can carry a partially-written index.

`/usr/sbin` joins the exported PATH: launchd hands this job a minimal one, and without `lsof` the holder test would fail closed on every tick.

A live-git lock is transient, so that path exits 0 and retries next tick, matching the existing `fetch-failed` convention.

## Tests

Three cases added to the existing hermetic suite. J3 is the sharp one: only the holder test separates it from J1, so a regression that drops `lsof` fails there and nowhere else.

| case | fixture | expected |
|---|---|---|
| J1 | lock backdated 2h, no holder | stolen + backed up, ff lands |
| J2 | lock created now | tick skipped, lock preserved, HEAD unmoved |
| J3 | lock backdated 2h, live process holding it | not stolen, HEAD unmoved |

```
bash scripts/pro/test_pro_git_pull.sh
=== 65 passed, 0 failed ===
```

## Bites

**Consumer:** `com.nuzantara.git-pull-main.15min` on Pro, via the wrapper `/Users/nuzantara/scripts/pro-git-pull-main.sh`, which executes `~/nuzantara-deploy/scripts/pro/pro-git-pull.sh`.

**Observation that proves it is in force:** after merge, the deploy checkout's copy of this script carries the new `clear_stale_git_index_lock` symbol and the live wrapper executes it. Verified by `grep -c clear_stale_git_index_lock ~/nuzantara-deploy/scripts/pro/pro-git-pull.sh` returning non-zero and a wrapper run logging `OK pulled` / up-to-date.

**Note for the gate:** the wrapper prefers `~/nuzantara-deploy` over `~/nuzantara`, and that deploy checkout is frozen at `9efef3964` (2026-09-01) with its puller disabled. Merging alone does **not** put this fix in force — the deploy step is what does. That delivery is performed and proven in the same mandate, not deferred.

The immediate outage is already cured out-of-band: the stale lock was backed up and removed by hand, and Pro fast-forwarded 46 commits to `ed07dda54c` with all three runtime-state files byte-identical to their pre-pull backups. This PR stops the next one.

## Cure on branch (declared, once — a1e0f2aa5d)

Gate REWORK-BUILD on `66599e6833`: the required `antidotes` check was RED on ubuntu-latest. Both halves of the first cut were BSD-only, and the doctrine's one exception applies because the red lived in this diff.

- **Fixture.** J1 backdated with `touch -t "$(date -v-2H ...)"`. GNU date rejects that flag, so the fixture went FATAL exit 3, J2 and J3 never ran, and `spec_collision_matrix.sh` never started. The change *lowered* CI coverage while appearing to raise it.
- **Function, the worse one.** It read mtime with `stat -f %m` behind a `|| echo "$now"` fallback. On GNU that fallback fires every tick, every lock measures 0s old, and the steal never happens — a silent no-op indistinguishable from a healthy repo, i.e. the exact invisible-stall class this function exists to end.

`file_mtime()` now tries GNU `stat -c %Y`, then BSD `stat -f %m`, then python3, and prints **nothing** if all three fail; an unknown mtime skips the tick rather than defaulting to a number. `backdate_2h()` uses python3 for the same reason. J3 no longer fails where `lsof` is absent: it cannot isolate the holder test there, so it asserts the no-lsof refusal path instead of a claim that would pass for the wrong reason.

The `/usr/sbin` PATH addition stays (F4): `lsof` lives only there on Pro and M5.

Local, macOS: `65 passed, 0 failed`, collision matrix `STABLE` at 102 cells. The GNU branch of `file_mtime` is provable only in CI — M5 has no GNU stat.

## PENDING-ARMS

| when | action | why |
|---|---|---|
| after merge | copy ONE file from `origin/main` to `/Users/nuzantara/nuzantara-deploy/scripts/pro/pro-git-pull.sh`, mode 0755 | the LaunchAgent wrapper `/Users/nuzantara/scripts/pro-git-pull-main.sh` still executes the deploy tree's copy, so merging alone does not put this fix in force |

Interim only. Lane 9 (`dux-parabellum-pro-one-tree`) repoints the wrapper; coordination happens by comment on this PR, and this lane does not touch the wrapper itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
