### PR TITLE
fix(db): retry the migration manager's pool creation on transport resets, with bounded backoff

### DIFF
--- a/apps/backend-rag/backend/db/migration_manager.py
+++ b/apps/backend-rag/backend/db/migration_manager.py
@@ -3,6 +3,7 @@ NUZANTARA PRIME - Migration Manager
 Centralized migration management system
 """
 
+import asyncio
 import logging
 from pathlib import Path
 from urllib.parse import urlparse
@@ -102,28 +103,82 @@ class MigrationManager:
             raise MigrationError("DATABASE_URL not configured")
         self.pool: asyncpg.Pool | None = None
 
+    # Transport-level failures while the pool is being created. Each of these
+    # means "the socket died before Postgres said anything", which is what a
+    # cold release_command machine sees when the private network resets the
+    # TLS handshake. Postgres-level refusals (bad password, no such database,
+    # role missing) are NOT in this set and still fail on the first attempt.
+    CONNECT_RETRY_EXCEPTIONS: tuple[type[BaseException], ...] = (
+        ConnectionError,  # ConnectionResetError, ConnectionRefusedError, ...
+        OSError,
+        asyncio.TimeoutError,
+        asyncpg.exceptions.InterfaceError,
+        asyncpg.exceptions.TargetServerAttributeNotMatched,
+    )
+    CONNECT_ATTEMPTS = 5
+    CONNECT_BACKOFF_BASE_SECONDS = 2.0
+
     async def connect(self) -> None:
         """
-        Create connection pool.
+        Create connection pool, retrying transport-level failures.
 
         Should be called before using the manager.
