### PR TITLE
feat(ops): PSE registry checker against Komdigi tdpse-list API

### DIFF
--- a/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/brief.yml
@@ -1,0 +1,52 @@
+task_id: pse-registry-check
+gear: 2
+l_level: L2
+gate_class: opus
+objective: >-
+  A read-only checker that tells the founder, for each company name or domain on a manual
+  outbound list, whether a TD-PSE record is LOCATED in the Komdigi registry
+  (POST https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list), implementing
+  pse-scanner.spec.md from the compliance-stack build (Lane B). The answer is located,
+  not_located or error, never "unregistered": a keyword search that finds nothing is not
+  proof that a company is unregistered.
+
+  Gear 2 by SIZE: --print-floor returns 2 and --print-floor-source returns "size" on this
+  changed-file list with the merge-base numstat supplied. No hot-zone path is touched. The
+  design for this build asks for gear 2 or 3 as computed; 2 is the computed floor.
+constraints:
+  - >-
+    A malformed response or {"status": "error"} is an ERROR row and exit 2, never a
+    not_located row. A silent API change must not read as "nobody is registered", and
+    --probe fails (exit 1) when the Tokopedia control keyword returns zero rows.
+  - >-
+    At most one request per second, exponential backoff on 429, 5xx and network errors,
+    and a hard stop after three consecutive failed requests. Clock, sleep and transport
+    are injected so the limit is asserted with a fake clock, not by waiting.
+  - >-
+    Standard library only (urllib), like the other urllib-based scripts under scripts/.
+    No new dependency, no lockfile touched.
+  - >-
+    Company names and domains only. The live registry returns sole-proprietor registrants
+    whose PSE name is a person's name as fuzzy hits; the CSV attached to this pack keeps
+    only rows whose pse_name contains the input, so no personal name is committed.
+  - >-
+    No outreach, no email generation, no schedule. Manual use until a human has worked
+    the list for two weeks (roundtable decision).
+acceptance:
+  - >-
+    WHEN the suite runs with the HTTP layer mocked, THEN it passes with at least 8 tests.
+    probe: pytest tests/scripts/test_pse_registry_check.py -q
+  - >-
+    WHEN --probe runs live, THEN Tokopedia returns rows and the exit code is 0.
+    probe: python3 scripts/pse_registry_check.py --probe
+  - >-
+    WHEN a CSV holds "Tokopedia" and "Bali Zero", THEN they come back located and
+    not_located. probe: test_tokopedia_located_and_bali_zero_not_located, and live-probe.csv
+  - >-
+    WHEN the endpoint answers HTTP 500 or 503, THEN every input is an error row and the
+    exit code is 2. probe: test_forced_http_error_exits_2_with_backoff_and_hard_stop,
+    test_http_error_through_urllib_transport_exits_2
+  - >-
+    WHEN several inputs are checked, THEN no two requests are less than one second apart
+    on a fake clock. probe: test_no_request_faster_than_one_per_second
+pii_scan: clean

--- a/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/brief.yml
@@ -33,20 +33,20 @@ constraints:
     No outreach, no email generation, no schedule. Manual use until a human has worked
     the list for two weeks (roundtable decision).
 acceptance:
-  - >-
-    WHEN the suite runs with the HTTP layer mocked, THEN it passes with at least 8 tests.
+  - text: WHEN the suite runs with the HTTP layer mocked, THEN it passes with at least 8 tests.
     probe: pytest tests/scripts/test_pse_registry_check.py -q
-  - >-
-    WHEN --probe runs live, THEN Tokopedia returns rows and the exit code is 0.
+  - text: WHEN --probe runs live, THEN Tokopedia returns rows and the exit code is 0.
     probe: python3 scripts/pse_registry_check.py --probe
-  - >-
-    WHEN a CSV holds "Tokopedia" and "Bali Zero", THEN they come back located and
-    not_located. probe: test_tokopedia_located_and_bali_zero_not_located, and live-probe.csv
-  - >-
-    WHEN the endpoint answers HTTP 500 or 503, THEN every input is an error row and the
-    exit code is 2. probe: test_forced_http_error_exits_2_with_backoff_and_hard_stop,
-    test_http_error_through_urllib_transport_exits_2
-  - >-
-    WHEN several inputs are checked, THEN no two requests are less than one second apart
-    on a fake clock. probe: test_no_request_faster_than_one_per_second
+  - text: >-
+      WHEN a CSV holds "Tokopedia" and "Bali Zero", THEN they come back located and
+      not_located (live run below; mocked in test_tokopedia_located_and_bali_zero_not_located).
+    probe: python3 scripts/pse_registry_check.py live-input.csv -o live-probe.csv --no-cache
+  - text: >-
+      WHEN the endpoint answers HTTP 500 or 503, THEN every input is an error row and the
+      exit code is 2.
+    probe: pytest tests/scripts/test_pse_registry_check.py -q -k "forced_http_error or urllib_transport"
+  - text: >-
+      WHEN several inputs are checked, THEN no two requests are less than one second apart
+      on a fake clock.
+    probe: pytest tests/scripts/test_pse_registry_check.py -q -k one_per_second
 pii_scan: clean

