### PR TITLE
feat(mouth): PSE registration in Indonesia guide article

### DIFF
--- a/apps/mouth/src/content/articles/business_regulations/pse-registration-indonesia.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pse-registration-indonesia.mdx
@@ -1,0 +1,112 @@
+---
+title: "PSE Registration in Indonesia: Who Must Register, What Happens If You Do Not, and How to Do It"
+slug: "pse-registration-indonesia"
+excerpt: "Any private operator whose website, app or platform is used by people in Indonesia must register as a PSE with Komdigi, including foreign operators with no Indonesian entity. Unregistered systems are blocked. This guide covers who is in scope, the enforcement record through June 2026, and the domestic and foreign filing routes."
+coverImageAlt: "PSE registration in Indonesia"
+category: "business_regulations"
+tags: ["business_regulations", "pse", "komdigi", "compliance", "data-protection"]
+publishedAt: "2026-09-11"
+author:
+  name: "Bali Zero"
+  avatar: /static/zantara-avatar.png
+trending: false
+featured: false
+readingTime: 7
+difficulty: "intermediate"
+seoTitle: "PSE Registration in Indonesia: 2026 Guide for Platforms and Apps"
+seoDescription: "Who must register as a PSE in Indonesia, what Komdigi does to unregistered websites and apps, and how domestic and foreign operators file. Primary sources cited."
+aiGenerated: true
+locale: "en"
+---
+
+Any private operator whose website, app or platform is used by people in Indonesia must register it with the Ministry of Communication and Digital Affairs (Komdigi, formerly Kominfo). The obligation covers foreign operators with no Indonesian office. An unregistered system can be blocked from Indonesia, and since 2022 the ministry has done exactly that to PayPal, Yahoo, Steam, eBay and KLM.
+
+## Summary
+
+<InfoCard
+  title="PSE registration at a glance"
+  items={[
+    { label: "What PSE means", value: "Penyelenggara Sistem Elektronik: an electronic system operator" },
+    { label: "Who", value: "Private operators whose systems are used in Indonesia, foreign ones included" },
+    { label: "Legal basis", value: "PP 71/2019 and Permenkominfo 5/2020, as amended by Permenkominfo 10/2021" },
+    { label: "Output", value: "A TD-PSE (tanda daftar), listed on the ministry's public registry" },
+    { label: "Fee", value: "None set in Permenkominfo 5/2020" },
+    { label: "If you do not register", value: "Access blocking from Indonesia (Art. 7)" },
+  ]}
+/>
+
+## Who must register
+
+PP 71/2019 Art. 6(1) makes registration an obligation for every electronic system operator. Permenkominfo 5/2020 Art. 2 applies it to private-scope operators (PSE Lingkup Privat), and Art. 2(3) says you register before users start using the system, not after.
+
+Art. 2(2) puts two groups in scope. The first is any operator regulated or supervised by a ministry or agency under sector law. The second is any operator with a portal, site or online application used to:
+
+1. offer or trade goods or services;
+2. provide financial transaction services;
+3. deliver paid digital content, whether by download, email or another application;
+4. provide communication services, including messaging, voice and video calls, email, online chat, digital platforms, networking and social media;
+5. run a search engine, or provide electronic information as text, sound, images, animation, music, video, film or games;
+6. process personal data for operational activities serving the public in connection with electronic transactions.
+
+Foreign operators are covered by Art. 4(1). An operator established or domiciled abroad must register if it provides services in Indonesia, does business in Indonesia, or its electronic system is used or offered in Indonesia. Not having an Indonesian entity takes you out of none of these three tests.
+
+## What happens if you do not register
+
+Permenkominfo 5/2020 Art. 7 sets the sanctions:
+
+- **Not registered at all:** access blocking of the electronic system (Art. 7(2)).
+- **Registered, but changes not reported or information incorrect:** a written warning by email, then temporary suspension if the warning is ignored, then access blocking and revocation of the TD-PSE if you do not respond within 7 days of the suspension (Art. 7(3)).
+- **Back in compliance:** the ministry restores access, which Komdigi calls normalisasi (Art. 7(4) and 7(5)).
+
+In practice, Komdigi sends a notification letter and a warning letter before it blocks. The deadlines in those letters are short, one week in the 2026 round below.
+
+## Enforcement record
+
+- **30 July 2022:** Kominfo cut access to eight sites and platforms: PayPal, Yahoo, Epic Games, Steam, Dota, Counter Strike, Xandr.com and Origin (EA). The action was later challenged at the Jakarta administrative court, case 424/G/TF/2022/PTUN.JKT.
+- **28 June 2025:** Komdigi blocked three operators under Art. 7: eBay Inc. (eBay), KLM Royal Dutch Airlines (KLM) and PT Dunia Luxindo (bathandbodyworks). The ministry said all three had received notification and warning letters and made no attempt to register before the deadline.
+- **26 June 2026:** Komdigi sent notification letters to 25 operators, 15 foreign and 10 domestic, covering 57 websites and apps, with a registration deadline of 3 July 2026. The list included Strava, Qatar Airways, Qantas, ANA, Accor, Best Western, Banyan Tree, Six Senses, The Ascott, Archipelago International, Aryaduta, Hotel Indonesia Group, Tauzia, Kodland, Stimuler and Engoo. The ministry said operators that missed the deadline would receive warning letters and then face access blocking.
+
+Airlines, hotel groups and education apps made up most of the 2026 list. Your operator does not need to be a social network or a marketplace to be in scope. A booking engine used by Indonesian guests is enough.
+
+## Domestic versus foreign registration
+
+| | Domestic PSE | Foreign PSE |
+|---|---|---|
+| Who | Operators established in Indonesia | Operators established or domiciled abroad that serve, do business with, or offer their system to users in Indonesia (Art. 4(1)) |
+| Where | OSS-RBA, the online business licensing system (Art. 3(2)) | Filed with the minister (Art. 3(1) and 4(2)); Komdigi runs the PSE registration portal at pse.komdigi.go.id |
+| System data | Name, sector, URL, domain or server IP, business model, how the system works, personal data processed, where the system and data are managed and stored, and a commitment to give authorities access for supervision (Art. 3(4)) | The same system data (Art. 4(2)) |
+| Company data | Filed through the OSS account; operators exempt from OSS add legal entity details, deed, NPWP and a contact person (Art. 3(5)) | Company identity, identity of the head of the company or responsible officer, domicile or certificate of incorporation with a sworn Indonesian translation, number of Indonesian users, and transaction value from Indonesia (Art. 4(2) and 4(3)) |
+| Fee | None set in the regulation | None set in the regulation |
+
+When the file is complete, the minister issues the TD-PSE and adds the system to the public list on the ministry's website (Art. 6). That list is what Komdigi checks, and what anyone can search at pse.komdigi.go.id.
+
+## After registration
+
+- **Keep the record current.** Any change to the registered information must be reported to the minister (Art. 5): a new app, a new domain, a new server location, a new responsible officer. Failing to report is itself sanctionable under Art. 7(3).
+- **Take down content when ordered.** A takedown order must be acted on within 24 hours of receipt (Art. 15(6)). For urgent requests (terrorism, child sexual abuse material, and content that disturbs public order, as listed in Art. 14(3)) the limit is 4 hours after the warning (Art. 15(8)).
+- **Protect personal data.** Registration sits alongside UU 27/2022 on personal data protection. The two are separate obligations and a TD-PSE does not satisfy the second.
+
+## Where people go wrong
+
+- Registering one domain when the group runs several websites and apps. The 2026 letters listed up to 12 booking domains for a single hotel group.
+- Mapping brand names to the wrong legal entity. The registry records the operator, and brands often sit under a different company from the one filing.
+- Assuming a foreign entity is out of scope because it has no Indonesian office. Art. 4(1) looks at where the users are, not where the company is.
+- Letting the responsible officer leave without updating the record.
+
+## What we do
+
+We assess whether your systems fall under Art. 2 and Art. 4, map every website and app to the right legal entity, prepare the document pack, file it, and follow up until the TD-PSE is issued. The fee is fixed and agreed before we start. Ongoing liaison with Komdigi after registration is a separate monthly service.
+
+[Check whether your systems are registered: a free twenty-minute call](/contact).
+
+## Sources
+
+- [PP 71/2019 on electronic systems and transactions (JDIH BPK)](https://peraturan.bpk.go.id/Details/122030/pp-no-71-tahun-2019)
+- [Permenkominfo 5/2020 on private-scope electronic system operators (JDIH BPK)](https://peraturan.bpk.go.id/Details/203049/permenkominfo-no-5-tahun-2020)
+- [Permenkominfo 5/2020 (JDIH Komdigi)](https://jdih.komdigi.go.id/produk_hukum/view/id/759/t/peraturan+menteri+komunikasi+dan+informatika+nomor+5+tahun+2020)
+- [Permenkominfo 10/2021 amending Permenkominfo 5/2020 (JDIH BPK)](https://peraturan.bpk.go.id/Details/203121/permenkominfo-no-10-tahun-2021)
+- [UU 27/2022 on personal data protection (JDIH BPK)](https://peraturan.bpk.go.id/Details/229798/uu-no-27-tahun-2022)
+- [Jakarta administrative court ruling 424/G/TF/2022/PTUN.JKT (JDIH Komdigi)](https://jdih.komdigi.go.id/storage/files/1701853177-salinan_putusan_424_G_TF_2022_PTUN_JKT.pdf)
+- [Komdigi press release 120/HM-KKD/06/2025, 28 June 2025: access cut for three operators](https://portal.komdigi.go.id/kanal-publik/berita-kini/9446)
+- [Komdigi press release, 1 July 2026: 25 operators notified](https://portal.komdigi.go.id/kanal-publik/berita-kini/10354)
+- [Komdigi PSE registration portal and public registry](https://pse.komdigi.go.id/)

--- a/evidence/2026-09/agent-nuzantara-mouth-pse-guide-article-3ebda666/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-mouth-pse-guide-article-3ebda666/brief.yml
@@ -1,0 +1,54 @@
+task_id: pse-guide-article
+gear: 2
+gear_reason: >-
+  The deterministic floor for this diff is 1, source `none`: one MDX content file,
+  112 net lines, no hot-zone path. Reproduced with
+  `bash scripts/ci/hotzone_changed_files.sh be45266252 HEAD` then
+  `python3 scripts/evidence_pack_lint.py --changed-files-file <list> --net-lines 112 --print-floor`
+  (prints 1) and `--print-floor-source` (prints none). Declared one above the floor
+  because the compliance-stack build contract (DESIGN-lanes.md) sets Gear 2 as the
+  minimum per lane, and the page makes regulatory claims to external readers.
+l_level: L1
+gate_class: opus
+objective: >-
+  Publish an English guide at /business/pse-registration-indonesia on PSE
+  (Penyelenggara Sistem Elektronik) registration in Indonesia, built from Page 2 of
+  the compliance-stack page-content draft. The file lives in
+  apps/mouth/src/content/articles/business_regulations/ because the article loader
+  (apps/mouth/src/lib/blog/articles.ts, ARTICLE_FOLDER_NAMES) only reads category
+  folders; a flat file under src/content/articles/ would never be indexed.
+  business_regulations is served under /business (lib/blog/categories.ts).
+constraints:
+  - >-
+    Every "(verify)" item in the draft was checked against a primary source and cited
+    in the article's Sources section: the Art. 2(2) scope categories, the Art. 14-15
+    takedown limits (24 hours, 4 hours for urgent requests) and the Art. 7 sanctions
+    are from the Permenkominfo 5/2020 text on peraturan.bpk.go.id; the 30 July 2022
+    blocks are from PTUN Jakarta ruling 424/G/TF/2022 on jdih.komdigi.go.id; the June
+    2025 and June 2026 enforcement is from Komdigi releases on portal.komdigi.go.id.
+  - >-
+    Domestic and foreign data requirements were rewritten from the regulation text
+    (Art. 3(4), 3(5), 4(2), 4(3)) in place of the draft's secondary-source list.
+    "Registration is free" is stated as "no fee set in Permenkominfo 5/2020", which is
+    what the text supports.
+  - >-
+    No price literal. The draft's "from USD 1,200" is a roundtable test price that
+    lane W1 keeps unlisted and noindex until the owner confirms it; publishing it on
+    an indexed article would bypass that gate and the price-SSOT rule.
+acceptance:
+  - >-
+    WHEN the app builds, THEN it exits 0. probe: cd apps/mouth && npm run build
+  - >-
+    WHEN the app lint runs, THEN it exits 0. probe: cd apps/mouth && npm run lint
+  - >-
+    WHEN the forbidden-phrase list is grepped against the article, THEN there are zero
+    hits. probe: grep -i -f <pattern file built from
+    skills/bali-zero-brand/voice/forbidden-phrases.md> on the article (exit 1)
+  - >-
+    WHEN the built app is served, THEN /business/pse-registration-indonesia returns
+    200, the sitemap lists it, and /api/blog/articles?category=business carries its
+    slug. probe: next start plus curl
+  - >-
+    WHEN the content integrity suites run, THEN they pass with the new file in the
+    corpus. probe: npx vitest --run src/content/*.test.ts
+pii_scan: clean


### PR DESCRIPTION
## What

A new English guide at `/business/pse-registration-indonesia`, built from Page 2 of the compliance-stack page-content draft. It lives in `apps/mouth/src/content/articles/business_regulations/pse-registration-indonesia.mdx`. The article loader (`lib/blog/articles.ts`, `ARTICLE_FOLDER_NAMES`) only reads category folders, so a flat file under `src/content/articles/` would never be indexed. `business_regulations` is served under `/business`. No registry file needs an update: the sitemap, the article API and `llms-full.txt` pick the file up from the folder.

## Verification of the draft's "(verify)" items (primary sources, all cited in the article)

| Claim | Source |
|---|---|
| Scope: Art. 2(2) groups (a) and (b)1-6, foreign scope in Art. 4(1) | Permenkominfo 5/2020 text, peraturan.bpk.go.id |
| Takedown limits: 24 hours (Art. 15(6)), 4 hours for urgent requests (Art. 15(8), Art. 14(3)) | same |
| Sanctions and normalisasi (Art. 7), TD-PSE and the public list (Art. 6) | same |
| 30 July 2022 blocks: PayPal, Yahoo, Epic Games, Steam, Dota, Counter Strike, Xandr.com, Origin | PTUN Jakarta 424/G/TF/2022, jdih.komdigi.go.id |
| 28 June 2025: eBay, KLM, PT Dunia Luxindo | Komdigi release 120/HM-KKD/06/2025, portal.komdigi.go.id |
| 26 June 2026: 25 operators, 57 systems, deadline 3 July, named list | Komdigi release of 1 July 2026, portal.komdigi.go.id |

All 9 source URLs returned HTTP 200 from curl on 2026-09-11. The domestic and foreign data rows were rewritten from Art. 3(4), 3(5), 4(2) and 4(3), replacing the draft's secondary-source list. "Free" is stated as "no fee set in Permenkominfo 5/2020", which is what the text supports.

**Left out on purpose:** the draft's "from USD 1,200" test price. Lane W1 keeps these prices unlisted and noindex until the owner confirms them, and the price-SSOT rule forbids literals on pages. The article says "fixed fee agreed before we start" instead.

## Checks run

- `npm run build` (apps/mouth): exit 0
- `npm run lint` (apps/mouth): exit 0, 0 errors (ESLint does not cover `.mdx`)
- `grep -i -f <62 patterns built from skills/bali-zero-brand/voice/forbidden-phrases.md> <article>`: exit 1, zero hits
- `python scripts/lint_content_reasoning_leak.py --path <article>`: exit 0
- `npx vitest --run` over the content integrity, cover image and MDX RSC suites: 49/49 passed
- `next start` on the build: `/business/pse-registration-indonesia` returned 200, `sitemap.xml` lists it, and `/api/blog/articles?category=business` carries the slug

Evidence: `evidence/2026-09/agent-nuzantara-mouth-pse-guide-article-3ebda666/brief.yml`. The computed floor is 1 (source none) and the brief declares Gear 2 per the lane contract, so this PR waits for the gate verdict.

Bites: consumer = a foreign platform's legal head reading the page; observation = the live URL https://balizero.com/business/pse-registration-indonesia returning 200 after Vercel deploy, checked by the imperator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
