### PR TITLE
fix(portal): re-uploading a removed vault file is not a duplicate, and a real duplicate is 409 not 404

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -29,6 +29,7 @@ from backend.app.utils.logging_utils import get_logger, sanitize_for_log
 from backend.core.cache import invalidate_cache
 from backend.services.portal.upload_validation import (
     PORTAL_UPLOAD_MIME_TYPES,
+    DuplicateDocumentError,
 )
 from backend.services.portal.upload_validation import (
     read_upload_bounded as _read_upload_bounded,
@@ -668,6 +669,17 @@ async def upload_document(
             "message": "Document uploaded successfully",
             "data": document,
         }
+    except DuplicateDocumentError as e:
+        # Same file name, same client, within the last hour: the client IS
+        # found — say what actually happened, as a conflict, not a 404.
+        logger.info(f"Duplicate upload rejected for client {sanitize_for_log(client['client_id'])}: {sanitize_for_log(e)}")
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "A file with this name was uploaded less than an hour ago. "
+                "Rename the file or wait before uploading it again."
+            ),
+        ) from e
     except ValueError as e:
         # Client soft-deleted / gone -> not-found, not a 500 (see get_dashboard).
         logger.warning(f"Client not found in upload_document for client {sanitize_for_log(client['client_id'])}: {sanitize_for_log(e)}")

--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -39,6 +39,7 @@ from backend.services.portal.document_processing import (
 )
 from backend.services.portal.qa_document_sink import QADocumentSinkClient
 from backend.services.portal.qa_support_mail_sink import QASupportMailSinkClient
+from backend.services.portal.upload_validation import DuplicateDocumentError
 
 logger = get_logger(__name__)
 
@@ -561,13 +562,18 @@ class PortalDocumentsMixin:
         file_name = self._sanitize_filename(file_name)
 
         async with self.pool.acquire() as conn:
