### PR TITLE
feat(compliance): obligations reviewer API with HITL bridge to compliance_alerts (A2)

### DIFF
--- a/apps/backend-rag/backend/app/routers/compliance_obligations.py
+++ b/apps/backend-rag/backend/app/routers/compliance_obligations.py
@@ -1,0 +1,407 @@
+"""Obligations reviewer API — HITL bridge from the obligations register into
+compliance_alerts (PR A2, lane backend-rag / obligations-review-queue).
+
+Prefix: /api/compliance/obligations
+
+Flow (design: DESIGN-lane-A.md, "PR A2"): ``propose()`` (PR A1) fills
+``client_obligations`` with ``status='proposed'`` rows. This router lets the tax
+team (CRM admins, ``app.utils.crm_utils.is_crm_admin``) list/generate/approve/
+reject them. ``approve`` is the ONLY place a row leaves the register and
+becomes visible to a client: it writes exactly one ``compliance_alerts`` row
+(category ``obligation``, dedup_key ``obligation:<client_id>:<rule_id>:<period_key>``)
+through the existing ``AlertRepository`` (m114) — never raw SQL — and stamps
+the obligation ``approved -> alerted`` with that alert_id, both inside ONE
+database transaction: either both writes land, or neither does. Reject and
+generate never touch compliance_alerts.
+
+RBAC: every route (reads included) requires ``is_crm_admin`` — obligations
+review is a CRM-admin/tax-team function with no per-user ownership axis (unlike
+``intake_review``'s own-chat scoping, which does not apply here), matching the
+gate DESIGN-lane-A.md specifies for the whole router.
+
+C4 follow-up from PR A1's gate (#6122): the applicability-edge case (a
+FOREIGN_PLATFORM client whose custom_fields set has_employees/pkp wrongly
+matching PPh 21/BPJS/PPN rules) was closed catalog-side in
+``backend/data/obligations_catalog.yaml`` (each of those rules now also
+requires ``company_type`` to be one of the non-platform types), so it is fixed
+before this router ever sees a proposal. The OTHER-classification edge
+(``profile_from_rows`` mapping unrecognised company_type spellings to OTHER,
+which silently drops LKPM/PPh 25/SPT Tahunan/RUPS) is surfaced HERE: POST
+``/generate`` flags ``needs_manual_classification`` in its response instead of
+silently producing an incomplete proposal set.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import date
+from functools import lru_cache
+from typing import Any
+
+import asyncpg
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
+from pydantic import BaseModel, Field
+
+from backend.app.dependencies import get_current_user, get_database_pool
+from backend.app.utils.crm_utils import is_crm_admin
+from backend.services.compliance.alert_repository import AlertRepository, AlertRow
+from backend.services.compliance.obligations_register import (
+    ObligationRule,
+    load_catalog,
+    profile_from_rows,
+    propose,
+)
+from backend.services.compliance.obligations_repository import (
+    STATUSES,
+    ObligationsRepository,
+)
+from backend.services.compliance.obligations_repository import (
+    ObligationRow as ObligationDbRow,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/compliance/obligations", tags=["compliance-obligations"])
+
+_NEEDS_MANUAL_CLASSIFICATION_MSG = (
+    "profile_from_rows could not map this client's company_type to a known type "
+    "(PT PMA / PT PMDN / CV / KP3A / KPPA / FOREIGN_PLATFORM) and defaulted to OTHER. "
+    "LKPM, PPh 25, SPT Tahunan Badan and RUPS annual obligations are skipped for OTHER "
+    "profiles (PR A1 gate #6122, C4) — classify the company manually before trusting "
+    "this proposal set."
+)
+
+
+@lru_cache(maxsize=1)
+def _cached_rules() -> tuple[ObligationRule, ...]:
+    """Catalog rules, loaded once per process. The YAML never changes at runtime."""
+    return tuple(load_catalog())
+
+
+def _require_admin(user: dict[str, Any]) -> None:
+    if not is_crm_admin(user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="CRM admin required")
+
+
+def _reviewer_email(user: dict[str, Any]) -> str:
+    email = (user.get("email") or "").strip().lower()
+    if not email:
+        raise HTTPException(status_code=403, detail="Reviewer email is required")
+    return email
+
+
+# --------------------------------------------------------------------------- #
+# Response models
+# --------------------------------------------------------------------------- #
+class ObligationOut(BaseModel):
+    id: int
+    client_id: int
+    rule_id: str
+    period_key: str
+    due_date: date
+    status: str
+    needs_review_reason: str | None
+    reviewer_email: str | None
+    reviewed_at: Any | None
+    review_note: str | None
+    alert_id: str | None
+    created_at: Any | None
+    updated_at: Any | None
+
+
+def _to_out(row: ObligationDbRow) -> ObligationOut:
+    return ObligationOut(
+        id=row.id,
+        client_id=row.client_id,
+        rule_id=row.rule_id,
+        period_key=row.period_key,
+        due_date=row.due_date,
+        status=row.status,
+        needs_review_reason=row.needs_review_reason,
+        reviewer_email=row.reviewer_email,
+        reviewed_at=row.reviewed_at,
+        review_note=row.review_note,
+        alert_id=row.alert_id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+class ObligationListOut(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    items: list[ObligationOut]
+
+
+class GenerateBody(BaseModel):
+    client_id: int
+    horizon_days: int = Field(90, ge=1, le=730)
+
+
+class GenerateOut(BaseModel):
+    client_id: int
+    inserted_count: int
+    company_type: str
+    needs_manual_classification: bool
+    warning: str | None
+    rows: list[ObligationOut]
+
+
+class ApproveBody(BaseModel):
+    note: str | None = None
+
+
+class ApproveOut(BaseModel):
+    obligation: ObligationOut
+    alert_id: str
+
+
+class RejectBody(BaseModel):
+    reason: str = Field(..., min_length=1)
+
+
+# --------------------------------------------------------------------------- #
+# GET "" — list (filters client_id/status, paginated like intake_review)
+# --------------------------------------------------------------------------- #
+@router.get("")
+async def list_obligations(
+    client_id: int | None = Query(None),
+    status_filter: str | None = Query(
+        "proposed",
+        alias="status",
+        description=f"One of {sorted(STATUSES)}, or 'all' for no status filter.",
+    ),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user: dict[str, Any] = Depends(get_current_user),
+    pool: asyncpg.Pool = Depends(get_database_pool),
+) -> ObligationListOut:
+    _require_admin(user)
+    normalized_status = None if status_filter in (None, "all") else status_filter
+    if normalized_status is not None and normalized_status not in STATUSES:
+        raise HTTPException(status_code=422, detail=f"unknown status {status_filter!r}")
+
+    repo = ObligationsRepository(pool)
+    total = await repo.count_filtered(client_id=client_id, status=normalized_status)
+    rows = await repo.list_filtered(
+        client_id=client_id, status=normalized_status, limit=limit, offset=offset
+    )
+    return ObligationListOut(
+        total=total, limit=limit, offset=offset, items=[_to_out(r) for r in rows]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# GET /{id} — detail
+# --------------------------------------------------------------------------- #
+@router.get("/{obligation_id}")
+async def get_obligation(
+    obligation_id: int = Path(..., ge=1),
+    user: dict[str, Any] = Depends(get_current_user),
+    pool: asyncpg.Pool = Depends(get_database_pool),
+) -> ObligationOut:
+    _require_admin(user)
+    repo = ObligationsRepository(pool)
+    row = await repo.get(obligation_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Obligation not found")
+    return _to_out(row)
+
+
+# --------------------------------------------------------------------------- #
+# POST /generate — profile_from_rows + propose() + upsert (idempotent)
+# --------------------------------------------------------------------------- #
+async def _load_client_and_company(
+    conn: asyncpg.Connection, client_id: int
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    client_row = await conn.fetchrow(
+        "SELECT id, custom_fields FROM clients WHERE id = $1 AND deleted_at IS NULL",
+        client_id,
+    )
+    if client_row is None:
+        return None, None
+    company_row = await conn.fetchrow(
+        """
+        SELECT c.company_type, c.custom_fields
+          FROM client_company_links ccl
+          JOIN companies c ON c.id = ccl.company_id
+         WHERE ccl.client_id = $1
+         ORDER BY ccl.is_primary DESC NULLS LAST, ccl.id ASC
+         LIMIT 1
+        """,
+        client_id,
+    )
+    return dict(client_row), (dict(company_row) if company_row is not None else None)
+
+
+@router.post("/generate")
+async def generate_obligations(
+    body: GenerateBody,
+    user: dict[str, Any] = Depends(get_current_user),
+    pool: asyncpg.Pool = Depends(get_database_pool),
+) -> GenerateOut:
+    _require_admin(user)
+
+    async with pool.acquire() as conn:
+        client_row, company_row = await _load_client_and_company(conn, body.client_id)
+    if client_row is None:
+        raise HTTPException(status_code=404, detail="Client not found")
+
+    profile = profile_from_rows(client_row, company_row)
+    proposals = propose(_cached_rules(), profile, date.today(), body.horizon_days)
+
+    repo = ObligationsRepository(pool)
+    inserted_count = await repo.upsert_proposals(body.client_id, proposals)
+    # Idempotent: existing (client, rule, period) rows are never duplicated
+    # (ON CONFLICT DO NOTHING in upsert_proposals), so a re-run of /generate
+    # over the same horizon returns inserted_count=0 and the same rows.
+    current_rows = await repo.list_filtered(
+        client_id=body.client_id, status="proposed", limit=200, offset=0
+    )
+
+    needs_manual = profile.company_type == "OTHER"
+    logger.info(
+        "compliance.obligations.generate client_id=%s inserted=%s company_type=%s "
+        "needs_manual_classification=%s",
+        body.client_id,
+        inserted_count,
+        profile.company_type,
+        needs_manual,
+    )
+    return GenerateOut(
+        client_id=body.client_id,
+        inserted_count=inserted_count,
+        company_type=profile.company_type,
+        needs_manual_classification=needs_manual,
+        warning=_NEEDS_MANUAL_CLASSIFICATION_MSG if needs_manual else None,
+        rows=[_to_out(r) for r in current_rows],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# POST /{id}/approve — proposed -> approved, then bridge into compliance_alerts
+# --------------------------------------------------------------------------- #
+def _obligation_dedup_key(client_id: int, rule_id: str, period_key: str) -> str:
+    return f"obligation:{client_id}:{rule_id}:{period_key}"
+
+
+@router.post("/{obligation_id}/approve")
+async def approve_obligation(
+    obligation_id: int = Path(..., ge=1),
+    body: ApproveBody = Body(default_factory=ApproveBody),
+    user: dict[str, Any] = Depends(get_current_user),
+    pool: asyncpg.Pool = Depends(get_database_pool),
+) -> ApproveOut:
+    """Approve a proposal and bridge it into compliance_alerts, atomically.
+
+    Both writes (client_obligations proposed->approved->alerted, and the ONE
+    compliance_alerts insert) happen inside a single transaction on the SAME
+    connection (``ObligationsRepository.with_connection`` /
+    ``AlertRepository.with_connection``): a failure anywhere — including the
+    alert insert — rolls back the obligation transition too, so a caller never
+    observes an obligation stuck ``approved`` with no alert, nor an alert with
+    no matching ``alerted`` obligation. No compensation logic is needed because
+    nothing is committed until the end of the ``async with conn.transaction()``
+    block. A concurrent second approve/reject loses the race at the guarded
+    ``UPDATE ... WHERE status='proposed'`` inside ``set_status`` (0 rows
+    returned under READ COMMITTED once the winner commits) and gets 409.
+    """
+    _require_admin(user)
+    reviewer_email = _reviewer_email(user)
+
+    async with pool.acquire() as conn, conn.transaction():
+        obl_repo = ObligationsRepository.with_connection(conn)
+        approved = await obl_repo.set_status(obligation_id, "approved", reviewer_email, body.note)
+        if approved is None:
+            existing = await conn.fetchrow(
+                "SELECT status FROM client_obligations WHERE id = $1", obligation_id
+            )
+            if existing is None:
+                raise HTTPException(status_code=404, detail="Obligation not found")
+            raise HTTPException(
+                status_code=409,
+                detail=f"Obligation must be proposed (status={existing['status']}).",
+            )
+
+        dedup_key = _obligation_dedup_key(approved.client_id, approved.rule_id, approved.period_key)
+        alert_repo = AlertRepository.with_connection(conn)
+        alert = await alert_repo.find_active_by_dedup_key(dedup_key)
+        if alert is None:
+            alert = await alert_repo.insert(
+                AlertRow(
+                    alert_id=f"alert_obligation_{approved.client_id}_{uuid.uuid4().hex[:8]}",
+                    client_id=approved.client_id,
+                    category="obligation",
+                    severity="warning",
+                    status="pending",
+                    deadline=approved.due_date,
+                    days_until=(approved.due_date - date.today()).days,
+                    compliance_item_ref=approved.rule_id,
+                    dedup_key=dedup_key,
+                    message_it=None,
+                    message_en=(
+                        f"Obligation {approved.rule_id} ({approved.period_key}) due "
+                        f"{approved.due_date.isoformat()}."
+                    ),
+                    message_id=None,
+                    suggested_action=approved.needs_review_reason,
+                    estimated_cost_idr=None,
+                    evidence_refs=[],
+                    nb2_ref=None,
+                )
+            )
+
+        alerted = await obl_repo.mark_alerted(obligation_id, alert.alert_id)
+        if alerted is None:  # pragma: no cover — guarded by the same-transaction lock above
+            raise HTTPException(
+                status_code=500, detail="Failed to bridge obligation into compliance_alerts."
+            )
+
+    logger.info(
+        "compliance.obligations.approve id=%s reviewer=%s alert_id=%s",
+        obligation_id,
+        reviewer_email,
+        alert.alert_id,
+    )
+    return ApproveOut(obligation=_to_out(alerted), alert_id=alert.alert_id)
+
+
+# --------------------------------------------------------------------------- #
+# POST /{id}/reject — proposed -> rejected (terminal, no compliance_alerts write)
+# --------------------------------------------------------------------------- #
+@router.post("/{obligation_id}/reject")
+async def reject_obligation(
+    obligation_id: int = Path(..., ge=1),
+    body: RejectBody = Body(...),
+    user: dict[str, Any] = Depends(get_current_user),
+    pool: asyncpg.Pool = Depends(get_database_pool),
+) -> ObligationOut:
+    _require_admin(user)
+    reviewer_email = _reviewer_email(user)
+
+    async with pool.acquire() as conn, conn.transaction():
+        repo = ObligationsRepository.with_connection(conn)
+        rejected = await repo.set_status(obligation_id, "rejected", reviewer_email, body.reason)
+        if rejected is None:
+            existing = await conn.fetchrow(
+                "SELECT status FROM client_obligations WHERE id = $1", obligation_id
+            )
+            if existing is None:
+                raise HTTPException(status_code=404, detail="Obligation not found")
+            raise HTTPException(
+                status_code=409,
+                detail=f"Obligation must be proposed (status={existing['status']}).",
+            )
+
+    logger.info(
+        "compliance.obligations.reject id=%s reviewer=%s reason=%s",
+        obligation_id,
+        reviewer_email,
+        body.reason[:200],
+    )
+    return _to_out(rejected)
+
+
+__all__ = ["router"]

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -335,6 +335,8 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
     RouterEntry(name="funnel_email", process_groups=_API, tags=("funnel", "email")),
     # ── Compliance Alerts (outcome recording + autotune metrics) ──
     RouterEntry(name="compliance_alerts", process_groups=_API, tags=("compliance",)),
+    # ── Compliance Obligations (A2: reviewer API, HITL bridge to compliance_alerts) ──
+    RouterEntry(name="compliance_obligations", process_groups=_API, tags=("compliance",)),
     # ── LKPM Compliance ──
     RouterEntry(name="lkpm", process_groups=_API, tags=("compliance",)),
     # ── LLM Cost Tracking (remote ingestion for Pro/Air cron agents) ──

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -44,6 +44,7 @@ def include_routers(api: FastAPI) -> None:
         channels,  # Channel health, DLQ, unified conversations
         collective_memory,
         compliance_alerts,
+        compliance_obligations,  # [A2] obligations reviewer API, HITL bridge to compliance_alerts
         conversations,
         crm_analytics,  # [NEW] CRM Analytics dashboard
         crm_clients,
@@ -307,6 +308,7 @@ def include_routers(api: FastAPI) -> None:
 
     # Compliance routers
     api.include_router(compliance_alerts.router)
+    api.include_router(compliance_obligations.router)  # [A2] obligations reviewer API
     api.include_router(e33_cases.router)  # [E33] Second Home internal console
     api.include_router(lkpm.router)  # LKPM Investment Activity Reports
 
@@ -543,6 +545,7 @@ def include_light_routers(api: FastAPI) -> None:
         channel_health,  # [HEARTBEAT] Sprint 1.B 2026-05-02 — Cell-side bridge
         channels,  # Channel health, DLQ, unified conversations
         compliance_alerts,
+        compliance_obligations,  # [A2] obligations reviewer API, HITL bridge to compliance_alerts
         crm_analytics,
         crm_clients_documents,
         crm_company,
@@ -768,6 +771,7 @@ def include_light_routers(api: FastAPI) -> None:
 
     # Compliance routers
     api.include_router(compliance_alerts.router)
+    api.include_router(compliance_obligations.router)  # [A2] obligations reviewer API
     api.include_router(e33_cases.router)  # [E33] Second Home internal console
     api.include_router(lkpm.router)
 

--- a/apps/backend-rag/backend/data/obligations_catalog.yaml
+++ b/apps/backend-rag/backend/data/obligations_catalog.yaml
@@ -31,6 +31,7 @@ rules:
     verified: false
     applies_if:
       - {attr: has_employees, op: is_true}
+      - {attr: company_type, op: in, value: [PT_PMA, PT_PMDN, CV, KP3A, KPPA, OTHER]}
     due: {frequency: monthly, day: 15, month: null, months_after_period_end: 1, roll: next_business_day}
 
   - id: spt_masa_pph21
@@ -40,6 +41,7 @@ rules:
     verified: false
     applies_if:
       - {attr: has_employees, op: is_true}
+      - {attr: company_type, op: in, value: [PT_PMA, PT_PMDN, CV, KP3A, KPPA, OTHER]}
     due: {frequency: monthly, day: 20, month: null, months_after_period_end: 1, roll: next_business_day}
 
   - id: pph23_26_payment
@@ -69,6 +71,7 @@ rules:
     verified: false
     applies_if:
       - {attr: pkp, op: is_true}
+      - {attr: company_type, op: in, value: [PT_PMA, PT_PMDN, CV, KP3A, KPPA, OTHER]}
     due: {frequency: monthly, day: 31, month: null, months_after_period_end: 1, roll: next_business_day}
 
   - id: pph25_installment
@@ -97,6 +100,7 @@ rules:
     verified: false
     applies_if:
       - {attr: has_employees, op: is_true}
+      - {attr: company_type, op: in, value: [PT_PMA, PT_PMDN, CV, KP3A, KPPA, OTHER]}
     due: {frequency: monthly, day: 10, month: null, months_after_period_end: 0, roll: none}
 
   - id: bpjs_ketenagakerjaan_monthly
@@ -106,6 +110,7 @@ rules:
     verified: false
     applies_if:
       - {attr: has_employees, op: is_true}
+      - {attr: company_type, op: in, value: [PT_PMA, PT_PMDN, CV, KP3A, KPPA, OTHER]}
     due: {frequency: monthly, day: 15, month: null, months_after_period_end: 1, roll: none}
     notes: "Expat layer: foreign workers employed 6+ months must be enrolled; payroll SaaS may disable BPJS fields for 'ekspatriat' tax status. Check the enrolment anniversary per expat."
 
@@ -181,6 +186,7 @@ rules:
     verified: false
     applies_if:
       - {attr: has_employees, op: is_true}
+      - {attr: company_type, op: in, value: [PT_PMA, PT_PMDN, CV, KP3A, KPPA, OTHER]}
     due: {frequency: event, month: null, months_after_period_end: 0, roll: none}
     trigger: "first hire (report within 30 days), then yearly in the same month (verify); the first-hire date is not a profile attribute"
 

--- a/apps/backend-rag/backend/services/compliance/obligations_repository.py
+++ b/apps/backend-rag/backend/services/compliance/obligations_repository.py
@@ -7,9 +7,11 @@ compliance_alerts (PR A2), not to this class.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, fields
 from datetime import date, datetime
+from typing import Any
 
 import asyncpg
 
@@ -35,6 +37,27 @@ UPDATE client_obligations
        reviewed_at = NOW(), updated_at = NOW()
  WHERE id = $1 AND status = 'proposed'
 RETURNING *
+"""
+
+_MARK_ALERTED_SQL = """
+UPDATE client_obligations
+   SET status = 'alerted', alert_id = $2, updated_at = NOW()
+ WHERE id = $1 AND status = 'approved'
+RETURNING *
+"""
+
+_LIST_FILTERED_SQL = """
+SELECT * FROM client_obligations
+ WHERE ($1::integer IS NULL OR client_id = $1)
+   AND ($2::text IS NULL OR status = $2)
+ ORDER BY due_date, id
+ LIMIT $3 OFFSET $4
+"""
+
+_COUNT_FILTERED_SQL = """
+SELECT COUNT(*) FROM client_obligations
+ WHERE ($1::integer IS NULL OR client_id = $1)
+   AND ($2::text IS NULL OR status = $2)
 """
 
 
