### PR TITLE
docs(ops): PSE self-registration data sheet for Bali Zero systems

### DIFF
--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -62,20 +62,20 @@ docs/
 
 ### 🔧 Development
 
-| Topic                   | Document                                                          |
-| ----------------------- | ----------------------------------------------------------------- |
-| **Onboarding**          | [AI_ONBOARDING.md](AI_ONBOARDING.md)                              |
-| **Code Standards**      | [DEVELOPMENT_GUIDELINES.md](DEVELOPMENT_GUIDELINES.md)            |
-| **Project Structure**   | [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md)                      |
+| Topic                   | Document                                                                   |
+| ----------------------- | -------------------------------------------------------------------------- |
+| **Onboarding**          | [AI_ONBOARDING.md](AI_ONBOARDING.md)                                       |
+| **Code Standards**      | [DEVELOPMENT_GUIDELINES.md](DEVELOPMENT_GUIDELINES.md)                     |
+| **Project Structure**   | [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md)                               |
 | **System Overview**     | [SYSTEM_MAP_4D.md](archive/system-map-history/SYSTEM_MAP_4D.md) (archived) |
-| **Living Architecture** | [LIVING_ARCHITECTURE.md](LIVING_ARCHITECTURE.md) (auto-generated) |
+| **Living Architecture** | [LIVING_ARCHITECTURE.md](LIVING_ARCHITECTURE.md) (auto-generated)          |
 
 ### 🗄️ Database
 
-| Topic                  | Document                                                   |
-| ---------------------- | ---------------------------------------------------------- |
-| **DB Architecture V2** | DATABASE_ARCHITECTURE_V2.md _(doc removed)_ |
-| **DB Guide**           | [DATABASE_V2_GUIDE.md](DATABASE_V2_GUIDE.md)               |
+| Topic                  | Document                                     |
+| ---------------------- | -------------------------------------------- |
+| **DB Architecture V2** | DATABASE_ARCHITECTURE_V2.md _(doc removed)_  |
+| **DB Guide**           | [DATABASE_V2_GUIDE.md](DATABASE_V2_GUIDE.md) |
 
 ### 👥 CRM System
 
@@ -87,38 +87,39 @@ docs/
 
 ### 🔍 Operations
 
-| Topic          | Document                                                               |
-| -------------- | ---------------------------------------------------------------------- |
-| **Monitoring** | [operations/OBSERVABILITY_GUIDE.md](operations/OBSERVABILITY_GUIDE.md) |
-| **Deploy**     | [operations/DEPLOY_CHECKLIST.md](operations/DEPLOY_CHECKLIST.md)       |
-| **Testing**    | [operations/LOCAL_TESTING_GUIDE.md](operations/LOCAL_TESTING_GUIDE.md) |
+| Topic                | Document                                                               |
+| -------------------- | ---------------------------------------------------------------------- |
+| **Monitoring**       | [operations/OBSERVABILITY_GUIDE.md](operations/OBSERVABILITY_GUIDE.md) |
+| **Deploy**           | [operations/DEPLOY_CHECKLIST.md](operations/DEPLOY_CHECKLIST.md)       |
+| **Testing**          | [operations/LOCAL_TESTING_GUIDE.md](operations/LOCAL_TESTING_GUIDE.md) |
+| **PSE registration** | [ops/pse-registration-balizero.md](ops/pse-registration-balizero.md)   |
 
 ### 🤖 AI/ML
 