--- a/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/live-probe.csv
+++ b/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/live-probe.csv
@@ -1,0 +1,14 @@
+input,keyword_used,result,pse_name,domain,nomor_tdpse,is_domestik,tanggal_terdaftar,status,checked_at
+Tokopedia,Tokopedia,located,GOTO GOJEK TOKOPEDIA,gojek.com,001758.01/DJAI.PSE/12/2021,true,2021-12-13,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,,000847.04/DJAI.PSE/09/2024,true,2024-09-05,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,,000847.05/DJAI.PSE/11/2024,true,2024-11-04,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,,000847.02/DJAI.PSE/03/2024,true,2024-03-22,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,tokopedia.com,000847.01/DJAI.PSE/06/2021,true,2021-06-02,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,partner.tokopedia.com,000847.10/DJAI.PSE/12/2024,true,2024-12-30,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,seller-id.tokopedia.com,000847.09/DJAI.PSE/12/2024,true,2024-12-19,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,,000847.08/DJAI.PSE/12/2024,true,2024-12-19,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,,000847.03/DJAI.PSE/07/2024,true,2024-07-26,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,ttlsbd.tiktok-go.com,000847.13/DJAI.PSE/08/2026,true,2026-08-21,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,,000847.06/DJAI.PSE/11/2024,true,2024-11-26,Terdaftar,2026-09-10T17:31:04+00:00
+Tokopedia,Tokopedia,located,TOKOPEDIA,,000847.12/DJAI.PSE/04/2026,true,2026-04-23,Terdaftar,2026-09-10T17:31:04+00:00
+Bali Zero,Bali Zero,not_located,,,,,,,2026-09-10T17:31:05+00:00

--- a/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/pack.yml
@@ -37,7 +37,7 @@ receipts:
   - claim: the mocked suite passes with at least 8 tests
     cmd: pytest tests/scripts/test_pse_registry_check.py -q
     result: "16 passed, 1 skipped (the network test)"
-    ts: "2026-09-10T17:32:30+00:00"
+    ts: "2026-09-10T17:35:08+00:00"
     seat: claude-opus-5 (Lane B Dux, Pro)
     exit: 0
   - claim: the network test passes when enabled
@@ -60,8 +60,14 @@ receipts:
     exit: 0
   - claim: a forced HTTP error exits 2, with backoff 1 s then 2 s and a hard stop after 3 failures
     cmd: pytest tests/scripts/test_pse_registry_check.py -q -k "forced_http_error or urllib_transport"
-    result: "both tests assert main() returns 2, and no error is reported as not_located"
-    ts: "2026-09-10T17:32:30+00:00"
+    result: "2 passed; both assert main() returns 2, and no error is reported as not_located"
+    ts: "2026-09-10T17:35:08+00:00"
+    seat: claude-opus-5 (Lane B Dux, Pro)
+    exit: 0
+  - claim: no two requests are less than one second apart on a fake clock
+    cmd: pytest tests/scripts/test_pse_registry_check.py -q -k one_per_second
+    result: "1 passed; 6 requests for 5 inputs, minimum gap >= 1.0 s, and the limiter slept"
+    ts: "2026-09-10T17:35:08+00:00"
     seat: claude-opus-5 (Lane B Dux, Pro)
     exit: 0
   - claim: the deterministic floor is 2 and its source is size

--- a/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/pack.yml
@@ -1,0 +1,89 @@
+task_id: pse-registry-check
+gear: 2
+gate_class: opus
+brief_ref: evidence/brief.yml
+date: 2026-09-11
+machine: Pro
+lanes:
+  - lane: PSE registry checker
+    role: build
+    seat: claude-opus-5 (Lane B Dux, Pro)
+    note:
+      scripts/pse_registry_check.py, tests/scripts/test_pse_registry_check.py, and a
+      two-line tests/scripts/conftest.py that registers the `network` marker so the live
+      test is marked without an unknown-marker warning
+outcome: >-
+  A stdlib-only CLI that checks company names or domains against the Komdigi TD-PSE
+  registry and writes located / not_located / error rows. Live, Tokopedia is located and
+  Bali Zero is not located; a forced HTTP 500 or 503 exits 2.
+diff:
+  files: 7
+  net_lines: "about 680 code and tests, plus this evidence pack"
+  shape:
+    "One new script, one new test module, one marker-registration conftest, and this pack
+    with its brief and the live CSV. No hot-zone path. Gear 2 comes from the SIZE term
+    alone."
+pii_scan: clean
+attachments:
+  - path: live-probe.csv
+    what: >-
+      Output of the live run on the input "Tokopedia" and "Bali Zero", filtered to company
+      names. The raw output had 21 rows (20 located for Tokopedia, 1 not_located for Bali
+      Zero). 8 located rows were withheld because their pse_name does not contain the input
+      keyword; some of those are sole-proprietor registrants whose PSE name is a person's
+      name. Rule applied: keep a row if result is not "located" or if the input appears in
+      pse_name, case-insensitive. 13 rows kept.
+receipts:
+  - claim: the mocked suite passes with at least 8 tests
+    cmd: pytest tests/scripts/test_pse_registry_check.py -q
+    result: "16 passed, 1 skipped (the network test)"
+    ts: "2026-09-10T17:32:30+00:00"
+    seat: claude-opus-5 (Lane B Dux, Pro)
+    exit: 0
+  - claim: the network test passes when enabled
+    cmd: PSE_REGISTRY_LIVE=1 pytest tests/scripts/test_pse_registry_check.py -q -k live
+    result: "1 passed, 15 deselected"
+    ts: "2026-09-10T17:31:00+00:00"
+    seat: claude-opus-5 (Lane B Dux, Pro)
+    exit: 0
+  - claim: the live probe finds Tokopedia on the final code
+    cmd: python3 scripts/pse_registry_check.py --probe
+    result: "checked 1 input(s): 1 located, 0 errored, 1 request(s)"
+    ts: "2026-09-10T17:33:04+00:00"
+    seat: claude-opus-5 (Lane B Dux, Pro)
+    exit: 0
+  - claim: a CSV with Tokopedia and Bali Zero gives located and not_located, live
+    cmd: python3 scripts/pse_registry_check.py live-input.csv -o live-probe.csv --no-cache
+    result: "checked 2 input(s): 1 located, 0 errored, 2 request(s); Tokopedia located, Bali Zero not_located"
+    ts: "2026-09-10T17:31:04+00:00"
+    seat: claude-opus-5 (Lane B Dux, Pro)
+    exit: 0
+  - claim: a forced HTTP error exits 2, with backoff 1 s then 2 s and a hard stop after 3 failures
+    cmd: pytest tests/scripts/test_pse_registry_check.py -q -k "forced_http_error or urllib_transport"
+    result: "both tests assert main() returns 2, and no error is reported as not_located"
+    ts: "2026-09-10T17:32:30+00:00"
+    seat: claude-opus-5 (Lane B Dux, Pro)
+    exit: 0
+  - claim: the deterministic floor is 2 and its source is size
+    cmd: python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file cf.txt --numstat-file ns.txt
+    result: "2, and --print-floor-source returns size (merge-base numstat, before this pack file was added)"
+    ts: "2026-09-10T17:34:00+00:00"
+    seat: claude-opus-5 (Lane B Dux, Pro)
+    exit: 0
+dissent:
+  - seat: claude-opus-5 (Lane B Dux, Pro)
+    objection: >-
+      The registry search is fuzzy. "located" means a keyword hit, and for Tokopedia 8 of
+      20 hits named other registrants. The tool reports every hit as the spec says; a human
+      still has to read pse_name and domain before treating a row as the company's own
+      record. A relevance filter would be a spec change and is left out.
+    status: CONFIRMED
+  - seat: claude-opus-5 (Lane B Dux, Pro)
+    objection: >-
+      tests/scripts has 5 failing tests in test_ai_pr_review_workflow.py. They fail the same
+      way with --noconftest and with this module excluded, so they are pre-existing and not
+      caused by the new conftest.
+    status: CONFIRMED
+appetite_exceeded: >-
+  The PR contract asks for about 400 net lines; code plus tests is about 680 (script 418,
+  tests 257). The script is one module and the tests cover each acceptance item. Not split.