@@ -65,7 +88,34 @@ def _to_row(record: asyncpg.Record) -> ObligationRow:
 
 
 class ObligationsRepository(BaseRepository):
-    """CRUD for client_obligations."""
+    """CRUD for client_obligations.
+
+    Supports two modes, mirroring ``alert_repository.AlertRepository``: pool mode
+    (``ObligationsRepository(pool)``, each call acquires its own connection) and
+    connection mode (``ObligationsRepository.with_connection(conn)``), which binds
+    every call to a single pre-acquired connection so the obligation transition and
+    the bridge into ``compliance_alerts`` (PR A2's ``approve``) commit or roll back
+    together in one transaction.
+    """
+
+    def __init__(self, db_pool: asyncpg.Pool) -> None:
+        super().__init__(db_pool)
+        self._conn: asyncpg.Connection | None = None
+
+    @classmethod
+    def with_connection(cls, conn: asyncpg.Connection) -> ObligationsRepository:
+        """Bind the repo to a single pre-acquired connection (transactional use)."""
+        inst = cls.__new__(cls)
+        inst.db_pool = None  # type: ignore[assignment]
+        inst.logger = logging.getLogger(cls.__qualname__)
+        inst._conn = conn
+        return inst
+
+    async def _exec(self, fn_name: str, query: str, *args: Any) -> Any:
+        if self._conn is not None:
+            return await getattr(self._conn, fn_name)(query, *args)
+        async with self.db_pool.acquire() as conn:
+            return await getattr(conn, fn_name)(query, *args)
 
     async def upsert_proposals(
         self, client_id: int, proposals: Sequence[ProposedObligation]
@@ -77,7 +127,8 @@ class ObligationsRepository(BaseRepository):
         """
         if not proposals:
             return 0
-        records = await self.fetch_safe(
+        records = await self._exec(
+            "fetch",
             _UPSERT_SQL,
             client_id,
             [p.rule_id for p in proposals],
@@ -93,7 +144,8 @@ class ObligationsRepository(BaseRepository):
         """Rows with the given status (None = all), earliest due date first."""
         if status is not None and status not in STATUSES:
             raise ValueError(f"unknown status {status!r}")
-        records = await self.fetch_safe(
+        records = await self._exec(
+            "fetch",
             """
             SELECT * FROM client_obligations
              WHERE ($1::text IS NULL OR status = $1::text)
@@ -106,9 +158,39 @@ class ObligationsRepository(BaseRepository):
         )
         return [_to_row(r) for r in records]
 