-| Topic                  | Document                                                                                         |
-| ---------------------- | ------------------------------------------------------------------------------------------------ |
-| **System Prompt**      | [ai/AI_HANDOVER_PROTOCOL.md](ai/AI_HANDOVER_PROTOCOL.md)                                         |
-| **KG Assessment**      | [KG_VALUE_ASSESSMENT_2026_01_18.md](KG_VALUE_ASSESSMENT_2026_01_18.md)                           |
-| **Architecture Brief** | BRIEF_KB_ARCHITECTURE_REASONING.md _(doc removed)_                   |
-| **KG Strategy**        | architecture/SUPER_KNOWLEDGE_GRAPH_STRATEGY.md _(doc removed)_ |
+| Topic                  | Document                                                               |
+| ---------------------- | ---------------------------------------------------------------------- |
+| **System Prompt**      | [ai/AI_HANDOVER_PROTOCOL.md](ai/AI_HANDOVER_PROTOCOL.md)               |
+| **KG Assessment**      | [KG_VALUE_ASSESSMENT_2026_01_18.md](KG_VALUE_ASSESSMENT_2026_01_18.md) |
+| **Architecture Brief** | BRIEF_KB_ARCHITECTURE_REASONING.md _(doc removed)_                     |
+| **KG Strategy**        | architecture/SUPER_KNOWLEDGE_GRAPH_STRATEGY.md _(doc removed)_         |
 
 ### ✨ Features
 
 | Topic                | Document                                                                 |
 | -------------------- | ------------------------------------------------------------------------ |
 | **KBLI Explorer**    | [features/KBLI_NOTEBOOK_EXPLORER.md](features/KBLI_NOTEBOOK_EXPLORER.md) |
-| **Article Composer** | ARTICLE_COMPOSER_API.md _(doc removed)_                       |
+| **Article Composer** | ARTICLE_COMPOSER_API.md _(doc removed)_                                  |
 | **Intel Scraper**    | [INTEL_ROUTER_API.md](INTEL_ROUTER_API.md)                               |
 
 ### 🔐 Security & CDN
 
-| Topic                          | Document                                                                                    |
-| ------------------------------ | ------------------------------------------------------------------------------------------- |
-| **CloudFlare CDN Plan**        | CLOUDFLARE_IMPLEMENTATION_PLAN.md _(doc removed)_ |
-| **CloudFlare CDN Quick Start** | CLOUDFLARE_CDN_SETUP.md _(doc removed)_            |
-| **CloudFlare DNS Setup**       | CLOUDFLARE_DNS_SETUP.md _(doc removed)_            |
-| **CloudFlare DNS Status**      | CLOUDFLARE_DNS_SETUP_COMPLETE.md _(doc removed)_   |
-| **Public Endpoints Audit**     | [security/PUBLIC_ENDPOINTS_SECURITY_AUDIT.md](security/PUBLIC_ENDPOINTS_SECURITY_AUDIT.md)  |
+| Topic                          | Document                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------ |
+| **CloudFlare CDN Plan**        | CLOUDFLARE_IMPLEMENTATION_PLAN.md _(doc removed)_                                          |
+| **CloudFlare CDN Quick Start** | CLOUDFLARE_CDN_SETUP.md _(doc removed)_                                                    |
+| **CloudFlare DNS Setup**       | CLOUDFLARE_DNS_SETUP.md _(doc removed)_                                                    |
+| **CloudFlare DNS Status**      | CLOUDFLARE_DNS_SETUP_COMPLETE.md _(doc removed)_                                           |
+| **Public Endpoints Audit**     | [security/PUBLIC_ENDPOINTS_SECURITY_AUDIT.md](security/PUBLIC_ENDPOINTS_SECURITY_AUDIT.md) |
 
 ---
 