-            # Check for duplicate file (same hash, same client, last 1 hour)
+            # Check for duplicate file (same name, same client, last 1 hour).
+            # Soft-deleted rows are NOT duplicates: a client who removes a file
+            # from the vault and uploads it again is doing the one thing the
+            # Remove button invites — before 2026-09-11 that re-upload was
+            # rejected here and surfaced as 404 "Client not found".
             duplicate = await conn.fetchrow(
                 """
                 SELECT id, file_name, created_at
                 FROM documents
                 WHERE client_id = $1
                 AND file_name LIKE $2
+                AND deleted_at IS NULL
                 AND created_at > NOW() - INTERVAL '1 hour'
                 ORDER BY created_at DESC
                 LIMIT 1
@@ -579,7 +585,9 @@ class PortalDocumentsMixin:
                 logger.info(
                     f"Duplicate file detected: {file_name} uploaded at {duplicate['created_at']}",
                 )
-                raise ValueError(f"File already uploaded recently at {duplicate['created_at']}")
+                raise DuplicateDocumentError(
+                    f"File already uploaded recently at {duplicate['created_at']}"
+                )
 
             # Verify practice belongs to client if provided
             if practice_id:

--- a/apps/backend-rag/backend/services/portal/upload_validation.py
+++ b/apps/backend-rag/backend/services/portal/upload_validation.py
@@ -100,6 +100,18 @@ _DOCX_FORBIDDEN_NAMES: Final = frozenset(
 )
 
 
+class DuplicateDocumentError(ValueError):
+    """The client already has a live document with this file name, uploaded
+    within the duplicate window.
+
+    A ``ValueError`` subclass so every existing ``except ValueError`` around
+    ``upload_document`` keeps working; the router catches THIS type first and
+    answers 409 with the reason, instead of the 404 "Client not found" that
+    the generic ``ValueError`` branch produces for every other ``ValueError``
+    (the client is very much found).
+    """
+
+
 class AsyncUploadReader(Protocol):
     """Minimal async interface required by the bounded upload reader."""
 

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -10,6 +10,7 @@ import pytest
 
 from backend.services.pii.violation_store import hash_subject
 from backend.services.portal.portal_service import PortalService
+from backend.services.portal.upload_validation import DuplicateDocumentError
 
 
 class _AsyncCtx:
@@ -375,7 +376,7 @@ async def test_upload_document_rejects_recent_duplicate() -> None:
         }
     )
 
-    with pytest.raises(ValueError, match="File already uploaded recently"):
+    with pytest.raises(DuplicateDocumentError, match="File already uploaded recently"):
         await service.upload_document(
             client_id=1,
             file_content=b"%PDF-1.4 clean passport",
@@ -386,6 +387,40 @@ async def test_upload_document_rejects_recent_duplicate() -> None:
         )
 
     assert mock_conn.fetchrow.await_count == 1
+    # The typed error is still a ValueError: every pre-existing
+    # `except ValueError` around upload_document keeps its behaviour.
+    assert issubclass(DuplicateDocumentError, ValueError)
+
+
+@pytest.mark.asyncio
+async def test_upload_document_duplicate_check_ignores_soft_deleted_rows() -> None:
+    """Re-uploading a file the client just REMOVED must not be a duplicate.
+
+    Born 2026-09-11 on my.balizero.com: upload -> Remove -> upload again of
+    the same file came back 404 "Client not found". The duplicate query
+    matched the soft-deleted row (same name, < 1 hour), raised ValueError,
+    and the router's generic ValueError branch renamed it. The predicate
+    must exclude `deleted_at IS NOT NULL` rows, and it must be the FIRST
+    fetchrow (the duplicate check runs before the practice/client lookups).
+    """
+    service, mock_conn = _make_service_with_fetchrow(row=None)
+    # duplicate check -> None, client lookup -> None (stops there, no Drive)
+    mock_conn.fetchrow.side_effect = [None, None]
+
+    with pytest.raises(ValueError, match="Client 1 not found"):
+        await service.upload_document(
+            client_id=1,
+            file_content=b"%PDF-1.4 clean passport",
+            file_name="passport.pdf",
+            document_type="passport",
+            mime_type="application/pdf",
+            current_user={"client_id": 1, "email": "client@example.com"},
+        )
+
+    duplicate_sql = mock_conn.fetchrow.await_args_list[0].args[0]
+    assert "FROM documents" in duplicate_sql
+    assert "deleted_at IS NULL" in duplicate_sql
+    assert "INTERVAL '1 hour'" in duplicate_sql
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal.py
@@ -335,6 +335,47 @@ class TestDocuments:
         assert data["success"] is True
         assert data["message"] == "Document uploaded successfully"
 
+    def test_upload_document_duplicate_is_409_not_client_not_found(
+        self, client, mock_portal_service
+    ):
+        """A recent same-name upload is a conflict the client can act on.
+
+        Before 2026-09-11 DuplicateDocumentError was a plain ValueError and
+        fell into the `except ValueError` branch below it, which answers
+        404 "Client not found" — false (the client exists) and unactionable
+        (the vault shows "Upload failed (404)"). The typed error must be
+        caught FIRST and answered 409 with the reason.
+        """
+        from backend.services.portal.upload_validation import DuplicateDocumentError
+
+        mock_portal_service.upload_document.side_effect = DuplicateDocumentError(
+            "File already uploaded recently at 2026-09-11 02:53:18+00:00"
+        )
+
+        response = client.post(
+            "/api/portal/documents/upload",
+            data={"document_type": "passport"},
+            files={"file": ("passport.pdf", _synthetic_pdf(), "application/pdf")},
+        )
+
+        assert response.status_code == 409
+        detail = response.json()["detail"]
+        assert "less than an hour ago" in detail
+        assert "Client not found" not in detail
+
+    def test_upload_document_other_value_error_still_404(self, client, mock_portal_service):
+        """The generic ValueError branch is untouched: a gone client is still 404."""
+        mock_portal_service.upload_document.side_effect = ValueError("Client 42 not found")
+
+        response = client.post(
+            "/api/portal/documents/upload",
+            data={"document_type": "passport"},
+            files={"file": ("passport.pdf", _synthetic_pdf(), "application/pdf")},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Client not found"
+
     def test_download_document_success_uses_portal_proxy(self, client, mock_portal_service):
         """Download returns bytes through the portal without exposing Drive URLs."""
         mock_portal_service.download_document.return_value = {
@@ -475,9 +516,7 @@ class TestMessages:
         mock_portal_service.send_message.assert_awaited_once()
         assert mock_portal_service.send_message.await_args.kwargs["practice_id"] == 603
 
-    def test_send_message_client_not_found_returns_404_not_500(
-        self, client, mock_portal_service
-    ):
+    def test_send_message_client_not_found_returns_404_not_500(self, client, mock_portal_service):
         """DEFECT 1: if the portal account is linked to a soft-deleted
         client, send_message raises ValueError('Client X not found') —
         same not-found shape as get_dashboard (BUG C) — and must surface


### PR DESCRIPTION
## What broke, live

my.balizero.com, client vault, 2026-09-11: upload `P2_vault_test.pdf` → Remove → upload the same file again → **404 "Client not found"** (`correlation_id c4abd501…`, and again `6077aab3…` on retry). The vault showed "Upload failed (404)". The client row was live (`clients.id=12400`, `deleted_at IS NULL`, `status=active`).

## Cause, two layers

1. `PortalService.upload_document`'s duplicate check (same file name, same client, last hour) did not exclude soft-deleted rows, so the just-removed document (`documents.id=19450`, `deleted_at` set) matched and the re-upload was rejected.
2. The rejection was a plain `ValueError`, and the router's `except ValueError` branch in `upload_document` exists for "client soft-deleted / gone" — so it renamed the duplicate into 404 "Client not found". Every other `ValueError` from the service (practice not accessible, …) gets the same wrong name; this PR fixes the one that bit and leaves the pattern visible in the code comment.

## Fix

- duplicate query adds `AND deleted_at IS NULL` — a removed file is not a duplicate of itself.
- the rejection is a typed `DuplicateDocumentError(ValueError)` in `services/portal/upload_validation.py`; subclassing keeps every pre-existing `except ValueError` behaving as before (the mixin test that used `pytest.raises(ValueError)` still passes and now asserts the subclass relation).
- the router catches it FIRST and answers **409** with an actionable detail ("A file with this name was uploaded less than an hour ago. Rename the file or wait before uploading it again."). The generic 404 branch is untouched, and a test pins that.

The frontend hook `useVaultUpload` shows `Upload failed (<status>)` and ignores `detail` for non-2xx — a client will see "Upload failed (409)" on a true duplicate. Surfacing `detail` for 4xx is a mouth change and a separate PR.

## Tests

Added: `test_upload_document_duplicate_check_ignores_soft_deleted_rows`, `test_upload_document_duplicate_is_409_not_client_not_found`, `test_upload_document_other_value_error_still_404`; hardened `test_upload_document_rejects_recent_duplicate`.

Falsification — the three new/changed tests run against `origin/main`'s `documents.py` + `portal.py` (files swapped in, committed cure restored after):

```
3 failed in 2.52s
```

On this branch, `test_documents_mixin.py` + `test_portal.py` + `test_data_invariant_tripwires.py` (upload/documents selection): `78 passed, 27 deselected in 8.72s`. The Invariant 7 SQL tripwire still passes on the edited `documents` query (`deleted_at` is a live column).

Bites: CONSUMER is `POST /api/portal/documents/upload` on my.balizero.com. Observation to make after the deploy that this merge triggers: on client 12400, upload `P2_vault_test.pdf` → Remove → upload the same file again returns **200** and the document is listed; uploading it a second time without removing returns **409** with the detail above, not 404. Recorded in this PR's thread once observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vV3hvzrWmVMEGSoe1YUZc