+    async def list_filtered(
+        self,
+        *,
+        client_id: int | None = None,
+        status: str | None = "proposed",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[ObligationRow]:
+        """Rows filtered by client_id and/or status (either None = no filter on it)."""
+        if status is not None and status not in STATUSES:
+            raise ValueError(f"unknown status {status!r}")
+        records = await self._exec(
+            "fetch",
+            _LIST_FILTERED_SQL,
+            client_id,
+            status,
+            max(1, min(limit, MAX_PAGE)),
+            max(0, offset),
+        )
+        return [_to_row(r) for r in records]
+
+    async def count_filtered(
+        self, *, client_id: int | None = None, status: str | None = "proposed"
+    ) -> int:
+        """Total rows matching the same filters as ``list_filtered`` (for pagination)."""
+        if status is not None and status not in STATUSES:
+            raise ValueError(f"unknown status {status!r}")
+        value = await self._exec("fetchval", _COUNT_FILTERED_SQL, client_id, status)
+        return int(value or 0)
+
     async def get(self, obligation_id: int) -> ObligationRow | None:
-        record = await self.fetchrow_safe(
-            "SELECT * FROM client_obligations WHERE id = $1", obligation_id
+        record = await self._exec(
+            "fetchrow", "SELECT * FROM client_obligations WHERE id = $1", obligation_id
         )
         return _to_row(record) if record else None
 
@@ -124,9 +206,21 @@ class ObligationsRepository(BaseRepository):
             raise ValueError(f"review outcome must be approved or rejected, got {status!r}")
         if not reviewer_email or not reviewer_email.strip():
             raise ValueError("reviewer_email is required")
-        record = await self.fetchrow_safe(
-            _REVIEW_SQL, obligation_id, status, reviewer_email.strip().lower(), note
+        record = await self._exec(
+            "fetchrow", _REVIEW_SQL, obligation_id, status, reviewer_email.strip().lower(), note
         )
+        return _to_row(record) if record else None
+
+    async def mark_alerted(self, obligation_id: int, alert_id: str) -> ObligationRow | None:
+        """Bridge step of ``approve``: approved -> alerted, stamping the compliance_alerts id.
+
+        Returns None when the row does not exist or is no longer ``approved`` — the caller
+        (running inside the same transaction as the ``compliance_alerts`` insert) should treat
+        that as a reason to roll back rather than leave an orphaned alert.
+        """
+        if not alert_id or not alert_id.strip():
+            raise ValueError("alert_id is required")
+        record = await self._exec("fetchrow", _MARK_ALERTED_SQL, obligation_id, alert_id)
         return _to_row(record) if record else None
 
 

--- a/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
@@ -140,6 +140,26 @@ def test_pse_registration_needs_online_and_unregistered(catalog):
     assert not applies(catalog["pse_registration"], PMA)
 
 
+# C4 (#6122): a FOREIGN_PLATFORM client must never get these six domestic-employer/VAT rules,
+# even with has_employees/pkp set true — the catalog's company_type list excludes it on purpose.
+@pytest.mark.parametrize(
+    "rule_id",
+    [
+        "pph21_payment",
+        "spt_masa_pph21",
+        "spt_masa_ppn",
+        "bpjs_kesehatan_monthly",
+        "bpjs_ketenagakerjaan_monthly",
+        "wajib_lapor_ketenagakerjaan",
+    ],
+)
+def test_foreign_platform_excluded_from_employer_and_vat_rules(catalog, rule_id):
+    platform = ClientProfile(company_type="FOREIGN_PLATFORM", has_employees=True, pkp=True)
+    pma = ClientProfile(company_type="PT_PMA", has_employees=True, pkp=True)
+    assert not applies(catalog[rule_id], platform)
+    assert applies(catalog[rule_id], pma)
+
+
 # -- due dates -------------------------------------------------------------------------------
 
 

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_compliance_obligations.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_compliance_obligations.py
@@ -36,6 +36,7 @@ class Store:
         self.companies: dict[int, dict[str, Any]] = {}
         self.obligations: list[dict[str, Any]] = []
         self.alerts: list[dict[str, Any]] = []
+        self.op_log: list[tuple[str, Any, bool]] = []
         self._next_id = 1
 
     def acquire(self) -> _AcquireCtx:
@@ -58,11 +59,20 @@ class _AcquireCtx:
         return False
 
 
-class _NoopTxn:
+class _CountingTxn:
+    """Records enter/exit on the owning FakeConn so tests can pin the boundary."""
+
+    def __init__(self, conn: FakeConn) -> None:
+        self.conn = conn
+
     async def __aenter__(self) -> None:
+        self.conn.txn_enter_count += 1
+        self.conn.in_txn = True
         return None
 
     async def __aexit__(self, *exc: object) -> bool:
+        self.conn.in_txn = False
+        self.conn.txn_exit_count += 1
         return False
 
 
@@ -71,9 +81,12 @@ class FakeConn:
 
     def __init__(self, store: Store) -> None:
         self.store = store
+        self.txn_enter_count = 0
+        self.txn_exit_count = 0
+        self.in_txn = False
 
-    def transaction(self) -> _NoopTxn:
-        return _NoopTxn()
+    def transaction(self) -> _CountingTxn:
+        return _CountingTxn(self)
 
     async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
         flat = " ".join(query.split())
@@ -106,6 +119,7 @@ class FakeObligationsRepository:
     def with_connection(cls, conn: FakeConn) -> FakeObligationsRepository:
         inst = cls.__new__(cls)
         inst.store = conn.store
+        inst.conn = conn
         return inst
 
     async def list_filtered(
@@ -177,6 +191,7 @@ class FakeObligationsRepository:
     async def set_status(
         self, obligation_id: int, status: str, reviewer_email: str, note: str | None = None
     ) -> ObligationRow | None:
+        self.store.op_log.append(("set_status", self.conn, self.conn.in_txn))
         for row in self.store.obligations:
             if row["id"] == obligation_id:
                 if row["status"] != "proposed":
@@ -190,6 +205,7 @@ class FakeObligationsRepository:
         return None
 
     async def mark_alerted(self, obligation_id: int, alert_id: str) -> ObligationRow | None:
+        self.store.op_log.append(("mark_alerted", self.conn, self.conn.in_txn))
         for row in self.store.obligations:
             if row["id"] == obligation_id:
                 if row["status"] != "approved":
@@ -206,6 +222,7 @@ class FakeAlertRepository:
     def with_connection(cls, conn: FakeConn) -> FakeAlertRepository:
         inst = cls.__new__(cls)
         inst.store = conn.store
+        inst.conn = conn
         return inst
 
     async def find_active_by_dedup_key(self, dedup_key: str) -> AlertRow | None:
@@ -219,6 +236,7 @@ class FakeAlertRepository:
         return None
 
     async def insert(self, row: AlertRow) -> AlertRow:
+        self.store.op_log.append(("alert_insert", self.conn, self.conn.in_txn))
         as_dict = row.__dict__.copy()
         as_dict["created_at"] = datetime.now(timezone.utc)
         self.store.alerts.append(as_dict)
@@ -428,6 +446,26 @@ def test_approve_writes_exactly_one_alert_and_transitions_to_alerted(store: Stor
     assert alert["category"] == "obligation"
     assert alert["client_id"] == 7
     assert alert["dedup_key"] == "obligation:7:pph21_payment:2026-09"
+
+
+def test_approve_runs_writes_inside_one_shared_transaction(store: Store) -> None:
+    _seed_proposed(store, id=1, client_id=7, rule_id="pph21_payment", period_key="2026-09")
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.post("/api/compliance/obligations/1/approve", json={})
+
+    assert resp.status_code == 200
+    assert [name for name, _conn, _in_txn in store.op_log] == [
+        "set_status",
+        "alert_insert",
+        "mark_alerted",
+    ]
+    assert all(in_txn for _name, _conn, in_txn in store.op_log)
+    conns = {conn for _name, conn, _in_txn in store.op_log}
+    assert len(conns) == 1, "both repositories must be bound to the same connection"
+    conn = conns.pop()
+    assert conn.txn_enter_count == 1
+    assert conn.txn_exit_count == 1
 
 
 def test_approve_twice_is_409(store: Store) -> None:

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_compliance_obligations.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_compliance_obligations.py
@@ -1,0 +1,501 @@
+"""Unit tests for the obligations reviewer API (PR A2).
+
+Follows the intake_review unit-test template (test_crm_enhanced_alerts.py):
+a bare FastAPI() app with dependency_overrides for the admin gate and a fake
+pool/connection, plus monkeypatched fake repositories so no real Postgres is
+needed. The fakes reuse the REAL ``ObligationRow``/``AlertRow`` dataclasses so
+the router's response-shaping code (``_to_out``) is exercised unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app.dependencies import get_current_user, get_database_pool
+from backend.app.routers import compliance_obligations
+from backend.services.compliance.alert_repository import AlertRow
+from backend.services.compliance.obligations_repository import ObligationRow
+
+ADMIN_USER = {"email": "admin@example.com", "role": "admin"}
+NON_ADMIN_USER = {"email": "user@example.com", "role": "user"}
+
+
+# --------------------------------------------------------------------------- #
+# In-memory fake DB: shared by direct-SQL calls (client/company lookups in
+# /generate, the 404-vs-409 status probe in approve/reject) and by the fake
+# repositories below (which the router uses for everything else).
+# --------------------------------------------------------------------------- #
+class Store:
+    def __init__(self) -> None:
+        self.clients: dict[int, dict[str, Any]] = {}
+        self.companies: dict[int, dict[str, Any]] = {}
+        self.obligations: list[dict[str, Any]] = []
+        self.alerts: list[dict[str, Any]] = []
+        self._next_id = 1
+
+    def acquire(self) -> _AcquireCtx:
+        return _AcquireCtx(self)
+
+    def next_id(self) -> int:
+        value = self._next_id
+        self._next_id += 1
+        return value
+
+
+class _AcquireCtx:
+    def __init__(self, store: Store) -> None:
+        self.store = store
+
+    async def __aenter__(self) -> FakeConn:
+        return FakeConn(self.store)
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+class _NoopTxn:
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+class FakeConn:
+    """Answers the THREE raw SQL calls the router makes directly on a connection."""
+
+    def __init__(self, store: Store) -> None:
+        self.store = store
+
+    def transaction(self) -> _NoopTxn:
+        return _NoopTxn()
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
+        flat = " ".join(query.split())
+        if "FROM clients" in flat:
+            row = self.store.clients.get(args[0])
+            return dict(row) if row is not None else None
+        if "FROM client_company_links" in flat:
+            row = self.store.companies.get(args[0])
+            return dict(row) if row is not None else None
+        if "SELECT status FROM client_obligations" in flat:
+            for row in self.store.obligations:
+                if row["id"] == args[0]:
+                    return {"status": row["status"]}
+            return None
+        raise AssertionError(f"unexpected fetchrow query in test fake: {query!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Fake repositories (monkeypatched over the real classes in the router module)
+# --------------------------------------------------------------------------- #
+def _ob_row(d: dict[str, Any]) -> ObligationRow:
+    return ObligationRow(**d)
+
+
+class FakeObligationsRepository:
+    def __init__(self, pool: Store) -> None:
+        self.store = pool
+
+    @classmethod
+    def with_connection(cls, conn: FakeConn) -> FakeObligationsRepository:
+        inst = cls.__new__(cls)
+        inst.store = conn.store
+        return inst
+
+    async def list_filtered(
+        self,
+        *,
+        client_id: int | None = None,
+        status: str | None = "proposed",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[ObligationRow]:
+        rows = [
+            r
+            for r in self.store.obligations
+            if (client_id is None or r["client_id"] == client_id)
+            and (status is None or r["status"] == status)
+        ]
+        rows.sort(key=lambda r: (r["due_date"], r["id"]))
+        return [_ob_row(r) for r in rows[offset : offset + limit]]
+
+    async def count_filtered(
+        self, *, client_id: int | None = None, status: str | None = "proposed"
+    ) -> int:
+        return len(
+            [
+                r
+                for r in self.store.obligations
+                if (client_id is None or r["client_id"] == client_id)
+                and (status is None or r["status"] == status)
+            ]
+        )
+
+    async def get(self, obligation_id: int) -> ObligationRow | None:
+        for row in self.store.obligations:
+            if row["id"] == obligation_id:
+                return _ob_row(row)
+        return None
+
+    async def upsert_proposals(self, client_id: int, proposals: Any) -> int:
+        existing_keys = {
+            (r["client_id"], r["rule_id"], r["period_key"]) for r in self.store.obligations
+        }
+        inserted = 0
+        now = datetime.now(timezone.utc)
+        for p in proposals:
+            key = (client_id, p.rule_id, p.period_key)
+            if key in existing_keys:
+                continue
+            existing_keys.add(key)
+            self.store.obligations.append(
+                {
+                    "id": self.store.next_id(),
+                    "client_id": client_id,
+                    "rule_id": p.rule_id,
+                    "period_key": p.period_key,
+                    "due_date": p.due_date,
+                    "status": "proposed",
+                    "needs_review_reason": p.needs_review_reason,
+                    "reviewer_email": None,
+                    "reviewed_at": None,
+                    "review_note": None,
+                    "alert_id": None,
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            )
+            inserted += 1
+        return inserted
+
+    async def set_status(
+        self, obligation_id: int, status: str, reviewer_email: str, note: str | None = None
+    ) -> ObligationRow | None:
+        for row in self.store.obligations:
+            if row["id"] == obligation_id:
+                if row["status"] != "proposed":
+                    return None
+                row["status"] = status
+                row["reviewer_email"] = reviewer_email
+                row["review_note"] = note
+                row["reviewed_at"] = datetime.now(timezone.utc)
+                row["updated_at"] = datetime.now(timezone.utc)
+                return _ob_row(row)
+        return None
+
+    async def mark_alerted(self, obligation_id: int, alert_id: str) -> ObligationRow | None:
+        for row in self.store.obligations:
+            if row["id"] == obligation_id:
+                if row["status"] != "approved":
+                    return None
+                row["status"] = "alerted"
+                row["alert_id"] = alert_id
+                row["updated_at"] = datetime.now(timezone.utc)
+                return _ob_row(row)
+        return None
+
+
+class FakeAlertRepository:
+    @classmethod
+    def with_connection(cls, conn: FakeConn) -> FakeAlertRepository:
+        inst = cls.__new__(cls)
+        inst.store = conn.store
+        return inst
+
+    async def find_active_by_dedup_key(self, dedup_key: str) -> AlertRow | None:
+        for row in self.store.alerts:
+            if row["dedup_key"] == dedup_key and row["status"] in (
+                "pending",
+                "sent",
+                "acknowledged",
+            ):
+                return AlertRow(**row)
+        return None
+
+    async def insert(self, row: AlertRow) -> AlertRow:
+        as_dict = row.__dict__.copy()
+        as_dict["created_at"] = datetime.now(timezone.utc)
+        self.store.alerts.append(as_dict)
+        return AlertRow(**as_dict)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def _fake_repositories(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(compliance_obligations, "ObligationsRepository", FakeObligationsRepository)
+    monkeypatch.setattr(compliance_obligations, "AlertRepository", FakeAlertRepository)
+
+
+@pytest.fixture
+def store() -> Store:
+    return Store()
+
+
+def _app(store: Store, user: dict[str, Any]) -> FastAPI:
+    app = FastAPI()
+    app.include_router(compliance_obligations.router)
+    app.dependency_overrides[get_database_pool] = lambda: store
+    app.dependency_overrides[get_current_user] = lambda: user
+    return app
+
+
+def _seed_proposed(store: Store, **overrides: Any) -> dict[str, Any]:
+    row = {
+        "id": store.next_id(),
+        "client_id": 1,
+        "rule_id": "pph21_payment",
+        "period_key": "2026-09",
+        "due_date": date.today() + timedelta(days=10),
+        "status": "proposed",
+        "needs_review_reason": None,
+        "reviewer_email": None,
+        "reviewed_at": None,
+        "review_note": None,
+        "alert_id": None,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    row.update(overrides)
+    store.obligations.append(row)
+    return row
+
+
+# --------------------------------------------------------------------------- #
+# RBAC: 403 for non-admin on every mutating route (and reads, per this
+# router's full-admin gate — DESIGN-lane-A.md specifies is_crm_admin for the
+# whole router, unlike intake_review's own-chat scoping which doesn't apply
+# to obligations).
+# --------------------------------------------------------------------------- #
+def test_list_403_for_non_admin(store: Store) -> None:
+    client = TestClient(_app(store, NON_ADMIN_USER))
+    resp = client.get("/api/compliance/obligations")
+    assert resp.status_code == 403
+
+
+def test_get_403_for_non_admin(store: Store) -> None:
+    _seed_proposed(store)
+    client = TestClient(_app(store, NON_ADMIN_USER))
+    resp = client.get("/api/compliance/obligations/1")
+    assert resp.status_code == 403
+
+
+def test_generate_403_for_non_admin(store: Store) -> None:
+    client = TestClient(_app(store, NON_ADMIN_USER))
+    resp = client.post("/api/compliance/obligations/generate", json={"client_id": 1})
+    assert resp.status_code == 403
+
+
+def test_approve_403_for_non_admin(store: Store) -> None:
+    _seed_proposed(store)
+    client = TestClient(_app(store, NON_ADMIN_USER))
+    resp = client.post("/api/compliance/obligations/1/approve", json={})
+    assert resp.status_code == 403
+
+
+def test_reject_403_for_non_admin(store: Store) -> None:
+    _seed_proposed(store)
+    client = TestClient(_app(store, NON_ADMIN_USER))
+    resp = client.post("/api/compliance/obligations/1/reject", json={"reason": "no"})
+    assert resp.status_code == 403
+
+
+# --------------------------------------------------------------------------- #
+# list / get shape
+# --------------------------------------------------------------------------- #
+def test_list_returns_paginated_shape(store: Store) -> None:
+    _seed_proposed(store, id=1, period_key="2026-09")
+    _seed_proposed(store, id=2, period_key="2026-10")
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.get("/api/compliance/obligations")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    assert body["limit"] == 50
+    assert body["offset"] == 0
+    assert len(body["items"]) == 2
+    assert body["items"][0]["status"] == "proposed"
+
+
+def test_list_filters_by_client_id_and_status(store: Store) -> None:
+    _seed_proposed(store, id=1, client_id=1)
+    _seed_proposed(store, id=2, client_id=2)
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.get("/api/compliance/obligations", params={"client_id": 2})
+
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["client_id"] == 2
+
+
+def test_get_returns_detail(store: Store) -> None:
+    _seed_proposed(store, id=1)
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.get("/api/compliance/obligations/1")
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 1
+    assert resp.json()["rule_id"] == "pph21_payment"
+
+
+def test_get_unknown_id_404(store: Store) -> None:
+    client = TestClient(_app(store, ADMIN_USER))
+    resp = client.get("/api/compliance/obligations/999")
+    assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# generate: persists + idempotent
+# --------------------------------------------------------------------------- #
+def test_generate_404_unknown_client(store: Store) -> None:
+    client = TestClient(_app(store, ADMIN_USER))
+    resp = client.post("/api/compliance/obligations/generate", json={"client_id": 1})
+    assert resp.status_code == 404
+
+
+def test_generate_persists_and_is_idempotent(store: Store) -> None:
+    store.clients[1] = {"id": 1, "custom_fields": {}}
+    store.companies[1] = {
+        "company_type": "PT PMA",
+        "custom_fields": {"has_employees": True, "pkp": True},
+    }
+    client = TestClient(_app(store, ADMIN_USER))
+
+    first = client.post(
+        "/api/compliance/obligations/generate",
+        json={"client_id": 1, "horizon_days": 400},
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+    assert first_body["inserted_count"] > 0
+    assert len(first_body["rows"]) == first_body["inserted_count"]
+    assert first_body["needs_manual_classification"] is False
+    assert first_body["warning"] is None
+    first_row_count = len(store.obligations)
+
+    second = client.post(
+        "/api/compliance/obligations/generate",
+        json={"client_id": 1, "horizon_days": 400},
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+    assert second_body["inserted_count"] == 0
+    assert len(second_body["rows"]) == first_body["inserted_count"]
+    assert len(store.obligations) == first_row_count  # no duplicates
+
+
+def test_generate_flags_other_company_type_for_manual_classification(store: Store) -> None:
+    store.clients[1] = {"id": 1, "custom_fields": {}}
+    store.companies[1] = {"company_type": "Some Unrecognised Foundation", "custom_fields": {}}
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.post("/api/compliance/obligations/generate", json={"client_id": 1})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["company_type"] == "OTHER"
+    assert body["needs_manual_classification"] is True
+    assert body["warning"]
+
+
+# --------------------------------------------------------------------------- #
+# approve: bridges into compliance_alerts exactly once, then refuses re-decision
+# --------------------------------------------------------------------------- #
+def test_approve_writes_exactly_one_alert_and_transitions_to_alerted(store: Store) -> None:
+    _seed_proposed(store, id=1, client_id=7, rule_id="pph21_payment", period_key="2026-09")
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.post("/api/compliance/obligations/1/approve", json={"note": "looks right"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["obligation"]["status"] == "alerted"
+    assert body["obligation"]["alert_id"] == body["alert_id"]
+    assert len(store.alerts) == 1
+    alert = store.alerts[0]
+    assert alert["category"] == "obligation"
+    assert alert["client_id"] == 7
+    assert alert["dedup_key"] == "obligation:7:pph21_payment:2026-09"
+
+
+def test_approve_twice_is_409(store: Store) -> None:
+    _seed_proposed(store, id=1)
+    client = TestClient(_app(store, ADMIN_USER))
+
+    first = client.post("/api/compliance/obligations/1/approve", json={})
+    assert first.status_code == 200
+
+    second = client.post("/api/compliance/obligations/1/approve", json={})
+    assert second.status_code == 409
+    assert len(store.alerts) == 1  # no second alert from the failed re-approve
+
+
+def test_reject_after_approve_is_409(store: Store) -> None:
+    _seed_proposed(store, id=1)
+    client = TestClient(_app(store, ADMIN_USER))
+
+    approve = client.post("/api/compliance/obligations/1/approve", json={})
+    assert approve.status_code == 200
+
+    reject = client.post("/api/compliance/obligations/1/reject", json={"reason": "too late"})
+    assert reject.status_code == 409
+
+
+def test_approve_unknown_id_404(store: Store) -> None:
+    client = TestClient(_app(store, ADMIN_USER))
+    resp = client.post("/api/compliance/obligations/999/approve", json={})
+    assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# reject: records the reason, terminal, no compliance_alerts write
+# --------------------------------------------------------------------------- #
+def test_reject_records_reason(store: Store) -> None:
+    _seed_proposed(store, id=1)
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.post("/api/compliance/obligations/1/reject", json={"reason": "not applicable"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "rejected"
+    assert body["review_note"] == "not applicable"
+    assert store.alerts == []  # reject never bridges into compliance_alerts
+
+
+def test_reject_without_reason_is_422(store: Store) -> None:
+    _seed_proposed(store, id=1)
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.post("/api/compliance/obligations/1/reject", json={})
+
+    assert resp.status_code == 422
+
+
+def test_reject_twice_is_409(store: Store) -> None:
+    _seed_proposed(store, id=1)
+    client = TestClient(_app(store, ADMIN_USER))
+
+    first = client.post("/api/compliance/obligations/1/reject", json={"reason": "no"})
+    assert first.status_code == 200
+
+    second = client.post("/api/compliance/obligations/1/reject", json={"reason": "no"})
+    assert second.status_code == 409
+
+
+def test_reject_unknown_id_404(store: Store) -> None:
+    client = TestClient(_app(store, ADMIN_USER))
+    resp = client.post("/api/compliance/obligations/999/reject", json={"reason": "no"})
+    assert resp.status_code == 404

--- a/evidence/2026-09/agent-nuzantara-backend-rag-obligations-router-fa43b9e8/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-obligations-router-fa43b9e8/brief.yml
@@ -1,0 +1,60 @@
+task: >-
+  Obligations reviewer API, PR A2 of the compliance-stack build (lane A): a router at
+  /api/compliance/obligations (list/get/generate/approve/reject), CRM-admin gated, that lets
+  the tax team review the rows PR A1's propose() proposes and bridges an approved obligation
+  into compliance_alerts (one row, category "obligation") through the existing AlertRepository,
+  in the same transaction as the proposed->approved->alerted state change. Also closes PR A1
+  gate #6122's C4 follow-up (catalog-side FOREIGN_PLATFORM exclusion + API-side
+  needs_manual_classification flag on POST /generate for OTHER company_type profiles).
+lane: backend-rag/obligations-router
+machine: Pro
+date: 2026-09-11
+
+gear: 2
+gear_reason: >-
+  Deterministic floor 2, source `size`: `git diff --numstat` against origin/main is 1021 added
+  lines / 7 removed, above SIZE_GEAR2_THRESHOLD (400) and below SIZE_GEAR3_THRESHOLD (1828).
+  No hot-zone path: no db/migrations_v2, no .env*, no fly.toml, no lockfile, no core/config.py,
+  no app/auth touched (migration 309 belongs to the sibling PR A1b, a separate worktree), so the
+  path term is 1. Computed exactly as CI: `git diff --name-only origin/main...HEAD` +
+  `git diff --numstat origin/main...HEAD` piped into
+  `scripts/evidence_pack_lint.py --print-floor`, which printed `2`. No pack.yml at gear 2.
+
+appetite:
+  wall_clock_hours: 3
+  adversarial_rounds: 1
+
+acceptance:
+  A1: >-
+    Every mutating route (generate, approve, reject) 403s a non-admin caller; the read routes
+    (list, get) are gated the same way (DESIGN-lane-A.md specifies is_crm_admin for the whole
+    router; intake_review's broader own-chat read access does not apply here — there is no
+    per-user ownership axis on obligations).
+    probe: PYTHONPATH=.:../crm-cell pytest backend/tests/unit/app/routers/test_compliance_obligations.py -k 403_for_non_admin
+  A2: >-
+    POST /generate persists new proposals and is idempotent: a second call over the same
+    (client, horizon) makes no new inserts and returns the same proposed rows.
+    probe: PYTHONPATH=.:../crm-cell pytest backend/tests/unit/app/routers/test_compliance_obligations.py -k generate_persists_and_is_idempotent
+  A3: >-
+    POST /{id}/approve writes exactly one compliance_alerts row and transitions
+    approved->alerted atomically; a second approve or a reject on an already-decided row is 409,
+    never a second alert.
+    probe: PYTHONPATH=.:../crm-cell pytest backend/tests/unit/app/routers/test_compliance_obligations.py -k "approve_writes_exactly_one_alert or approve_twice_is_409 or reject_after_approve_is_409"
+  A4: >-
+    POST /{id}/reject requires and records a non-empty reason (422 without one), is terminal, and
+    never writes compliance_alerts.
+    probe: PYTHONPATH=.:../crm-cell pytest backend/tests/unit/app/routers/test_compliance_obligations.py -k reject
+  A5: >-
+    The router is registered in both include_routers()/include_light_routers() and declared in
+    router_manifest.py (mirrors compliance_alerts — light process, no RAG deps); the whole
+    registration/manifest parity suite stays green.
+    probe: PYTHONPATH=.:../crm-cell pytest backend/tests/setup/test_manifest_registration_parity.py backend/tests/setup/test_router_registration_parity.py backend/tests/setup/test_router_manifest.py
+
+out_of_scope: >-
+  Migration 309 (client_obligations) — owned by the sibling PR A1b in another worktree; this PR
+  must merge AFTER it and is not deployed by this session. Sending obligation reminders
+  (compliance_alerts' own dispatcher does that, unchanged). National holidays in the due-date
+  roll (declared out of scope in PR A1). A dedicated real-DB test for ObligationsRepository (none
+  existed before this PR; this router is covered at the HTTP layer with fake repositories,
+  matching the intake_review unit-test template — DB-level coverage of upsert_proposals'
+  ON CONFLICT DO NOTHING is PR A1's contract, already gated in #6122).


### PR DESCRIPTION
## Summary
- Adds `app/routers/compliance_obligations.py` (`/api/compliance/obligations`), the reviewer queue for the rows PR A1's `propose()` produces: CRM-admin-gated list/get/generate/approve/reject.
- `POST /{id}/approve` is the only place a proposal becomes visible to a client — it transitions `client_obligations` `proposed -> approved -> alerted` **and** writes exactly one `compliance_alerts` row (category `obligation`, `dedup_key = obligation:<client_id>:<rule_id>:<period_key>`) through the existing `AlertRepository` (m114), in one DB transaction. `reject` is terminal and never touches `compliance_alerts`.
- Extends `services/compliance/obligations_repository.py` with `with_connection()` / `mark_alerted()` / `list_filtered()` / `count_filtered()` (mirrors `alert_repository.AlertRepository`'s pool/connection duality) so the two writes in `approve` can share one transaction.
- Registers the router in `router_registration.py` (`include_routers` + `include_light_routers`, same placement as `compliance_alerts`) and `router_manifest.py`.
- Closes PR A1 gate #6122's C4 follow-up (see disposition below).

## Endpoints
| Method | Path | Gate | Notes |
|---|---|---|---|
| GET | `/api/compliance/obligations` | admin | filters `client_id`, `status` (default `proposed`, `all` clears it); `{total, limit, offset, items}` like `intake_review` |
| GET | `/api/compliance/obligations/{id}` | admin | 404 if unknown |
| POST | `/api/compliance/obligations/generate` | admin | body `{client_id, horizon_days=90}`; loads the client+company row, runs `profile_from_rows` + `propose()`, upserts (idempotent — repository's `ON CONFLICT DO NOTHING`), returns `{inserted_count, company_type, needs_manual_classification, warning, rows}` |
| POST | `/api/compliance/obligations/{id}/approve` | admin | body `{note?}`; bridges into `compliance_alerts`, returns `{obligation, alert_id}`; 409 if not `proposed` |
| POST | `/api/compliance/obligations/{id}/reject` | admin | body `{reason}` (required, 422 if missing/empty); 409 if not `proposed` |

## C4 disposition (PR A1 gate #6122)
Gate comment: `gh pr view 6122 --comments | grep -n -A6 C4`. Two items, both closed:
1. **FOREIGN_PLATFORM getting PPh 21/BPJS/PPN via has_employees/pkp flags alone** — fixed catalog-side: `pph21_payment`, `spt_masa_pph21`, `spt_masa_ppn`, `bpjs_kesehatan_monthly`, `bpjs_ketenagakerjaan_monthly`, `wajib_lapor_ketenagakerjaan` in `obligations_catalog.yaml` now also require `company_type in [PT_PMA, PT_PMDN, CV, KP3A, KPPA, OTHER]` (the same exclusion pattern `pph23_26_payment` already used), so a FOREIGN_PLATFORM profile can never match them regardless of custom_fields. Verified no A1 test exercises FOREIGN_PLATFORM against these rule ids.
2. **`profile_from_rows` mapping unrecognised company_type spellings to OTHER, silently dropping LKPM/PPh25/SPT Tahunan/RUPS** — fixed API-side, as asked: `POST /generate` now sets `needs_manual_classification: true` and a `warning` string in its response whenever the resolved profile is `OTHER`, instead of silently returning an incomplete proposal set.

## Test plan
Unit tests follow the `intake_review` template: bare `FastAPI()` + `dependency_overrides` for `get_current_user`/`get_database_pool`, plus monkeypatched fake `ObligationsRepository`/`AlertRepository` backed by an in-memory `Store` (no real Postgres). New file: `backend/tests/unit/app/routers/test_compliance_obligations.py` (21 tests) — 403 on every route for a non-admin, list/get shape + filters, generate persistence + idempotency + OTHER-flagging, approve's single-alert bridge + 409 on re-decision, reject's reason + 409 + 422.

Mutation check (temporarily reverted before this commit) — proves the tests are load-bearing, not just checking trivial things:
```
$ pytest ... -k "reject_403_for_non_admin or generate_persists_and_is_idempotent"
FAILED test_reject_403_for_non_admin - assert 200 == 403        # admin gate removed
FAILED test_generate_persists_and_is_idempotent - assert 128 == 0   # idempotency counter hardcoded
2 failed, 18 deselected
```
Green after reverting the mutation:
```
$ cd apps/backend-rag && PYTHONPATH=.:../crm-cell .venv/bin/python -m pytest \
    backend/tests/unit/app/routers/test_compliance_obligations.py backend/tests/services/compliance -p no:cacheprovider
...
374 passed, 1 skipped, 1 warning in 3.58s
```
(the 1 skip is A1's pre-existing migration-309-deferred skip, unrelated to this PR)

Also green — router registration/manifest parity (this PR adds an entry to both):
```
$ pytest backend/tests/setup/test_manifest_registration_parity.py backend/tests/setup/test_router_registration_parity.py backend/tests/setup/test_router_manifest.py
388 passed
```
`ruff check` / `ruff format --check` clean on every file this PR touches or creates.

## Evidence
`evidence/2026-09/agent-nuzantara-backend-rag-obligations-router-fa43b9e8/brief.yml` — gear 2 (floor computed via `evidence_pack_lint.py --print-floor` on `git diff --numstat origin/main...HEAD`: 1021 added / 7 removed lines, no hot-zone path). No pack.yml required at gear 2.

## Adversarial review
- **Transaction boundary on approve**: `set_status` (proposed→approved), the `compliance_alerts` insert (or dedup-key reuse), and `mark_alerted` (approved→alerted) all run on the SAME `asyncpg` connection inside one `async with conn.transaction():` block via `ObligationsRepository.with_connection()` / `AlertRepository.with_connection()`. No compensation logic exists or is needed — a failure anywhere before the block exits rolls back both the obligation transition and the alert insert, so an obligation can never be left `approved` with no alert, nor an alert exist with no `alerted` obligation pointing at it.
- **Admin gate coverage**: every route — including the two GET reads — requires `is_crm_admin`. This is stricter than `intake_review`'s template (which lets a non-admin read their own-chat rows); I gated GET the same as the mutating routes because DESIGN-lane-A.md specifies `is_crm_admin` for the whole router and obligations have no per-user ownership axis analogous to `received_by`. Verified with a 403 test on every route, and a mutation (admin check removed on reject) that the test suite catches (see Test plan).
- **Idempotency of generate**: `upsert_proposals` relies on the repository's `(client_id, rule_id, period_key)` UNIQUE constraint + `ON CONFLICT DO NOTHING` (PR A1's contract, gated in #6122) — this PR does not re-verify that SQL-level guarantee against a real Postgres (no `test_obligations_repository.py` exists yet against a real DB either, before or after this PR). What this PR's tests DO verify is that the router calls `upsert_proposals` and re-reads the `proposed` set correctly on every call, and a mutation test (hardcoding `inserted_count`) proves that wiring is load-bearing.

## Dependency
Runtime depends on **migration 309** (`client_obligations`), owned by a sibling PR in another worktree (not yet opened as of this PR). `ObligationsRepository` already assumes that schema (built in PR A1, #6122). **This PR must merge AFTER migration 309 lands**, and is not deployed by this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
