### PR TITLE
docs(runbook): queue-shepherd live-fire drill

### DIFF
--- a/docs/runbooks/queue-shepherd-live-fire.md
+++ b/docs/runbooks/queue-shepherd-live-fire.md
@@ -1,0 +1,68 @@
+# queue-shepherd live-fire drill
+
+The shepherd's READ path proves itself every ten minutes: a tick that examines every open PR,
+classifies each candidate and logs a named refusal is visible in `~/logs/queue-shepherd.log`
+without anyone doing anything. Its WRITE path does not. `rearm_pr` only runs when a PR is
+ejected from the merge queue with an INFRA-flavoured cause, and a healthy week can pass without
+one — after the 2026-09-10 ship, eight consecutive ticks logged `rearmed=0` for exactly that
+reason. "Never ran" and "runs correctly" look identical in the log.
+
+This drill closes that gap on purpose: it induces one controlled ejection and watches the
+shepherd re-arm it. Superscar #2 in one line — a green cron is not a working cron, and the
+only proof that a write path works is having watched it write.
+
+## What the shepherd will see
+
+`_run_has_infra_signature` reads a merge_group run whose own conclusion is `cancelled` (with no
+job that failed for a real reason) as INFRA. `classify_ejection_reason` turns that into the
+INFRA class, `decide_rearm` allows it while the per-(PR, head) budget has room
+(`INFRA_BUDGET_MAX`, rolling 24 h), and `rearm_pr` runs `gh pr merge <n> --auto`. So cancelling
+the merge_group run of a PR that is sitting in the queue produces precisely the ejection the
+write path exists for.
+
+## Procedure
+
+1. **Pick a sacrificial PR.** Small, low-risk, genuinely mergeable — this document's own PR was
+   the first one. Never someone else's work.
+2. **Arm it and let it enter the queue.** `gh pr merge <n> --auto`, then poll
+   `mergeQueueEntry` until `state` is `AWAITING_CHECKS`.
+3. **Read the batch before touching it.** GitHub batches queue entries: one
+   `gh-readonly-queue/main/pr-<n>-<sha>` branch can carry several PRs. Cancelling its run ejects
+   EVERY PR in that batch, including other people's.
+
+   ```
+   gh api "repos/<owner>/<repo>/actions/runs?event=merge_group&per_page=100" \
+     --jq '.workflow_runs[] | select(.head_branch|contains("pr-<n>-")) | .head_branch' | sort -u
+   ```
+
+   If the branch name carries a PR number that is not yours, **stop and wait** for a batch that
+   is yours alone. This is the one step of the drill that can hurt somebody else.
+
+4. **Cancel the run**, not the PR: `gh run cancel <run_id>` for the merge_group run(s) of that
+   branch. GitHub ejects the PR with reason `failed_checks`.
+5. **Watch the next tick** (they are ten minutes apart) in `~/logs/queue-shepherd.log`:
+
+   ```
+   PR #<n> head=<sha8> class=INFRA allowed=True (infra_budget_ok(1/3))
+   tick complete: examined=… candidates=… rearmed=1 …
+   ```
+
+   `rearmed=1` is the observation the drill exists to make. Anything else — `class=CODE`,
+   `allowed=False`, `unverified=1` — is a finding, not a failed drill: write down what the log
+   says and why before touching any code.
+
+6. **Let it merge.** The re-arm puts the PR back in the queue; it goes through normally.
+
+## Reading the aftermath
+
+- The budget file records the re-arm against `(PR, head_sha)`. Three INFRA re-arms of the same
+  head in 24 h exhaust it — the drill costs one.
+- The red-state file records one red for the PR. Three reds with the SAME cause fingerprint
+  suspend it (Builder Contract §1); one cancellation is far from that.
+- The drill leaves no code behind. If you find yourself editing `queue_shepherd.py` to make the
+  drill work, the drill has become a fiction — stop.
+
+## When to run it
+
+After any change to the classification or re-arm path, and otherwise whenever the log has shown
+`rearmed=0` for long enough that nobody can say when the write path last executed.


### PR DESCRIPTION
The shepherd's READ path proves itself every ten minutes. Its WRITE path does not: `rearm_pr` only runs on an INFRA-flavoured ejection, and the eight ticks since #6127 shipped all logged `rearmed=0`. In a log, "never ran" and "runs correctly" are the same picture — superscar #2.

This runbook induces one controlled ejection and names the exact line to look for on the next tick (`class=INFRA allowed=True (infra_budget_ok(1/3))`, then `rearmed=1`). It also names the step that can hurt someone else and makes it a stop: GitHub batches queue entries, so one `gh-readonly-queue/main/pr-<n>-<sha>` run can carry several PRs, and cancelling it ejects all of them. The batch is read before anything is cancelled; a batch carrying another lane's PR means wait, not proceed.

**Bites:** the consumer is this PR itself — it is the drill's first subject. Once it is in the merge queue as a batch of its own, its merge_group run gets cancelled, and the observation to be reported is the shepherd's next tick logging `class=INFRA allowed=True` and `rearmed=1` for this PR number, followed by its own re-armed merge. The observation will be posted on this PR before the work is called done; if the tick says anything else, that is a finding to write up, not a drill to retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)