### PR TITLE
fix(vercel-deploy): promote a READY build of a main commit that INCLUDES the target (merge-queue batches)

### DIFF
--- a/scripts/tests/test_vercel_prod_deploy_promote_descendant.py
+++ b/scripts/tests/test_vercel_prod_deploy_promote_descendant.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Corpus for `vercel_prod_deploy._ready_deployment_including` — the merge-queue batch case.
+
+WHY THIS EXISTS
+---------------
+2026-09-11, 03:13-03:45 WITA: the GitHub merge queue landed #6136 + #6134 + #6139 in ONE push,
+so Vercel built only the batch HEAD (a docs commit) and the newest bundle-relevant commit never
+had a build of its own. `_ready_deployment_for` (exact sha) found nothing; the --promote-only
+fallback walks OLDER bundle-relevant commits and found nothing either. Mini's autopromote organ
+exited 3 every 120s while four READY builds that all CONTAINED the cure sat STAGED, and
+production served a 35-minute-old build until a human promoted one of them.
+
+The rule is the sentinel's: production must INCLUDE the target, not EQUAL it. Guilt: the
+selector finds the newest READY build on main that descends from the target. Innocence: it
+never offers a build that is not on origin/main, one that does not contain the target, a
+non-READY one, or the target's own build (that is `_ready_deployment_for`'s job).
+
+No network, no git: `_api` and `_git` are replaced per-case.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest.mock
+
+import pytest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+vpd = pytest.importorskip("vercel_prod_deploy")
+
+TARGET = "8a2c49cfbe96499ccbbb4d89d020e2b3b8f0a396"   # newest bundle-relevant, never built
+BATCH_HEAD = "6fef72cd75ccaf38041d67b06ef7bc4cc40f9b1a"  # docs commit that closed the batch
+LATER = "b7fdaf7eabea0b776c566594b7638959f1b97e66"      # a later main commit, also built
+OLDER = "70546e5d9628be1f6f57fe71adc6ba9b6744fc42"      # what production served
+STRAY = "b82d44e3bb000000000000000000000000000000"      # a branch build, not on main
+
+# ancestry as git would answer it: (ancestor, descendant) pairs that are TRUE
+_ANCESTRY = {
+    (OLDER, TARGET), (OLDER, BATCH_HEAD), (OLDER, LATER),
+    (TARGET, BATCH_HEAD), (TARGET, LATER), (BATCH_HEAD, LATER),
+    (OLDER, "origin/main"), (TARGET, "origin/main"), (BATCH_HEAD, "origin/main"), (LATER, "origin/main"),
+}
+
+
+def _fake_git(*args):
+    if args[:2] == ("merge-base", "--is-ancestor"):
+        return "" if (args[2], args[3]) in _ANCESTRY else None
+    raise AssertionError(f"unexpected git call {args}")
+
+
+def _dep(uid, state, substate, sha):
+    return {"uid": uid, "state": state, "readySubstate": substate, "meta": {"githubCommitSha": sha}}
+
+
+def _with(deployments, status=200, git=_fake_git):
+    def fake_api(method, path, body=None):
+        assert path.startswith("/v6/deployments")
+        return status, {"deployments": deployments}
+    return (
+        unittest.mock.patch.object(vpd, "_api", side_effect=fake_api),
+        unittest.mock.patch.object(vpd, "_git", side_effect=git),
+    )
+
+
+# ---------------------------------------------------------------- guilt
+
+def test_finds_the_batch_head_build_that_includes_the_target():
+    """The measured shape: no build of TARGET, a STAGED build of the batch HEAD that contains it."""
+    a, g = _with([_dep("dpl_head", "READY", "STAGED", BATCH_HEAD)])
+    with a, g:
+        assert vpd._ready_deployment_including(TARGET) == ("dpl_head", "STAGED", BATCH_HEAD)
+
+
+def test_prefers_the_newest_descendant_when_several_are_ready():
+    """Vercel lists newest first; the newest READY descendant carries the most of main."""
+    a, g = _with([
+        _dep("dpl_later", "READY", "STAGED", LATER),
+        _dep("dpl_head", "READY", "STAGED", BATCH_HEAD),
+    ])
+    with a, g:
+        assert vpd._ready_deployment_including(TARGET)[0] == "dpl_later"
+
+
+# ---------------------------------------------------------------- innocence
+
+def test_never_offers_a_build_that_does_not_contain_the_target():
+    """The build production already serves is an ancestor of the target, not a cure for it."""
+    a, g = _with([_dep("dpl_old", "READY", "PROMOTED", OLDER)])
+    with a, g:
+        assert vpd._ready_deployment_including(TARGET) is None
+
+
+def test_never_offers_a_build_of_a_commit_that_is_not_on_main():
+    """A branch build can be READY and even descend from the target after a rebase — never it."""
+    stray_ancestry = _ANCESTRY | {(TARGET, STRAY)}
+    def git(*args):
+        if args[:2] == ("merge-base", "--is-ancestor"):
+            return "" if (args[2], args[3]) in stray_ancestry else None
+        raise AssertionError(args)
+    a, g = _with([_dep("dpl_stray", "READY", "STAGED", STRAY)], git=git)
+    with a, g:
+        assert vpd._ready_deployment_including(TARGET) is None
+
+
+def test_never_offers_a_canceled_errored_or_building_one():
+    a, g = _with([
+        _dep("dpl_c", "CANCELED", None, LATER),
+        _dep("dpl_e", "ERROR", None, LATER),
+        _dep("dpl_b", "BUILDING", None, LATER),
+    ])
+    with a, g:
+        assert vpd._ready_deployment_including(TARGET) is None
+
+
+def test_the_targets_own_build_is_not_this_selectors_answer():
+    """Exact matches belong to _ready_deployment_for; this one only widens to descendants."""
+    a, g = _with([_dep("dpl_exact", "READY", "STAGED", TARGET)])
+    with a, g:
+        assert vpd._ready_deployment_including(TARGET) is None
+
+
+def test_git_that_cannot_answer_fails_closed():
+    a, g = _with([_dep("dpl_head", "READY", "STAGED", BATCH_HEAD)], git=lambda *a: None)
+    with a, g:
+        assert vpd._ready_deployment_including(TARGET) is None
+
+
+def test_api_failure_returns_none_so_the_rebuild_path_still_runs():
+    a, g = _with([], status=500)
+    with a, g:
+        assert vpd._ready_deployment_including(TARGET) is None
+
+
+# ---------------------------------------------------------------- end to end: the probe follows the build
+
+def test_promote_only_promotes_the_descendant_and_probes_for_ITS_sha(capsys):
+    """After promoting the batch HEAD's build, production serves BATCH_HEAD, not TARGET. The
+    probe compares by equality, so it must be told the build's sha — or a correct promote
+    would be reported as a failure."""
+    promoted = []
+    probed = []
+
+    def fake_promote(dpl, sha):
+        promoted.append((dpl, sha))
+        probed.append(sha)
+        return True
+
+    with unittest.mock.patch.object(vpd, "_served_commit", return_value=OLDER), \
+         unittest.mock.patch.object(vpd, "_production_includes", side_effect=lambda target, live: target == OLDER), \
+         unittest.mock.patch.object(vpd, "_ready_deployment_for", return_value=None), \
+         unittest.mock.patch.object(vpd, "_ready_deployment_including", return_value=("dpl_head", "STAGED", BATCH_HEAD)), \
+         unittest.mock.patch.object(vpd, "_promote", side_effect=fake_promote), \
+         unittest.mock.patch.object(sys, "argv", ["vercel_prod_deploy.py", "--ref", TARGET, "--promote-only"]):
+        assert vpd.main() == 0
+    assert promoted == [("dpl_head", BATCH_HEAD)]
+    out = capsys.readouterr().out
+    assert "merge-queue batch" in out and BATCH_HEAD[:9] in out
+
+
+def test_dry_run_reports_the_descendant_plan_and_changes_nothing():
+    calls = []
+    with unittest.mock.patch.object(vpd, "_served_commit", return_value=OLDER), \
+         unittest.mock.patch.object(vpd, "_production_includes", return_value=False), \
+         unittest.mock.patch.object(vpd, "_ready_deployment_for", return_value=None), \
+         unittest.mock.patch.object(vpd, "_ready_deployment_including", return_value=("dpl_head", "STAGED", BATCH_HEAD)), \
+         unittest.mock.patch.object(vpd, "_api", side_effect=lambda *a, **k: calls.append(a) or (200, {})), \
+         unittest.mock.patch.object(vpd, "_promote", side_effect=AssertionError("dry-run must not promote")), \
+         unittest.mock.patch.object(sys, "argv", ["vercel_prod_deploy.py", "--ref", TARGET, "--dry-run"]):
+        assert vpd.main() == 0
+    assert calls == []

