### PR TITLE
fix(portal): route the service-account upload fallback through a Drive client that exists

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -925,7 +925,6 @@ class PortalDocumentsMixin:
                     return result
                 # Use Service Account for upload
                 return await self._upload_with_service_account(
-                    team_drive,
                     client_id,
                     client_name,
                     document_type,
@@ -1033,7 +1032,6 @@ class PortalDocumentsMixin:
 
     async def _upload_with_service_account(
         self,
-        team_drive: Any,
         client_id: int,
         client_name: str,
         document_type: str,
@@ -1042,11 +1040,23 @@ class PortalDocumentsMixin:
         mime_type: str | None,
         result: dict[str, Any],
     ) -> dict[str, Any]:
-        """Upload file using Service Account (fallback when OAuth fails)."""
+        """Upload file using Service Account (fallback when OAuth fails).
+
+        Routes through ServiceAccountDriveService — the component that
+        actually owns a Drive API client built from the same
+        settings.google_credentials_json that
+        TeamDriveService.service_account_available checks — instead of a
+        `team_drive.drive_service` attribute TeamDriveService never defined.
+        That attribute meant this branch raised AttributeError on every real
+        invocation (production and test alike); see cicatrix BUG C.
+        """
         try:
             from datetime import datetime
 
             from backend.app.core.config import settings
+            from backend.services.integrations.service_account_drive_service import (
+                ServiceAccountDriveService,
+            )
 
             # Create folder structure
             timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
@@ -1056,26 +1066,18 @@ class PortalDocumentsMixin:
             folder_path = f"Zantara Portal Uploads/{client_id}_{safe_client_name}/{document_type.replace('_', ' ').title()}"
             drive_file_name = f"{timestamp}_{file_name}"
 
-            # Upload using Service Account
-            file_metadata = {
-                "name": drive_file_name,
-                "parents": [settings.google_drive_root_folder_id or "root"],
-            }
-
-            import io
-
-            from googleapiclient.http import MediaIoBaseUpload
-
-            media = MediaIoBaseUpload(
-                io.BytesIO(file_content),
-                mimetype=mime_type or "application/octet-stream",
-                resumable=True,
-            )
-
-            uploaded_file = (
-                team_drive.drive_service.files()
-                .create(body=file_metadata, media_body=media, fields="id, name, webViewLink")
-                .execute()
+            # Upload using Service Account. ServiceAccountDriveService wraps
+            # the (synchronous) googleapiclient .execute() call in
+            # asyncio.to_thread internally, so this does not block the
+            # event loop the way the old team_drive.drive_service.files()...
+            # .execute() call would have (never reached in practice).
+            root_folder_id = settings.google_drive_root_folder_id or "root"
+            sa_drive = ServiceAccountDriveService(root_folder_id=root_folder_id)
+            uploaded_file = await sa_drive.upload_file_to_folder(
+                folder_id=root_folder_id,
+                file_content=file_content,
+                file_name=drive_file_name,
+                mime_type=mime_type,
             )
 
             result["success"] = True

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -1024,6 +1024,105 @@ async def test_upload_to_drive_uses_service_account_fallback() -> None:
     service._upload_with_service_account.assert_awaited_once()
 
 
+# =============================================================================
+# BUG C REGRESSION — _upload_with_service_account never had a working Drive
+# client (drive-sa-upload-attr worktree). team_drive.drive_service does not
+# exist on TeamDriveService; every prior test of this branch mocked
+# _upload_with_service_account itself (see test_upload_to_drive_uses_
+# service_account_fallback above), so the branch's own body had never
+# actually executed, in production or in a test. These exercise the real
+# method — only the external Google Drive API boundary
+# (ServiceAccountDriveService) is mocked, not the method's own control flow.
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_upload_with_service_account_routes_through_service_account_drive_service() -> None:
+    """Guilt-proof: restore `team_drive.drive_service.files()...execute()`
+    (the old body) and this fails — result["success"] stays False with
+    "...has no attribute 'drive_service'" in result["error"], because nothing
+    in that old code path can reach ServiceAccountDriveService at all.
+    """
+    service = PortalService(MagicMock())
+    result: dict[str, Any] = {
+        "success": False,
+        "file_id": None,
+        "file_url": None,
+        "folder_path": "",
+        "error": None,
+    }
+
+    mock_sa_instance = MagicMock()
+    mock_sa_instance.upload_file_to_folder = AsyncMock(
+        return_value={
+            "id": "sa_file_1",
+            "name": "20260910_000000_passport.pdf",
+            "webViewLink": "https://drive.google.com/file/d/sa_file_1/view",
+        }
+    )
+
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=mock_sa_instance,
+    ) as sa_cls:
+        out = await service._upload_with_service_account(
+            client_id=1,
+            client_name="Client One!",
+            document_type="passport_scan",
+            file_content=b"PDF",
+            file_name="passport.pdf",
+            mime_type="application/pdf",
+            result=result,
+        )
+
+    sa_cls.assert_called_once()
+    mock_sa_instance.upload_file_to_folder.assert_awaited_once()
+    call_kwargs = mock_sa_instance.upload_file_to_folder.call_args.kwargs
+    assert call_kwargs["file_content"] == b"PDF"
+    assert call_kwargs["file_name"].endswith("_passport.pdf")
+    assert call_kwargs["mime_type"] == "application/pdf"
+
+    assert out["success"] is True
+    assert out["file_id"] == "sa_file_1"
+    assert out["file_url"] == "https://drive.google.com/file/d/sa_file_1/view"
+    assert out["method"] == "service_account"
+    assert out["folder_path"] == "Zantara Portal Uploads/1_Client One/Passport Scan"
+
+
+@pytest.mark.asyncio
+async def test_upload_with_service_account_surfaces_drive_errors_without_raising() -> None:
+    """A real Drive-side failure (bad/expired credential, API error) must
+    still return an error dict, never raise — the method's own error
+    contract, now actually exercised end to end instead of asserted in the
+    abstract."""
+    service = PortalService(MagicMock())
+    result: dict[str, Any] = {
+        "success": False,
+        "file_id": None,
+        "file_url": None,
+        "folder_path": "",
+        "error": None,
+    }
+
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        side_effect=ValueError("GOOGLE_SERVICE_ACCOUNT_JSON not configured in settings"),
+    ):
+        out = await service._upload_with_service_account(
+            client_id=1,
+            client_name="Client One",
+            document_type="passport",
+            file_content=b"PDF",
+            file_name="passport.pdf",
+            mime_type="application/pdf",
+            result=result,
+        )
+
+    assert out["success"] is False
+    assert "Service Account upload failed" in out["error"]
+    assert "GOOGLE_SERVICE_ACCOUNT_JSON" in out["error"]
+
+
 @pytest.mark.asyncio
 async def test_upload_to_drive_oauth_success() -> None:
     service, _mock_conn = _make_service_with_fetchrow(row=None)