--- a/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/pack.yml
@@ -17,8 +17,8 @@ outcome: >-
   registry and writes located / not_located / error rows. Live, Tokopedia is located and
   Bali Zero is not located; a forced HTTP 500 or 503 exits 2.
 diff:
-  files: 7
-  net_lines: "about 680 code and tests, plus this evidence pack"
+  files: 6
+  net_lines: "838 insertions, 0 deletions: the script 418, the test module 257, the conftest 2, evidence 161"
   shape:
     "One new script, one new test module, one marker-registration conftest, and this pack
     with its brief and the live CSV. No hot-zone path. Gear 2 comes from the SIZE term

--- a/scripts/pse_registry_check.py
+++ b/scripts/pse_registry_check.py
@@ -42,6 +42,7 @@ import argparse
 import csv
 import datetime as dt
 import hashlib
+import http.client
 import io
 import json
 import os
@@ -247,12 +248,15 @@ class RegistryClient:
         path = self._cache_path(keyword)
         if path is None:
             return
-        path.parent.mkdir(parents=True, exist_ok=True)
         blob = {"keyword": keyword, "fetched_at": result.fetched_at, "total_rows": result.total_rows, "rows": result.rows}
-        fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(blob, handle, ensure_ascii=False)
-        os.replace(tmp, path)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(blob, handle, ensure_ascii=False)
+            os.replace(tmp, path)
+        except OSError:
+            pass
 
     def search(self, keyword: str) -> SearchResult:
         cached = self._cache_get(keyword)
@@ -266,8 +270,8 @@ class RegistryClient:
             retryable = True
             try:
                 status, raw = self._transport(ENDPOINT, body, dict(REQUEST_HEADERS), REQUEST_TIMEOUT_S)
-            except OSError as exc:
-                error = f"network error: {exc}"
+            except (OSError, http.client.HTTPException) as exc:
+                error = f"network error: {exc!r}"
             else:
                 if status == 200:
                     try:

--- a/scripts/pse_registry_check.py
+++ b/scripts/pse_registry_check.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""pse_registry_check.py — is a TD-PSE record LOCATED in the Komdigi registry?
+
+Read-only lookup tool for a manual list of company names or domains. For each
+input it searches the public registry behind pse.komdigi.go.id and reports
+"located" (with the records found) or "not_located". It never says
+"unregistered": absence from a keyword search is not proof of non-registration
+(the legal entity may be spelled differently, the search is fuzzy). A located
+record is a keyword hit — a human still reads pse_name/domain before using it.
+
+API (verified 2026-09-11 from the site's Next.js bundle, re-probed live):
+    POST https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list
+    body {"keyword": str, "length": 20, "start": 0}
+    -> {"status": "success", "data": {"total_rows": N, "data": [record, ...]}}
+
+Behaviour (spec: pse-scanner.spec.md, compliance-stack build Lane B):
+  * keywords per input: the raw input, the registrable part of a domain
+    (kita.example.co.id -> example.co.id), and the optional second-column legal
+    entity; records deduplicated by nomor_tdpse.
+  * at most one request per second; exponential backoff on HTTP 429/5xx and
+    network errors; the run HARD-STOPS after 3 consecutive failed requests.
+  * successful responses cached on disk for 24 h, keyed by keyword.
+  * a malformed or {"status": "error"} response is an ERROR, never a
+    "not_located" — a silent API change must not read as "nobody registered".
+
+Exit codes: 0 every input checked · 2 any input errored (or no input at all)
+            · 1 --probe returned zero rows for "Tokopedia".
+
+Boundaries: company names and domains only (no personal data), no outreach, no
+email generation, not scheduled (manual use only until a human has run the list
+for two weeks).
+
+Usage:
+    python3 scripts/pse_registry_check.py companies.csv -o result.csv
+    printf 'Tokopedia\\nBali Zero\\n' | python3 scripts/pse_registry_check.py -
+    python3 scripts/pse_registry_check.py --probe
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import hashlib
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+ENDPOINT = "https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list"
+REQUEST_HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/128.0 Safari/537.36"
+    ),
+    "Origin": "https://pse.komdigi.go.id",
+    "Referer": "https://pse.komdigi.go.id/",
+}
+PAGE_LENGTH = 20
+MIN_INTERVAL_S = 1.0
+BACKOFF_BASE_S = 1.0
+MAX_CONSECUTIVE_FAILURES = 3
+CACHE_TTL_S = 24 * 3600
+REQUEST_TIMEOUT_S = 30.0
+PROBE_KEYWORD = "Tokopedia"
+DEFAULT_CACHE_DIR = Path.home() / ".cache" / "nuzantara" / "pse_registry_check"
+
+OUTPUT_COLUMNS = (
+    "input",
+    "keyword_used",
+    "result",
+    "pse_name",
+    "domain",
+    "nomor_tdpse",
+    "is_domestik",
+    "tanggal_terdaftar",
+    "status",
+    "checked_at",
+)
+RECORD_FIELDS = ("pse_name", "domain", "nomor_tdpse", "is_domestik", "tanggal_terdaftar", "status")
+HEADER_CELLS = {"input", "name", "company", "company_name", "domain"}
+SECOND_LEVEL_SUFFIXES = {
+    "co.id", "ac.id", "go.id", "or.id", "web.id", "my.id", "biz.id", "sch.id",
+    "net.id", "mil.id", "desa.id", "ponpes.id",
+    "co.uk", "org.uk", "com.au", "com.sg", "com.my", "co.jp", "com.cn", "com.hk",
+    "co.nz", "co.za", "com.br",
+}
+_HOST_RE = re.compile(r"[a-z0-9-]+(\.[a-z0-9-]+)+")
+
+Transport = Callable[[str, bytes, dict, float], "tuple[int, bytes]"]
+
+
+class QueryError(Exception):
+    """One keyword could not be checked."""
+
+
+class HardStop(QueryError):
+    """MAX_CONSECUTIVE_FAILURES failed requests in a row: stop the whole run."""
+
+
+@dataclass
+class Entry:
+    raw: str
+    legal_entity: str = ""
+    keywords: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SearchResult:
+    total_rows: int
+    rows: list[dict]
+    fetched_at: float
+    from_cache: bool = False
+
+
+def urllib_transport(url: str, body: bytes, headers: dict, timeout: float) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read() or b""
+
+
+def _host_of(text: str) -> str:
+    value = text.strip().lower()
+    if "://" in value:
+        value = urllib.parse.urlsplit(value).hostname or ""
+    else:
+        value = value.split("/", 1)[0]
+    value = value.split(":", 1)[0].rstrip(".")
+    return value[4:] if value.startswith("www.") else value
+
+
+def registrable_domain(text: str) -> Optional[str]:
+    if " " in text.strip():
+        return None
+    host = _host_of(text)
+    if not _HOST_RE.fullmatch(host):
+        return None
+    labels = host.split(".")
+    keep = 3 if len(labels) >= 3 and ".".join(labels[-2:]) in SECOND_LEVEL_SUFFIXES else 2
+    return ".".join(labels[-keep:])
+
+
+def build_keywords(raw: str, legal_entity: str = "") -> list[str]:
+    candidates = [raw.strip(), registrable_domain(raw) or "", legal_entity.strip()]
+    keywords: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate and candidate.lower() not in seen:
+            seen.add(candidate.lower())
+            keywords.append(candidate)
+    return keywords
+
+
+def parse_input(text: str) -> list[Entry]:
+    entries: list[Entry] = []
+    for index, row in enumerate(csv.reader(io.StringIO(text))):
+        cells = [cell.strip() for cell in row]
+        if not cells or not cells[0] or cells[0].startswith("#"):
+            continue
+        if index == 0 and cells[0].lower() in HEADER_CELLS:
+            continue
+        legal = cells[1] if len(cells) > 1 else ""
+        entries.append(Entry(raw=cells[0], legal_entity=legal, keywords=build_keywords(cells[0], legal)))
+    return entries
+
+
+def parse_response(raw: bytes) -> tuple[int, list[dict]]:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise QueryError(f"response is not JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise QueryError("response is not a JSON object")
+    if payload.get("status") == "error":
+        raise QueryError(f"API error: {payload.get('message') or payload.get('error') or 'unspecified'}")
+    data = payload.get("data")
+    if not isinstance(data, dict) or not isinstance(data.get("data"), list):
+        raise QueryError("unexpected response shape: data.data is not a list")
+    total = data.get("total_rows")
+    if not isinstance(total, int) or isinstance(total, bool):
+        raise QueryError("unexpected response shape: data.total_rows is not an integer")
+    return total, [row for row in data["data"] if isinstance(row, dict)]
+
+
+class RegistryClient:
+    def __init__(
+        self,
+        transport: Optional[Transport] = None,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+        now: Callable[[], float] = time.time,
+        cache_dir: Optional[Path] = None,
+        min_interval: float = MIN_INTERVAL_S,
+    ) -> None:
+        self._transport = transport or urllib_transport
+        self._clock = clock
+        self._sleep = sleep
+        self._now = now
+        self._cache_dir = cache_dir
+        self._min_interval = max(MIN_INTERVAL_S, min_interval)
+        self._last_request: Optional[float] = None
+        self.consecutive_failures = 0
+        self.requests_made = 0
+
+    def _throttle(self) -> None:
+        if self._last_request is not None:
+            wait = self._last_request + self._min_interval - self._clock()
+            if wait > 0:
+                self._sleep(wait)
+        self._last_request = self._clock()
+
+    def _cache_path(self, keyword: str) -> Optional[Path]:
+        if self._cache_dir is None:
+            return None
+        digest = hashlib.sha256(keyword.strip().lower().encode("utf-8")).hexdigest()[:32]
+        return self._cache_dir / f"{digest}.json"
+
+    def _cache_get(self, keyword: str) -> Optional[SearchResult]:
+        path = self._cache_path(keyword)
+        if path is None or not path.is_file():
+            return None
+        try:
+            cached = json.loads(path.read_text(encoding="utf-8"))
+            fetched_at = float(cached["fetched_at"])
+            total, rows = int(cached["total_rows"]), list(cached["rows"])
+        except (OSError, ValueError, KeyError, TypeError):
+            return None
+        if not 0 <= self._now() - fetched_at < CACHE_TTL_S:
+            return None
+        return SearchResult(total, rows, fetched_at, from_cache=True)
+
+    def _cache_put(self, keyword: str, result: SearchResult) -> None:
+        path = self._cache_path(keyword)
+        if path is None:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        blob = {"keyword": keyword, "fetched_at": result.fetched_at, "total_rows": result.total_rows, "rows": result.rows}
+        fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(blob, handle, ensure_ascii=False)
+        os.replace(tmp, path)
+
+    def search(self, keyword: str) -> SearchResult:
+        cached = self._cache_get(keyword)
+        if cached is not None:
+            return cached
+        body = json.dumps({"keyword": keyword, "length": PAGE_LENGTH, "start": 0}).encode("utf-8")
+        attempt = 0
+        while True:
+            self._throttle()
+            self.requests_made += 1
+            retryable = True
+            try:
+                status, raw = self._transport(ENDPOINT, body, dict(REQUEST_HEADERS), REQUEST_TIMEOUT_S)
+            except OSError as exc:
+                error = f"network error: {exc}"
+            else:
+                if status == 200:
+                    try:
+                        total, rows = parse_response(raw)
+                    except QueryError as exc:
+                        error, retryable = str(exc), False
+                    else:
+                        self.consecutive_failures = 0
+                        result = SearchResult(total, rows, self._now())
+                        self._cache_put(keyword, result)
+                        return result
+                else:
+                    error = f"HTTP {status}"
+                    retryable = status == 429 or 500 <= status < 600
+            self.consecutive_failures += 1
+            if self.consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                raise HardStop(f"{error} ({self.consecutive_failures} consecutive failures, run stopped)")
+            if not retryable:
+                raise QueryError(error)
+            self._sleep(BACKOFF_BASE_S * 2**attempt)
+            attempt += 1
+
+
+def _iso(ts: float) -> str:
+    return dt.datetime.fromtimestamp(ts, dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def _row(entry: Entry, keyword: str, result: str, checked_at: str, record: Optional[dict] = None) -> dict:
+    row = dict.fromkeys(OUTPUT_COLUMNS, "")
+    row.update(input=entry.raw, keyword_used=keyword, result=result, checked_at=checked_at)
+    for name in RECORD_FIELDS:
+        value = (record or {}).get(name, "")
+        row[name] = str(value).lower() if isinstance(value, bool) else ("" if value is None else str(value))
+    return row
+
+
+def check_entries(entries: Iterable[Entry], client: RegistryClient, now: Callable[[], float] = time.time,
+                  log: Callable[[str], None] = lambda msg: None) -> tuple[list[dict], int]:
+    rows: list[dict] = []
+    errored = 0
+    stopped: Optional[str] = None
+    for entry in entries:
+        if stopped:
+            rows.append(_row(entry, " | ".join(entry.keywords), "error", _iso(now())))
+            log(f"error: {entry.raw!r} not checked, {stopped}")
+            errored += 1
+            continue
+        found: dict[str, tuple[str, dict, float]] = {}
+        errors: list[str] = []
+        fetched: list[float] = []
+        for keyword in entry.keywords:
+            try:
+                result = client.search(keyword)
+            except HardStop as exc:
+                errors.append(keyword)
+                stopped = str(exc)
+                log(f"error: {entry.raw!r} keyword {keyword!r}: {exc}")
+                break
+            except QueryError as exc:
+                errors.append(keyword)
+                log(f"error: {entry.raw!r} keyword {keyword!r}: {exc}")
+                continue
+            fetched.append(result.fetched_at)
+            for record in result.rows:
+                key = str(record.get("nomor_tdpse") or record.get("se_id") or json.dumps(record, sort_keys=True))
+                found.setdefault(key, (keyword, record, result.fetched_at))
+        for keyword, record, fetched_at in found.values():
+            rows.append(_row(entry, keyword, "located", _iso(fetched_at), record))
+        if errors:
+            rows.append(_row(entry, " | ".join(errors), "error", _iso(now())))
+            errored += 1
+        elif not found:
+            rows.append(_row(entry, " | ".join(entry.keywords), "not_located", _iso(max(fetched))))
+    return rows, errored
+
+
+def _csv_safe(value: str) -> str:
+    formula = value[:1] in ("=", "+", "@") or (value[:1] == "-" and len(value) > 1)
+    return "'" + value if formula else value
+
+
+def write_csv(rows: list[dict], handle) -> None:
+    writer = csv.DictWriter(handle, fieldnames=OUTPUT_COLUMNS, lineterminator="\n")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({key: _csv_safe(value) for key, value in row.items()})
+
+
+def main(
+    argv: Optional[list[str]] = None,
+    *,
+    transport: Optional[Transport] = None,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+    now: Callable[[], float] = time.time,
+) -> int:
+    parser = argparse.ArgumentParser(description="Check company names/domains against the Komdigi TD-PSE registry.")
+    parser.add_argument("input", nargs="?", help="CSV or newline list (name or domain[, legal entity]); '-' = stdin")
+    parser.add_argument("-o", "--output", help="output CSV path (default: stdout)")
+    parser.add_argument("--probe", action="store_true", help=f"live self-test: {PROBE_KEYWORD!r} must return rows")
+    parser.add_argument("--no-cache", action="store_true", help="bypass the 24 h on-disk cache")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    args = parser.parse_args(argv)
+
+    def log(message: str) -> None:
+        print(message, file=sys.stderr)
+
+    if args.probe:
+        entries = parse_input(PROBE_KEYWORD)
+    elif not args.input:
+        parser.error("an input file (or '-') is required unless --probe is given")
+    else:
+        try:
+            text = sys.stdin.read() if args.input == "-" else Path(args.input).read_text(encoding="utf-8")
+        except OSError as exc:
+            log(f"error: cannot read {args.input}: {exc}")
+            return 2
+        entries = parse_input(text)
+    if not entries:
+        log("error: no inputs found — an empty run is not a clean run")
+        return 2
+
+    cache_dir = None if (args.no_cache or args.probe) else args.cache_dir
+    client = RegistryClient(transport=transport, clock=clock, sleep=sleep, now=now, cache_dir=cache_dir)
+    rows, errored = check_entries(entries, client, now=now, log=log)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8", newline="") as handle:
+            write_csv(rows, handle)
+    else:
+        write_csv(rows, sys.stdout)
+
+    located = sum(1 for e in entries if any(r["input"] == e.raw and r["result"] == "located" for r in rows))
+    log(f"checked {len(entries)} input(s): {located} located, {errored} errored, {client.requests_made} request(s)")
+    if errored:
+        return 2
+    if args.probe and not any(r["result"] == "located" for r in rows):
+        log(f"PROBE FAILED: {PROBE_KEYWORD!r} returned 0 rows — treat as an API change, not as 'nobody registered'")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,2 @@
+def pytest_configure(config):
+    config.addinivalue_line("markers", "network: needs live internet; skipped unless explicitly enabled")

--- a/tests/scripts/test_pse_registry_check.py
+++ b/tests/scripts/test_pse_registry_check.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import http.client
 import importlib.util
 import io
 import json
@@ -176,6 +177,24 @@ def test_429_backs_off_then_succeeds(tmp_path: Path) -> None:
     assert len(transport.calls) == 2
     assert clock.sleeps[0] == pse.BACKOFF_BASE_S
     assert {r["result"] for r in rows} == {"located"}
+
+
+def test_protocol_error_is_retried_and_unwritable_cache_does_not_crash(tmp_path: Path) -> None:
+    clock = FakeClock()
+    calls = {"n": 0}
+
+    def flaky(url, body, headers, timeout):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise http.client.IncompleteRead(b"")
+        return 200, ok_body(TOKOPEDIA_ROWS)
+
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("x")
+    client = pse.RegistryClient(transport=flaky, clock=clock.monotonic, sleep=clock.sleep, now=clock.wall,
+                                cache_dir=blocker / "cache")
+    assert client.search("Tokopedia").total_rows == 2
+    assert calls["n"] == 2 and client.consecutive_failures == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_pse_registry_check.py
+++ b/tests/scripts/test_pse_registry_check.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import io
+import json
+import os
+import sys
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("pse_registry_check", ROOT / "scripts" / "pse_registry_check.py")
+assert SPEC is not None and SPEC.loader is not None
+pse = importlib.util.module_from_spec(SPEC)
+sys.modules["pse_registry_check"] = pse
+SPEC.loader.exec_module(pse)
+
+TOKOPEDIA_ROWS = [
+    {
+        "domain": "tokopedia.com",
+        "is_domestik": True,
+        "nama_se": "TOKOPEDIA",
+        "nomor_tdpse": "000847.04/DJAI.PSE/09/2024",
+        "pse_name": "TOKOPEDIA",
+        "se_id": "a",
+        "status": "Terdaftar",
+        "tanggal_terdaftar": "2024-09-05",
+    },
+    {
+        "domain": "gojek.com",
+        "is_domestik": True,
+        "nama_se": "GOJEK",
+        "nomor_tdpse": "001758.01/DJAI.PSE/12/2021",
+        "pse_name": "GOTO GOJEK TOKOPEDIA",
+        "se_id": "b",
+        "status": "Terdaftar",
+        "tanggal_terdaftar": "2021-12-13",
+    },
+]
+
+
+def ok_body(rows: list[dict], total: int | None = None) -> bytes:
+    payload = {"data": {"data": rows, "total_rows": len(rows) if total is None else total}, "status": "success"}
+    return json.dumps(payload).encode()
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.t += seconds
+
+    def wall(self) -> float:
+        return 1_800_000_000.0 + self.t
+
+
+class FakeTransport:
+    def __init__(self, clock: FakeClock, responder, latency: float = 0.05) -> None:
+        self.clock = clock
+        self.responder = responder
+        self.latency = latency
+        self.calls: list[tuple[float, dict]] = []
+
+    def __call__(self, url: str, body: bytes, headers: dict, timeout: float):
+        payload = json.loads(body)
+        self.calls.append((self.clock.t, payload))
+        self.clock.t += self.latency
+        return self.responder(payload)
+
+
+def by_keyword(payload: dict):
+    if "tokopedia" in payload["keyword"].lower():
+        return 200, ok_body(TOKOPEDIA_ROWS)
+    return 200, ok_body([])
+
+
+def run(tmp_path: Path, text: str, responder, extra: list[str] | None = None):
+    clock = FakeClock()
+    transport = FakeTransport(clock, responder)
+    src = tmp_path / "in.csv"
+    out = tmp_path / "out.csv"
+    src.write_text(text, encoding="utf-8")
+    argv = [str(src), "-o", str(out), "--cache-dir", str(tmp_path / "cache")] + (extra or [])
+    code = pse.main(argv, transport=transport, clock=clock.monotonic, sleep=clock.sleep, now=clock.wall)
+    rows = list(csv.DictReader(out.open(encoding="utf-8"))) if out.exists() else []
+    return code, rows, transport, clock
+
+
+def test_keywords_raw_registrable_domain_and_legal_entity_deduplicated() -> None:
+    assert pse.build_keywords("kita.balizero.com") == ["kita.balizero.com", "balizero.com"]
+    assert pse.build_keywords("https://www.shop.example.co.id/path") == [
+        "https://www.shop.example.co.id/path",
+        "example.co.id",
+    ]
+    assert pse.build_keywords("tokopedia.com") == ["tokopedia.com"]
+    assert pse.build_keywords("Bali Zero", "PT Bali Zero") == ["Bali Zero", "PT Bali Zero"]
+    assert pse.build_keywords("Tokopedia", "tokopedia") == ["Tokopedia"]
+
+
+def test_parse_input_accepts_csv_and_newline_list() -> None:
+    entries = pse.parse_input("input,legal\nTokopedia\n\n# note\nkita.balizero.com,PT Bali Zero\n")
+    assert [(e.raw, e.legal_entity) for e in entries] == [("Tokopedia", ""), ("kita.balizero.com", "PT Bali Zero")]
+    assert entries[1].keywords == ["kita.balizero.com", "balizero.com", "PT Bali Zero"]
+
+
+def test_tokopedia_located_and_bali_zero_not_located(tmp_path: Path) -> None:
+    code, rows, _, _ = run(tmp_path, "Tokopedia\nBali Zero\n", by_keyword)
+    assert code == 0
+    assert tuple(rows[0].keys()) == pse.OUTPUT_COLUMNS
+    toko = [r for r in rows if r["input"] == "Tokopedia"]
+    bali = [r for r in rows if r["input"] == "Bali Zero"]
+    assert {r["result"] for r in toko} == {"located"}
+    assert {r["nomor_tdpse"] for r in toko} == {row["nomor_tdpse"] for row in TOKOPEDIA_ROWS}
+    assert toko[0]["is_domestik"] == "true"
+    assert [r["result"] for r in bali] == ["not_located"]
+    assert "unregistered" not in (tmp_path / "out.csv").read_text()
+
+
+def test_records_deduplicated_by_nomor_tdpse_across_keywords(tmp_path: Path) -> None:
+    code, rows, transport, _ = run(tmp_path, "www.tokopedia.co.id,Tokopedia\n", lambda p: (200, ok_body(TOKOPEDIA_ROWS)))
+    assert code == 0
+    assert len(transport.calls) == 3
+    assert len(rows) == 2
+    assert all(r["keyword_used"] == "www.tokopedia.co.id" for r in rows)
+
+
+def test_forced_http_error_exits_2_with_backoff_and_hard_stop(tmp_path: Path) -> None:
+    code, rows, transport, clock = run(tmp_path, "Tokopedia\nBali Zero\n", lambda p: (500, b"oops"))
+    assert code == 2
+    assert len(transport.calls) == pse.MAX_CONSECUTIVE_FAILURES
+    assert clock.sleeps[:2] == [1.0, 2.0]
+    assert [r["result"] for r in rows] == ["error", "error"]
+    assert "not_located" not in {r["result"] for r in rows}
+
+
+def test_http_error_through_urllib_transport_exits_2(tmp_path: Path) -> None:
+    error = urllib.error.HTTPError(pse.ENDPOINT, 503, "Service Unavailable", {}, io.BytesIO(b"down"))
+    clock = FakeClock()
+    src = tmp_path / "in.txt"
+    src.write_text("Tokopedia\n", encoding="utf-8")
+    with patch("pse_registry_check.urllib.request.urlopen", side_effect=error) as urlopen:
+        code = pse.main([str(src), "-o", str(tmp_path / "o.csv"), "--no-cache"],
+                        clock=clock.monotonic, sleep=clock.sleep, now=clock.wall)
+    assert code == 2
+    assert urlopen.call_count == pse.MAX_CONSECUTIVE_FAILURES
+    request = urlopen.call_args[0][0]
+    assert request.full_url == pse.ENDPOINT and request.get_method() == "POST"
+    assert json.loads(request.data) == {"keyword": "Tokopedia", "length": 20, "start": 0}
+
+
+def test_no_request_faster_than_one_per_second(tmp_path: Path) -> None:
+    names = "\n".join(["Tokopedia", "Bali Zero", "kita.balizero.com", "Gojek", "Traveloka"]) + "\n"
+    code, _, transport, clock = run(tmp_path, names, by_keyword)
+    assert code == 0
+    stamps = [t for t, _ in transport.calls]
+    assert len(stamps) == 6
+    gaps = [b - a for a, b in zip(stamps, stamps[1:])]
+    assert min(gaps) >= pse.MIN_INTERVAL_S - 1e-9
+    assert clock.sleeps, "the limiter must actually wait, not rely on latency"
+
+
+def test_429_backs_off_then_succeeds(tmp_path: Path) -> None:
+    replies = iter([(429, b""), (200, ok_body(TOKOPEDIA_ROWS))])
+    code, rows, transport, clock = run(tmp_path, "Tokopedia\n", lambda p: next(replies))
+    assert code == 0
+    assert len(transport.calls) == 2
+    assert clock.sleeps[0] == pse.BACKOFF_BASE_S
+    assert {r["result"] for r in rows} == {"located"}
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        json.dumps({"status": "error", "message": "bad keyword"}).encode(),
+        json.dumps({"status": "success", "data": {"data": []}}).encode(),
+        b"<html>maintenance</html>",
+    ],
+)
+def test_api_error_or_changed_shape_is_error_never_not_located(tmp_path: Path, body: bytes) -> None:
+    code, rows, transport, _ = run(tmp_path, "Bali Zero\n", lambda p: (200, body))
+    assert code == 2
+    assert len(transport.calls) == 1
+    assert [r["result"] for r in rows] == ["error"]
+
+
+def test_cache_hit_within_24h_and_refetch_after_expiry(tmp_path: Path) -> None:
+    clock = FakeClock()
+    transport = FakeTransport(clock, by_keyword)
+    kwargs = dict(transport=transport, clock=clock.monotonic, sleep=clock.sleep, now=clock.wall, cache_dir=tmp_path)
+    pse.RegistryClient(**kwargs).search("Tokopedia")
+    again = pse.RegistryClient(**kwargs).search("tokopedia ")
+    assert again.from_cache and again.total_rows == 2 and len(transport.calls) == 1
+    clock.t += pse.CACHE_TTL_S + 1
+    fresh = pse.RegistryClient(**kwargs).search("Tokopedia")
+    assert not fresh.from_cache and len(transport.calls) == 2
+
+
+def test_probe_exit_codes(tmp_path: Path) -> None:
+    def probe(responder):
+        clock = FakeClock()
+        transport = FakeTransport(clock, responder)
+        code = pse.main(["--probe", "-o", str(tmp_path / "p.csv")], transport=transport,
+                        clock=clock.monotonic, sleep=clock.sleep, now=clock.wall)
+        return code, transport
+
+    code, transport = probe(by_keyword)
+    assert code == 0 and transport.calls[0][1]["keyword"] == "Tokopedia"
+    assert probe(lambda p: (200, ok_body([])))[0] == 1
+    assert probe(lambda p: (502, b""))[0] == 2
+
+
+def test_empty_input_is_not_a_clean_run(tmp_path: Path) -> None:
+    code, rows, transport, _ = run(tmp_path, "# nothing\n\n", by_keyword)
+    assert code == 2 and rows == [] and transport.calls == []
+
+
+def test_formula_like_cells_are_neutralised(tmp_path: Path) -> None:
+    evil = [dict(TOKOPEDIA_ROWS[0], pse_name="=HYPERLINK(\"x\")", domain="-")]
+    _, rows, _, _ = run(tmp_path, "Tokopedia\n", lambda p: (200, ok_body(evil)))
+    assert rows[0]["pse_name"].startswith("'=")
+    assert rows[0]["domain"] == "-"
+
+
+@pytest.mark.network
+@pytest.mark.skipif(not os.environ.get("PSE_REGISTRY_LIVE"), reason="network test: set PSE_REGISTRY_LIVE=1")
+def test_live_probe_tokopedia_returns_rows() -> None:
+    result = pse.RegistryClient().search(pse.PROBE_KEYWORD)
+    assert result.total_rows > 0 and result.rows


