### PR TITLE
fix(portal): drop two non-existent columns from the documents INSERT

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -694,14 +694,14 @@ class PortalDocumentsMixin:
                         INSERT INTO documents (
                             client_id, practice_id, document_type, document_category, file_name,
                             status, uploaded_by, uploaded_source, file_size_kb, mime_type,
-                            storage_type, storage_path, file_id, file_url,
-                            extracted_text, expiry_date, document_purpose,
+                            storage_type, file_id, file_url,
+                            expiry_date, document_purpose,
                             client_visible, created_at
                         )
                         VALUES (
-                            $1, $2, $3, $13, $4, 'received', $5, 'client', $6, $7,
-                            $15, $8, $9, $10,
-                            $11, $12, $14,
+                            $1, $2, $3, $11, $4, 'received', $5, 'client', $6, $7,
+                            $13, $8, $9,
+                            $10, $12,
                             true, NOW()
                         )
                         RETURNING id, document_type, file_name, status, created_at, expiry_date
@@ -713,12 +713,8 @@ class PortalDocumentsMixin:
                         client["email"],
                         file_size_kb,
                         mime_type,
-                        drive_result.get("folder_path"),
                         drive_result.get("file_id"),
                         drive_result.get("file_url"),
-                        ocr_result.get("text")[:10000]
-                        if ocr_result.get("text")
-                        else None,  # Limit text size
                         expiry_result.get("expiry_date"),
                         doc_category,
                         document_purpose,

--- a/apps/backend-rag/backend/tests/test_data_invariant_tripwires.py
+++ b/apps/backend-rag/backend/tests/test_data_invariant_tripwires.py
@@ -1327,3 +1327,83 @@ def test_portal_profile_read_and_update_paths_agree_on_team_members_columns() ->
         "an alias's source column legitimately moved, update BOTH files in "
         "the same commit — not just one."
     )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 7 — the documents upload INSERT projects only columns that
+# actually exist on the live `documents` table
+# ---------------------------------------------------------------------------
+#
+# Born 2026-09-11. `POST /api/portal/documents/upload` was 500ing for every
+# file, every client, since 2026-05-10 — a stack of defects that had never
+# executed until a real upload finally reached each one in turn. The last of
+# the stack: the primary `INSERT INTO documents (...)` in
+# `_mixins/documents.py` named `storage_path` (Postgres's own
+# `UndefinedColumnError`) AND `extracted_text` — a SECOND column that has
+# never existed on this table, which would only have surfaced as its own 500
+# one deploy later, after `storage_path` was fixed in isolation. Both were
+# removed rather than added as migrations: the Drive folder path is
+# derivable from `file_id` via the Drive API, and `documents` already has a
+# `notes`/`ocr_extracted_data` (jsonb) home if OCR text genuinely needs
+# persisting — that is a follow-up, not smuggled into this fix.
+#
+# `documents`'s real columns, verified live 2026-09-11 via
+# `information_schema.columns` against the production `nuzantara_rag` DB
+# (`scripts/pg.sh`). This does not pin call-sites to a subset — new columns
+# added by a migration are fine — it only pins that nothing selected here is
+# fictional.
+_DOCUMENTS_LIVE_COLUMNS = {
+    "id", "client_id", "practice_id", "document_type", "file_name",
+    "storage_type", "file_id", "file_url", "file_size_kb", "mime_type",
+    "status", "uploaded_by", "verified_by", "verified_at", "expiry_date",
+    "notes", "rejection_reason", "created_at", "updated_at", "user_profile_id",
+    "client_visible", "document_category", "family_member_id",
+    "google_drive_file_url", "is_archived", "uploaded_source", "ocr_status",
+    "ocr_completed_at", "ocr_extracted_data", "issue_date", "drive_verified_at",
+    "subfolder", "content_hash", "intake_idempotency_key", "intake_proposal_id",
+    "document_purpose", "deleted_at", "deleted_by",
+}
+
+_INSERT_DOCUMENTS_COLUMNS = re.compile(
+    r"INSERT INTO documents\s*\(\s*(.*?)\)\s*VALUES", re.DOTALL | re.IGNORECASE,
+)
+
+
+def _documents_insert_column_lists(path: Path) -> list[list[str]]:
+    """Every column list out of an `INSERT INTO documents (...) VALUES` in
+    `path`, one list per statement found (this mixin has two: the primary
+    insert and its "backward compatibility" fallback)."""
+    src = path.read_text(encoding="utf-8")
+    return [
+        [c.strip() for c in block.split(",") if c.strip()]
+        for block in _INSERT_DOCUMENTS_COLUMNS.findall(src)
+    ]
+
+
+def test_documents_upload_insert_only_projects_columns_that_exist() -> None:
+    """See the "Invariant 7" block comment above for the incident this pins."""
+    documents_path = (
+        _repo_root() / "apps/backend-rag/backend/services/portal/_mixins/documents.py"
+    )
+    assert documents_path.exists(), f"documents.py mixin missing at {documents_path}"
+
+    column_lists = _documents_insert_column_lists(documents_path)
+    assert column_lists, (
+        "No `INSERT INTO documents (...) VALUES` found in documents.py — the "
+        "upload path stopped writing to this table, or the statement's shape "
+        "changed. Update this test's regex if the query moved rather than "
+        "deleting the check."
+    )
+
+    for columns in column_lists:
+        bad = set(columns) - _DOCUMENTS_LIVE_COLUMNS
+        assert not bad, (
+            f"An `INSERT INTO documents` in documents.py names column(s) "
+            f"{sorted(bad)} that do not exist on the live `documents` table "
+            "(verified via information_schema.columns, 2026-09-11). This is "
+            "exactly how `storage_path` and `extracted_text` shipped: the "
+            "INSERT was never exercised end to end until a real portal "
+            "upload hit it in production. If a column here is genuinely new, "
+            "add the migration AND update `_DOCUMENTS_LIVE_COLUMNS` in the "
+            "same commit; otherwise drop it from the INSERT."
+        )