--- a/scripts/vercel_prod_deploy.py
+++ b/scripts/vercel_prod_deploy.py
@@ -450,6 +450,50 @@ def _ready_deployment_for(sha: str) -> tuple[str, str] | None:
     return None
 
 
+# How many recent production deployments to scan for a build that INCLUDES the target. Merge
+# queue batches land 2-3 PRs per push; 20 covers a whole busy night (~7 builds/hour).
+DESCENDANT_SCAN_LIMIT = 20
+
+
+def _ready_deployment_including(sha: str) -> tuple[str, str, str] | None:
+    """A READY production build of a main commit that INCLUDES the target — the merge-queue case.
+
+    Measured 2026-09-11 (03:13-03:45 WITA): the GitHub merge queue BATCHES PRs, so one push moved
+    main by three commits (#6136, #6134, #6139) and Vercel built only the batch HEAD — a docs
+    commit. The newest bundle-relevant commit (8a2c49cfb) never got a build of its own, so
+    `_ready_deployment_for` found nothing, the --promote-only fallback (which walks OLDER
+    bundle-relevant commits) found nothing either, and Mini's autopromote organ exited 3 every
+    120s for half an hour while four READY builds that all contained the cure sat STAGED.
+
+    The rule is the sentinel's rule: production must INCLUDE the target, not EQUAL it. So any
+    READY production build whose commit is on main and descends from the target is promotable.
+    Guilt: finds the newest such build. Innocence: never a build of a commit that is not on
+    origin/main (a preview, a fork, a rebased branch), never one that does not contain the
+    target, never a non-READY one. Returns (deployment_id, substate, build_sha) or None; any
+    failure returns None so the rebuild path still runs.
+    """
+    status, body = _api(
+        "GET", f"/v6/deployments?projectId={PROJECT_ID}&target=production&limit={DESCENDANT_SCAN_LIMIT}"
+    )
+    if status != 200:
+        return None
+    for dep in body.get("deployments", []):  # newest first
+        if dep.get("state") != "READY":
+            continue
+        build_sha = (dep.get("meta") or {}).get("githubCommitSha")
+        uid = dep.get("uid")
+        if not build_sha or not uid or build_sha == sha:
+            continue
+        # `_git` is None on rc!=0: `merge-base --is-ancestor` answers with the exit code alone,
+        # so "" (rc 0, empty stdout) is YES and None is NO-or-could-not-look. Both must be yes.
+        if _git("merge-base", "--is-ancestor", build_sha, "origin/main") is None:
+            continue
+        if _git("merge-base", "--is-ancestor", sha, build_sha) is None:
+            continue
+        return str(uid), str(dep.get("readySubstate")), str(build_sha)
+    return None
+
+
 def _promote(deployment_id: str, sha: str) -> bool:
     status, body = _api("POST", f"/v10/projects/{PROJECT_ID}/promote/{deployment_id}", {})
     print(f"promote HTTP {status}: {json.dumps(body)[:300]}")
