### PR TITLE
fix(claude-hooks): bound mailbox Stop wake-ups to one per natural stop (stop_hook_active guard)

### DIFF
--- a/infra/claude-hooks/mailbox_inject.py
+++ b/infra/claude-hooks/mailbox_inject.py
@@ -62,6 +62,23 @@ session and every subagent, 45 of them repeat `queue_unstick` DIRTY-PR
 pages (one PR paged 12 times) — see fleet retro
 research/operations/2026-08-26-retro-fleet-sessions-25-26.md item S3.
 
+CHAINED-STOP GUARD (2026-09-10): the harness sets `stop_hook_active: true`
+on a Stop (or SubagentStop) that fired only because a previous Stop-hook
+wake-up kept the turn alive. On such a chained Stop this hook delivers
+DIRECT mail only — each direct file is delivered at most once, so a chain
+can only continue while new targeted mail keeps arriving — and leaves
+broadcasts untouched (not marked seen) for the next natural event, where
+they drain at MAX_MESSAGES_PER_FIRE per fire. A natural Stop still wakes
+the session once for them; the chain is bounded to one wake-up per natural
+stop instead of one per 3 backlog files. Before the guard, every new
+session drained the whole live broadcast set (50 files on 2026-09-10) at
+3 per Stop; the harness's consecutive-continuation cap (default 8,
+CLAUDE_CODE_STOP_HOOK_BLOCK_CAP) is what finally ended one such chain in
+the session that shipped this — a backstop of 8 forced turns per natural
+stop, with the backlog resuming at the next one, not a cure. Only the
+harness-set boolean on a stop event counts: a `PostToolUse` payload or a
+string value never suppresses anything.
+
 Kill switch: NUZ_MAILBOX_OFF=1. Root override: NUZ_MAILBOX_DIR.
 """
 from __future__ import annotations
@@ -374,6 +391,9 @@ def main() -> None:
     session_id = payload.get("session_id") or ""
     if not hook_event_name or not _valid_session_id(session_id):
         sys.exit(0)
+    chained_stop = (  # see CHAINED-STOP GUARD: only the harness-set boolean, only on stop events
+        hook_event_name in ("Stop", "SubagentStop") and payload.get("stop_hook_active") is True
+    )
 
     root = _mailbox_root()
     try:
@@ -382,7 +402,8 @@ def main() -> None:
         session_dir = root / session_id
         now = time.time()
         messages = _collect_direct(session_dir, MAX_MESSAGES_PER_FIRE, now=now)
-        messages += _collect_broadcast(root, session_dir, MAX_MESSAGES_PER_FIRE - len(messages), now=now)
+        if not chained_stop:
+            messages += _collect_broadcast(root, session_dir, MAX_MESSAGES_PER_FIRE - len(messages), now=now)
     except SystemExit:
         raise
     except Exception:

--- a/infra/claude-hooks/test_mailbox_inject.py
+++ b/infra/claude-hooks/test_mailbox_inject.py
@@ -239,5 +239,48 @@ class MailboxInjectTests(unittest.TestCase):
         self.assertEqual(ctx.count("<cross-machine-message"), 1)  # no forged second opening tag
 
 
+    # ── chained Stop (stop_hook_active) ────────────────────────────────
+    def test_chained_stop_never_delivers_broadcast(self):
+        bmsg = self.root / "broadcast" / "20260101T000000-0001.md"
+        write_msg(bmsg, "mini:cron", "Fleet-wide notice.")
+        chained = {"session_id": self.sid, "hook_event_name": "Stop", "stop_hook_active": True}
+        p1 = run_hook(chained, self.root)
+        self.assertEqual(p1.returncode, 0)
+        self.assertEqual(p1.stdout.strip(), "")  # a backlog must never chain wake-ups
+        # not consumed by the chained Stop: the next NATURAL Stop still gets it
+        natural = {"session_id": self.sid, "hook_event_name": "Stop", "stop_hook_active": False}
+        p2 = run_hook(natural, self.root)
+        out = json.loads(p2.stdout)
+        self.assertIn("Fleet-wide notice.", out["hookSpecificOutput"]["additionalContext"])
+
+    def test_chained_stop_still_delivers_direct_mail(self):
+        write_msg(self.root / "broadcast" / "20260101T000000-0001.md", "mini:cron", "Fleet-wide notice.")
+        write_msg(self.root / self.sid / "20260101T000000-0002.md", "pro:sess", "Direct for you.")
+        chained = {"session_id": self.sid, "hook_event_name": "Stop", "stop_hook_active": True}
+        p = run_hook(chained, self.root)
+        out = json.loads(p.stdout)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("Direct for you.", ctx)
+        self.assertNotIn("Fleet-wide notice.", ctx)
+        # direct mail is at-most-once on the chained path too
+        p2 = run_hook(chained, self.root)
+        self.assertEqual(p2.stdout.strip(), "")
+        # the broadcast survived untouched for the next natural Stop
+        p3 = run_hook({"session_id": self.sid, "hook_event_name": "Stop"}, self.root)
+        ctx3 = json.loads(p3.stdout)["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("Fleet-wide notice.", ctx3)
+        self.assertNotIn("Direct for you.", ctx3)
+
+    def test_flag_outside_stop_events_or_non_boolean_is_ignored(self):
+        write_msg(self.root / "broadcast" / "20260101T000000-0001.md", "mini:cron", "Fleet-wide notice.")
+        for payload in (
+            {"session_id": self.sid, "hook_event_name": "PostToolUse", "stop_hook_active": True},
+            {"session_id": self.sid2, "hook_event_name": "Stop", "stop_hook_active": "true"},
+        ):
+            p = run_hook(payload, self.root)
+            ctx = json.loads(p.stdout)["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("Fleet-wide notice.", ctx, payload)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Every NEW session drained the whole live broadcast set at 3 messages per Stop wake-up.
Measured live in the Pro session that opened this PR on 2026-09-10: 50 live broadcast
files (about 90% fleet-watch `queue_stall:<pr>:<reason>` keys), `.broadcast_seen` 50/50
after the chain, i.e. ~17 hook-forced continuation turns before the session could idle.

The harness's consecutive-continuation cap (`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, default 8 in
claude 2.1.267) is what finally ended one such chain in that session: exactly 8 wake-ups, then
the override. It is a backstop, not a cure: 8 forced turns per natural stop, and the backlog
resumes at the next one. The harness's own override text names the cure: "check
`stop_hook_active` in the input".

## What

- `infra/claude-hooks/mailbox_inject.py`: on a Stop carrying `stop_hook_active: true`
  (the harness flag meaning this Stop fired only because a previous Stop-hook wake-up kept
  the turn alive) the hook delivers DIRECT mail only. Broadcasts are not collected and not
  marked seen, so they drain on the next natural event at `MAX_MESSAGES_PER_FIRE` without
  forcing a turn. A payload without the field behaves exactly as before (fail-open unchanged).
- `infra/claude-hooks/test_mailbox_inject.py`: guilt `test_chained_stop_never_delivers_broadcast`
  (silent on a chained Stop, still delivered on the next natural Stop), innocence
  `test_chained_stop_still_delivers_direct_mail` (direct delivered at most once, broadcast
  preserved for the next natural Stop) and `test_flag_outside_stop_events_or_non_boolean_is_ignored`
  (a `PostToolUse` payload or a string value never suppresses). Red before the guard, green
  after; suite 18/18 against the repo copy.

Gear 1 by floor (`evidence_pack_lint.py --print-floor` = 1, source none). One Codex spalla at
xhigh reasoning (different family): MEDIUM, no blocker. All three findings folded in: the guard is
bound to `Stop`/`SubagentStop` and to the literal boolean, the docstring no longer claims the harness
cap is inapplicable, and the test matrix covers duplicate direct delivery, mixed-case broadcast
recovery and the event/type matrix. Transcript: `~/logs/codex-spalla/20260910T154930Z-96f0-review-chained-Stop-guard-in-infra-claude-hooks.md` (Pro).

## Bites

Bites: consumer = the installed `~/.claude/hooks/mailbox_inject.py` on Pro, Mini and M5,
installed from post-merge `main` via `infra/claude-hooks/install_mailbox_hook.sh`, which
self-verifies the INSTALLED copy with this suite through `MAILBOX_HOOK_PATH`. Observation per
host after install: the installed hook fed a Stop payload with `stop_hook_active: true` against
a scratch `NUZ_MAILBOX_DIR` holding one live broadcast prints nothing (rc 0); the same payload
without the flag prints the broadcast; installed md5 equals the `origin/main` blob. Recorded as
a PR comment after merge.

## Not in this PR (owner call)

Whether fleet-watch `queue_stall` pages should be broadcast to every interactive session at
all. That is the backlog's source and a policy question, not this hook's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