### PR DESCRIPTION
## What

`scripts/pse_registry_check.py`: a read-only CLI that takes a CSV or newline list of company names or domains and reports, per input, whether a TD-PSE record is **located** in the Komdigi registry (`POST https://pse.komdigi.go.id/api/v1/tdpse/tdpse-list`). Result is `located | not_located | error`, never "unregistered". Implements `pse-scanner.spec.md` (compliance-stack build, Lane B).

- Keywords per input: raw input, registrable domain part (`kita.balizero.com` → `balizero.com`), optional second-column legal entity. Records deduplicated by `nomor_tdpse`.
- At most 1 request/s; exponential backoff on 429/5xx/network errors; hard stop after 3 consecutive failures; 24 h on-disk cache keyed by keyword.
- A malformed or `{"status": "error"}` response is an `error` row, never `not_located`. `--probe` exits 1 if Tokopedia returns 0 rows, so a silent API change fails loudly.
- Exit codes: 0 all checked, 2 any error or empty input, 1 probe with zero rows.
- Stdlib only (`urllib`); clock, sleep and transport are injectable.

Tests: `tests/scripts/test_pse_registry_check.py` (16 mocked + 1 network test skipped unless `PSE_REGISTRY_LIVE=1`); `tests/scripts/conftest.py` registers the `network` marker.