+
+        Born 2026-09-10 19:13Z-19:57Z: four consecutive Fly release_commands
+        died in this call with ``ConnectionResetError`` inside asyncpg's TLS
+        ``start_tls`` (plus ``TargetServerAttributeNotMatched`` from its
+        multi-host fallback) while the Postgres cluster reported 3/3 checks
+        passing and ~36/300 connections. A single bare ``create_pool`` turned
+        every such reset into a hard deploy failure; this is the bounded
+        retry that was missing (superscar #8, network flap).
         """
-        if self.pool is None:
-            self.pool = await asyncpg.create_pool(
-                self.database_url,
-                min_size=1,
-                max_size=5,
-                command_timeout=60,
-                # Every ACQUIRE assumes the runtime role (not just connection
-                # creation): the ledger tables (`_ensure_migration_log`) and the
-                # advisory lock go through this pool, a `CREATE TABLE IF NOT
-                # EXISTS` here must not mint a migrator-owned table, and
-                # asyncpg's release-time `RESET ALL` undoes `SET ROLE` -- so an
-                # `init`-only hook would hold for the first acquire and silently
-                # lapse on the second (kimi, 2026-09-11). The hook is idempotent.
-                setup=assume_runtime_role,
-            )
-            logger.info("Migration manager connection pool created")
+        if self.pool is not None:
+            return
+        last_error: BaseException | None = None
+        for attempt in range(1, self.CONNECT_ATTEMPTS + 1):
+            try:
+                self.pool = await asyncpg.create_pool(
+                    self.database_url,
+                    min_size=1,
+                    max_size=5,
+                    command_timeout=60,
+                    # Every ACQUIRE assumes the runtime role (not just connection
+                    # creation): the ledger tables (`_ensure_migration_log`) and the
+                    # advisory lock go through this pool, a `CREATE TABLE IF NOT
+                    # EXISTS` here must not mint a migrator-owned table, and
+                    # asyncpg's release-time `RESET ALL` undoes `SET ROLE` -- so an
+                    # `init`-only hook would hold for the first acquire and silently
+                    # lapse on the second (kimi, 2026-09-11). The hook is idempotent.
+                    setup=assume_runtime_role,
+                )
+            except self.CONNECT_RETRY_EXCEPTIONS as exc:
+                last_error = exc
+                if attempt == self.CONNECT_ATTEMPTS:
+                    break
+                delay = self.CONNECT_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+                logger.warning(
+                    "Migration manager connect attempt %d/%d failed (%s: %s); retrying in %.0fs",
+                    attempt,
+                    self.CONNECT_ATTEMPTS,
+                    type(exc).__name__,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+            else:
+                if attempt > 1:
+                    logger.info("Migration manager connection pool created on attempt %d", attempt)
+                else:
+                    logger.info("Migration manager connection pool created")
+                return
+        assert last_error is not None
+        logger.error(
+            "Migration manager could not connect after %d attempts: %s: %s",
+            self.CONNECT_ATTEMPTS,
+            type(last_error).__name__,
+            last_error,
+        )
+        raise last_error
 
     async def close(self) -> None:
         """Close connection pool"""

--- a/apps/backend-rag/backend/tests/db/test_migration_manager_connect_retry.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_manager_connect_retry.py
@@ -1,0 +1,110 @@
+"""MigrationManager.connect() retries transport-level failures with backoff.
+
+Born 2026-09-10: four consecutive Fly release_commands died in
+``asyncpg.create_pool`` with ``ConnectionResetError`` inside the TLS
+handshake while Postgres itself was healthy. The bare call had no retry, so
+each reset was a hard deploy failure (superscar #8).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import asyncpg
+import pytest
+
+from backend.db.migration_manager import MigrationManager
+
+
+def _manager() -> MigrationManager:
+    return MigrationManager(database_url="postgresql://u:p@db.example.internal:5432/x")
+
+
+@pytest.mark.asyncio
+async def test_connect_retries_connection_reset_then_succeeds() -> None:
+    manager = _manager()
+    pool = object()
+    create_pool = AsyncMock(side_effect=[ConnectionResetError("reset by peer"), pool])
+    sleep = AsyncMock()
+
+    with (
+        patch("backend.db.migration_manager.asyncpg.create_pool", create_pool),
+        patch("backend.db.migration_manager.asyncio.sleep", sleep),
+    ):
+        await manager.connect()
+
+    assert manager.pool is pool
+    assert create_pool.await_count == 2
+    sleep.assert_awaited_once_with(MigrationManager.CONNECT_BACKOFF_BASE_SECONDS)
+
+
+@pytest.mark.asyncio
+async def test_connect_retries_target_server_attribute_not_matched() -> None:
+    """asyncpg's multi-host fallback error is the OTHER shape the incident took."""
+    manager = _manager()
+    pool = object()
+    create_pool = AsyncMock(
+        side_effect=[asyncpg.exceptions.TargetServerAttributeNotMatched("no host matched"), pool]
+    )
+
+    with (
+        patch("backend.db.migration_manager.asyncpg.create_pool", create_pool),
+        patch("backend.db.migration_manager.asyncio.sleep", AsyncMock()),
+    ):
+        await manager.connect()
+
+    assert manager.pool is pool
+    assert create_pool.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_connect_gives_up_after_bounded_attempts_with_exponential_backoff() -> None:
+    manager = _manager()
+    create_pool = AsyncMock(side_effect=ConnectionResetError("reset by peer"))
+    sleep = AsyncMock()
+
+    with (
+        patch("backend.db.migration_manager.asyncpg.create_pool", create_pool),
+        patch("backend.db.migration_manager.asyncio.sleep", sleep),
+    ):
+        with pytest.raises(ConnectionResetError):
+            await manager.connect()
+
+    assert manager.pool is None
+    assert create_pool.await_count == MigrationManager.CONNECT_ATTEMPTS
+    base = MigrationManager.CONNECT_BACKOFF_BASE_SECONDS
+    delays = [c.args[0] for c in sleep.await_args_list]
+    assert delays == [base * (2**i) for i in range(MigrationManager.CONNECT_ATTEMPTS - 1)]
+
+
+@pytest.mark.asyncio
+async def test_connect_does_not_retry_postgres_level_refusals() -> None:
+    """A bad password / missing database is a real error, not a flap."""
+    manager = _manager()
+    create_pool = AsyncMock(
+        side_effect=asyncpg.exceptions.InvalidPasswordError("password authentication failed")
+    )
+    sleep = AsyncMock()
+
+    with (
+        patch("backend.db.migration_manager.asyncpg.create_pool", create_pool),
+        patch("backend.db.migration_manager.asyncio.sleep", sleep),
+    ):
+        with pytest.raises(asyncpg.exceptions.InvalidPasswordError):
+            await manager.connect()
+
+    assert create_pool.await_count == 1
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_is_idempotent_once_connected() -> None:
+    manager = _manager()
+    pool = object()
+    create_pool = AsyncMock(return_value=pool)
+
+    with patch("backend.db.migration_manager.asyncpg.create_pool", create_pool):
+        await manager.connect()
+        await manager.connect()
+
+    assert create_pool.await_count == 1


### PR DESCRIPTION
## What broke

Five consecutive Fly deploys of `nuzantara-rag` failed on 2026-09-10 between 19:13Z and 20:04Z (releases v4390–v4394, runs 34519143375, 34521809533 ×2 attempts, 34523442161). Every one died in the `release_command` (`python -m backend.db.migrate apply-all && python -m backend.db.schema_audit`) inside `MigrationManager.connect()` → `asyncpg.create_pool` → TLS `start_tls` → `ConnectionResetError` (asyncpg's multi-host fallback then reports `TargetServerAttributeNotMatched`). Production stayed on v4389 (healthy, `/health` 200), so PRs #6142 and #6145 are merged but not live.

## What the evidence says

- `nuzantara-postgres`: 3/3 checks passing on all three machines, primary unchanged since 2025-10-31, ~36/300 connections, repmgrd "normal state" every 5 min across the window, no SSL/reset/terminate lines.
- No code or `DATABASE_URL` change between v4389 (ok) and v4390 (fail).
- From a RUNNING app machine, a fresh pool through the same code path and DSN connected fine at 20:07:53Z and 20:08:25Z (`fly ssh console -C "python -m backend.db.migrate status"` → "Migration manager connection pool created").
- On the ephemeral release machine the reset comes **~2 s after "Machine started"** in all three transcripts examined (19:48:02→19:48:04Z, 19:56:39→19:56:41Z, 20:04:46→20:04:48Z), with no warning lines before the traceback.

So: a boot-time network-readiness race on a cold release machine, and a `create_pool` with **no retry at all** turning every such reset into a hard deploy failure (superscar #8). Diagnosis by a backend-verifier subagent, verified by this session.

## Fix

`MigrationManager.connect()` retries transport-level failures only — `ConnectionError`, `OSError`, `asyncio.TimeoutError`, `asyncpg.InterfaceError`, `asyncpg.TargetServerAttributeNotMatched` — up to 5 attempts with exponential backoff from 2 s (2+4+8+16 = 30 s worst case), logging each attempt and re-raising the last error. Postgres-level refusals (bad password, missing database/role) are not in the set and still fail on the first attempt. The `setup=assume_runtime_role` pool hook is untouched. `schema_audit` reuses the same `MigrationManager`, so both halves of the release command are covered.

## Tests

`backend/tests/db/test_migration_manager_connect_retry.py` — 5 cases: reset-then-success, `TargetServerAttributeNotMatched`-then-success, bounded attempts with the exact backoff sequence, no retry on `InvalidPasswordError`, idempotent once connected. Falsification: 4 of the 5 fail against the previous `connect()` (`4 failed, 20 passed` with the old file; `30 passed` with this one, together with `test_schema_audit.py` and `test_migration_rollback_extraction.py`). Ruff check/format clean.

Bites: CONSUMER is the Fly `release_command` of the deploy this merge triggers — it runs THIS code on a fresh release machine. Observation: the release log shows either "connection pool created" first try, or `connect attempt 1/5 failed (ConnectionResetError…); retrying in 2s` followed by "created on attempt N", and the deploy completes; `fly releases` shows the new version `complete` after five `failed`. Recorded in this PR's thread once observed. If the deploy still fails after 5 attempts over 30 s, the cause is not a boot race and this PR's premise is wrong — that outcome is reported, not rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vV3hvzrWmVMEGSoe1YUZc