### PR DESCRIPTION
## Summary

- `_upload_with_service_account` (`documents.py` ~line 1076) called `team_drive.drive_service.files()...execute()` — but `TeamDriveService` has no `drive_service` attribute at all (only `db_pool`, `http_client`, `audit`, `auth`, `operations`, `permissions`). Every real invocation of this branch — in production, and in every test written before this PR — raised `AttributeError`. It was caught by the method's own try/except and surfaced as a generic `"Service Account upload failed: ..."`, so the service-account upload fallback had never actually executed, anywhere, ever.
- Fixed by routing the upload through `ServiceAccountDriveService` instead: it is the component that actually owns a Drive API client, constructed from the same `settings.google_credentials_json` that `TeamDriveService.service_account_available` checks (#6107). It already wraps the synchronous `googleapiclient` `.execute()` call in `asyncio.to_thread` — the old dead code called `.execute()` directly and would have blocked the event loop had it ever run.
- Dropped the now-unused `team_drive` parameter from `_upload_with_service_account` and its call site (the gate check `team_drive.service_account_available` in `_upload_to_drive` is untouched).
- Deliberately did **not** invent a `drive_service` attribute on `TeamDriveService` to satisfy the old call site — that would silence the `AttributeError` without making the upload work, moving the symptom further from the cause. Checked: `TeamDriveService.operations` (`DriveOperationsManager`) has no upload capability either (`list_files`/`search_files`/`get_storage_stats`/`get_file_metadata`/`delete_file`/`move_file`/`copy_file` only) — so it wasn't a viable route.

**Bites:** consumer is the client-portal document upload endpoint's service-account fallback path (`POST /api/portal/documents/upload` → `_upload_to_drive` → `_upload_with_service_account`). Observation: `test_upload_with_service_account_routes_through_service_account_drive_service` drives the real method end to end (mocking only the external Drive API boundary) and asserts `ServiceAccountDriveService.upload_file_to_folder` is actually awaited with the right file content/name/mime-type, and that the result dict reflects its response — not just that the method returns without raising.

**What this bug proves, and why the test is structured this way:** the whole service-account upload branch had never executed, in production or in any test — two separate defects (this one, and the dead `service_account_available` gate fixed in #6107) were stacked, and each hid the other. Every prior test of this call path (`test_upload_to_drive_uses_service_account_fallback`) mocked `_upload_with_service_account` itself, so it could never have caught this. The two new tests here exercise the method's real control flow instead — mocking only the one thing that genuinely cannot be exercised without live Google Drive access (the API call itself).

**Guilt-proof (measured, not asserted):**
- Reverted to the old `team_drive.drive_service.files()...execute()` body → both new tests fail: `test_upload_with_service_account_routes_through_service_account_drive_service` fails with `AssertionError: Expected 'ServiceAccountDriveService' to have been called once. Called 0 times.` (result stays `success: False`); `test_upload_with_service_account_surfaces_drive_errors_without_raising` fails its content assertion because the (different, but still present) error message doesn't match. 2 failed.
- Fix applied → both pass; full `test_documents_mixin.py`: 43 passed; broader `backend/tests -k "drive or portal"`: 1272 passed, 0 failed, 48 pre-existing errors (`garuda_portal` integration tests missing `policy_scope` column / `garuda_account_sessions` table in the local test DB — unrelated to this change, confirmed by inspecting the error messages and file paths).

## Honesty check — what still stands between this and a working upload

This PR makes `_upload_with_service_account` actually reach and use a real Drive client. It does **not** by itself mean client-portal document upload works end to end on the live machine.

Since 2026-05-10, `GoogleDriveService._refresh_token` deliberately declines to refresh the SYSTEM OAuth token — see its docstring: *"OAuth SYSTEM disabled 2026-05-10: legacy SYSTEM-wide OAuth flow has been replaced by ServiceAccountDriveService (domain-wide delegation impersonating zero@balizero.com) ... The SYSTEM token in google_drive_tokens is intentionally left unrefreshed: callers that still request it receive None ... instead of generating an OAuth refresh storm against a revoked token."* So `get_valid_token("SYSTEM") -> None` is by design, not a missing credential — `_upload_to_drive` taking the service-account branch is the intended, permanent behavior since that date, not a fallback of last resort. Nobody needs to re-authorize anything; that path just could not run until this PR and #6107.

What genuinely remains unverified, and is not fixed here:

1. Whatever Drive-side configuration `ServiceAccountDriveService` itself needs to succeed in production — domain-wide delegation and the folder permissions for the impersonated user `zero@balizero.com` — has not been verified against live Drive from here; only that the code path is correct and reachable.

A reader should treat this as "the fallback branch is no longer structurally broken," not "upload now works."

## Test plan

- [x] `pytest backend/tests/unit/app/services/portal/test_documents_mixin.py -k upload_with_service_account -v` — 2 passed
- [x] `pytest backend/tests/unit/app/services/portal/test_documents_mixin.py -v` — 43 passed
- [x] `pytest backend/tests -k "drive or portal" -v` — 1272 passed, 48 pre-existing unrelated errors, 0 failed
- [x] Guilt-proof: reverted to old body → 2 new tests fail; restored → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnaXYe8mcUMTfRGty8e2uW

---

**Correction, recorded rather than deleted.** An earlier revision of this body listed a *"missing SYSTEM OAuth token, human-owned"* as a remaining blocker. That was my diagnosis and it was wrong: `GoogleDriveService._refresh_token` declines to refresh the SYSTEM token deliberately — *"OAuth SYSTEM disabled 2026-05-10: legacy SYSTEM-wide OAuth flow has been replaced by ServiceAccountDriveService (domain-wide delegation)"* — so `get_valid_token("SYSTEM") -> None` is designed behaviour and no credential was ever missing. The claim is retracted here instead of being quietly removed, because a body that silently loses a wrong call reads, later, as if the call was never made. — conducting session