### PR TITLE
feat(mouth): nuzantara.co.id Bahasa holding page and DNS runbook

### DIFF
--- a/apps/mouth/src/__tests__/middleware.test.ts
+++ b/apps/mouth/src/__tests__/middleware.test.ts
@@ -747,4 +747,57 @@ describe("Middleware - Multi-domain Routing", () => {
       });
     }
   });
+
+  // =======================================================================
+  // nuzantara.co.id → (nuzantara) route group at /nuzantara/*, same rewrite
+  // shape as tax.balizero.com → /tax-calendar/*.
+  // =======================================================================
+  describe("Nuzantara Domain (nuzantara.co.id)", () => {
+    const rewrittenPath = (res: Response) => {
+      const target = res.headers.get("x-middleware-rewrite");
+      return target ? new URL(target).pathname : null;
+    };
+
+    const cases: Array<[string, string, string]> = [
+      ["nuzantara.co.id", "/", "/nuzantara"],
+      ["www.nuzantara.co.id", "/", "/nuzantara"],
+      ["nuzantara.co.id", "/privasi", "/nuzantara/privasi"],
+      ["www.nuzantara.co.id", "/privasi", "/nuzantara/privasi"],
+      ["nuzantara.co.id", "/nuzantara", "/nuzantara"],
+      ["nuzantara.co.id", "/nuzantara/metode", "/nuzantara/metode"],
+      ["nuzantara.co.id", "/nuzantarax", "/nuzantara/nuzantarax"],
+    ];
+
+    for (const [host, from, to] of cases) {
+      it(`rewrites ${host}${from} → ${to} with noindex`, () => {
+        const res = proxy(createRequest(`https://${host}${from}`));
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get("location")).toBeNull();
+        expect(rewrittenPath(res)).toBe(to);
+        expect(res.headers.get("x-pathname")).toBe(from);
+        expect(res.headers.get("X-Robots-Tag")).toBe("noindex, nofollow");
+      });
+    }
+
+    it.each(["NUZANTARA.CO.ID:443", "nuzantara.co.id."])(
+      "normalizes host %s before matching",
+      (host) => {
+        const res = proxy(
+          new NextRequest("https://nuzantara.co.id/", { headers: { host } }),
+        );
+
+        expect(rewrittenPath(res)).toBe("/nuzantara");
+      },
+    );
+
+    it.each(["evilnuzantara.co.id", "nuzantara.co.id.evil.test"])(
+      "does not rewrite lookalike host %s",
+      (host) => {
+        const res = proxy(createRequest(`https://${host}/`));
+
+        expect(rewrittenPath(res)).toBeNull();
+      },
+    );
+  });
 });

--- a/apps/mouth/src/app/(nuzantara)/nuzantara/layout.tsx
+++ b/apps/mouth/src/app/(nuzantara)/nuzantara/layout.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+
+const DESCRIPTION =
+  "Kepatuhan usaha Anda, dikerjakan tim kami, dicek ulang oleh manusia.";
+
+// Served on nuzantara.co.id through the NUZANTARA_DOMAIN rewrite in proxy.ts.
+// Every field below that the root layout sets with Bali Zero copy is
+// overridden here, so the domestic brand does not inherit it.
+export const metadata: Metadata = {
+  title: { absolute: "Nuzantara" },
+  description: DESCRIPTION,
+  keywords: ["kepatuhan usaha", "LKPM", "pajak bulanan", "PSE"],
+  authors: [{ name: "Nuzantara" }],
+  creator: "Nuzantara",
+  publisher: "Nuzantara",
+  appleWebApp: { capable: true, title: "Nuzantara", statusBarStyle: "default" },
+  openGraph: {
+    type: "website",
+    locale: "id_ID",
+    url: "https://nuzantara.co.id",
+    title: "Nuzantara",
+    description: DESCRIPTION,
+    siteName: "Nuzantara",
+  },
+  twitter: { card: "summary", title: "Nuzantara", description: DESCRIPTION },
+  alternates: { canonical: "https://nuzantara.co.id" },
+  robots: { index: false, follow: false },
+};
+
+export default function NuzantaraLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div lang="id" className="min-h-screen flex flex-col">
+      {children}
+    </div>
+  );
+}

