### PR TITLE
fix(portal): make service_account_available answer the real question

### DIFF
--- a/apps/backend-rag/backend/services/integrations/drive/drive_auth.py
+++ b/apps/backend-rag/backend/services/integrations/drive/drive_auth.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 import os
@@ -30,6 +31,35 @@ class DriveAuthManager:
         self.db_pool = db_pool
         self.http_client = http_client
         self.scopes = ["https://www.googleapis.com/auth/drive"]
+
+    @property
+    def service_account_available(self) -> bool:
+        """True if a service-account credential is configured and structurally valid.
+
+        Lightweight, non-network check (no token mint): parses the same
+        credential `_get_service_account_token`/`ServiceAccountDriveService`
+        would load (raw or base64-encoded JSON, `settings.google_credentials_json`
+        which resolves GOOGLE_CREDENTIALS_JSON / GOOGLE_SERVICE_ACCOUNT_JSON /
+        GOOGLE_SERVICE_ACCOUNT / GEMINI_SA_TOKEN) and confirms it looks like a
+        service-account key. This used to be a bare `getattr(..., False)` probe
+        on an attribute this class never defined, so it was permanently False
+        regardless of whether a usable credential existed.
+        """
+        from backend.app.core.config import settings
+
+        creds_str = getattr(settings, "google_credentials_json", None)
+        if not creds_str:
+            return False
+
+        try:
+            info = json.loads(creds_str)
+        except json.JSONDecodeError:
+            try:
+                info = json.loads(base64.b64decode(creds_str).decode("utf-8"))
+            except Exception:
+                return False
+
+        return info.get("type") == "service_account"
 
     async def get_access_token(self, user_id: str = "system") -> str | None:
         """

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -1,6 +1,7 @@
 """Unit tests for PortalService document mixin helpers and failure paths."""
 
 import inspect
+import json
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1113,6 +1114,65 @@ def test_team_drive_service_has_service_account_available_attribute() -> None:
         # Case 4: auth is None → safe fallback
         service.auth = None
         assert service.service_account_available is False
+
+
+def test_service_account_available_reflects_a_real_credential() -> None:
+    """Effect guard, not shape: True only when a usable SA credential exists.
+
+    The test above (BUG B) mocked `auth.service_account_available` directly,
+    so it stayed green even though `DriveAuthManager` never defined that
+    attribute at all — `getattr(auth, "service_account_available", False)`
+    silently fell through to `False` forever, on every real deploy, no matter
+    how valid the configured credential was. This is BUG C: the fallback in
+    `_upload_to_drive` could never engage despite `ServiceAccountDriveService`
+    constructing fine from the exact same credential.
+
+    Guilt-proof: revert `DriveAuthManager.service_account_available` (the
+    `@property` added in drive_auth.py) and this test fails — the True-branch
+    assertions below observe `False` instead.
+    """
+    from backend.app.core.config import settings
+    from backend.services.integrations.drive.drive_auth import DriveAuthManager
+    from backend.services.integrations.team_drive_service import TeamDriveService
+
+    valid_sa_json = json.dumps(
+        {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "abc123",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+            "client_email": "test@test-project.iam.gserviceaccount.com",
+        }
+    )
+    original = settings.google_credentials_json
+    try:
+        # Present + structurally valid → the auth manager itself must report True.
+        settings.google_credentials_json = valid_sa_json
+        auth = DriveAuthManager(db_pool=MagicMock(), http_client=MagicMock())
+        assert auth.service_account_available is True
+
+        # The facade `_upload_to_drive` actually reads must agree — real auth
+        # manager, not a mock standing in for it.
+        with (
+            patch("backend.services.integrations.team_drive_service.DriveOperationsManager"),
+            patch("backend.services.integrations.team_drive_service.DrivePermissionsManager"),
+            patch("backend.services.integrations.team_drive_service.DriveAuditLogger"),
+            patch("httpx.AsyncClient"),
+        ):
+            team_drive = TeamDriveService(db_pool=MagicMock())
+            assert team_drive.service_account_available is True
+
+        # Absent credential → no fallback, must stay False.
+        settings.google_credentials_json = None
+        auth_no_cred = DriveAuthManager(db_pool=MagicMock(), http_client=MagicMock())
+        assert auth_no_cred.service_account_available is False
+
+        # Malformed JSON → False, never raises.
+        settings.google_credentials_json = "{not json"
+        auth_bad_json = DriveAuthManager(db_pool=MagicMock(), http_client=MagicMock())
+        assert auth_bad_json.service_account_available is False
+    finally:
+        settings.google_credentials_json = original
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `DriveAuthManager` never defined `service_account_available`; `TeamDriveService`'s `getattr(self.auth, "service_account_available", False)` was probing an attribute that has never existed, so it silently fell through to `False` on every deploy — even when a valid service-account credential was configured. This permanently disabled the service-account fallback in `documents.py::_upload_to_drive`.
- Added `DriveAuthManager.service_account_available` (`backend/services/integrations/drive/drive_auth.py`): a lightweight, non-network property that parses `settings.google_credentials_json` (raw or base64 JSON, same source `ServiceAccountDriveService` uses — resolves `GOOGLE_CREDENTIALS_JSON` / `GOOGLE_SERVICE_ACCOUNT_JSON` / `GOOGLE_SERVICE_ACCOUNT` / `GEMINI_SA_TOKEN`) and confirms it looks like a service-account key (`type == "service_account"`). No token mint, no network call — it answers "is a credential usable" without the cost of constructing a full `ServiceAccountDriveService` (whose constructor does synchronous live Drive API validation calls).
- Replaced the existing BUG-B regression test's blind spot: it only mocked `auth.service_account_available` and asserted the property didn't raise, so it stayed green through the entire outage. Added `test_service_account_available_reflects_a_real_credential` in `backend/tests/unit/app/services/portal/test_documents_mixin.py`, which builds a REAL `DriveAuthManager`/`TeamDriveService` (not mocked) against a real service-account JSON and asserts the actual effect (True when present+valid, False when absent or malformed).

**Bites:** consumer is `_upload_to_drive`'s service-account fallback branch (`documents.py` ~line 920-927). Observation: before this PR, `TeamDriveService(...).service_account_available` is `False` on the live machine today despite valid credentials (`settings.google_credentials_json` set, `ServiceAccountDriveService()` constructs without raising) — that's the exact contradiction the diagnosis measured live. After this PR it is `True` under the same credential. `app/routers/team_drive.py:303` reads the same property for its `mode` field and is corrected by the same fix (was permanently reporting `"not_configured"`).

**Guilt-proof (measured, not asserted):**
- Fix reverted → `test_service_account_available_reflects_a_real_credential` fails with `AttributeError: 'DriveAuthManager' object has no attribute 'service_account_available'` (1 failed, 2 passed in the targeted `-k service_account` run).
- Fix applied → same 3 tests pass; full `test_documents_mixin.py` file: 42 passed; full drive-related suite (`backend/tests -k drive`): 476 passed, 20 pre-existing unrelated skips.

**Honesty check — this does NOT make document upload work.** Since 2026-05-10, `GoogleDriveService._refresh_token` deliberately declines to refresh the SYSTEM OAuth token — see its docstring: *"OAuth SYSTEM disabled 2026-05-10: legacy SYSTEM-wide OAuth flow has been replaced by ServiceAccountDriveService (domain-wide delegation impersonating zero@balizero.com) ... The SYSTEM token in google_drive_tokens is intentionally left unrefreshed: callers that still request it receive None ... instead of generating an OAuth refresh storm against a revoked token."* So `get_valid_token("SYSTEM") -> None` is designed behavior, not a missing credential — nobody needs to re-authorize anything. Since that date the service-account path has been the ONLY intended route for portal uploads, and it could not run because of two stacked defects:

1. This PR's fix — the dead `service_account_available` gate (above).
2. `_upload_with_service_account` (`documents.py` ~line 1076) calling `team_drive.drive_service.files()...`, an attribute `TeamDriveService` never defined — raises `AttributeError` on every real invocation. Fixed separately in #6108.

What genuinely remains unverified even after both PRs land: whatever Drive-side configuration `ServiceAccountDriveService` needs in production — domain-wide delegation and the folder permissions for the impersonated user `zero@balizero.com` — has not been checked against live Drive from here, only that the code path is correct and reachable.

## Test plan

- [x] `pytest backend/tests/unit/app/services/portal/test_documents_mixin.py -k service_account -v` — 3 passed
- [x] `pytest backend/tests/unit/app/services/portal/test_documents_mixin.py -v` — 42 passed
- [x] `pytest backend/tests -k drive -v` — 476 passed, 20 skipped (pre-existing, unrelated)
- [x] Guilt-proof: property reverted → new test fails (AttributeError); restored → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnaXYe8mcUMTfRGty8e2uW

---

**Correction, recorded rather than deleted.** An earlier revision of this body listed a *"missing SYSTEM OAuth token, human-owned"* as a remaining blocker. That was my diagnosis and it was wrong: `GoogleDriveService._refresh_token` declines to refresh the SYSTEM token deliberately — *"OAuth SYSTEM disabled 2026-05-10: legacy SYSTEM-wide OAuth flow has been replaced by ServiceAccountDriveService (domain-wide delegation)"* — so `get_valid_token("SYSTEM") -> None` is designed behaviour and no credential was ever missing. The claim is retracted here instead of being quietly removed, because a body that silently loses a wrong call reads, later, as if the call was never made. — conducting session