@@ -520,10 +564,27 @@ def main() -> int:
         print("production already includes this commit — nothing to do")
         return 0
     # Prefer promoting an existing READY build for this exact commit over rebuilding it.
+    # The sha the probe must see AFTER a promote: the target itself, or — when the build that
+    # carries it is a descendant — that build's commit (production serves the descendant, which
+    # includes the target; `_probe_until` compares by equality, so it must be told which).
+    probe_sha = sha
     existing = _ready_deployment_for(sha)
     if existing:
         dpl, substate = existing
         print(f"already built     : {dpl} (readySubstate={substate}) — promote, do not rebuild")
+    # No build of this exact commit: the merge queue may have batched it, so the build that
+    # carries it is a DESCENDANT on main. Promoting that one serves the target too (the verdict
+    # is inclusion, never equality) and costs ~3s where a rebuild costs ~6 minutes.
+    if not existing:
+        descendant = _ready_deployment_including(sha)
+        if descendant:
+            dpl, substate, build_sha = descendant
+            print(
+                f"no build of {sha[:9]} itself (merge-queue batch?) — a READY build of "
+                f"{build_sha[:9]}, which includes it, is unpromoted: {dpl} (readySubstate={substate})"
+            )
+            existing = (dpl, substate)
+            probe_sha = build_sha
     # No READY build for the newest bundle-relevant commit yet — before giving up (dry-run's
     # verdict and --promote-only's real behaviour must agree), look for an older bundle-relevant
     # commit that IS already built. Only relevant to the two restricted paths below; the