--- a/docs/ops/pse-registration-balizero.md
+++ b/docs/ops/pse-registration-balizero.md
@@ -1,0 +1,242 @@
+# PSE self-registration data sheet: Bali Zero systems
+
+Status: draft for the staff member filing on OSS-RBA. Prepared 2026-09-11.
+Scope: every Bali Zero electronic system with Indonesian users, recorded as a domestic
+private-scope PSE (Penyelenggara Sistem Elektronik Lingkup Privat).
+
+This sheet records categories of data only. It holds no personal data values. Every fact
+names the repo file or live probe it comes from. Items marked "to confirm" need the owner
+or accounting before submission.
+
+## 1. Registry status: not located in the registry on 2026-09-11
+
+No TD-PSE registration was found for Bali Zero, balizero.com, Nuzantara or Zantara.
+
+Method: the public search on the Komdigi PSE portal calls a JSON API, queried directly:
+
+```bash
+curl -s -X POST https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list \
+  -H 'Content-Type: application/json' \
+  -d '{"keyword": "Bali Zero", "length": 20, "start": 0}'
+```
+
+The response carries `data.total_rows` and, when rows exist, the PSE name, domain, TDPSE
+number, domestic flag, registration date and status ("Terdaftar").
+
+| Keyword             | `total_rows` | Probe                     |
+| ------------------- | ------------ | ------------------------- |
+| Tokopedia (control) | 22           | this sheet, 2026-09-11    |
+| Bali Zero           | 0            | this sheet and prep-check |
+| balizero            | 0            | this sheet and prep-check |
+| balizero.com        | 0            | this sheet and prep-check |
+| Nuzantara           | 0            | this sheet and prep-check |
+| zantara             | 0            | this sheet and prep-check |
+| PT Bali Zero        | 0            | prep-check, 2026-09-11    |
+| Bali Zero Services  | 0            | prep-check, 2026-09-11    |
+| kita.balizero       | 0            | prep-check, 2026-09-11    |
+| zantara.balizero    | 0            | prep-check, 2026-09-11    |
+
+The control keyword returns rows, so the API answers correctly. One caveat: if the PT's
+legal name on the akta does not contain "Bali Zero", repeat the search with that exact
+legal name before concluding.
+
+## 2. Company-level fields (shared by every system)
+
+| Field                   | Value                                                                 | Source                                         |
+| ----------------------- | --------------------------------------------------------------------- | ---------------------------------------------- |
+| Legal entity            | PT PMA, legal name as on the akta (to confirm)                        | `apps/mouth/src/app/terms/page.tsx` ("PT PMA") |
+| NIB                     | Active NIB number (to confirm)                                        | owner / accounting                             |
+| KBLI                    | KBLI on the NIB that covers the electronic systems below (to confirm) | owner / accounting                             |
+| NPWP                    | Company NPWP (to confirm)                                             | owner / accounting                             |
+| Akta and SK Kemenkumham | Deed of establishment and ministry decree (to confirm)                | owner / accounting                             |
+| Responsible officer     | `<to be named by the owner>`                                          | owner decision                                 |
+| Data-protection contact | privacy@balizero.com (role address published in the privacy policy)   | `apps/mouth/src/app/privacy/page.tsx`          |
+| Privacy policy          | https://balizero.com/privacy                                          | `apps/mouth/src/app/privacy/page.tsx`          |
+| Terms of service        | https://balizero.com/terms                                            | `apps/mouth/src/app/terms/page.tsx`            |
+| Registration fee        | None (no PNBP fee)                                                    | prep-check §3                                  |
+
+The privacy policy states it follows UU PDP No. 27/2022 and lists the data categories,
+legal bases, storage locations and retention periods reused in section 3.
+
+## 3. Systems
+
+All web frontends are one Next.js app, `apps/mouth`, deployed as the Vercel project
+`mouth` (`apps/mouth/vercel.json`). Host-to-route mapping lives in `apps/mouth/src/proxy.ts`.
+`vercel.json` pins no region; the live responses on 2026-09-11 carried an `x-vercel-id`
+starting with `sin1` (Vercel Singapore edge). All frontends call the backend API in
+section 3.7.
+
+Storage locations for personal data, as stated in section 5 of the published privacy
+policy:
+
+| Store                       | Provider and location | Role                                                |
+| --------------------------- | --------------------- | --------------------------------------------------- |
+| Application and PostgreSQL  | Fly.io, Singapore     | API hosting and primary database                    |
+| Vector search               | Qdrant Cloud, US      | Knowledge and document search                       |
+| Documents and AI processing | Google, global        | Google Drive document storage, Gemini AI processing |
+| Cache                       | Upstash, global       | Redis cache, 5-minute TTL                           |
+| Document OCR                | Local server, Bali    | Ollama OCR, no cross-border transfer                |
+
+### 3.1 balizero.com and www.balizero.com
+
+| Field               | Value                                                                                                                                                                                                                                           |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Purpose             | Public website: services, articles, tools (KBLI lookup, Visa Oracle eligibility check), contact, newsletter                                                                                                                                     |
+| URL                 | https://balizero.com and https://www.balizero.com (www redirects to the apex)                                                                                                                                                                   |
+| Users               | Prospective and current clients, public readers                                                                                                                                                                                                 |
+| Hosting and region  | Vercel project `mouth`, Singapore edge (`sin1`); backend: Fly.io `sin`                                                                                                                                                                          |
+| Repo source         | `apps/mouth` route groups `(marketing)`, `(blog)`; `PUBLIC_DOMAIN` in `apps/mouth/src/proxy.ts`                                                                                                                                                 |
+| Data categories     | Newsletter email address; inquiry contact details (name, email, phone, message); Visa Oracle answers held in the browser session (`evaluation-identity-store.ts`); web analytics (Google Analytics, per the CSP in `apps/mouth/next.config.ts`) |
+| Privacy policy      | https://balizero.com/privacy; Visa Oracle has its own notice at https://balizero.com/visa-oracle/privacy                                                                                                                                        |
+| Responsible officer | `<to be named by the owner>`                                                                                                                                                                                                                    |
+| KBLI                | To confirm                                                                                                                                                                                                                                      |
+
+### 3.2 kita.balizero.com
+
+| Field               | Value                                                                                                                                                                                                                                                                                                             |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Purpose             | Internal staff workspace: clients (CRM), case processing, WhatsApp inbox, team management, analytics, notifications, admin                                                                                                                                                                                        |
+| URL                 | https://kita.balizero.com (root redirects to `/login`)                                                                                                                                                                                                                                                            |
+| Users               | Bali Zero staff only, login required, `noindex`                                                                                                                                                                                                                                                                   |
+| Hosting and region  | Vercel project `mouth`, Singapore edge (`sin1`); backend: Fly.io `sin`                                                                                                                                                                                                                                            |
+| Repo source         | `APP_DOMAIN` and `INTERNAL_ROUTES` in `apps/mouth/src/proxy.ts`                                                                                                                                                                                                                                                   |
+| Data categories     | Staff accounts and roles; client records: identity (name, nationality, date of birth, gender, address), passport data, contact details, family members, company data; case and permit status; client documents (passport, KTP, NPWP scans); message history across channels; financial data for visa applications |
+| Privacy policy      | https://balizero.com/privacy                                                                                                                                                                                                                                                                                      |
+| Responsible officer | `<to be named by the owner>`                                                                                                                                                                                                                                                                                      |
+| KBLI                | To confirm                                                                                                                                                                                                                                                                                                        |
+
+### 3.3 my.balizero.com
+
+| Field               | Value                                                                                                                                                                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Purpose             | Client portal: a client follows visas, companies, taxes, LKPM, documents, messages and billing                                                                                                                        |
+| URL                 | https://my.balizero.com (unauthenticated visitors go to `/portal/login`)                                                                                                                                              |
+| Users               | Bali Zero clients, login required                                                                                                                                                                                     |
+| Hosting and region  | Vercel project `mouth`, Singapore edge (`sin1`); backend: Fly.io `sin`                                                                                                                                                |
+| Repo source         | `PORTAL_DOMAIN` in `apps/mouth/src/proxy.ts`; pages in `apps/mouth/src/app/portal/(authenticated)/`                                                                                                                   |
+| Data categories     | Client account and session cookie; profile; family members; company data; visa and permit status; tax and LKPM data; document vault (passport, KTP, NPWP scans); messages and chat; billing records; privacy settings |
+| Privacy policy      | https://balizero.com/privacy                                                                                                                                                                                          |
+| Responsible officer | `<to be named by the owner>`                                                                                                                                                                                          |
+| KBLI                | To confirm                                                                                                                                                                                                            |
+
+### 3.4 zantara.balizero.com
+
+| Field               | Value                                                                                                                                                                                                                                          |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Purpose             | Zantara AI assistant chat (root rewritten to `/chat`)                                                                                                                                                                                          |
+| URL                 | https://zantara.balizero.com                                                                                                                                                                                                                   |
+| Users               | Clients and staff, `noindex`                                                                                                                                                                                                                   |
+| Hosting and region  | Vercel, Singapore (`sin1` edge and function region observed); backend: Fly.io `sin`                                                                                                                                                            |
+| Repo source         | `ZANTARA_DOMAIN` in `apps/mouth/src/proxy.ts`. `apps/web/README.md` also names this host; the live response carries the `x-pathname` header set by the mouth proxy, so mouth serves it today. Confirm in Vercel which project owns the domain. |
+| Data categories     | Chat messages and conversation history; account and session                                                                                                                                                                                    |
+| Privacy policy      | https://balizero.com/privacy                                                                                                                                                                                                                   |
+| Responsible officer | `<to be named by the owner>`                                                                                                                                                                                                                   |
+| KBLI                | To confirm                                                                                                                                                                                                                                     |
+
+### 3.5 tax.balizero.com
+
+| Field               | Value                                                                                         |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| Purpose             | Tax Compliance Calendar: deadlines and reminders for businesses in Bali                       |
+| URL                 | https://tax.balizero.com                                                                      |
+| Users               | Public                                                                                        |
+| Hosting and region  | Vercel project `mouth`, Singapore edge (`sin1`)                                               |
+| Repo source         | `TAX_DOMAIN` in `apps/mouth/src/proxy.ts`; route group `apps/mouth/src/app/(tax-calendar)/`   |
+| Data categories     | No input form found in the route group on 2026-09-11: public content only, plus web analytics |
+| Privacy policy      | https://balizero.com/privacy                                                                  |
+| Responsible officer | `<to be named by the owner>`                                                                  |
+| KBLI                | To confirm                                                                                    |
+
+DNS setup for this host: [tax-balizero-dns-setup.md](tax-balizero-dns-setup.md).
+
+### 3.6 prime.balizero.com
+
+| Field               | Value                                                                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Purpose             | Prime Nexus: Bali geospatial decision hub for property, with an assistant chat                                                     |
+| URL                 | https://prime.balizero.com                                                                                                         |
+| Users               | Prospective and current property clients                                                                                           |
+| Hosting and region  | Vercel project `mouth`, Singapore edge (`sin1`); backend: Fly.io `sin`                                                             |
+| Repo source         | `prime` rewrite in `apps/mouth/src/proxy.ts`; `apps/mouth/src/app/prime/`; chat route `apps/mouth/src/app/api/prime/chat/route.ts` |
+| Data categories     | Chat questions forwarded to the backend API; property proposal pages reached by token link                                         |
+| Privacy policy      | https://balizero.com/privacy                                                                                                       |
+| Responsible officer | `<to be named by the owner>`                                                                                                       |
+| KBLI                | To confirm                                                                                                                         |
+
+### 3.7 Backend API: Fly app nuzantara-rag
+
+| Field               | Value                                                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Purpose             | Backend for every system above: accounts, CRM, documents, AI assistant and knowledge search                               |
+| Host                | `nuzantara-rag.fly.dev` (named in the CSP `connect-src` of `apps/mouth/next.config.ts`); health: `GET /health`            |
+| Users               | No direct end users; called by the frontends                                                                              |
+| Hosting and region  | Fly.io app `nuzantara-rag`, `primary_region = 'sin'` (Singapore), processes `api` and `rag` (`apps/backend-rag/fly.toml`) |
+| Data categories     | All categories in 3.1 to 3.6; stores listed in the table at the start of section 3                                        |
+| Privacy policy      | https://balizero.com/privacy                                                                                              |
+| Responsible officer | `<to be named by the owner>`                                                                                              |
+| KBLI                | To confirm                                                                                                                |
+
+The API answers `GET` only: `curl -I` (HEAD) returns 404 on `/health` while `GET /health`
+returns 200. Probe it with GET.
+
+## 4. OSS-RBA submission checklist
+
+Channel: OSS-RBA (https://oss.go.id), integrated with the Komdigi PSE portal
+(https://pse.komdigi.go.id). Output: an electronic TD-PSE certificate.
+
+- [ ] Active NIB with a KBLI coherent with the systems in section 3 (KBLI to confirm)
+- [ ] Akta pendirian and SK Kemenkumham
+- [ ] Company NPWP
+- [ ] Responsible officer: `<to be named by the owner>`, with position and a reachable contact
+- [ ] System description and technology, one per system (section 3)
+- [ ] Domain or URL for every system, web and app filed separately (section 3)
+- [ ] Server and data location (section 3 storage table and each system's hosting row)
+- [ ] Privacy policy URL: https://balizero.com/privacy
+- [ ] Content categories for each system
+- [ ] Repeat the registry search with the PT's exact legal name (section 1) before filing
+
+Cost: no PNBP fee. Processing time: not found.
+
+Legal basis: PP 71/2019; Permenkominfo 5/2020 as amended by Permenkominfo 10/2021; UU ITE;
+UU PDP 27/2022. No 2024 to 2026 update was found, which does not rule one out.
+
+Obligations after registration: keep the registered data up to date; keep the responsible
+officer reachable; give authorised authorities access to the systems; take content down on
+request. The 24-hour and 4-hour (urgent) takedown windows appear only in secondary sources.
+
+Sanctions: written warning, temporary suspension, blocking. An unregistered PSE risks
+direct blocking.
+
+Sources for this section are secondary (izin.co.id guide on PSE Kominfo; aptika.kominfo.go.id
+on sanctions; jdih.komdigi.go.id for Permenkominfo 5/2020) because the Komdigi pages did not
+render for a fetch. Check the live OSS-RBA form before relying on the list.
+
+## 5. Open items for the owner
+
+1. Name the responsible officer.
+2. Confirm the legal name, NIB, KBLI and NPWP, then re-run the section 1 search with the
+   legal name.
+3. Confirm in Vercel which project owns zantara.balizero.com (section 3.4).
+4. Confirm the storage locations in the privacy policy still hold (Qdrant Cloud region
+   stated as US).
+
+## 6. Reachability check (2026-09-11)
+
+`curl -sI -m 20` on every URL in this sheet. Endpoints that do not route HEAD were also
+probed with the method they serve.
+
+| URL                                               | HEAD | Served method |
+| ------------------------------------------------- | ---- | ------------- |
+| https://balizero.com                              | 200  |               |
+| https://www.balizero.com                          | 308  |               |
+| https://kita.balizero.com                         | 307  |               |
+| https://my.balizero.com                           | 307  |               |
+| https://zantara.balizero.com                      | 200  |               |
+| https://tax.balizero.com                          | 200  |               |
+| https://prime.balizero.com                        | 200  |               |
+| https://balizero.com/privacy                      | 200  |               |
+| https://balizero.com/terms                        | 200  |               |
+| https://balizero.com/visa-oracle/privacy          | 200  |               |
+| https://oss.go.id                                 | 307  |               |
+| https://pse.komdigi.go.id                         | 200  |               |
+| https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list | 405  | POST 200      |

--- a/evidence/2026-09/agent-nuzantara-docs-pse-self-registration-9b95ae0e/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-docs-pse-self-registration-9b95ae0e/brief.yml
@@ -1,0 +1,35 @@
+task_id: pse-self-registration
+gear: 1
+l_level: L2
+gate_class: opus
+grader: Fresh Opus 5 on-disk gate commissioned by the imperator; no verdict asserted here.
+pii: none
+objective: >
+  Write docs/ops/pse-registration-balizero.md, the data sheet a Bali Zero staff member uses to
+  file the domestic PSE self-registration on OSS-RBA: one section per system with Indonesian
+  users (balizero.com and www, kita., my., zantara., tax., prime., the Fly API nuzantara-rag)
+  with purpose, URL, hosting and region read from the repo, data categories, privacy policy URL,
+  responsible-officer placeholder and KBLI to confirm; the OSS-RBA checklist from the prep-check
+  section 3; and the "not located in the registry on 2026-09-11" note with the tdpse-list API
+  method. Link it from the nearest docs index.
+constraints:
+  - Docs only. Never touch fly.toml, .env*, zantara_core.py or lockfiles; fly.toml is read, not edited.
+  - No personal names and no personal data values; emails only as generic role addresses.
+  - Responsible officer stays the literal placeholder `<to be named by the owner>`.
+  - Hosting facts come from the repo (apps/backend-rag/fly.toml, apps/mouth/vercel.json,
+    apps/mouth/src/proxy.ts) or a dated live probe, each named next to the fact.
+acceptance:
+  - text:
+      Every URL in the doc SHALL return HTTP 200 or 3xx to `curl -sI -m 20`, except the
+      POST-only Komdigi API, which SHALL return 200 to its documented POST.
+    probe: "grep -oE 'https?://[^ )`|]+' docs/ops/pse-registration-balizero.md | sort -u | xargs -n1 curl -sI -m 20 -o /dev/null -w '%{url_effective} %{http_code}\\n'"
+  - text: The responsible-officer placeholder SHALL appear at least once.
+    probe: "grep -c '<to be named by the owner>' docs/ops/pse-registration-balizero.md"
+  - text: The only email in the doc SHALL be a generic role address.
+    probe: "grep -n '@' docs/ops/pse-registration-balizero.md"
+  - text: The doc SHALL be linked from docs/DOCUMENTATION_INDEX.md.
+    probe: "grep -n 'pse-registration-balizero' docs/DOCUMENTATION_INDEX.md"
+  - text: The docs-sync gate and Prettier SHALL pass on the changed markdown.
+    probe: "bash scripts/ci/docs_sync_gate.sh check <changed-files> && npx prettier --check docs/ops/pse-registration-balizero.md docs/DOCUMENTATION_INDEX.md"
+consumer_map:
+  - The staff member filing the PSE self-registration on OSS-RBA, reading the checklist and the curl table.

--- a/evidence/2026-09/agent-nuzantara-docs-pse-self-registration-9b95ae0e/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-docs-pse-self-registration-9b95ae0e/pack.yml
@@ -1,0 +1,52 @@
+brief_ref: evidence/2026-09/agent-nuzantara-docs-pse-self-registration-9b95ae0e/brief.yml
+task_id: pse-self-registration
+gear: 1
+date: 2026-09-11
+machine: Pro
+machine_note: worktree /Users/nuzantara/nuzantara/.worktrees/docs-pse-self-registration, branch agent/nuzantara/docs/pse-self-registration
+floor: >-
+  compute_floor = 1, floor source "none" (python3 scripts/evidence_pack_lint.py
+  --changed-files-file <hotzone_changed_files.sh list + this pack> --numstat-file <git diff
+  --numstat origin/main...HEAD> --print-floor); measured 2 files +272/-29, below
+  SIZE_GEAR2_THRESHOLD 400; no hot-zone path.
+lanes:
+  - lane: pse-self-registration
+    role: build
+    seat: claude-opus-5 (Lane C Dux, Pro worktree)
+pii_scan: clean
+dissent: []
+receipts:
+  - claim: Every URL in the doc answers HEAD with 200 or 3xx (13 URLs, 0 failures), except the POST-only Komdigi tdpse-list API, which answers HEAD 405 and its documented POST 200.
+    cmd: "grep -oE 'https?://[^ )`|]+' docs/ops/pse-registration-balizero.md | sort -u, then curl -sI -m 20 per URL; curl -s -X POST https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list with the JSON body in the doc"
+    result: balizero.com 200, www 308, kita 307, my 307, zantara 200, tax 200, prime 200, /privacy 200, /terms 200, /visa-oracle/privacy 200, oss.go.id 307, pse.komdigi.go.id 200, tdpse-list HEAD 405 POST 200
+    exit: 0
+    ts: "2026-09-10T17:33:33Z"
+    seat: claude-opus-5
+  - claim: The Fly API host named in the doc (not written as a URL) serves GET /health 200; HEAD is not routed by the API (404).
+    cmd: curl -s -m 20 -o /dev/null -w '%{http_code}' https://nuzantara-rag.fly.dev/health
+    result: GET 200, HEAD 404
+    exit: 0
+    ts: "2026-09-10T17:31:00Z"
+    seat: claude-opus-5
+  - claim: The registry has no row for Bali Zero, balizero, balizero.com, Nuzantara or zantara, while the Tokopedia control returns rows.
+    cmd: POST https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list with {"keyword":<k>,"length":5,"start":0}, 1.2 s apart
+    result: Tokopedia total_rows 22; the five Bali Zero keywords total_rows 0
+    exit: 0
+    ts: "2026-09-10T17:28:09Z"
+    seat: claude-opus-5
+  - claim: The placeholder appears 9 times; the only @ in the doc is the role address privacy@balizero.com; the index links the doc.
+    cmd: grep -c '<to be named by the owner>' docs/ops/pse-registration-balizero.md; grep -n '@' docs/ops/pse-registration-balizero.md; grep -n 'pse-registration-balizero' docs/DOCUMENTATION_INDEX.md
+    result: "9; line 53 privacy@balizero.com; index line 95"
+    exit: 0
+    ts: "2026-09-10T17:33:33Z"
+    seat: claude-opus-5
+  - claim: The docs-sync gate and Prettier pass on both changed markdown files.
+    cmd: PYTHON=python3 bash scripts/ci/docs_sync_gate.sh check <changed-files>; npx prettier --check docs/ops/pse-registration-balizero.md docs/DOCUMENTATION_INDEX.md
+    result: DOCSYNC OK; All matched files use Prettier code style
+    exit: 0
+    ts: "2026-09-10T17:33:35Z"
+    seat: claude-opus-5
+outcome: >-
+  docs/ops/pse-registration-balizero.md (242 lines) added and linked from the Operations table of
+  docs/DOCUMENTATION_INDEX.md. The pre-commit Prettier hook re-padded the index's existing tables
+  (30 additions, 29 deletions, one new row). No file outside docs/ and this pack touched.


### PR DESCRIPTION
## Summary
- New `docs/ops/pse-registration-balizero.md`: one section per Bali Zero system with Indonesian users (balizero.com + www, kita., my., zantara., tax., prime., Fly API `nuzantara-rag`) with purpose, URL, hosting + region read from the repo (`apps/backend-rag/fly.toml` `primary_region = 'sin'`, Vercel project `mouth`, host map in `apps/mouth/src/proxy.ts`), data categories (no values), privacy policy URL (`https://balizero.com/privacy`, from `apps/mouth/src/app/privacy/page.tsx`), officer placeholder `<to be named by the owner>`, KBLI to confirm.
- OSS-RBA submission checklist (prep-check §3) and the "not located in the registry on 2026-09-11" note with the method `POST https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list` (JSON `keyword`/`length`/`start`); re-probed today: Tokopedia control 22 rows, all Bali Zero keywords 0.
- Linked from `docs/DOCUMENTATION_INDEX.md` (Operations table). The pre-commit Prettier hook re-padded that file's existing tables (+30/-29, one new row).
- Evidence: `evidence/2026-09/agent-nuzantara-docs-pse-self-registration-9b95ae0e/` (brief + pack, gear 1 = compute_floor, source none).

## Curl table (`curl -sI -m 20`, 2026-09-11 WITA)
| URL | HEAD |
|---|---|
| https://balizero.com | 200 |
| https://www.balizero.com | 308 |
| https://kita.balizero.com | 307 |
| https://my.balizero.com | 307 |
| https://zantara.balizero.com | 200 |
| https://tax.balizero.com | 200 |
| https://prime.balizero.com | 200 |
| https://balizero.com/privacy | 200 |
| https://balizero.com/terms | 200 |
| https://balizero.com/visa-oracle/privacy | 200 |
| https://oss.go.id | 307 |
| https://pse.komdigi.go.id | 200 |
| https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list | 405 to HEAD, 200 to the documented POST |

The Fly API is recorded as the host `nuzantara-rag.fly.dev` (GET `/health` 200; the API does not route HEAD).

## Checks
- `grep -c "<to be named by the owner>" docs/ops/pse-registration-balizero.md` → 9
- `grep -n '@' docs/ops/pse-registration-balizero.md` → only `privacy@balizero.com` (role address)
- `bash scripts/ci/docs_sync_gate.sh check <changed>` → DOCSYNC OK; `npx prettier --check` → clean
- `python3 scripts/evidence_pack_lint.py <pack>` → clean

Bites: consumer = the staff member filing the PSE self-registration on OSS-RBA; observation = the OSS-RBA checklist in section 4 and the curl table above (every browsable URL 200/3xx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
