### PR TITLE
fix(portal): stop asserting "Compliant" on the tax surfaces — show a warning or nothing

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/dashboard.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/dashboard.py
@@ -238,15 +238,20 @@ class PortalDashboardMixin:
         }
 
     def _get_tax_status(self, next_deadline) -> str:
-        """Determine tax compliance status."""
+        """Determine tax status relative to the next generic deadline.
+
+        Never returns "compliant": status is derived only from distance to
+        the next calendar deadline, not from actual filing/payment data, so
+        it cannot assert compliance.
+        """
         if not next_deadline:
-            return "compliant"
+            return "none"
         days = next_deadline["days_until"]
         if days < 0:
             return "overdue"
         if days <= 14:
             return "attention"
-        return "compliant"
+        return "upcoming"
 
     def _build_action_items(self, action_items, visa_data) -> list[dict[str, Any]]:
         """Build action items for dashboard."""
@@ -845,8 +850,10 @@ class PortalDashboardMixin:
                 next_deadline = deadlines[0]["due_date"]
                 days_to_deadline = deadlines[0]["days_until"]
 
-            # Determine status based on deadlines
-            status = "compliant"
+            # Determine status based on deadlines (never "compliant": this
+            # is only distance to the next generic calendar deadline, not
+            # actual filing/payment data)
+            status = "none" if days_to_deadline is None else "upcoming"
             if days_to_deadline is not None:
                 if days_to_deadline < 0:
                     status = "overdue"

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_dashboard_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_dashboard_mixin.py
@@ -472,7 +472,8 @@ async def test_get_tax_overview_shapes_obligations_and_history() -> None:
 
     result = await service.get_tax_overview(1, current_user=_ctx())
 
