### PR TITLE
docs(runbook): drill log table for the queue-shepherd live-fire

### DIFF
--- a/docs/runbooks/queue-shepherd-live-fire.md
+++ b/docs/runbooks/queue-shepherd-live-fire.md
@@ -66,3 +66,12 @@ write path exists for.
 
 After any change to the classification or re-arm path, and otherwise whenever the log has shown
 `rearmed=0` for long enough that nobody can say when the write path last executed.
+
+## Drill log
+
+One line per execution. A drill that was aborted is worth recording too: the abort condition
+(a batch carrying someone else's PR) is the part of this procedure people get wrong.
+
+| Date       | Subject PR | Outcome |
+| ---------- | ---------- | ------- |
+| 2026-09-11 | this PR    | pending |


### PR DESCRIPTION
The live-fire runbook shipped in #6157 without a place to record executions. This adds one table, one row per drill — including aborted ones, because the abort condition (a merge-queue batch carrying another lane's PR) is the step of the procedure people get wrong. #6157 itself hit it: its batch carried #6154 from another session, so the drill was stopped rather than run.

**This PR is the subject of the first drill.** It was chosen because it is the smallest genuinely-mergeable change available and it is mine: the runbook forbids using someone else's work as the subject. Its own row is filled in by the drill it triggers.

**Bites:** the consumer is `scripts/queue_shepherd.py`'s WRITE path — `rearm_pr`, which has not executed once in the eleven ticks since #6127 shipped. The observation to be made on this PR: its merge_group run is cancelled while it sits alone at position 1 of the queue (verified by `compare main...gh-readonly-queue/main/pr-<n>-<sha>` returning exactly one commit — this PR's), GitHub ejects it with reason `failed_checks`, and the shepherd's next scheduled tick logs `class=INFRA allowed=True (infra_budget_ok(…))` and `rearmed=1` for this number. That log line, quoted verbatim, is what closes the drill; the row is then updated with the outcome. If the tick says anything else, the row records that instead — a drill that finds something is not a failed drill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)