@@ -572,15 +633,15 @@ def main() -> int:
             # was nothing to promote" and report a healthy-ish heartbeat forever. Measured,
             # not imagined: running --promote-only against the pre-merge copy on Mini exits 2.
             return 3
-        if _promote(existing[0], sha):
-            print(f"OK — kita.balizero.com serves {sha[:9]} (promoted {existing[0]}, no rebuild)")
+        if _promote(existing[0], probe_sha):
+            print(f"OK — kita.balizero.com serves {probe_sha[:9]} (promoted {existing[0]}, no rebuild)")
             return 0
-        print(f"::error::promote of {existing[0]} did not prove kita.balizero.com serves {sha[:9]}")
+        print(f"::error::promote of {existing[0]} did not prove kita.balizero.com serves {probe_sha[:9]}")
         return 1
 
     if existing:
-        if _promote(existing[0], sha):
-            print(f"OK — kita.balizero.com serves {sha[:9]} (promoted {existing[0]}, no rebuild)")
+        if _promote(existing[0], probe_sha):
+            print(f"OK — kita.balizero.com serves {probe_sha[:9]} (promoted {existing[0]}, no rebuild)")
             return 0
         # Fall through rather than fail: the build may be genuinely unusable (an alias
         # conflict, a deployment deleted mid-flight). A rebuild is slower, never wrong.


### PR DESCRIPTION
## Why

The GitHub merge queue lands 2-3 PRs per push, so Vercel builds only the batch HEAD. When the newest bundle-relevant commit is not that HEAD it never gets a build of its own: `_ready_deployment_for` (exact sha) finds nothing, the `--promote-only` fallback walks OLDER bundle-relevant commits and finds nothing, and Mini's `com.nuzantara.vercel-autopromote` exits 3 every 120s while READY builds that all contain the cure sit STAGED.

Measured 2026-09-11 03:13-03:45 WITA: `#6136 + #6134 + #6139` landed in one push (HEAD `6fef72cd75`, a docs commit); the newest bundle-relevant commit `8a2c49cfbe` had no build; production served `70546e5d96` for 35 minutes with four READY STAGED builds waiting (`469c91cc00`, `5b08222601`, `6fef72cd75`, `b7fdaf7eab`); Mini's run.log: `NO READY BUILD — nothing promoted` × 14 ticks, rc=3. A manual `--ref <b7fdaf7eab> --promote-only` ended it in 40s.

## What

- `_ready_deployment_including(sha)`: the newest READY production build whose commit is on `origin/main` and descends from the target (`git merge-base --is-ancestor`, both directions checked). Innocence: never a build not on main, never one that does not contain the target, never non-READY, never the target's own build (that stays `_ready_deployment_for`'s job).
- `main()` consults it when the exact lookup is empty, in every mode (interactive, `--dry-run`, `--promote-only`), and the post-promote probe is told the build's sha because `_probe_until` compares by equality.
- 10 new tests (`test_vercel_prod_deploy_promote_descendant.py`), guilt + innocence + two end-to-end; the 43 existing Vercel tests still pass.

## Bites

Consumer: `scripts/vercel_prod_deploy.py` as run by Mini's `com.nuzantara.vercel-autopromote` (`--promote-only`, every 120s) and by hand. Observation, run live on M5 against the real Vercel API with this branch, for the exact sha that was blind tonight:

```
$ python3 scripts/vercel_prod_deploy.py --ref 8a2c49cfbe96499ccbbb4d89d020e2b3b8f0a396 --dry-run --force
target commit   : 8a2c49cfbe96499ccbbb4d89d020e2b3b8f0a396
production runs : b7fdaf7eabea0b776c566594b7638959f1b97e66
no build of 8a2c49cfb itself (merge-queue batch?) — a READY build of 7f8b70b7f, which includes it, is unpromoted: dpl_DVkrScgQwwjmzBnN4tnnL2nZPtrE (readySubstate=STAGED)
dry-run: would PROMOTE the build above, changing nothing
```

Before this branch the same command printed `dry-run: no READY build for this commit — would deploy`. After merge: Mini pulls, next tick logs rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3VLJR7EffGoue6x75uS82