--- a/apps/mouth/src/app/(nuzantara)/nuzantara/page.tsx
+++ b/apps/mouth/src/app/(nuzantara)/nuzantara/page.tsx
@@ -1,0 +1,83 @@
+const PROMISE =
+  "Kepatuhan usaha Anda, dikerjakan tim kami, dicek ulang oleh manusia.";
+
+const SERVICES = [
+  {
+    name: "LKPM",
+    detail:
+      "Laporan Kegiatan Penanaman Modal disiapkan dan dilaporkan melalui OSS sesuai jadwal.",
+  },
+  {
+    name: "Pajak bulanan",
+    detail:
+      "SPT Masa PPh dan PPN dihitung, disiapkan, dan dilaporkan setiap bulan.",
+  },
+  {
+    name: "PSE",
+    detail:
+      "Pendaftaran Penyelenggara Sistem Elektronik lingkup privat untuk situs dan aplikasi usaha Anda.",
+  },
+];
+
+const WA_GREETING =
+  "Halo Nuzantara, saya ingin bertanya tentang kepatuhan usaha saya.";
+
+function whatsappHref(): string | null {
+  const digits = (process.env.NEXT_PUBLIC_NUZANTARA_WA ?? "").replace(
+    /\D/g,
+    "",
+  );
+  if (!digits) return null;
+  return `https://wa.me/${digits}?text=${encodeURIComponent(WA_GREETING)}`;
+}
+
+export default function NuzantaraPage() {
+  const waHref = whatsappHref();
+
+  return (
+    <>
+      <main className="mx-auto w-full max-w-2xl flex-1 px-6 py-20">
+        <h1 className="text-4xl font-bold tracking-tight">Nuzantara</h1>
+        <p className="mt-4 text-lg text-[var(--text-secondary)]">{PROMISE}</p>
+
+        <section className="mt-12" aria-labelledby="layanan">
+          <h2 id="layanan" className="text-xl font-semibold">
+            Apa yang kami kerjakan
+          </h2>
+          <ul className="mt-4 space-y-3">
+            {SERVICES.map((s) => (
+              <li key={s.name}>
+                <span className="font-semibold">{s.name}</span>: {s.detail}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="mt-12" aria-labelledby="kontak">
+          <h2 id="kontak" className="text-xl font-semibold">
+            Hubungi kami
+          </h2>
+          {waHref ? (
+            <a
+              href={waHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-block rounded-md bg-[var(--accent-whatsapp)] px-5 py-3 font-semibold text-[var(--accent-whatsapp-ink)]"
+            >
+              Chat lewat WhatsApp
+            </a>
+          ) : (
+            <p className="mt-4" data-placeholder="NEXT_PUBLIC_NUZANTARA_WA">
+              WhatsApp: {"<nomor WhatsApp>"}
+            </p>
+          )}
+        </section>
+      </main>
+
+      <footer className="mx-auto w-full max-w-2xl px-6 py-8 text-sm text-[var(--text-secondary)]">
+        <p>Nuzantara adalah layanan dari {"<nama PT>"}, sebuah PT PMA.</p>
+        <p className="mt-1">Bahasa Indonesia</p>
+      </footer>
+    </>
+  );
+}

--- a/apps/mouth/src/proxy.ts
+++ b/apps/mouth/src/proxy.ts
@@ -67,6 +67,7 @@ const MOBILE_DOMAIN = "mo.balizero.com";
 const ZANTARA_DOMAIN = "zantara.balizero.com";
 const VISA_DOMAIN = "visa.balizero.com";
 const TAX_DOMAIN = "tax.balizero.com";
+const NUZANTARA_DOMAIN = "nuzantara.co.id";
 const ASSESSMENT_DOMAIN = "subhi.balizero.com";
 // SSO subdomains: standalone apps on *.balizero.com that share auth via cookie.
 // mouth does not serve these hostnames directly (each is its own Vercel deploy
@@ -235,6 +236,7 @@ export function proxy(request: NextRequest) {
   );
   const isVisaDomain = matchesDomain(hostname, VISA_DOMAIN);
   const isTaxDomain = matchesDomain(hostname, TAX_DOMAIN);
+  const isNuzantaraDomain = matchesDomain(hostname, NUZANTARA_DOMAIN);
   const isPublicDomain = matchesDomain(hostname, PUBLIC_DOMAIN);
   const isAppDomain =
     matchesDomain(hostname, APP_DOMAIN) ||
@@ -351,6 +353,26 @@ export function proxy(request: NextRequest) {
     }
     const rewriteResponse = NextResponse.rewrite(rewriteUrl);
     rewriteResponse.headers.set("x-pathname", pathname);
+    return rewriteResponse;
+  }
+
+  // === NUZANTARA DOMAIN (nuzantara.co.id) ===
+  // Bahasa Indonesia holding page for the domestic brand, same shape as the
+  // TAX DOMAIN block: every path is rewritten under the (nuzantara) route
+  // group at /nuzantara/*. noindex until launch (docs/ops/nuzantara-co-id-dns-setup.md).
+  if (isNuzantaraDomain) {
+    const rewriteUrl = request.nextUrl.clone();
+    if (pathname === "/" || pathname === "") {
+      rewriteUrl.pathname = "/nuzantara";
+    } else if (
+      pathname !== "/nuzantara" &&
+      !pathname.startsWith("/nuzantara/")
+    ) {
+      rewriteUrl.pathname = `/nuzantara${pathname}`;
+    }
+    const rewriteResponse = NextResponse.rewrite(rewriteUrl);
+    rewriteResponse.headers.set("x-pathname", pathname);
+    rewriteResponse.headers.set("X-Robots-Tag", "noindex, nofollow");
     return rewriteResponse;
   }
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,0 +1,10 @@
+# docs/ops — operational runbooks and notes
+
+## DNS runbooks (manual Cloudflare + Vercel operator steps)
+
+- [tax-balizero-dns-setup.md](tax-balizero-dns-setup.md) — `tax.balizero.com` → mouth `(tax-calendar)`
+- [nuzantara-co-id-dns-setup.md](nuzantara-co-id-dns-setup.md) — `nuzantara.co.id` → mouth `(nuzantara)` holding page, plus the PSE registration gate before launch
+
+## 2026-04-30 renaissance PR notes
+
+- [2026-04-30-renaissance-summary.md](2026-04-30-renaissance-summary.md) — summary; the other `2026-04-30-*` files are the per-PR notes it links.

--- a/docs/ops/nuzantara-co-id-dns-setup.md
+++ b/docs/ops/nuzantara-co-id-dns-setup.md
@@ -1,0 +1,111 @@
+# DNS setup nuzantara.co.id — Vercel domain + 2 Cloudflare records (manual)
+
+**Status at 2026-09-11:**
+
+- Domain: `nuzantara.co.id` registered 2025-09-26, nameservers on Cloudflare, zone has **no records**.
+- Application code: ready. `NUZANTARA_DOMAIN` in `apps/mouth/src/proxy.ts` rewrites every
+  path on `nuzantara.co.id` and `www.nuzantara.co.id` to the `(nuzantara)` route group at
+  `/nuzantara/*`, with `X-Robots-Tag: noindex, nofollow`. The page itself also declares
+  `robots: { index: false, follow: false }`.
+- Operator action (owner): steps 1 and 2 below. Nothing here is automated; the available
+  `CF_API_TOKEN` is `Zone:Read` only (see `tax-balizero-dns-setup.md`).
+- Launch is gated: see "Before launch" at the end. Adding DNS makes the holding page
+  reachable; it does not make it a launch.
+
+## Step 1 — Add the domain to the Vercel project `mouth`
+
+Vercel dashboard → project `mouth` → Settings → Domains → **Add**:
+
+1. `nuzantara.co.id` (primary).
+2. `www.nuzantara.co.id`, set to **redirect to `nuzantara.co.id`** (308).
+
+Equivalent API call (token from the operator env, never pasted into docs or chat):
+
+```bash
+PROJECT=prj_LcXb9ZgeUvWpxaIM9K47tQYPeuee
+TEAM=team_jX3mEbUemBs0Zy4i8aFYZsjS
+curl -s -X POST -H "Authorization: Bearer $VERCEL_TOKEN" -H "Content-Type: application/json" \
+  "https://api.vercel.com/v10/projects/$PROJECT/domains?teamId=$TEAM" \
+  -d '{"name":"nuzantara.co.id"}'
+curl -s -X POST -H "Authorization: Bearer $VERCEL_TOKEN" -H "Content-Type: application/json" \
+  "https://api.vercel.com/v10/projects/$PROJECT/domains?teamId=$TEAM" \
+  -d '{"name":"www.nuzantara.co.id","redirect":"nuzantara.co.id","redirectStatusCode":308}'
+```
+
+After adding, the Domains panel shows the exact DNS values Vercel expects for this project.
+**If they differ from the table below, use the values from the panel.** If the panel asks for a
+`_vercel` TXT verification record, add it too, copying the value verbatim from the panel (it is
+issued per domain; do not reuse the `tax.balizero.com` value).
+
+## Step 2 — The 2 records to add on Cloudflare
+
+dash.cloudflare.com → zone `nuzantara.co.id` → DNS → Records → **Add record**.
+
+### Record 1 — A (apex)
+
+| Field        | Value                                                           |
+| ------------ | --------------------------------------------------------------- |
+| Type         | `A`                                                             |
+| Name         | `@` (`nuzantara.co.id`)                                         |
+| IPv4 address | `76.76.21.21`                                                   |
+| TTL          | Auto                                                            |
+| Proxy        | **DNS only** (grey cloud, not orange — required for Vercel SSL) |
+
+### Record 2 — CNAME (www)
+
+| Field  | Value                                                           |
+| ------ | --------------------------------------------------------------- |
+| Type   | `CNAME`                                                         |
+| Name   | `www`                                                           |
+| Target | `cname.vercel-dns.com`                                          |
+| TTL    | Auto                                                            |
+| Proxy  | **DNS only** (grey cloud, not orange — required for Vercel SSL) |
+
+## Verify after creation
+
+Wait about a minute for propagation, then:
+
+```bash
+dig +short nuzantara.co.id
+# expected: 76.76.21.21 (or the value the Vercel panel gave)
+dig +short www.nuzantara.co.id
+# expected: cname.vercel-dns.com. followed by Vercel IPs
+
+curl -s -o /dev/null -w "%{http_code}\n" https://nuzantara.co.id/
+# expected: 200 (proxy rewrite → /nuzantara)
+curl -sI https://nuzantara.co.id/ | grep -i x-robots-tag
+# expected: x-robots-tag: noindex, nofollow
+curl -s https://nuzantara.co.id/ | grep -o "dicek ulang oleh manusia"
+# expected: one match (the page promise)
+```
+
+## Before launch (not a DNS step, but it blocks launch)
+
+- **PSE registration.** `nuzantara.co.id` is an electronic system serving Indonesian users, so it
+  must be registered as a domestic private-scope PSE (PSE Lingkup Privat) through OSS-RBA
+  (`oss.go.id`) under the NIB of the PT PMA that operates it, **before** the page is launched
+  (indexed, linked, or promoted). Per the 2026-09-11 board (verbale giro 3), this registration
+  is not started before day 30 of the Bali Zero pilot.
+- Replace the placeholders on the page: `<nama PT>` in the footer (legal name of the PT PMA)
+  and the WhatsApp number via the `NEXT_PUBLIC_NUZANTARA_WA` env var on the Vercel project
+  (build-time variable; redeploy after setting it).
+- Flip `robots` in `apps/mouth/src/app/(nuzantara)/nuzantara/layout.tsx` and the
+  `X-Robots-Tag` in the `NUZANTARA_DOMAIN` block of `proxy.ts` only at launch, in one PR.
+
+## Rollback
+
+1. Remove the `NUZANTARA_DOMAIN` block from `apps/mouth/src/proxy.ts` and delete
+   `apps/mouth/src/app/(nuzantara)/`.
+2. Remove the domain from Vercel:
+   ```bash
+   curl -X DELETE -H "Authorization: Bearer $VERCEL_TOKEN" \
+     "https://api.vercel.com/v9/projects/prj_LcXb9ZgeUvWpxaIM9K47tQYPeuee/domains/nuzantara.co.id?teamId=team_jX3mEbUemBs0Zy4i8aFYZsjS"
+   ```
+3. Delete the two Cloudflare records.
+
+## Technical notes
+
+- Vercel project ID mouth: `prj_LcXb9ZgeUvWpxaIM9K47tQYPeuee`; team ID: `team_jX3mEbUemBs0Zy4i8aFYZsjS`
+  (same as `tax-balizero-dns-setup.md`).
+- The route also answers at `balizero.com/nuzantara` (same as `balizero.com/tax-calendar`);
+  it is noindex there too and is not listed in `apps/mouth/src/app/sitemap.ts`.

--- a/evidence/2026-09/agent-nuzantara-mouth-nuzantara-co-id-holding-25e12a9f/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-mouth-nuzantara-co-id-holding-25e12a9f/brief.yml
@@ -1,0 +1,52 @@
+task_id: nuzantara-co-id-holding
+gear: 1
+gear_reason: >-
+  Computed, not chosen. scripts/evidence_pack_lint.py --print-floor over this branch's own
+  changed-file set (scripts/ci/hotzone_changed_files.sh, merge-base be45266252) and its
+  numstat returns 1, --print-floor-source returns `none`: no HOTZONE_PATTERNS hit
+  (apps/mouth/src/proxy.ts is not a hot-zone path) and 319 net lines over 6 files stay under
+  the size thresholds. The lane design allowed 2 or 3; a declared gear above the floor on a
+  Gear-1-shaped diff is what compute_ceiling exists to flag, so the brief follows the floor.
+l_level: L1
+gate_class: opus
+objective: >-
+  Wire nuzantara.co.id into apps/mouth the way tax.balizero.com is wired (lane F of the
+  2026-09-11 compliance-stack build). A NUZANTARA_DOMAIN constant in proxy.ts rewrites every
+  path on nuzantara.co.id and www.nuzantara.co.id to the (nuzantara) route group at
+  /nuzantara/*, with X-Robots-Tag noindex, nofollow. The group layout (lang="id") overrides
+  every Bali Zero metadata field the root layout sets and declares robots index:false
+  follow:false; the one Bahasa Indonesia page carries the name, the promise line, three
+  services without prices, an env-driven WhatsApp link with a visible placeholder, and the
+  <nama PT> PT PMA footer line. docs/ops/nuzantara-co-id-dns-setup.md is the operator runbook
+  (Vercel domain add, the A and CNAME records on Cloudflare, the OSS-RBA PSE gate), linked
+  from the new docs/ops/README.md index.
+constraints:
+  - >-
+    No price, no "AI" wording, no taboo phrase from skills/bali-zero-brand/voice/forbidden-phrases.md
+    in the page or layout copy. No invented WhatsApp number: NEXT_PUBLIC_NUZANTARA_WA unset
+    renders the literal placeholder "<nomor WhatsApp>".
+  - >-
+    Not touched: fly.toml, .env*, zantara_core.py, lockfiles, sitemap.ts (a static list that
+    never auto-lists routes), robots.ts (adding the host there would block the crawl and hide
+    the noindex, the trap robots.ts's own comment describes).
+  - >-
+    Declared residual, not fixed: the root layout's hardcoded <head> (llms/AI-sitemap/AI-plugin
+    link titles, the ai-content-declaration meta key, Bali Zero JSON-LD) still renders on every
+    route including this one. Removing it per host needs a host-aware root layout, which is a
+    separate concern. The visible body has zero "AI" tokens (measured on the built HTML).
+acceptance:
+  - >-
+    WHEN a request arrives with Host nuzantara.co.id or www.nuzantara.co.id, THEN proxy()
+    rewrites it under /nuzantara with X-Robots-Tag noindex, nofollow; lookalike hosts are not
+    rewritten. probe: cd apps/mouth && npx vitest run src/__tests__/middleware.test.ts
+  - >-
+    WHEN apps/mouth builds, THEN /nuzantara is prerendered static with <title>Nuzantara</title>,
+    meta robots noindex, nofollow and canonical https://nuzantara.co.id.
+    probe: cd apps/mouth && npm run build && grep -o '<meta name="robots"[^>]*>' .next/server/app/nuzantara.html
+  - >-
+    WHEN the page and layout copy are grepped for AI, THEN zero hits.
+    probe: grep -i -E "\bAI\b" "apps/mouth/src/app/(nuzantara)/nuzantara/page.tsx" "apps/mouth/src/app/(nuzantara)/nuzantara/layout.tsx"
+  - >-
+    WHEN docs/ops is opened, THEN the index links the runbook.
+    probe: grep -n "nuzantara-co-id-dns-setup.md" docs/ops/README.md
+pii_scan: clean


### PR DESCRIPTION
## What

Lane F of the 2026-09-11 compliance-stack build. Wires `nuzantara.co.id` into `apps/mouth` the way `tax.balizero.com` is wired.

- `apps/mouth/src/proxy.ts`: `NUZANTARA_DOMAIN` constant + rewrite block (same shape as TAX DOMAIN). Apex and `www.` map every path to `/nuzantara/*`, with `X-Robots-Tag: noindex, nofollow`.
- `apps/mouth/src/app/(nuzantara)/nuzantara/layout.tsx`: own layout (`lang="id"` wrapper), metadata that overrides every Bali Zero field the root layout sets (title `absolute`, description, OG, twitter, keywords, canonical `https://nuzantara.co.id`), `robots: { index: false, follow: false }`.
- `apps/mouth/src/app/(nuzantara)/nuzantara/page.tsx`: one Bahasa Indonesia page. Name, the promise line, three services (LKPM, pajak bulanan, PSE) with no prices, a WhatsApp link from `NEXT_PUBLIC_NUZANTARA_WA` (visible `<nomor WhatsApp>` placeholder when unset, no invented number), footer `<nama PT>` PT PMA line + "Bahasa Indonesia".
- `apps/mouth/src/__tests__/middleware.test.ts`: 11 new cases. Apex/www rewrites, subpaths, already-prefixed paths, port/trailing-dot normalisation, lookalike hosts not rewritten.
- `docs/ops/nuzantara-co-id-dns-setup.md`: Vercel domain add, the A (apex) + CNAME (www) Cloudflare records (operator action), verification curls, rollback, and the OSS-RBA domestic PSE registration gate before launch.
- `docs/ops/README.md`: **new**. `docs/ops` had no index, and `tax-balizero-dns-setup.md` was linked from nowhere. The new index links both DNS runbooks.

`sitemap.ts` is a static list and never auto-lists routes, so it is untouched. `robots.ts` is untouched on purpose: adding the host there blocks the crawl and hides the noindex (see its own comment).

## Verification (Pro, this worktree)

| Check | Command | Exit |
|---|---|---|
| Build | `cd apps/mouth && npm run build` (`/nuzantara` prerendered static) | 0 |
| Proxy tests | `npx vitest run src/__tests__/middleware.test.ts` (92 passed) | 0 |
| Guard tests | `npx vitest run src/app/{metadata-title-template,sitemap,whatsapp-ink.guard,robots}.test.ts` (46 passed) | 0 |
| Lint | `npx eslint` on the 4 touched TS/TSX files | 0 |
| AI grep | `grep -i -E "\bAI\b"` on page + layout: 0 hits | 1 (no match) |
| Docs link | `grep -n nuzantara-co-id-dns-setup.md docs/ops/README.md` → line 6 | 0 |

Built HTML: `<title>Nuzantara</title>`, `<meta name="robots" content="noindex, nofollow"/>`, canonical `https://nuzantara.co.id`, visible body 0 "AI" tokens.

**Declared residual:** the root layout's hardcoded `<head>` (llms / "AI Sitemap" / "AI Plugin" link titles, the `ai-content-declaration` meta key, Bali Zero JSON-LD) and `<html lang="en">` still render on every route, this one included. A nested layout cannot remove them. Doing it per host needs a host-aware root layout, which is a separate concern.

Evidence: `evidence/2026-09/agent-nuzantara-mouth-nuzantara-co-id-holding-25e12a9f/brief.yml`. Gear 1 is the computed floor (`--print-floor` = 1, source `none`, no hot-zone path, 6 code/doc files).

Bites: consumer = the owner adding `nuzantara.co.id` in Vercel (project mouth) and the two records in Cloudflare per `docs/ops/nuzantara-co-id-dns-setup.md`; observation = `curl -s -H "Host: nuzantara.co.id" <vercel-preview-url>/ | grep -o "dicek ulang oleh manusia"` on the Vercel preview, pasted post-deploy by the imperator. If the preview edge refuses the foreign Host, the fallback is `curl -s <vercel-preview-url>/nuzantara`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