## Verification

| Check | Command | Exit |
|---|---|---|
| Suite | `pytest tests/scripts/test_pse_registry_check.py -q` → 16 passed, 1 skipped | 0 |
| Live probe | `python3 scripts/pse_registry_check.py --probe` → Tokopedia located | 0 |
| Live CSV | `Tokopedia` → located, `Bali Zero` → not_located | 0 |
| Forced HTTP 500/503 | `-k "forced_http_error or urllib_transport"` asserts `main()` returns 2 | 0 |
| 1 req/s | `-k one_per_second` (fake clock, min gap ≥ 1.0 s) | 0 |
| Floor | `evidence_pack_lint.py --print-floor` → 2, source `size` | 0 |

Evidence: `evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/` (brief.yml gear 2, pack.yml, live-probe.csv).

## Boundaries and notes

- Company names and domains only. The registry returns fuzzy hits that include sole-proprietor registrants named after people. `live-probe.csv` keeps only rows whose `pse_name` contains the input (13 of 21 rows); the rule is recorded in pack.yml.
- "located" is a keyword hit. A human reads `pse_name`/`domain` before relying on it; a relevance filter would be a spec change and is not included.
- No outreach, no email, no schedule (manual use for two weeks first, per the roundtable).
- 5 pre-existing failures in `tests/scripts/test_ai_pr_review_workflow.py` are unrelated (same result with `--noconftest`).

Bites: consumer = the founder's manual outbound list; observation = the CSV produced by the live probe (`evidence/2026-09/agent-nuzantara-ops-pse-registry-check-221e5dd8/live-probe.csv`, company names only: Tokopedia located, Bali Zero not_located).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