-    assert result["summary"]["status"] in {"compliant", "attention", "overdue"}
+    assert result["summary"]["status"] in {"none", "upcoming", "attention", "overdue"}
+    assert result["summary"]["status"] != "compliant"
     assert result["summary"]["totalDue"] == 0
     assert len(result["obligations"]) == 3
     assert result["history"] == [

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_portal_service.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_portal_service.py
@@ -268,9 +268,9 @@ class TestPortalServiceHelpers:
         exc.sqlstate = "42P01"
         assert PortalService._is_undefined_table_error(exc) is True
 
-    def test_get_tax_status_compliant(self, portal_service):
-        """Tax status is compliant with no deadline."""
-        assert portal_service._get_tax_status(None) == "compliant"
+    def test_get_tax_status_none(self, portal_service):
+        """Tax status is 'none' with no deadline."""
+        assert portal_service._get_tax_status(None) == "none"
 
     def test_get_tax_status_overdue(self, portal_service):
         """Tax status is overdue when days < 0."""
@@ -280,9 +280,14 @@ class TestPortalServiceHelpers:
         """Tax status is attention when days <= 14."""
         assert portal_service._get_tax_status({"days_until": 7}) == "attention"
 
-    def test_get_tax_status_compliant_far(self, portal_service):
-        """Tax status is compliant when days > 14."""
-        assert portal_service._get_tax_status({"days_until": 30}) == "compliant"
+    def test_get_tax_status_upcoming_far(self, portal_service):
+        """Tax status is 'upcoming' when days > 14."""
+        assert portal_service._get_tax_status({"days_until": 30}) == "upcoming"
+
+    def test_get_tax_status_never_compliant(self, portal_service):
+        """Tax status never asserts compliance regardless of deadline distance."""
+        assert portal_service._get_tax_status(None) != "compliant"
+        assert portal_service._get_tax_status({"days_until": 400}) != "compliant"
 
 
 # ============================================================================

--- a/apps/backend-rag/backend/tests/unit/services/portal/test_portal_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/portal/test_portal_service.py
@@ -381,8 +381,10 @@ class TestPortalServiceDashboardHelpers:
         result = self.service._build_visa_dashboard_data(visa)
         assert result["status"] == "pending"
 
-    def test_get_tax_status_compliant(self) -> None:
-        assert self.service._get_tax_status(None) == "compliant"
+    def test_get_tax_status_none_without_deadline(self) -> None:
+        # Never "compliant": the status is only distance to the next generic
+        # calendar deadline, not filing/payment data (PR #6150).
+        assert self.service._get_tax_status(None) == "none"
 
     def test_get_tax_status_attention(self) -> None:
         deadline = {"days_until": 10}
@@ -392,9 +394,13 @@ class TestPortalServiceDashboardHelpers:
         deadline = {"days_until": -5}
         assert self.service._get_tax_status(deadline) == "overdue"
 
-    def test_get_tax_status_compliant_far(self) -> None:
+    def test_get_tax_status_upcoming_far(self) -> None:
         deadline = {"days_until": 30}
-        assert self.service._get_tax_status(deadline) == "compliant"
+        assert self.service._get_tax_status(deadline) == "upcoming"
+
+    def test_get_tax_status_never_asserts_compliance(self) -> None:
+        for deadline in (None, {"days_until": 15}, {"days_until": 30}, {"days_until": 400}):
+            assert self.service._get_tax_status(deadline) != "compliant"
 
     def test_build_action_items_empty(self) -> None:
         visa_data = {"status": "active", "daysRemaining": 200}

--- a/apps/mouth/src/app/portal/(authenticated)/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/page.test.tsx
@@ -21,7 +21,7 @@ const createMockDashboard = (
     totalCompanies: 1,
   },
   taxes: {
-    status: "compliant",
+    status: "upcoming",
     nextDeadline: null,
     daysToDeadline: null,
   },
@@ -49,7 +49,7 @@ const createEmptyDashboard = (): PortalDashboard => ({
     totalCompanies: 0,
   },
   taxes: {
-    status: "compliant", // Default to compliant for empty state
+    status: "none", // No deadline tracked for empty state
     nextDeadline: null,
     daysToDeadline: null,
   },

--- a/apps/mouth/src/app/portal/(authenticated)/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/page.tsx
@@ -204,7 +204,7 @@ export default function PortalHomePage() {
       totalCompanies: 0,
     },
     taxes: {
-      status: "compliant" as const,
+      status: "none" as const,
       nextDeadline: null,
       daysToDeadline: null,
     },
@@ -273,12 +273,12 @@ export default function PortalHomePage() {
                   month: "short",
                   day: "numeric",
                 })
-              : "All Good"
+              : "No Deadline"
           }
           subLabel={
             defaultDashboard.taxes.daysToDeadline
               ? `${defaultDashboard.taxes.daysToDeadline} days`
-              : "Up to date"
+              : "None tracked"
           }
           onClick={() => router.push("/portal/taxes")}
         />
