### PR TITLE
feat(secrets-audit): watch ~/nuzantara/.secrets as a custody root, report-only for credentials

### DIFF
--- a/evidence/2026-09/agent-nuzantara-infra-s2-custody-3c9ec9a6/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-infra-s2-custody-3c9ec9a6/brief.yml
@@ -1,0 +1,111 @@
+gear: 2
+task_id: s2-custody-roots
+mission: S2
+colour: BLUE
+l_level: L1
+deadline: 2026-09-10T19:59:24Z # opened in ~/.claude/state/child-mandates (mandate_budget.py) at 15:1xZ
+base_sha: af8f2da124fe6ae3003fb615170af45216298f2b
+objective: >-
+  The credential-custody detector (scripts/secrets_permissions_audit.py) looks inside
+  ~/nuzantara/.secrets and judges it as custody: a loosened credential file there is a finding
+  whatever the directory chain says. .env* findings become report-only (never chmod'ed), and the
+  three false-positive classes measured on Pro's live default-roots scan stop being findings, so
+  the schedule that follows (PR2) raises only real exposures.
+scope:
+  - scripts/secrets_permissions_audit.py
+  - scripts/tests/test_secrets_permissions_audit.py
+  - evidence/2026-09/agent-nuzantara-infra-s2-custody-3c9ec9a6/
+constraints:
+  - >-
+    The auditor never opens a file it audits (os.lstat/os.stat/os.listdir and path strings only).
+    .env* files carry an explicit READ-ONLY exception to the off-limits rule: their mode is
+    stat'ed and reported, they are never opened and never chmod'ed.
+  - >-
+    No chmod under ~/nuzantara/.secrets or anywhere else, by this window or by the detector
+    (staff-room correction round 3): custody and .env* findings are detected and REPORTED only;
+    the chmod is Zero's gesture. The mktemp guilt fixture is not a credential and may be chmod'ed.
+  - >-
+    Existing consumer (staff-room C1): Mini's com.nuzantara.secrets-perms-sweep runs
+    /usr/bin/python3 (3.9.6) ~/nuzantara/scripts/secrets_permissions_audit.py --fix every 6h on the
+    default roots, from a checkout Mini's puller keeps on main. This change only makes it chmod
+    LESS: --fix refuses by name any path under a .secrets directory and any .env* file; ordinary
+    findings are untouched (test_t13). Baseline before merge: last run 2026-09-10T16:00:20Z
+    rc=0, FINDINGS 0, FIXED 0 FAILED 0, 6821 files under 10 roots; Mini has no ~/nuzantara/.secrets.
+  - >-
+    No paid per-token Anthropic endpoint, no secret printed, no client PII or filename of a
+    credential file in any alert, ledger row or artifact.
+acceptance:
+  - text: >-
+      WHEN a 0644 probe.json sits in "$(mktemp -d)/.secrets" the auditor SHALL report exactly one
+      finding with --no-default-roots --root <that dir> --json, and none after chmod 600
+      (verified pre-change: count 0 — the closed mktemp chain absolved it).
+    probe: mandate-guilt-fixture
+  - text: >-
+      The default roots SHALL include ~/nuzantara/.secrets, proven by a test that fails without
+      the change.
+    probe: pytest test_t1_default_roots_include_main_checkout_secrets
+  - text: >-
+      IF a 0600 file is in a scratch .secrets directory THEN it SHALL be clean, and a .env.example
+      elsewhere in the tree SHALL never be flagged.
+    probe: pytest test_t3_custody_innocence_locked_files_and_dir_mode_not_a_finding + test_t5_env_templates_never_flagged_and_custody_report_counts
+  - text: >-
+      WHEN --fix meets a .env* finding it SHALL print one report line for it and make zero chmod
+      calls on it (mode unchanged).
+    probe: pytest test_t6_fix_never_chmods_env_shaped + test_t8_fix_findings_ignores_credentials_even_when_hand_built + test_t12_fix_never_chmods_a_custody_file + test_t13_fix_touches_exactly_what_it_touched_before
+  - text: >-
+      WHEN run from the main checkout on Pro against ~/nuzantara/.secrets the CUSTODY line SHALL
+      show a file count equal to `find ~/nuzantara/.secrets -type f | wc -l` and a finding count
+      equal to `find ~/nuzantara/.secrets -type f -perm +077 | wc -l`, taken in the same minute.
+    probe: live-custody-oracle
+assumptions:
+  - text: The live .secrets directory holds only regular files (no symlinks, no subdirectories).
+    status: verified
+    probe: python os.listdir classification 15:1xZ — 7 total, 7 regular, 0 symlinks, 0 subdirs, 0 env-shaped
+  - text: Every live default-roots finding on Pro before the change is a false positive.
+    status: verified
+    probe: >-
+      scan of default roots 15:1xZ — 53,680 files, 1.82 s, 4 findings, all group-reachable only:
+      a plugin .env.example template, a 22-byte .npmrc in a plugin marketplace checkout, two
+      ~/.qwen token-usage logs. None is a credential.
+  - text: The scheduled run (PR2) will not raise any finding on Pro's current state.
+    status: unverified
+    probe: post-merge default-roots run from the main checkout shows 0 findings
+appetite:
+  wall_clock_hours: 5
+  adversarial_rounds: 2
+  tokens: 1500000
+team:
+  dux:
+    seat: claude-opus-5[1m]
+    effort: max # observed from the harness; the board names xhigh — recorded, not hidden
+    thread: e5578f19-643a-4789-bb51-d384bef4443a
+    role: plan, integration, evidence, ledger, release (release owner)
+  builder_pr1:
+    seat: kimi-code/kimi-for-coding (scripts/seat_build.sh --seat kimi --tier coding, prepare-only)
+    worktree: .worktrees/infra-s2-roots-kimi
+    thread: .worktrees/seat-build-kimi-20260910T152253Z-3166.log
+  implementer_pr2:
+    seat: claude-sonnet-5 (Agent, model pinned sonnet)
+    worktree: .worktrees/infra-s2-schedule-sonnet
+    thread: recorded in PR2's own brief
+  reviewer:
+    seat: codex (account default model, model_reasoning_effort=xhigh, .claude/scripts/codex-spalla.sh)
+    liveness: self-test LGTM rc=0 at 15:20Z (~/logs/codex-spalla/20260910T152015Z-12209-self-test-self-test.md)
+    thread: ~/logs/codex-spalla/ (report path quoted in the PR body)
+  final_gate:
+    seat: claude-opus-5 --effort xhigh, fresh `claude -p` session outside the chain, commissioned by this Dux
+    thread: pending
+siblings:
+  open_prs_touching_perimeter_or_ledger:
+    ts: 2026-09-10T15:20:19Z
+    result: "#6081, #6080, #5072 touch .claude/skills/modus/PENDING-ARMS.md; none touches scripts/secrets_permissions_audit.py, infra/launchagents/ or scripts/tg_notify.py"
+  agent_start_list:
+    ts: 2026-09-10T15:20:20Z
+    result: "live lanes near this one: s2-custody (infra), s2-roots-kimi (infra, this mission's builder), s1-arm-the-armer (ops, S1), fable-max-sessions-0910 (docs, staff room board #6104); 6 orphans unrelated"
+  list_agents:
+    ts: 2026-09-10T15:20Z
+    result: "peers website-03 (staff room, busy) and website-77 (busy); this session website-30"
+  fleet_mail_list:
+    ts: 2026-09-10T15:20:22Z
+    cmd: scripts/fleet_mail.sh local --list # the board's `pro` has no ssh route from Pro itself
+    result: "12 live sessions; staff room = e8a86e26 (claude-fable-5-1), S1 window running"

--- a/evidence/2026-09/agent-nuzantara-infra-s2-custody-3c9ec9a6/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-infra-s2-custody-3c9ec9a6/brief.yml
@@ -8,9 +8,10 @@ base_sha: af8f2da124fe6ae3003fb615170af45216298f2b
 objective: >-
   The credential-custody detector (scripts/secrets_permissions_audit.py) looks inside
   ~/nuzantara/.secrets and judges it as custody: a loosened credential file there is a finding
-  whatever the directory chain says. .env* findings become report-only (never chmod'ed), and the
-  three false-positive classes measured on Pro's live default-roots scan stop being findings, so
-  the schedule that follows (PR2) raises only real exposures.
+  whatever the directory chain says, including through a symlinked root or a .secrets directory met
+  during a walk. Custody and .env* findings are report-only (never chmod'ed). The two measured
+  false-positive classes that would reach an alert (.env templates, token-usage jsonl logs) stop
+  being findings, excluded no wider than measured (Codex R1).
 scope:
   - scripts/secrets_permissions_audit.py
   - scripts/tests/test_secrets_permissions_audit.py
@@ -51,7 +52,12 @@ acceptance:
   - text: >-
       WHEN --fix meets a .env* finding it SHALL print one report line for it and make zero chmod
       calls on it (mode unchanged).
-    probe: pytest test_t6_fix_never_chmods_env_shaped + test_t8_fix_findings_ignores_credentials_even_when_hand_built + test_t12_fix_never_chmods_a_custody_file + test_t13_fix_touches_exactly_what_it_touched_before
+    probe: pytest test_t6_fix_never_chmods_env_shaped + test_t8_fix_findings_ignores_credentials_even_when_hand_built + test_t12_fix_never_chmods_a_custody_file + test_t13_fix_touches_exactly_what_it_touched_before + test_t14_symlinked_custody_root_is_judged_and_never_chmoded + test_t17_fix_findings_refuses_symlinks_and_custody_flags
+  - text: >-
+      IF a custody root is reached through a symlink, met during a walk (any case), or cannot be
+      stat'ed or traversed THEN its loosened file SHALL still be a custody finding, or the audit
+      SHALL be BLIND (rc 2) — never clean (Codex R1 BLOCKERs + MEDIUMs).
+    probe: pytest test_t14 + test_t15_custody_met_during_the_walk_any_case_is_strict + test_t16_custody_access_errors_are_blind_never_clean
   - text: >-
       WHEN run from the main checkout on Pro against ~/nuzantara/.secrets the CUSTODY line SHALL
       show a file count equal to `find ~/nuzantara/.secrets -type f | wc -l` and a finding count
@@ -67,9 +73,14 @@ assumptions:
       scan of default roots 15:1xZ — 53,680 files, 1.82 s, 4 findings, all group-reachable only:
       a plugin .env.example template, a 22-byte .npmrc in a plugin marketplace checkout, two
       ~/.qwen token-usage logs. None is a credential.
-  - text: The scheduled run (PR2) will not raise any finding on Pro's current state.
-    status: unverified
-    probe: post-merge default-roots run from the main checkout shows 0 findings
+  - text: >-
+      The scheduled run (PR2) will not raise any ALERT on Pro's current state. It will list one
+      ordinary finding in its log: a 0644 .npmrc inside a plugin marketplace checkout under
+      ~/.claude, group-reachable through the staff-traversable home. The marketplace prune was
+      dropped (Codex R1: a directory name does not prove its contents public), so this finding is
+      exactly what origin/main already reports. Ordinary findings raise no alert.
+    status: verified
+    probe: default-roots scan with this code 17:26Z — 54,079 files, 12 roots, count 1 (that file), report_only 0, custody 7 files / 0 findings / dir 0700
 appetite:
   wall_clock_hours: 5
   adversarial_rounds: 2

--- a/scripts/secrets_permissions_audit.py
+++ b/scripts/secrets_permissions_audit.py
@@ -20,13 +20,25 @@ Usage:
     secrets_permissions_audit.py [--json] [--fix] [--root PATH ...]
                                   [--max-depth N]
 
+Custody roots (2026-09-10 incident): a directory named like
+~/nuzantara/.secrets is judged by the FILE's own mode — any group/other
+bit is a finding whatever the directory chain says; the chain is one
+chmod away from opening, the file modes are the invariant the owner
+restored by hand. Custody and `.env*` findings are REPORT-ONLY: printed
+for a human, never chmod'ed — `--fix` refuses, by name, any file under a
+`.secrets` directory and any `.env*` file. Credentials stay with the
+human (Builder Contract rule 5); automated edits of `.env*` are
+off-limits in this repo.
+
 Exit codes:
     Report mode (default): 0 if no findings, 1 if any findings.
-    --fix mode:             0 if every finding was fixed (or none existed),
-                             1 if any chmod failed.
+    --fix mode:             0 only if nothing failed AND no report-only
+                             finding remains, else 1.
     Either mode:            2 if the scan was BLIND (roots exist but zero
-                             files traversed — TCC/sandbox denial): a blind
-                             audit never certifies "clean" (W84 discipline).
+                             files traversed — TCC/sandbox denial, or a
+                             custody directory that cannot be listed): a
+                             blind audit never certifies "clean" (W84
+                             discipline).
 """
 
 from __future__ import annotations
@@ -80,6 +92,10 @@ _DEFAULT_ROOT_RELATIVE_PATHS: Tuple[str, ...] = (
     "~/scripts",
     "~/Library/LaunchAgents",
     "~/.nuzantara-cron",
+    # Main checkout's credential directory (2026-09-10: found loosened,
+    # restored by hand — the auditor never looked here: root was missing).
+    # Relative to HOME so it is the same on every node; skipped if absent.
+    "~/nuzantara/.secrets",
 )
 
 #: Name globs (case-insensitive) that mark a file as credential-like.
@@ -110,12 +126,27 @@ SECRET_NAME_GLOBS: Tuple[str, ...] = (
 
 #: Name globs (case-insensitive) that are false positives and must never
 #: be reported, even if they also match a SECRET_NAME_GLOBS pattern.
+#: The template and token-usage entries are live 2026-09-10 Pro false
+#: positives (a plugin's .env.example, token-usage-2026-09.jsonl — usage
+#: accounting, same family as *token_count*).
 EXCLUDE_NAME_GLOBS: Tuple[str, ...] = (
     "*.pub",
     "known_hosts*",
     "*token_count*",
     "*tokenizer*",
+    "*token-usage*",
+    "*token_usage*",
+    "*.example",
+    "*.sample",
+    "*.template",
 )
+
+#: Directory basenames that mark a credential CUSTODY root: inside one the
+#: FILE's own mode is the invariant (see is_custody_root / scan strict).
+CUSTODY_DIR_NAMES = frozenset({".secrets"})
+
+#: `.env*` files are report-only: shown for a human, never chmod'ed.
+ENV_NAME_GLOBS: Tuple[str, ...] = (".env*", "*.env*")
 
 #: Trailing backup-suffix pattern: ".bak", ".bak-<anything without / or .>",
 #: ".orig", or a lone trailing "~". A backup inherits the sensitivity of
@@ -133,6 +164,34 @@ class Finding:
 
     path: Path
     mode: int  # permission bits only, e.g. 0o644 (see stat.S_IMODE)
+    # Custody: judged by the file's own mode alone — the directory chain
+    # is one chmod away from opening (2026-09-10).
+    custody: bool = False
+    # Custody or `.env*`: reported for a human, never chmod'ed;
+    # fix_findings re-checks the name, never this flag.
+    report_only: bool = False
+
+
+@dataclass(frozen=True)
+class CustodyRootReport:
+    """Per-custody-root summary for main() (text line and JSON entry)."""
+
+    root: Path
+    files_traversed: int
+    findings: int
+    dir_mode: Optional[str]  # octal string, e.g. "0700"; None if unstatable
+    blind: bool  # dir exists but os.listdir raised — the walk saw nothing
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """Merged custody (strict) + plain (reachability) scan result."""
+
+    findings: List[Finding]
+    custody: List[CustodyRootReport]
+    roots_existing: int
+    files_traversed: int
+    blind: bool
 
 
 # --------------------------------------------------------------------------
@@ -186,9 +245,54 @@ def is_candidate_path(path: Path) -> bool:
     return _fnmatch_any(str(path), SECRET_NAME_GLOBS)
 
 
+def is_custody_root(root: Path) -> bool:
+    """True when the NAMED root's basename (after expanduser, BEFORE any
+    symlink resolution) marks a credential custody directory.
+
+    WHY custody: the file's own mode decides inside one, not the directory
+    chain — the chain is one chmod away from opening, so an audit that
+    waits for it reports the exposure one mistake late (2026-09-10: a
+    0644 probe inside a still-closed .secrets read count: 0).
+    """
+    return Path(root).expanduser().name in CUSTODY_DIR_NAMES
+
+
+def is_env_shaped(path: Path) -> bool:
+    """True when the basename — or its backup-stripped form — matches an
+    `.env*` glob. Same helpers as is_candidate_path, case-insensitive.
+
+    `.env*` files are off-limits to automated edits in this repo: their
+    modes are reported for a human, never fixed.
+    """
+    name = path.name
+    stripped = strip_backup_suffix(name)
+    variants = {name} if stripped == name else {name, stripped}
+    return any(_fnmatch_any(variant, ENV_NAME_GLOBS) for variant in variants)
+
+
+def is_under_custody(path: Path) -> bool:
+    """True when any directory above `path` is named like a custody root —
+    whether the caller NAMED that root or the walk merely met it.
+
+    Credentials stay with the human (Builder Contract rule 5): a file under
+    a `.secrets` directory is reported, never chmod'ed. Checked by name so
+    fix_findings needs nothing but the path.
+    """
+    return any(part in CUSTODY_DIR_NAMES for part in Path(path).parent.parts)
+
+
 # --------------------------------------------------------------------------
 # Filesystem walk (depth-capped, symlink-safe)
 # --------------------------------------------------------------------------
+
+
+def _is_plugin_marketplace(dirpath: Path, name: str) -> bool:
+    """A `marketplaces` directory whose parent is named `plugins`: public
+    third-party plugin marketplace checkouts (live 2026-09-10 case: a
+    22-byte .npmrc in one). Not descended. A `marketplaces` directory
+    under any other parent is still walked.
+    """
+    return name == "marketplaces" and dirpath.name == "plugins"
 
 
 def _iter_candidate_paths_under_dir(
@@ -207,7 +311,12 @@ def _iter_candidate_paths_under_dir(
         if depth >= max_depth:
             dirnames[:] = []
         else:
-            dirnames[:] = [d for d in dirnames if d not in PRUNE_DIR_NAMES]
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if d not in PRUNE_DIR_NAMES
+                and not _is_plugin_marketplace(Path(dirpath), d)
+            ]
 
         if stats is not None:
             stats["files_traversed"] = stats.get("files_traversed", 0) + len(filenames)
@@ -337,6 +446,7 @@ def scan(
     roots: Iterable[Path],
     max_depth: int = DEFAULT_MAX_DEPTH,
     stats: Optional[dict] = None,
+    strict: bool = False,
 ) -> List[Finding]:
     """Scan `roots` for credential-like files with group/other permission
     bits set. Returns findings sorted by path. Never opens file contents —
@@ -346,6 +456,11 @@ def scan(
     `files_traversed` so the caller can detect a BLIND scan (roots exist
     but zero files were walked — TCC/sandbox denial): a scan that cannot
     see must never certify "clean" (W84 dead-green discipline).
+
+    `strict` (custody semantics, used by audit() for custody roots):
+    skips the reachability check — any group/other bit on the file is a
+    finding whatever the chain says — and marks findings `custody=True`.
+    Default False keeps reachability exactly as before.
     """
     findings: List[Finding] = []
     seen_files: set = set()
@@ -369,14 +484,27 @@ def scan(
         if not mode_bits & 0o077:
             continue
 
-        # The mode says who MAY read; the directory chain says who can get
-        # here at all. Both have to be true for the file to be exposed.
-        can_group, can_other = reachable_by(candidate, traversal_cache)
-        exposed = (bool(mode_bits & 0o070) and can_group) or (
-            bool(mode_bits & 0o007) and can_other
-        )
+        if strict:
+            # Custody semantics: the file's own mode is the invariant.
+            exposed = True
+        else:
+            # The mode says who MAY read; the directory chain says who can
+            # get here at all. Both have to be true for exposure.
+            can_group, can_other = reachable_by(candidate, traversal_cache)
+            exposed = (bool(mode_bits & 0o070) and can_group) or (
+                bool(mode_bits & 0o007) and can_other
+            )
         if exposed:
-            findings.append(Finding(path=candidate, mode=mode_bits))
+            findings.append(
+                Finding(
+                    path=candidate,
+                    mode=mode_bits,
+                    custody=strict,
+                    report_only=strict
+                    or is_under_custody(candidate)
+                    or is_env_shaped(candidate),
+                )
+            )
 
     findings.sort(key=lambda f: str(f.path))
     return findings
@@ -391,12 +519,92 @@ def default_roots() -> List[Path]:
 
 
 # --------------------------------------------------------------------------
+# audit — custody roots one-by-one in strict mode, everything else together
+# --------------------------------------------------------------------------
+
+
+def audit(
+    roots: Sequence[Path], max_depth: int = DEFAULT_MAX_DEPTH
+) -> AuditResult:
+    """Scan `roots` with custody semantics: custody roots one-by-one in
+    strict mode (the file's own mode decides, whatever the chain), all
+    other roots together with reachability. Findings merge, deduped by
+    os.path.abspath with the custody finding winning. `blind` is True
+    when roots exist but zero files were traversed, or any custody
+    directory cannot be listed (W84: a blind audit never certifies clean).
+    """
+    merged: dict = {}
+    reports: List[CustodyRootReport] = []
+    total_roots_existing = 0
+    total_files = 0
+
+    custody_roots = [r for r in roots if is_custody_root(r)]
+    plain_roots = [r for r in roots if not is_custody_root(r)]
+
+    seen_custody: set = set()
+    for raw_root in custody_roots:
+        root = Path(raw_root).expanduser()
+        if not os.path.isdir(root):
+            continue  # a custody root that does not exist is omitted
+        key = os.path.realpath(root)
+        if key in seen_custody:
+            continue  # named twice (default + --root): one report, not two
+        seen_custody.add(key)
+        stats: dict = {}
+        findings = scan([root], max_depth=max_depth, stats=stats, strict=True)
+        for finding in findings:
+            merged[os.path.abspath(finding.path)] = finding  # custody wins
+        try:
+            os.listdir(root)
+            blind_dir = False
+        except OSError:
+            blind_dir = True
+        try:
+            dir_mode: Optional[str] = _mode_octal(
+                stat.S_IMODE(os.stat(root).st_mode)
+            )
+        except OSError:
+            dir_mode = None
+        reports.append(
+            CustodyRootReport(
+                root=root,
+                files_traversed=stats.get("files_traversed", 0),
+                findings=len(findings),
+                dir_mode=dir_mode,
+                blind=blind_dir,
+            )
+        )
+        total_roots_existing += stats.get("roots_existing", 0)
+        total_files += stats.get("files_traversed", 0)
+
+    if plain_roots:
+        stats = {}
+        findings = scan(plain_roots, max_depth=max_depth, stats=stats)
+        for finding in findings:
+            merged.setdefault(os.path.abspath(finding.path), finding)
+        total_roots_existing += stats.get("roots_existing", 0)
+        total_files += stats.get("files_traversed", 0)
+
+    blind = (total_roots_existing > 0 and total_files == 0) or any(
+        r.blind for r in reports
+    )
+    return AuditResult(
+        findings=sorted(merged.values(), key=lambda f: str(f.path)),
+        custody=reports,
+        roots_existing=total_roots_existing,
+        files_traversed=total_files,
+        blind=blind,
+    )
+
+
+# --------------------------------------------------------------------------
 # --fix
 # --------------------------------------------------------------------------
 
 
 def fix_findings(findings: Sequence[Finding]) -> Tuple[int, int, List[str]]:
-    """chmod every finding to 0o600 and verify via a fresh lstat.
+    """chmod every finding to 0o600 — except custody and `.env*` files,
+    which are never touched — and verify via a fresh lstat.
 
     Returns (fixed_count, failed_count, failure_messages). Failure
     messages carry only the path and the exception CLASS NAME — never
@@ -407,6 +615,11 @@ def fix_findings(findings: Sequence[Finding]) -> Tuple[int, int, List[str]]:
     failures: List[str] = []
 
     for finding in findings:
+        if is_env_shaped(finding.path) or is_under_custody(finding.path):
+            # Custody and `.env*` are report-only: never chmod'ed, counted
+            # by main(). Re-checked by NAME, never the flag — a hand-built
+            # Finding must not smuggle a credential past this skip.
+            continue
         try:
             os.chmod(finding.path, 0o600)
             verify = os.lstat(finding.path)
@@ -452,7 +665,12 @@ def _mode_octal(mode: int) -> str:
 
 
 def _finding_to_dict(finding: Finding) -> dict:
-    return {"path": str(finding.path), "mode": _mode_octal(finding.mode)}
+    return {
+        "path": str(finding.path),
+        "mode": _mode_octal(finding.mode),
+        "custody": finding.custody,
+        "report_only": finding.report_only,
+    }
 
 
 def resolve_roots(
@@ -478,7 +696,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
-    parser.add_argument("--fix", action="store_true", help="chmod 0600 every finding.")
+    parser.add_argument("--fix", action="store_true", help="chmod 0600 every ordinary finding (custody and .env* stay report-only).")
     parser.add_argument(
         "--no-default-roots",
         action="store_true",
@@ -506,15 +724,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     roots = resolve_roots(args.roots, no_defaults=args.no_default_roots)
-    stats: dict = {}
-    findings = scan(roots, max_depth=args.max_depth, stats=stats)
+    result = audit(roots, max_depth=args.max_depth)
 
-    roots_existing = stats.get("roots_existing", 0)
-    files_traversed = stats.get("files_traversed", 0)
+    findings = result.findings
+    roots_existing = result.roots_existing
+    files_traversed = result.files_traversed
     # BLIND-scan guard (W84 dead-green): roots exist but the walk saw ZERO
-    # files → TCC/sandbox/permission denial is hiding the world. A blind
-    # audit must never certify "clean".
-    blind = roots_existing > 0 and files_traversed == 0
+    # files, or a custody directory cannot be listed. Never certify "clean".
+    blind = result.blind
+    report_only = sum(1 for f in findings if f.report_only)
 
     fixed: Optional[int] = None
     failed = 0
@@ -532,11 +750,39 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             "roots_existing": roots_existing,
             "files_traversed": files_traversed,
             "blind": blind,
+            "custody": [
+                {
+                    "root": str(r.root),
+                    "files_traversed": r.files_traversed,
+                    "findings": r.findings,
+                    "dir_mode": r.dir_mode,
+                    "blind": r.blind,
+                }
+                for r in result.custody
+            ],
+            "report_only": report_only,
         }
         print(json.dumps(payload))
     else:
+        home = str(Path.home())
+        for r in result.custody:
+            shown = str(r.root)
+            if shown.startswith(home):
+                shown = "~" + shown[len(home):]
+            line = (
+                f"CUSTODY {shown}: {r.files_traversed} file(s) checked, "
+                f"{r.findings} finding(s), dir {r.dir_mode or '????'}"
+            )
+            if r.blind:
+                line += " — BLIND: directory cannot be listed"
+            print(line)
         for finding in findings:
-            print(f"{_mode_octal(finding.mode)} {finding.path}")
+            line = f"{_mode_octal(finding.mode)} {finding.path}"
+            if finding.custody:
+                line += "  CUSTODY"
+            if finding.report_only:
+                line += "  REPORT-ONLY (never chmod'ed)"
+            print(line)
         print(
             f"FINDINGS: {len(findings)} file(s) with group/other permissions "
             f"matching credential name patterns "
@@ -549,14 +795,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 "filesystem. Result is NOT trustworthy; do not read as clean."
             )
         if args.fix and not blind:
-            print(f"FIXED: {fixed}  FAILED: {failed}")
+            print(f"FIXED: {fixed}  FAILED: {failed}  REPORT-ONLY: {report_only}")
             for failure in failures:
                 print(f"  ! {failure}")
 
     if blind:
         return 2
     if args.fix:
-        return 0 if failed == 0 else 1
+        # 0 only when nothing failed AND no report-only finding remains
+        # (custody and .env* are never chmod'ed, so one keeps rc 1).
+        return 0 if failed == 0 and report_only == 0 else 1
     return 0 if not findings else 1
 
 

--- a/scripts/secrets_permissions_audit.py
+++ b/scripts/secrets_permissions_audit.py
@@ -126,23 +126,26 @@ SECRET_NAME_GLOBS: Tuple[str, ...] = (
 
 #: Name globs (case-insensitive) that are false positives and must never
 #: be reported, even if they also match a SECRET_NAME_GLOBS pattern.
-#: The template and token-usage entries are live 2026-09-10 Pro false
-#: positives (a plugin's .env.example, token-usage-2026-09.jsonl — usage
-#: accounting, same family as *token_count*).
+#: The last five are the measured 2026-09-10 Pro false positives and no
+#: wider: `.env` TEMPLATES (a plugin's .env.example) and usage-accounting
+#: jsonl logs (token-usage-2026-09.jsonl, same family as *token_count*).
+#: Kept this narrow on purpose — `id_rsa.example`, `token-usage.pem` or
+#: `credentials.json.template` are still candidates. Never applied inside custody.
 EXCLUDE_NAME_GLOBS: Tuple[str, ...] = (
     "*.pub",
     "known_hosts*",
     "*token_count*",
     "*tokenizer*",
-    "*token-usage*",
-    "*token_usage*",
-    "*.example",
-    "*.sample",
-    "*.template",
+    "*token-usage*.jsonl",
+    "*token_usage*.jsonl",
+    ".env*.example",
+    ".env*.sample",
+    ".env*.template",
 )
 
-#: Directory basenames that mark a credential CUSTODY root: inside one the
-#: FILE's own mode is the invariant (see is_custody_root / scan strict).
+#: Directory basenames (compared lower-case) that mark a credential CUSTODY
+#: directory: inside one EVERY file is a credential and its own mode is the
+#: invariant — no name filter, no exclusion, no chain (see scan strict).
 CUSTODY_DIR_NAMES = frozenset({".secrets"})
 
 #: `.env*` files are report-only: shown for a human, never chmod'ed.
@@ -167,8 +170,8 @@ class Finding:
     # Custody: judged by the file's own mode alone — the directory chain
     # is one chmod away from opening (2026-09-10).
     custody: bool = False
-    # Custody or `.env*`: reported for a human, never chmod'ed;
-    # fix_findings re-checks the name, never this flag.
+    # Custody or `.env*`: reported for a human, never chmod'ed.
+    # fix_findings honours this flag AND re-checks the name.
     report_only: bool = False
 
 
@@ -254,7 +257,7 @@ def is_custody_root(root: Path) -> bool:
     waits for it reports the exposure one mistake late (2026-09-10: a
     0644 probe inside a still-closed .secrets read count: 0).
     """
-    return Path(root).expanduser().name in CUSTODY_DIR_NAMES
+    return Path(root).expanduser().name.lower() in CUSTODY_DIR_NAMES
 
 
 def is_env_shaped(path: Path) -> bool:
@@ -278,7 +281,7 @@ def is_under_custody(path: Path) -> bool:
     a `.secrets` directory is reported, never chmod'ed. Checked by name so
     fix_findings needs nothing but the path.
     """
-    return any(part in CUSTODY_DIR_NAMES for part in Path(path).parent.parts)
+    return any(part.lower() in CUSTODY_DIR_NAMES for part in Path(path).parent.parts)
 
 
 # --------------------------------------------------------------------------
@@ -286,23 +289,18 @@ def is_under_custody(path: Path) -> bool:
 # --------------------------------------------------------------------------
 
 
-def _is_plugin_marketplace(dirpath: Path, name: str) -> bool:
-    """A `marketplaces` directory whose parent is named `plugins`: public
-    third-party plugin marketplace checkouts (live 2026-09-10 case: a
-    22-byte .npmrc in one). Not descended. A `marketplaces` directory
-    under any other parent is still walked.
-    """
-    return name == "marketplaces" and dirpath.name == "plugins"
-
-
 def _iter_candidate_paths_under_dir(
-    root: Path, max_depth: int, stats: Optional[dict] = None
+    root: Path, max_depth: int, stats: Optional[dict] = None, all_files: bool = False
 ) -> Iterator[Path]:
     """Yield candidate-named file paths under a directory `root`.
 
     Depth 0 = files directly in `root`. Descent stops once a directory's
     depth reaches `max_depth` (files at that depth are still yielded; its
     subdirectories are not visited). Never follows symlinked directories.
+
+    `all_files` (a custody root, possibly reached through a symlink that
+    dropped the `.secrets` name) yields every file and prunes nothing; a
+    `.secrets` directory met during an ordinary walk gets the same.
     """
     for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
         rel = Path(dirpath).relative_to(root)
@@ -310,24 +308,22 @@ def _iter_candidate_paths_under_dir(
 
         if depth >= max_depth:
             dirnames[:] = []
-        else:
-            dirnames[:] = [
-                d
-                for d in dirnames
-                if d not in PRUNE_DIR_NAMES
-                and not _is_plugin_marketplace(Path(dirpath), d)
-            ]
+        elif not all_files:
+            dirnames[:] = [d for d in dirnames if d not in PRUNE_DIR_NAMES]
 
         if stats is not None:
             stats["files_traversed"] = stats.get("files_traversed", 0) + len(filenames)
         for filename in filenames:
             candidate = Path(dirpath) / filename
-            if is_candidate_path(candidate):
+            if all_files or is_under_custody(candidate) or is_candidate_path(candidate):
                 yield candidate
 
 
 def _iter_candidate_paths(
-    roots: Iterable[Path], max_depth: int, stats: Optional[dict] = None
+    roots: Iterable[Path],
+    max_depth: int,
+    stats: Optional[dict] = None,
+    all_files: bool = False,
 ) -> Iterator[Path]:
     """Yield candidate-named file paths across all `roots`.
 
@@ -368,11 +364,13 @@ def _iter_candidate_paths(
             if key in seen_dirs:
                 continue
             seen_dirs.add(key)
-            yield from _iter_candidate_paths_under_dir(root, max_depth, stats)
+            yield from _iter_candidate_paths_under_dir(
+                root, max_depth, stats, all_files
+            )
         elif stat.S_ISREG(root_lstat.st_mode):
             if stats is not None:
                 stats["files_traversed"] = stats.get("files_traversed", 0) + 1
-            if is_candidate_path(root):
+            if all_files or is_candidate_path(root):
                 yield root
         # sockets/fifos/char-devices as roots: nothing sensible to scan
 
@@ -458,23 +456,29 @@ def scan(
     see must never certify "clean" (W84 dead-green discipline).
 
     `strict` (custody semantics, used by audit() for custody roots):
-    skips the reachability check — any group/other bit on the file is a
-    finding whatever the chain says — and marks findings `custody=True`.
-    Default False keeps reachability exactly as before.
+    every file under the root is a candidate, reachability is skipped —
+    any group/other bit on the file is a finding whatever the chain says —
+    and findings are `custody=True`. A file under a `.secrets` directory
+    met during an ordinary walk is judged the same way. A custody file
+    that cannot be lstat'ed is counted in stats["unreadable"]: audit()
+    turns that into BLIND, never "clean".
     """
     findings: List[Finding] = []
     seen_files: set = set()
     traversal_cache: dict = {}  # one scan's worth — see _dir_traversal
 
-    for candidate in _iter_candidate_paths(roots, max_depth, stats):
+    for candidate in _iter_candidate_paths(roots, max_depth, stats, strict):
         key = os.path.abspath(candidate)
         if key in seen_files:
             continue
         seen_files.add(key)
 
+        custody = strict or is_under_custody(candidate)
         try:
             lst = os.lstat(candidate)
         except OSError:
+            if custody and stats is not None:
+                stats["unreadable"] = stats.get("unreadable", 0) + 1
             continue
 
         if not stat.S_ISREG(lst.st_mode):
@@ -484,7 +488,7 @@ def scan(
         if not mode_bits & 0o077:
             continue
 
-        if strict:
+        if custody:
             # Custody semantics: the file's own mode is the invariant.
             exposed = True
         else:
@@ -499,10 +503,8 @@ def scan(
                 Finding(
                     path=candidate,
                     mode=mode_bits,
-                    custody=strict,
-                    report_only=strict
-                    or is_under_custody(candidate)
-                    or is_env_shaped(candidate),
+                    custody=custody,
+                    report_only=custody or is_env_shaped(candidate),
                 )
             )
 
@@ -537,6 +539,7 @@ def audit(
     reports: List[CustodyRootReport] = []
     total_roots_existing = 0
     total_files = 0
+    unreadable = 0
 
     custody_roots = [r for r in roots if is_custody_root(r)]
     plain_roots = [r for r in roots if not is_custody_root(r)]
@@ -544,8 +547,16 @@ def audit(
     seen_custody: set = set()
     for raw_root in custody_roots:
         root = Path(raw_root).expanduser()
-        if not os.path.isdir(root):
+        try:
+            root_stat = os.stat(root)
+        except (FileNotFoundError, NotADirectoryError):
             continue  # a custody root that does not exist is omitted
+        except OSError:
+            # Exists but cannot be stat'ed (EACCES on the chain): BLIND.
+            reports.append(CustodyRootReport(root, 0, 0, None, True))
+            continue
+        if not stat.S_ISDIR(root_stat.st_mode):
+            continue
         key = os.path.realpath(root)
         if key in seen_custody:
             continue  # named twice (default + --root): one report, not two
@@ -556,15 +567,10 @@ def audit(
             merged[os.path.abspath(finding.path)] = finding  # custody wins
         try:
             os.listdir(root)
-            blind_dir = False
+            blind_dir = stats.get("unreadable", 0) > 0
         except OSError:
             blind_dir = True
-        try:
-            dir_mode: Optional[str] = _mode_octal(
-                stat.S_IMODE(os.stat(root).st_mode)
-            )
-        except OSError:
-            dir_mode = None
+        dir_mode: Optional[str] = _mode_octal(stat.S_IMODE(root_stat.st_mode))
         reports.append(
             CustodyRootReport(
                 root=root,
@@ -584,9 +590,12 @@ def audit(
             merged.setdefault(os.path.abspath(finding.path), finding)
         total_roots_existing += stats.get("roots_existing", 0)
         total_files += stats.get("files_traversed", 0)
+        unreadable += stats.get("unreadable", 0)
 
-    blind = (total_roots_existing > 0 and total_files == 0) or any(
-        r.blind for r in reports
+    blind = (
+        (total_roots_existing > 0 and total_files == 0)
+        or unreadable > 0
+        or any(r.blind for r in reports)
     )
     return AuditResult(
         findings=sorted(merged.values(), key=lambda f: str(f.path)),
@@ -604,7 +613,8 @@ def audit(
 
 def fix_findings(findings: Sequence[Finding]) -> Tuple[int, int, List[str]]:
     """chmod every finding to 0o600 — except custody and `.env*` files,
-    which are never touched — and verify via a fresh lstat.
+    which are never touched, and anything that is not a regular file (a
+    symlink would hand the chmod to its target) — and verify via lstat.
 
     Returns (fixed_count, failed_count, failure_messages). Failure
     messages carry only the path and the exception CLASS NAME — never
@@ -615,12 +625,22 @@ def fix_findings(findings: Sequence[Finding]) -> Tuple[int, int, List[str]]:
     failures: List[str] = []
 
     for finding in findings:
-        if is_env_shaped(finding.path) or is_under_custody(finding.path):
+        if (
+            finding.custody
+            or finding.report_only
+            or is_env_shaped(finding.path)
+            or is_under_custody(finding.path)
+        ):
             # Custody and `.env*` are report-only: never chmod'ed, counted
-            # by main(). Re-checked by NAME, never the flag — a hand-built
-            # Finding must not smuggle a credential past this skip.
+            # by main(). The flag covers a custody root reached through a
+            # symlink (its path lost the name); the NAME covers a hand-built
+            # Finding — either one is enough to skip.
             continue
         try:
+            if not stat.S_ISREG(os.lstat(finding.path).st_mode):
+                failed += 1
+                failures.append(f"{finding.path}: NotARegularFile")
+                continue
             os.chmod(finding.path, 0o600)
             verify = os.lstat(finding.path)
         except OSError as exc:

--- a/scripts/tests/test_secrets_permissions_audit.py
+++ b/scripts/tests/test_secrets_permissions_audit.py
@@ -175,8 +175,10 @@ def test_symlink_to_secret_is_skipped(tmp_path: Path) -> None:
 
 
 def test_fix_chmods_to_0600_and_rescan_is_clean(tmp_path: Path) -> None:
-    target = tmp_path / ".env.master"
-    target.write_text("SECRET=deadbeef\n")
+    # credentials.json, not .env.master: .env* is report-only by design
+    # (T6/T8) and must never be chmod'ed by fix_findings.
+    target = tmp_path / "credentials.json"
+    target.write_text("{}\n")
     target.chmod(0o644)
 
     findings = audit.scan([tmp_path], max_depth=4)
@@ -194,8 +196,8 @@ def test_fix_chmods_to_0600_and_rescan_is_clean(tmp_path: Path) -> None:
 
 
 def test_fix_via_main_cli_exit_codes(tmp_path: Path) -> None:
-    target = tmp_path / ".env.master"
-    target.write_text("SECRET=deadbeef\n")
+    target = tmp_path / "credentials.json"
+    target.write_text("{}\n")
     target.chmod(0o644)
 
     exit_code = audit.main(["--no-default-roots", "--root", str(tmp_path), "--fix"])
@@ -526,3 +528,284 @@ def test_scan_still_reports_the_same_file_when_the_chain_is_open(
 
     assert [f.path.name for f in findings] == ["credentials.env"]
     assert findings[0].mode == 0o644
+
+
+# --------------------------------------------------------------------------
+# Custody roots + report-only .env* (2026-09-10 incident):
+# ~/nuzantara/.secrets was found loosened and restored by hand; the auditor
+# never looked there (not a default root), and reachable_by() absolves a
+# 0644 file whose chain is still closed — invisible until a SECOND mistake
+# opens the directory. Custody judges the file's own mode.
+# --------------------------------------------------------------------------
+
+
+def _touch(path: Path, mode: int, content: str = "x\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    path.chmod(mode)
+    return path
+
+
+def _json_main(module, args: list, capsys) -> tuple:
+    import json
+
+    rc = module.main(args)
+    return rc, json.loads(capsys.readouterr().out)
+
+
+def test_t1_default_roots_include_main_checkout_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert tmp_path / "nuzantara" / ".secrets" in audit.default_roots()
+
+
+def _custody_fixture(tmp_path: Path):
+    """0644 probe.json behind a CLOSED chain (outer 0700), inside a
+    `.secrets` dir left at mkdir default — the dir mode must NOT decide.
+    Real reachability (open_chain=False): the whole point is the chain."""
+    module = _load_module(open_chain=False)
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    outer.chmod(0o700)
+    scr = outer / ".secrets"
+    scr.mkdir()  # 0755 — deliberately NOT tightened
+    probe = _touch(scr / "probe.json", 0o644, "{}\n")
+    return module, outer, scr, probe
+
+
+def test_t2_custody_guilt_behind_closed_chain(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    module, outer, scr, probe = _custody_fixture(tmp_path)
+    args = ["--no-default-roots", "--root", str(scr), "--json"]
+
+    rc, payload = _json_main(module, args, capsys)
+    assert rc == 1
+    assert payload["count"] == 1
+    assert payload["findings"][0]["custody"] is True
+    assert payload["findings"][0]["report_only"] is True
+    report = payload["custody"][0]
+    assert report["files_traversed"] == 1
+    assert report["findings"] == 1
+    assert report["dir_mode"] == "0755"
+
+    # Same file, same chain, locked down: clean. Paired so neither case
+    # can pass because the file was never a candidate.
+    probe.chmod(0o600)
+    rc, payload = _json_main(module, args, capsys)
+    assert rc == 0
+    assert payload["count"] == 0
+
+
+def test_t3_custody_innocence_locked_files_and_dir_mode_not_a_finding(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """0600/0400 inside a 0755 .secrets read clean; the dir mode is
+    INFORMATIONAL only (mkdir -p makes a scratch .secrets 0755)."""
+    module = _load_module(open_chain=False)
+    scr = tmp_path / ".secrets"
+    scr.mkdir()  # 0755 — must not itself be a finding
+    _touch(scr / "a.json", 0o600, "{}\n")
+    _touch(scr / "b.json", 0o400, "{}\n")
+    # Named twice on purpose: one custody report, not two.
+    args = ["--no-default-roots", "--root", str(scr), "--root", str(scr), "--json"]
+
+    rc, payload = _json_main(module, args, capsys)
+    assert rc == 0
+    assert payload["count"] == 0
+    assert len(payload["custody"]) == 1
+    assert payload["custody"][0]["findings"] == 0
+    assert payload["custody"][0]["dir_mode"] == "0755"
+
+
+def test_t4_same_file_behind_closed_chain_outside_custody_is_absolved(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Paired with T2: only the directory NAME turns custody semantics on;
+    reachability outside custody roots is untouched."""
+    module = _load_module(open_chain=False)
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    outer.chmod(0o700)
+    _touch(outer / "vault" / "probe.json", 0o644, "{}\n")
+
+    rc, payload = _json_main(
+        module, ["--no-default-roots", "--root", str(outer), "--json"], capsys
+    )
+    assert rc == 0
+    assert payload["count"] == 0
+
+
+def test_t5_env_templates_never_flagged_and_custody_report_counts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Live 2026-09-10 false positives: credential TEMPLATES shipped in
+    repos at 0644 (.env.example, .env.sample) must never be flagged."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    secrets = tmp_path / "nuzantara" / ".secrets"
+    secrets.mkdir(parents=True)
+    _touch(secrets / "a.json", 0o600, "{}\n")
+    _touch(tmp_path / "nuzantara" / "apps" / "web" / ".env.example", 0o644, "# t\n")
+    for name in (".env.example", ".env.sample"):  # inside a default root
+        _touch(tmp_path / ".claude" / "skills" / "x" / name, 0o644, "# t\n")
+
+    rc, payload = _json_main(audit, ["--json"], capsys)
+    assert rc == 0
+    flagged = [f["path"] for f in payload["findings"]]
+    assert not any(".example" in p or ".sample" in p for p in flagged)
+    report = {c["root"]: c for c in payload["custody"]}[str(secrets)]
+    assert report["files_traversed"] == 1
+    assert report["findings"] == 0
+
+
+def test_t6_fix_never_chmods_env_shaped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    target = _touch(tmp_path / ".env.master", 0o644, "SECRET=1\n")
+
+    real_chmod = os.chmod
+    calls: list = []
+
+    def spy_chmod(path, mode, *args, **kwargs):
+        calls.append(Path(path))
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "chmod", spy_chmod)
+
+    rc = audit.main(["--no-default-roots", "--root", str(tmp_path), "--fix"])
+    out = capsys.readouterr().out
+
+    assert target not in calls
+    assert _mode_of(target) == 0o644
+    lines = [ln for ln in out.splitlines() if str(target) in ln]
+    assert len(lines) == 1
+    assert "REPORT-ONLY" in lines[0]
+    assert rc == 1
+
+
+@pytest.mark.parametrize("relpath", [".env.master", ".secrets/probe.json"])
+def test_t8_fix_findings_ignores_credentials_even_when_hand_built(
+    tmp_path: Path, relpath: str
+) -> None:
+    """Defense in depth: fix_findings re-checks the NAME, never the flag —
+    a hand-built Finding for an .env* file or a file under .secrets must
+    not get a chmod (credentials stay with the human)."""
+    target = _touch(tmp_path / relpath, 0o644, "SECRET=1\n")
+
+    result = audit.fix_findings([audit.Finding(path=target, mode=0o644)])
+
+    assert result == (0, 0, [])
+    assert _mode_of(target) == 0o644
+
+
+def test_t9_live_false_positives_are_excluded(tmp_path: Path) -> None:
+    """2026-09-10 Pro scan: usage-accounting logs (token-usage jsonl, same
+    family as *token_count*) and credential templates are not findings;
+    a real service.token in the same directory still is."""
+    _touch(tmp_path / "token-usage-2026-09.jsonl", 0o644, "{}\n")
+    _touch(tmp_path / "token_usage.log", 0o644)
+    _touch(tmp_path / "creds.json.template", 0o644, "{}\n")
+    _touch(tmp_path / ".env.sample", 0o644, "# t\n")
+    real = _touch(tmp_path / "service.token", 0o644, "tok\n")
+
+    findings = audit.scan([tmp_path], max_depth=4)
+
+    assert _paths(findings) == {real}
+
+
+def test_t10_plugin_marketplace_checkouts_are_pruned(tmp_path: Path) -> None:
+    """Public third-party plugin checkouts are not descended (live case: a
+    22-byte .npmrc in one); marketplaces under any OTHER parent is walked."""
+    vendored = _touch(
+        tmp_path / "plugins" / "marketplaces" / "vendor" / ".npmrc", 0o644, "//\n"
+    )
+    other = _touch(tmp_path / "other" / "marketplaces" / ".npmrc", 0o644, "//\n")
+
+    findings = audit.scan([tmp_path], max_depth=4)
+
+    assert vendored not in _paths(findings)
+    assert other in _paths(findings)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores permission bits")
+def test_t11_custody_blind_directory_cannot_be_listed(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """A custody dir that exists but cannot be listed (chmod 000) makes the
+    whole audit BLIND — never certify 'clean' over zero files."""
+    module = _load_module(open_chain=False)
+    scr = tmp_path / ".secrets"
+    scr.mkdir()
+    _touch(scr / "a.json", 0o600, "{}\n")
+    scr.chmod(0o000)
+    try:
+        rc, payload = _json_main(
+            module, ["--no-default-roots", "--root", str(scr), "--json"], capsys
+        )
+    finally:
+        scr.chmod(0o700)
+
+    assert rc == 2
+    assert payload["blind"] is True
+    assert payload["custody"][0]["blind"] is True
+
+
+def test_t12_fix_never_chmods_a_custody_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Credentials stay with the human: --fix reports a loosened file under a
+    .secrets root and leaves its mode alone (S2 round-3 ruling, 2026-09-10)."""
+    module, _outer, scr, probe = _custody_fixture(tmp_path)
+    calls: list = []
+    real_chmod = os.chmod
+
+    def spy_chmod(path, mode, *args, **kwargs):
+        calls.append(Path(path))
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "chmod", spy_chmod)
+    rc = module.main(["--no-default-roots", "--root", str(scr), "--fix"])
+    out = capsys.readouterr().out
+
+    assert calls == []
+    assert _mode_of(probe) == 0o644
+    lines = [ln for ln in out.splitlines() if str(probe) in ln]
+    assert len(lines) == 1
+    assert "CUSTODY" in lines[0] and "REPORT-ONLY" in lines[0]
+    assert "REPORT-ONLY: 1" in out
+    assert rc == 1
+
+
+def test_t13_fix_touches_exactly_what_it_touched_before(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """This change must not widen what --fix alters: its live consumer is
+    Mini's com.nuzantara.secrets-perms-sweep (--fix on the default roots,
+    every 6 h). Only the ordinary credential is chmod'ed; .env* and every file
+    under a .secrets directory, named root or walked into, keep their mode."""
+    root = tmp_path / "root"
+    ordinary = _touch(root / "service.token", 0o644)
+    env = _touch(root / ".env.master", 0o644)
+    walked = _touch(root / "app" / ".secrets" / "walked.json", 0o644)
+    named_root = tmp_path / "named" / ".secrets"
+    named = _touch(named_root / "named.json", 0o644)
+    calls: list = []
+    real_chmod = os.chmod
+
+    def spy_chmod(path, mode, *args, **kwargs):
+        calls.append(Path(path))
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "chmod", spy_chmod)
+    rc = audit.main(
+        ["--no-default-roots", "--root", str(root), "--root", str(named_root), "--fix"]
+    )
+    out = capsys.readouterr().out
+
+    assert calls == [ordinary]
+    assert _mode_of(ordinary) == 0o600
+    assert {_mode_of(p) for p in (env, walked, named)} == {0o644}
+    assert "FIXED: 1  FAILED: 0  REPORT-ONLY: 3" in out
+    assert rc == 1

--- a/scripts/tests/test_secrets_permissions_audit.py
+++ b/scripts/tests/test_secrets_permissions_audit.py
@@ -624,18 +624,24 @@ def test_t4_same_file_behind_closed_chain_outside_custody_is_absolved(
     tmp_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
     """Paired with T2: only the directory NAME turns custody semantics on;
-    reachability outside custody roots is untouched."""
+    reachability outside custody roots is untouched. A candidate NAME, so
+    the innocence comes from the closed chain, not from the name filter —
+    the open-chain control below proves it is the chain that absolves."""
     module = _load_module(open_chain=False)
     outer = tmp_path / "outer"
     outer.mkdir()
     outer.chmod(0o700)
-    _touch(outer / "vault" / "probe.json", 0o644, "{}\n")
+    _touch(outer / "vault" / "credentials.json", 0o644, "{}\n")
+    args = ["--no-default-roots", "--root", str(outer), "--json"]
 
-    rc, payload = _json_main(
-        module, ["--no-default-roots", "--root", str(outer), "--json"], capsys
-    )
+    rc, payload = _json_main(module, args, capsys)
     assert rc == 0
     assert payload["count"] == 0
+
+    rc, payload = _json_main(audit, args, capsys)  # chain declared open
+    assert rc == 1
+    assert payload["count"] == 1
+    assert payload["findings"][0]["custody"] is False
 
 
 def test_t5_env_templates_never_flagged_and_custody_report_counts(
@@ -700,33 +706,42 @@ def test_t8_fix_findings_ignores_credentials_even_when_hand_built(
     assert _mode_of(target) == 0o644
 
 
-def test_t9_live_false_positives_are_excluded(tmp_path: Path) -> None:
-    """2026-09-10 Pro scan: usage-accounting logs (token-usage jsonl, same
-    family as *token_count*) and credential templates are not findings;
-    a real service.token in the same directory still is."""
+def test_t9_live_false_positives_are_excluded_and_no_wider(tmp_path: Path) -> None:
+    """2026-09-10 Pro scan: usage-accounting jsonl logs (same family as
+    *token_count*) and `.env` templates are not findings. The exclusion is
+    exactly that narrow: key/credential names that merely CONTAIN the
+    excluded words, and non-.env templates, are still findings."""
     _touch(tmp_path / "token-usage-2026-09.jsonl", 0o644, "{}\n")
-    _touch(tmp_path / "token_usage.log", 0o644)
-    _touch(tmp_path / "creds.json.template", 0o644, "{}\n")
+    _touch(tmp_path / "token_usage-2026-09.jsonl", 0o644, "{}\n")
     _touch(tmp_path / ".env.sample", 0o644, "# t\n")
-    real = _touch(tmp_path / "service.token", 0o644, "tok\n")
+    _touch(tmp_path / ".env.local.template", 0o644, "# t\n")
+    real = {
+        _touch(tmp_path / name, 0o644, "x\n")
+        for name in (
+            "service.token",
+            "token-usage.pem",
+            "token_usage.key",
+            "id_rsa.example",
+            "credentials.json.template",
+            "credentials.json.template.bak",
+        )
+    }
 
     findings = audit.scan([tmp_path], max_depth=4)
 
-    assert _paths(findings) == {real}
+    assert _paths(findings) == real
 
 
-def test_t10_plugin_marketplace_checkouts_are_pruned(tmp_path: Path) -> None:
-    """Public third-party plugin checkouts are not descended (live case: a
-    22-byte .npmrc in one); marketplaces under any OTHER parent is walked."""
+def test_t10_plugin_marketplace_checkouts_are_walked(tmp_path: Path) -> None:
+    """A directory's name does not prove its contents public: a credential
+    inside a plugin marketplace checkout is found like any other."""
     vendored = _touch(
-        tmp_path / "plugins" / "marketplaces" / "vendor" / ".npmrc", 0o644, "//\n"
+        tmp_path / "plugins" / "marketplaces" / "vendor" / "id_rsa", 0o644, "k\n"
     )
-    other = _touch(tmp_path / "other" / "marketplaces" / ".npmrc", 0o644, "//\n")
 
     findings = audit.scan([tmp_path], max_depth=4)
 
-    assert vendored not in _paths(findings)
-    assert other in _paths(findings)
+    assert vendored in _paths(findings)
 
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores permission bits")
@@ -809,3 +824,134 @@ def test_t13_fix_touches_exactly_what_it_touched_before(
     assert {_mode_of(p) for p in (env, walked, named)} == {0o644}
     assert "FIXED: 1  FAILED: 0  REPORT-ONLY: 3" in out
     assert rc == 1
+
+
+def _spy_chmod(monkeypatch: pytest.MonkeyPatch) -> list:
+    calls: list = []
+    real_chmod = os.chmod
+
+    def spy_chmod(path, mode, *args, **kwargs):
+        calls.append(Path(path))
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "chmod", spy_chmod)
+    return calls
+
+
+def test_t14_symlinked_custody_root_is_judged_and_never_chmoded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Codex R1 BLOCKERs: `.secrets -> vault` resolves before the walk, so
+    the path loses the name. Every file there is still a custody finding —
+    no name filter, no exclusion — and --fix still leaves it alone."""
+    module = _load_module(open_chain=False)
+    vault = tmp_path / "vault"
+    probe = _touch(vault / "probe.json", 0o644, "{}\n")
+    pub = _touch(vault / "id_rsa.pub", 0o644, "k\n")
+    link = tmp_path / ".secrets"
+    link.symlink_to(vault)
+    args = ["--no-default-roots", "--root", str(link)]
+
+    rc, payload = _json_main(module, args + ["--json"], capsys)
+    assert rc == 1
+    assert {f["path"] for f in payload["findings"]} == {str(probe), str(pub)}
+    assert all(f["custody"] and f["report_only"] for f in payload["findings"])
+
+    calls = _spy_chmod(monkeypatch)
+    rc = module.main(args + ["--fix"])
+    out = capsys.readouterr().out
+    assert calls == []
+    assert {_mode_of(probe), _mode_of(pub)} == {0o644}
+    assert "FIXED: 0  FAILED: 0  REPORT-ONLY: 2" in out
+    assert rc == 1
+
+    for path in (probe, pub):  # innocence on the same fixture
+        path.chmod(0o600)
+    rc, payload = _json_main(module, args + ["--json"], capsys)
+    assert rc == 0
+    assert payload["count"] == 0
+
+
+def test_t15_custody_met_during_the_walk_any_case_is_strict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Naming the PARENT of a `.Secrets` directory behind a closed chain
+    still reports its loosened file as custody, and --fix leaves it."""
+    module = _load_module(open_chain=False)
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    outer.chmod(0o700)
+    probe = _touch(outer / ".Secrets" / "probe.json", 0o644, "{}\n")
+    args = ["--no-default-roots", "--root", str(outer)]
+
+    rc, payload = _json_main(module, args + ["--json"], capsys)
+    assert rc == 1
+    assert payload["count"] == 1
+    assert payload["findings"][0]["custody"] is True
+
+    calls = _spy_chmod(monkeypatch)
+    module.main(args + ["--fix"])
+    capsys.readouterr()
+    assert calls == []
+    assert _mode_of(probe) == 0o644
+
+    probe.chmod(0o600)
+    rc, payload = _json_main(module, args + ["--json"], capsys)
+    assert rc == 0
+    assert payload["count"] == 0
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores permission bits")
+@pytest.mark.parametrize("case", ["parent-closed", "dir-0400"])
+def test_t16_custody_access_errors_are_blind_never_clean(
+    tmp_path: Path, capsys: pytest.CaptureFixture, case: str
+) -> None:
+    """A custody root that cannot be stat'ed (EACCES on its chain), or one
+    that lists but cannot be traversed (0400), is BLIND — never 'clean'."""
+    module = _load_module(open_chain=False)
+    parent = tmp_path / "p"
+    scr = parent / ".secrets"
+    _touch(scr / "probe.json", 0o644, "{}\n")
+    locked = parent if case == "parent-closed" else scr
+    locked.chmod(0o000 if case == "parent-closed" else 0o400)
+    try:
+        rc, payload = _json_main(
+            module, ["--no-default-roots", "--root", str(scr), "--json"], capsys
+        )
+    finally:
+        locked.chmod(0o700)
+
+    assert rc == 2
+    assert payload["blind"] is True
+    assert payload["custody"][0]["blind"] is True
+
+    rc, payload = _json_main(  # innocence: same fixture, access restored
+        module, ["--no-default-roots", "--root", str(scr), "--json"], capsys
+    )
+    assert rc == 1
+    assert payload["blind"] is False
+
+
+def test_t17_fix_findings_refuses_symlinks_and_custody_flags(tmp_path: Path) -> None:
+    """A hand-built Finding on a symlink would hand the chmod to its target
+    (here an .env file); a Finding flagged custody is skipped even when its
+    path lost the name. An ordinary regular file is still fixed."""
+    target = _touch(tmp_path / ".env.real", 0o644, "SECRET=1\n")
+    link = tmp_path / "credentials.json"
+    link.symlink_to(target)
+    flagged = _touch(tmp_path / "vault" / "probe.json", 0o644, "{}\n")
+    ordinary = _touch(tmp_path / "service.token", 0o644, "tok\n")
+
+    fixed, failed, failures = audit.fix_findings(
+        [
+            audit.Finding(path=link, mode=0o644),
+            audit.Finding(path=flagged, mode=0o644, custody=True, report_only=True),
+            audit.Finding(path=ordinary, mode=0o644),
+        ]
+    )
+
+    assert (fixed, failed) == (1, 1)
+    assert failures == [f"{link}: NotARegularFile"]
+    assert _mode_of(target) == 0o644
+    assert _mode_of(flagged) == 0o644
+    assert _mode_of(ordinary) == 0o600


### PR DESCRIPTION
## Why

On 2026-09-10 a late reader found `~/nuzantara/.secrets` and its files loosened; they were restored by hand to 0700 / 0600 / 0400 (21:05 WITA). The credential-custody detector never looked there: it is not a default root. Adding the root alone would not have caught the next one either: `reachable_by()` absolves a 0644 file whose directory chain is closed, so a loosened credential inside a still-0700 `.secrets` stays invisible until a second mistake opens the directory. Measured on `origin/main` (af8f2da): the board's guilt fixture (a 0644 `probe.json` in `$(mktemp -d)/.secrets`) returns `"count": 0`.

## What changes

- **Default root** `~/nuzantara/.secrets`, relative to HOME so it is the same on every node, and skipped where it does not exist (Mini and M5 today).
- **Custody semantics.** Inside a `.secrets` directory, every file is a credential and its own mode decides: no name filter, no exclusion, no prune, no chain. Any group/other bit is a finding. This holds when the root is named, reached through a symlink (the resolved path loses the name, so a flag carries it), or met during an ordinary walk. The name is compared lower-case. The directory's mode is reported (`dir 0700`) but is never a finding.
- **Report-only for credentials.** Custody and `.env*` findings are printed for a human and never chmod'ed (Builder Contract rule 5). `.env*` has an explicit read-only exception to the off-limits rule: stat'ed, never opened. `fix_findings()` skips a finding when its custody/report-only flag is set OR its name is under `.secrets` / `.env*`, and refuses any path that is not a regular file (a symlink would hand the chmod to its target). `--fix` prints one `REPORT-ONLY` line per such file and exits 1 while one remains.
- **Blind, never clean.** A custody root that exists but cannot be stat'ed, listed or traversed makes the audit BLIND (rc 2).
- **Two measured false-positive classes excluded, no wider:** `.env` templates (`.env*.example/.sample/.template`) and usage-accounting jsonl logs (`*token-usage*.jsonl`, `*token_usage*.jsonl`). `id_rsa.example`, `token-usage.pem` and `credentials.json.template` are still findings.
- **Output**: one `CUSTODY <dir>: N file(s) checked, K finding(s), dir <mode>` line per custody root. The JSON gains a `custody` block, per-finding `custody` / `report_only` flags and a `report_only` count; `schema` stays 1 (additive).

## Consumers

- **Mini `com.nuzantara.secrets-perms-sweep`** (live today) runs `/usr/bin/python3` (3.9.6) `~/nuzantara/scripts/secrets_permissions_audit.py --fix` on the default roots every 6 h, from a checkout Mini's puller keeps on main. After this merge it only chmods LESS: nothing under a `.secrets` directory, no `.env*`, no symlink. Ordinary findings are fixed exactly as before (`test_t13_fix_touches_exactly_what_it_touched_before`). Baseline before merge: run 2026-09-10T16:00:20Z, rc=0, FINDINGS 0, FIXED 0, FAILED 0, 6,821 files under 10 roots. Mini has no `~/nuzantara/.secrets`.
- **Pro schedule**: this mission's follow-up PR installs `com.nuzantara.secrets-permissions-audit`, which runs this script hourly and hands custody and `.env*` findings to `tg_notify.py`. Ordinary findings stay in its log and raise no alert. Today there is exactly one: a 0644 `.npmrc` inside a plugin marketplace checkout under `~/.claude`, which `origin/main` already reports.

## Verification

Run on Pro at `8edef9c2c8`:

| Check | Command | Result |
|---|---|---|
| Test file | `~/nuzantara/.venv/bin/python3 -m pytest scripts/tests/test_secrets_permissions_audit.py -q` | 48 passed |
| Lint | `ruff check` on both files | clean |
| Python 3.9 (Mini) | `/usr/bin/python3 -c "import ast; ast.parse(..., feature_version=(3,9))"` | ok |
| Guilt → innocence, both interpreters | board fixture: 0644 `probe.json` in `$(mktemp -d)/.secrets`, then `chmod 600` | `python3` 1 → 0, `/usr/bin/python3` 1 → 0 (origin/main: 0) |
| Live custody oracle (read-only, 17:26:45Z) | `--no-default-roots --root ~/nuzantara/.secrets` vs `find -type f` / `find -type f -perm +077` | `7 file(s) checked, 0 finding(s), dir 0700` = 7 / 0 |
| Default roots (read-only) | `--json` | 54,079 files, 12 roots, count 1 (the ordinary `.npmrc` above), report_only 0, blind false |

Size: about 730 net lines, 433 of them tests. Every guilt test has its paired innocence test on the same fixture.

## Review and gate

- **Codex round 1** (`codex-spalla.sh review origin/main`, cross-family, transcript `~/logs/codex-spalla/20260910T165438Z-12815-review-…md`): 2 BLOCKER, 5 MEDIUM, 1 LOW, each with a repro. All were accepted and fixed in `8edef9c2c8`. The BLOCKERs: a symlinked `.secrets` root could hide a loosened file, and `--fix` chmod'ed a report-only custody finding by its resolved path. The MEDIUMs: walked-into or case-variant custody lost strictness, exclusions were broader than measured, the marketplace prune hid whole trees, an EACCES custody root read clean, and a hand-built symlink Finding reached chmod. The LOW: T4's innocence did not depend on the chain. The paired tests are T4 (open-chain control), T9, T10 and T14–T17.
- **Codex round 2** (last in budget, transcript `~/logs/codex-spalla/20260910T172747Z-151d1-review-…md`): 1 BLOCKER, 4 MEDIUM, 3 LOW, all synthetic edge classes. **None is a regression versus `origin/main`**: Codex observed zero new chmods on 168 comparative fixtures. The BLOCKER: a symlinked PARENT alias into `.secrets` can still be chmod'ed by `--fix`, exactly as the base does today. The MEDIUMs: a 0000 subdirectory inside custody reads clean; the prune still applies inside walked custody; a symlinked `.env*` root; a file root inside custody re-applies the exclusions. **Not fixed here, by contract.** A third round would be a fix-of-a-fix at depth 2. The surface is under-specified: custody identity must be physical (realpath), not lexical. That spec is filed as one queued-window row in this mission's ledger-only PR, with the staff room's approval. The live `~/nuzantara/.secrets` holds only regular files, with no subdirectory or link, so none of these classes exists there today.
- **Detect Secrets (red, not a required context)**: a known false positive, the 40-hex `base_sha` in the evidence `brief.yml` read as a Hex High Entropy String. This branch is armed and frozen, so it stays; the stacked schedule PR carries the allowlist pragma.
- **Final on-disk gate**: a fresh Opus 5 `xhigh` session is running on `8edef9c2c8` and gets Codex R2 in front of it before it signs. Its receipt is posted as a PR comment, and `harness/fable-gate` is published only from its verdict.

Built by `kimi-code/kimi-for-coding` in a prepare-only lane (`scripts/seat_build.sh --seat kimi --tier coding`, own worktree). Integrated and completed by the S2 Dux (Opus 5): report-only custody, T12–T17, and the Codex round-1 fixes. Cross-family review by Codex. Final on-disk gate by a fresh Opus 5 `xhigh` session.

Bites: consumer = the next run of Mini's `com.nuzantara.secrets-perms-sweep` after its puller brings this merge (scheduled 2026-09-10T22:00Z). Observation = its `~/logs/mini-secrets_perms_sweep/run.log` shows `run done rc=0` and `FIXED: 0  FAILED: 0  REPORT-ONLY: 0`: FIXED unchanged from the pre-merge baseline, and the new field proves the new code ran. On Pro, the pulled main checkout's `scripts/secrets_permissions_audit.py --no-default-roots --root ~/nuzantara/.secrets` prints `CUSTODY ~/nuzantara/.secrets: N file(s) checked, K finding(s)`, with N = `find ~/nuzantara/.secrets -type f | wc -l` and K = `find ~/nuzantara/.secrets -type f -perm +077 | wc -l` taken in the same minute. The Mini run falls after this mission's deadline, so it is carried as a PENDING-ARMS row in the mission's ledger-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
