### PR TITLE
fix(evaluator): surface backend failure reason when ingest-full message is null

### DIFF
--- a/apps/evaluator/nlm_deep_research/peraturan_ingestion_trigger.py
+++ b/apps/evaluator/nlm_deep_research/peraturan_ingestion_trigger.py
@@ -449,8 +449,12 @@ def _ingest_to_backend(pdf_path: Path, row: RegulationRow) -> dict:
             result = poll.json()
 
         if result.get("status") in ("failed", "error"):
+            status = str(result.get("status") or "")
+            message = str(result.get("message") or "")[:200]
+            error = str(result.get("error") or "")[:200]
             raise RuntimeError(
-                f"ingest-full job {job_id} failed: {result.get('message', '')[:200]}"
+                f"ingest-full job {job_id} failed: status={status} "
+                f"message={message} error={error}"
             )
 
     # Intel Lake Wave 4 (2026-05-12): enqueue regulation observation to

--- a/apps/evaluator/tests/test_peraturan_ingestion_trigger.py
+++ b/apps/evaluator/tests/test_peraturan_ingestion_trigger.py
@@ -1,0 +1,87 @@
+"""
+Regression test for _ingest_to_backend swallowing the real failure reason
+when the backend's terminal-state response carries message=None.
+
+Live incident 2026-09-10 19:00Z: ingest-full job 88a120aa failed with
+message=null and error="pending: ...", and the feeder raised a bare
+TypeError ('NoneType' object is not subscriptable) instead of surfacing
+status/message/error to the caller.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "nlm_deep_research"))
+
+import peraturan_ingestion_trigger as trigger  # noqa: E402
+
+
+def _row(**overrides) -> trigger.RegulationRow:
+    defaults = dict(
+        row_index=2,
+        nome="PMK Nomor 43 Tahun 2026",
+        tipo="PMK",
+        categoria="Tax",
+        anno="2026",
+        sintesi_it="",
+        categoria_en="",
+        sintesi_en="",
+        status="PENDING",
+        url="https://peraturan.go.id/fake.pdf",
+        drive_file_id="",
+        timestamp="",
+    )
+    defaults.update(overrides)
+    return trigger.RegulationRow(**defaults)
+
+
+def _mock_client(terminal_payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = terminal_payload
+
+    client = MagicMock()
+    client.post.return_value = response
+    client.__enter__.return_value = client
+    client.__exit__.return_value = False
+    return client
+
+
+def test_null_message_surfaces_status_and_error_without_typeerror():
+    payload = {
+        "job_id": "j1",
+        "status": "failed",
+        "message": None,
+        "error": "pending: ",
+    }
+    with patch.object(trigger.httpx, "Client", return_value=_mock_client(payload)):
+        try:
+            trigger._ingest_to_backend(Path("/tmp/fake.pdf"), _row())
+        except TypeError as exc:
+            raise AssertionError(f"TypeError escaped, message=None not handled: {exc}") from exc
+        except RuntimeError as exc:
+            text = str(exc)
+            assert "j1" in text
+            assert "failed" in text
+            assert "pending" in text
+        else:
+            raise AssertionError("expected RuntimeError, none was raised")
+
+
+def test_string_message_still_surfaced():
+    payload = {
+        "job_id": "j2",
+        "status": "error",
+        "message": "boom",
+        "error": None,
+    }
+    with patch.object(trigger.httpx, "Client", return_value=_mock_client(payload)):
+        try:
+            trigger._ingest_to_backend(Path("/tmp/fake.pdf"), _row())
+        except RuntimeError as exc:
+            assert "boom" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError, none was raised")

--- a/evidence/2026-09/agent-nuzantara-backend-rag-feeder-none-message-6f89b929/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-feeder-none-message-6f89b929/brief.yml
@@ -1,0 +1,38 @@
+task: >-
+  Fix a live bug in apps/evaluator/nlm_deep_research/peraturan_ingestion_trigger.py's
+  _ingest_to_backend: when the backend's terminal ingest-full response carries
+  message=null, `result.get("message", "")[:200]` returns None and `None[:200]`
+  raises TypeError, hiding the real failure reason and job id. Observed live
+  2026-09-10 19:00Z on job 88a120aa (status=failed, message=null,
+  error="pending: "). Coerce message/status/error to str before slicing and
+  include all three in the RuntimeError text.
+lane: backend-rag/feeder-none-message
+machine: Pro
+date: 2026-09-11
+
+gear: 1
+gear_reason: >-
+  Deterministic floor from `scripts/evidence_pack_lint.py --print-floor` against
+  origin/main...HEAD: one production file touched (peraturan_ingestion_trigger.py,
+  6 lines changed) plus one new test file, no hot-zone path, well under the
+  Gear-2 size threshold.
+
+appetite:
+  wall_clock_hours: 1
+  adversarial_rounds: 0
+
+acceptance:
+  A1: >-
+    A terminal ingest-full response with status=failed and message=null no longer
+    raises TypeError; the RuntimeError text includes the job id, status and error.
+    probe: /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -m pytest apps/evaluator/tests/test_peraturan_ingestion_trigger.py -p no:cacheprovider
+  A2: >-
+    A terminal ingest-full response with a normal string message still surfaces
+    that message in the RuntimeError text (no regression on the happy-failure path).
+    probe: /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -m pytest apps/evaluator/tests/test_peraturan_ingestion_trigger.py::test_string_message_still_surfaced -p no:cacheprovider
+
+out_of_scope: >-
+  The intel_lake_outbox best-effort enqueue block (try/except around the
+  /Users/nuzantara/scripts import) — untouched per instruction. Any other
+  .get("message"/'message' slice pattern elsewhere in the repo; grep found only
+  this one occurrence in this file.


### PR DESCRIPTION
## Summary
- `_ingest_to_backend`'s terminal-failure branch did `result.get("message", "")[:200]` — when the backend returns `message: null`, `.get` returns `None` and `None[:200]` raises `TypeError`, hiding the real failure and the job id.
- Coerce `message`/`status`/`error` with `str(x or "")` before slicing, and include all three in the `RuntimeError` text so the caller (and logs) see status, message and error instead of a bare TypeError.
- Live incident 2026-09-10 19:00Z: ingest-full job `88a120aa` failed with `message=null` and `error="pending: "`; the feeder raised `TypeError: 'NoneType' object is not subscriptable` instead of surfacing that.

## Adversarial review
- Only touches the one `.get("message", ...)` slice in this file (grep confirmed no sibling occurrences); scope stayed to the reported bug, no refactor.
- The `intel_lake_outbox` enqueue try/except block right below was left untouched per instruction even though it also does unguarded dict access — out of scope, flagged in the evidence brief's `out_of_scope`.
- Test mocks `httpx.Client` at module level rather than hitting a real backend, so it can't catch a real-world shape drift in the JSON payload (e.g. a differently-cased key) — accepted risk, matches the existing test style in this repo for this module (none existed before).

## Test plan
- [x] Red: test run against unfixed code reproduces the exact live `TypeError: 'NoneType' object is not subscriptable`.
- [x] Green: same test passes after the fix, plus a mirror case with a normal string `message` to guard against regression on the happy-failure path.
- [x] Evidence pack floor recomputed post-commit via `scripts/evidence_pack_lint.py --print-floor` = 1, matches declared gear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
