### PR TITLE
fix(pro): acquire_lock read mtime the BSD-only way and declined in silence

### DIFF
--- a/scripts/pro/pro-git-pull.sh
+++ b/scripts/pro/pro-git-pull.sh
@@ -211,16 +211,33 @@ clear_stale_git_index_lock() {
 
 # Atomic single-instance lock via mkdir (POSIX-atomic). Steals a lock older than
 # LOCK_STALE_SECONDS (crash leftover). Returns 0 if acquired, 1 if a live peer holds it.
+#
+# The age is read through file_mtime() for the same reason clear_stale_git_index_lock does:
+# the old `stat -f %m ... || echo "$now"` was BSD-only, and its fallback did not fail, it
+# LIED. On GNU every held lock measured 0s, the steal branch never fired, and the function
+# returned 1 with no log line at all — the log file was not even created. A crash leftover
+# would have blocked the puller forever while looking like ordinary contention with a live
+# peer. That is the same invisible-stall class as W89's sibling rule: once the helper exists,
+# the sibling in the same file gets fixed, not ledgered.
+#
+# An unreadable mtime now DECLINES and says so. Refusing to steal is the safe half — the
+# worst case is a skipped tick that retries in 15 minutes — but refusing SILENTLY is not,
+# because a permanent stall and a busy peer then look identical from the outside.
 acquire_lock() {
   if mkdir "$LOCK_DIR" 2>/dev/null; then echo $$ > "$LOCK_DIR/pid" 2>/dev/null; return 0; fi
   local now mtime age
   now=$(date +%s)
-  mtime=$(stat -f %m "$LOCK_DIR" 2>/dev/null || echo "$now")
+  mtime="$(file_mtime "$LOCK_DIR")"
+  if [ -z "$mtime" ]; then
+    log "Lock dir held but its mtime is unreadable (no usable stat/python3) — declining to steal, skip tick"
+    return 1
+  fi
   age=$(( now - mtime ))
   if [ "$age" -gt "$LOCK_STALE_SECONDS" ]; then
     log "Stale lock ${age}s old, stealing"
     rm -rf "$LOCK_DIR"
     if mkdir "$LOCK_DIR" 2>/dev/null; then echo $$ > "$LOCK_DIR/pid" 2>/dev/null; return 0; fi
+    log "  ERROR: could not recreate the lock dir after clearing a stale one — skip tick"
   fi
   return 1
 }

--- a/scripts/pro/test_pro_git_pull.sh
+++ b/scripts/pro/test_pro_git_pull.sh
@@ -345,5 +345,33 @@ else
 fi
 rm -rf "$SANDBOX"
 
+# ── K: acquire_lock's own stale-lock branch. It had NO coverage, and on GNU it was a
+# silent no-op: `stat -f %m` failed, the `|| echo "$now"` fallback made every held lock
+# measure 0s, the steal never fired and the function returned 1 without writing a single log
+# line. A crash leftover would stall the puller forever while looking like a busy peer.
+# The fixture plants a lock dir whose recorded pid is DEAD — note the script decides on the
+# DIRECTORY's age and never reads that pid file, so the pid documents the scenario while the
+# assertion rests on mtime, which is the thing that was broken.
+echo "[K1] stale lock dir (dead pid) → stolen, tick proceeds"
+setup_case K1; advance_origin "docs/k1.md" "hello"; git -C "$LOCAL" fetch -q origin main
+sleep 0 & DEADPID=$!; wait "$DEADPID" 2>/dev/null   # a pid that has certainly exited
+mkdir -p "$SANDBOX/pull.lock.d" || fatal "K1 lock dir"
+echo "$DEADPID" > "$SANDBOX/pull.lock.d/pid" || fatal "K1 pid file"
+backdate_2h "$SANDBOX/pull.lock.d" || fatal "K1 backdate"
+RC=$(run_puller); eq_ne "$RC" "0" "K1 rc=0"
+eq_ne "$(head_of)" "$(remote_head)" "K1 HEAD advanced (stale lock was stolen)"
+grep -q "Stale lock" "$SANDBOX/pull.log" 2>/dev/null && ok "K1 steal is logged, not silent" || bad "K1 no log line (the GNU silent no-op)"
+[ "$(cat "$SANDBOX/pull.lock.d/pid" 2>/dev/null)" != "$DEADPID" ] && ok "K1 lock dir retaken by this run" || bad "K1 dead pid still owns the lock"
+rm -rf "$SANDBOX"
+
+echo "[K2] fresh lock dir → live peer presumed, tick skipped"
+setup_case K2; advance_origin "docs/k2.md" "hello"; git -C "$LOCAL" fetch -q origin main
+mkdir -p "$SANDBOX/pull.lock.d" || fatal "K2 lock dir"
+echo "999999" > "$SANDBOX/pull.lock.d/pid" || fatal "K2 pid file"
+RC=$(run_puller); eq_ne "$RC" "0" "K2 rc=0 (silent skip, a peer is running)"
+ne_ne "$(head_of)" "$(remote_head)" "K2 HEAD did NOT move"
+[ "$(cat "$SANDBOX/pull.lock.d/pid" 2>/dev/null)" = "999999" ] && ok "K2 young lock left to its owner" || bad "K2 stole a lock a peer may still hold!"
+rm -rf "$SANDBOX"
+
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Follow-up to #6098, which is the condition that PR's gate attached (PASS-WITH-CONDITIONS, [receipt](https://github.com/Bali-Zero/Teman2/pull/6098#issuecomment-5618860420)). Branched from `origin/main` at `fc1a22465c`.

## The sibling

#6098 gave this file `file_mtime()`. Its sibling in `acquire_lock()` still read the lock directory's age with `stat -f %m ... || echo "$now"`. W89 class-audit: now that the helper exists the sibling gets **fixed, not ledgered**.

That fallback did not fail, it lied. On GNU `stat -f` is rejected, so every held lock measured 0s old, the stale-steal branch never fired, and the function returned 1 without writing a single log line — the log file was not even created. A crash leftover would have stalled the puller forever while looking exactly like ordinary contention with a live peer. Same invisible-stall class the `index.lock` cure was written to end.

## Change

`acquire_lock()` reads through `file_mtime()`, and an empty result **declines and says why**. Refusing to steal is the safe half, since the worst case is a tick that retries in fifteen minutes. Refusing *silently* is not, because a permanent stall and a busy peer then look identical from outside. A failed re-`mkdir` after clearing a stale lock now logs as well.

Net 46 lines. No behaviour change on BSD, where the old spelling already worked.

## Coverage, and it is not vacuous

K1 and K2 give the branch its first coverage. On macOS K1 would pass against the old code too, so non-vacuity is **proved rather than asserted**: replaying the new tests against the pre-merge `acquire_lock` with `stat -f %m` forced to fail, standing in for GNU, fails K1 on exactly the three assertions that carry the meaning.

```
FAIL: K1 HEAD advanced (stale lock was stolen)
FAIL: K1 no log line (the GNU silent no-op)
FAIL: K1 dead pid still owns the lock
=== 69 passed, 3 failed ===
```

K2 and the other 69 still pass there. The test bites the guilty and only the guilty.

The fixture plants a lock directory whose recorded pid is dead. Worth stating plainly: the script decides on the **directory's** age and never reads that pid file, so the pid documents the scenario while the assertion rests on mtime, which is the thing that was broken. A pid-liveness check would be strictly better than an age heuristic here, the way the `index.lock` holder test is, but that is a behaviour change and not this PR.

Local, macOS: `72 passed, 0 failed`, collision matrix `STABLE` at 102 cells. The GNU proof is the `antidotes` log on ubuntu, read before this is called green.

## Class audit

The only surviving `stat -f %m` in `scripts/pro/pro-git-pull.sh` is the BSD arm **inside** `file_mtime()`, where it belongs. No BSD-only `date -v` or `stat` remains in `spec_collision_matrix.sh` or the suite.

## Bites

**Consumer:** `com.nuzantara.git-pull-main.15min` on Pro.

**Where the work lives:** the main checkout `/Users/nuzantara/nuzantara`, which the 15-minute puller updates on its own. **No deploy-tree copy this time** — lane 9 (`dux-parabellum-pro-one-tree`) is repointing the wrapper away from `/Users/nuzantara/nuzantara-deploy`, so the interim copy #6098 recorded is not repeated here unless that lane says otherwise. Coordination happens by comment, and this lane does not touch the wrapper.

**Observation:** after merge, `grep -c 'file_mtime "$LOCK_DIR"' /Users/nuzantara/nuzantara/scripts/pro/pro-git-pull.sh` returns 1 on Pro once the puller has ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)