@@ -435,7 +435,7 @@ function StatusCard({
     | "expired"
     | "pending"
     | "none"
-    | "compliant"
+    | "upcoming"
     | "attention"
     | "overdue";
   label: string;
@@ -452,7 +452,6 @@ function StatusCard({
   const getStatusStyle = (s: string) => {
     switch (s) {
       case "active":
-      case "compliant":
         return "bg-[color-mix(in_srgb,var(--state-success)_6%,transparent)] text-[var(--state-success)] border-[color-mix(in_srgb,var(--state-success)_25%,transparent)]";
       case "warning":
       case "attention":
@@ -468,7 +467,6 @@ function StatusCard({
   const getIcon = (s: string) => {
     switch (s) {
       case "active":
-      case "compliant":
         return <CheckCircle2 className="w-5 h-5" />;
       case "warning":
       case "attention":

--- a/apps/mouth/src/app/portal/(authenticated)/taxes/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/taxes/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 const { mockGetTaxOverview, mockToastError } = vi.hoisted(() => ({
@@ -185,5 +185,53 @@ describe("TaxesPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(await screen.findByText("Tax Status")).toBeInTheDocument();
     expect(mockGetTaxOverview).toHaveBeenCalledTimes(callsAfterFailure + 1);
+  });
+
+  it("shows no compliance badge or wording in the Tax Status card when there is no deadline", async () => {
+    mockGetTaxOverview.mockResolvedValue({
+      ...TAX_DATA,
+      summary: {
+        ...TAX_DATA.summary,
+        status: "none",
+        nextDeadline: null,
+        daysToDeadline: null,
+      },
+    });
+    render(<TaxesPage />);
+    const headerRow = (await screen.findByText("Tax Status")).closest(
+      "div.justify-between",
+    ) as HTMLElement;
+
+    expect(screen.queryByText("Compliant")).not.toBeInTheDocument();
+    expect(within(headerRow).queryByText("Compliant")).not.toBeInTheDocument();
+    expect(headerRow.querySelector(".rounded-full")).toBeNull();
+  });
+
+  it("shows no compliance badge or wording in the Tax Status card when the deadline is far away", async () => {
+    mockGetTaxOverview.mockResolvedValue({
+      ...TAX_DATA,
+      summary: { ...TAX_DATA.summary, status: "upcoming" },
+    });
+    render(<TaxesPage />);
+    const headerRow = (await screen.findByText("Tax Status")).closest(
+      "div.justify-between",
+    ) as HTMLElement;
+
+    expect(screen.queryByText("Compliant")).not.toBeInTheDocument();
+    expect(within(headerRow).queryByText("Compliant")).not.toBeInTheDocument();
+    expect(headerRow.querySelector(".rounded-full")).toBeNull();
+  });
+
+  it("renders the Overdue badge in the Tax Status card when tax status is overdue", async () => {
+    mockGetTaxOverview.mockResolvedValue({
+      ...TAX_DATA,
+      summary: { ...TAX_DATA.summary, status: "overdue" },
+    });
+    render(<TaxesPage />);
+    const summarySection = (await screen.findByText("Tax Status")).closest(
+      "section",
+    ) as HTMLElement;
+
+    expect(within(summarySection).getByText("Overdue")).toBeInTheDocument();
   });
 });

--- a/apps/mouth/src/app/portal/(authenticated)/taxes/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/taxes/page.tsx
@@ -200,7 +200,10 @@ export default function TaxesPage() {
             />
             <h2 className="text-lg font-semibold">Tax Status</h2>
           </div>
-          <StatusBadge status={taxData.summary.status} />
+          {(taxData.summary.status === "attention" ||
+            taxData.summary.status === "overdue") && (
+            <StatusBadge status={taxData.summary.status} />
+          )}
         </div>
 
         <div className="grid grid-cols-2 gap-4">

--- a/apps/mouth/src/lib/api/integration/portal.integration.test.ts
+++ b/apps/mouth/src/lib/api/integration/portal.integration.test.ts
@@ -21,7 +21,7 @@ const createMockDashboard = (
     totalCompanies: 1,
   },
   taxes: {
-    status: "compliant",
+    status: "upcoming",
     nextDeadline: null,
     daysToDeadline: null,
   },
@@ -49,7 +49,7 @@ const createEmptyDashboard = (): PortalDashboard => ({
     totalCompanies: 0,
   },
   taxes: {
-    status: "compliant",
+    status: "none",
     nextDeadline: null,
     daysToDeadline: null,
   },

--- a/apps/mouth/src/lib/api/portal/portal.api.test.ts
+++ b/apps/mouth/src/lib/api/portal/portal.api.test.ts
@@ -36,7 +36,7 @@ const createMockDashboard = (
     totalCompanies: 1,
   },
   taxes: {
-    status: "compliant",
+    status: "upcoming",
     nextDeadline: null,
     daysToDeadline: null,
   },
@@ -100,7 +100,7 @@ const createMockTaxOverview = (
   overrides?: Partial<TaxOverview>,
 ): TaxOverview => ({
   summary: {
-    status: "ok",
+    status: "none",
     totalDue: 0,
     nextDeadline: null,
     daysToDeadline: null,

--- a/apps/mouth/src/lib/api/portal/portal.api.ts
+++ b/apps/mouth/src/lib/api/portal/portal.api.ts
@@ -305,7 +305,8 @@ export class PortalApi {
     return {
       summary: {
         status:
-          pick<TaxOverview["summary"]["status"]>(summary, ["status"]) ?? "ok",
+          pick<TaxOverview["summary"]["status"]>(summary, ["status"]) ??
+          "none",
         totalDue: pick<number>(summary, ["totalDue", "total_due"]) ?? 0,
         nextDeadline:
           pick<string>(summary, ["nextDeadline", "next_deadline"]) ?? null,

--- a/apps/mouth/src/lib/api/portal/portal.types.ts
+++ b/apps/mouth/src/lib/api/portal/portal.types.ts
@@ -20,7 +20,7 @@ export interface PortalDashboard {
     totalCompanies: number;
   };
   taxes: {
-    status: "compliant" | "attention" | "overdue";
+    status: "none" | "upcoming" | "attention" | "overdue";
     nextDeadline: string | null;
     daysToDeadline: number | null;
   };
@@ -130,7 +130,7 @@ export interface ComplianceItem {
 
 export interface TaxOverview {
   summary: {
-    status: "ok" | "attention" | "critical";
+    status: "none" | "upcoming" | "attention" | "overdue";
     totalDue: number;
     nextDeadline: string | null;
     daysToDeadline: number | null;


### PR DESCRIPTION
## Why

my.balizero.com showed a green **Compliant** badge on `/portal/taxes` (and "All Good" / "Up to date" on the dashboard Tax card) whenever the client had no deadline within 14 days. The status was derived only from the distance to the next *generic* calendar deadline, and `totalDue` is a literal zero (`# No payment tracking yet`). That is a compliance claim Bali Zero has no data to make, shown to clients. Zero asked for it to go (2026-09-11).

Removed, not renamed: `ok` / `good` / `all_clear` would be the same claim in other letters. Where there is nothing to warn about, the surface shows nothing. API and page change in the same PR so they never contradict each other.

## What

**Backend** (`services/portal/_mixins/dashboard.py`): `_get_tax_status` and `get_tax_overview` emit `none` (no deadline), `upcoming` (> 14 days), `attention` (≤ 14 days), `overdue` (< 0). Never `compliant`. Grepped the portal mixins: these two were the only sources.

**Frontend** (`apps/mouth`):
- `/portal/taxes`: the Tax Status badge renders only for `attention` / `overdue`; heading and card stay, no badge otherwise.
- dashboard Tax `StatusCard`: dropped the `compliant` case; `none`/`upcoming` fall into the existing neutral default (no wording). The label fallbacks "All Good" / "Up to date" became "No Deadline" / "None tracked" — same claim in prose.
- `portal.types.ts`: both tax status unions now match what the backend actually returns. `TaxOverview.summary.status` was typed `"ok" | "attention" | "critical"` — values the backend never emitted; `portal.api.ts` also defaulted a missing status to `"ok"`, now `"none"`.

Untouched on purpose: `StatusBadge.tsx`'s generic `compliant` map entry (other surfaces), the companies page per-company compliance roll-up (different domain: licence/obligation list), and the staff-facing tax department widget.

## Tests

- Backend: `test_portal_service.py` + `test_dashboard_mixin.py` → 76 passed; the status tests now assert `none`/`upcoming` and that neither function ever yields `compliant`.
- Frontend: `vitest run` on the four touched test files → 60 passed (taxes page: `none` and `upcoming` render no badge and no "Compliant" text; `overdue` renders the Overdue badge). `npm run typecheck` clean.

Bites: CONSUMER is `/portal/taxes` and the dashboard Tax card on my.balizero.com for a client with no tracked deadline (e.g. client 12400). Observation, after this merge deploys the backend and Vercel ships mouth: `GET /api/portal/taxes/overview` returns `summary.status = "none"` and the rendered page contains no "Compliant" text; the dashboard Tax card says "No Deadline". Recorded in this PR's thread once observed.

Implemented by a Sonnet subagent in a dedicated worktree; reviewed and shipped by the Fable session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vV3hvzrWmVMEGSoe1YUZc