### PR DESCRIPTION
## Summary

Fourth defect in the stack blocking `POST /api/portal/documents/upload` since 2026-05-10 (after #6106, #6107, #6108). With those merged, a real production upload now reaches the DB insert and dies:

```
asyncpg.exceptions.UndefinedColumnError: column "storage_path" of relation "documents" does not exist
```

Checked the WHOLE column list of the primary `INSERT INTO documents (...)` in `backend/services/portal/_mixins/documents.py` against `information_schema.columns` on the live `nuzantara_rag` DB (via `scripts/pg.sh`), not just the column Postgres named — because Postgres stops at the first bad column, so a second one would only surface after this fix shipped, one deploy later. Found exactly that:

1. **`storage_path`** — the column Postgres reported. Bound to `drive_result.get("folder_path")`.
2. **`extracted_text`** — a SECOND column that also does not exist on `documents`. Bound to a truncated `ocr_result.get("text")`. This one was silent (no error yet) purely because `storage_path` fails first in column order.

Both dropped from the INSERT rather than migrated in:
- `storage_path` / the Drive folder path is derivable from `file_id` via the Drive API, and `documents` already records where the file lives (`file_id`, `file_url`, `google_drive_file_url`, `storage_type`). Adding a column to a live table mid-incident is heavier than the fix that unblocks the feature.
- `extracted_text` / if OCR text genuinely needs persisting, `documents` already has `ocr_extracted_data` (jsonb) as a candidate home — that's a follow-up decision (schema/shape), not something to smuggle into this fix.

The second, simpler fallback `INSERT INTO documents` a few dozen lines below (the "backward compatibility" branch) was already free of both columns — it independently confirms this minimal-safe column set.

Verified every remaining column in the primary INSERT (`client_id`, `practice_id`, `document_type`, `document_category`, `file_name`, `status`, `uploaded_by`, `uploaded_source`, `file_size_kb`, `mime_type`, `storage_type`, `file_id`, `file_url`, `expiry_date`, `document_purpose`, `client_visible`, `created_at`) against the live schema — all exist.

## Tripwire

Added **Invariant 7** to `backend/tests/test_data_invariant_tripwires.py`: `test_documents_upload_insert_only_projects_columns_that_exist` parses every `INSERT INTO documents (...) VALUES` column list out of `documents.py` and asserts it against a pinned, live-verified `documents` schema — the same "parse SQL out of source, pin against a live-verified invariant" pattern this file already uses (Invariant 6, `tm.*` alias drift).

**Guilt-proof:**
- With `storage_path`/`extracted_text` reintroduced into the INSERT: **1 failed** (`AssertionError: ... names column(s) ['extracted_text', 'storage_path'] that do not exist ...`).
- With the fix in place: **1 passed**.
- Full regression: `test_data_invariant_tripwires.py` + `test_documents_mixin.py` → **61 passed**.

## What this does NOT prove

This takes the upload path one step further (past the DB insert), but whether the upload then completes end to end — Drive file lands, timeline event fires, response returns 200 — can only be measured on the deployed machine. Not claiming upload is fixed; that verification is the team lead's to run post-merge.

## Bites

`POST /api/portal/documents/upload` (`backend/services/portal/_mixins/documents.py`, primary `INSERT INTO documents`) — the observation proving this is in force is the guilt-proof above: the tripwire fails on the pre-fix column list and passes on the post-fix one, and both are printed in the PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnaXYe8mcUMTfRGty8e2uW