### PR TITLE
fix(queue-stall-classifier): drop the checkSuites fan-out for a name-filtered check-runs read

### DIFF
--- a/scripts/queue_stall_classifier.py
+++ b/scripts/queue_stall_classifier.py
@@ -32,8 +32,9 @@ guess, and never a silent skip (queue_shepherd.py's own fail-visible convention)
 CORRECTNESS TRAPS THIS SCRIPT RESPECTS (each already measured, live, in this repo):
 
   (a) `gh pr view --json` has NO `mergeQueueEntry` field at all — every field this script needs
-      (mergeStateStatus, autoMergeRequest, mergeQueueEntry, statusCheckRollup, checkSuites) is
-      read via `gh api graphql`, mirroring queue_shepherd.py's own REARM_CANDIDATES_QUERY.
+      (mergeStateStatus, autoMergeRequest, mergeQueueEntry, statusCheckRollup) is read via
+      `gh api graphql`, mirroring queue_shepherd.py's own REARM_CANDIDATES_QUERY. The one
+      exception is the named check-run conclusion (trap (d)), which is a REST read, not GraphQL.
 
   (b) `autoMergeRequest: null` ALONE never means "not armed" — a queued PR has it consumed
       (null) while it still holds a `mergeQueueEntry` (W111,
@@ -46,16 +47,26 @@ CORRECTNESS TRAPS THIS SCRIPT RESPECTS (each already measured, live, in this rep
       whose bulk `mergeStateStatus == "DIRTY"` gets ONE extra, immediate, single-PR re-fetch
       (fetch_fresh_merge_state) before the verdict is finalized.
 
-  (d) checkSuites PAGINATION: a real PR in this repo (#4569, measured live 2026-08-31) carries
-      38 check suites / 59 check runs — "Harness floor recompute" was suite #30. A naive
-      `checkSuites(first:20)` (the size queue_shepherd.py's OWN REARM_CANDIDATES_QUERY uses for
-      an unrelated, lower-stakes lookup) would silently never find it on a PR shaped like this
-      one, misreading "not found" as "gate not applicable" when it is really "gate hiding past
-      page 1". CHECK_SUITES_PAGE_SIZE is sized at 100 (>2.5x that measurement, not a guess), and
-      `fetch_check_runs_flat` explicitly detects truncation (totalCount > fetched nodes, at
-      EITHER the suite or the per-suite checkRuns level) and reports it — a truncated "not
-      found" downgrades that PR's row to CANNOT-VERIFY rather than silently defaulting to
-      required-check-red, which would make the table lie about the single most common cause.
+  (d) checkSuites FAN-OUT ELIMINATED (S1 diet, 2026-09-11 — the Mini sibling brought into the
+      same perimeter queue_shepherd.py's own S1 cure already occupies). The ORIGINAL shape here
+      paginated `checkSuites(first:100){ totalCount nodes { checkRuns(first:20) { totalCount
+      nodes {...} } } }` to find "Harness floor recompute" among EVERY check suite on the commit
+      — a real PR in this repo (#4569, measured live 2026-08-31) carries 38 check suites / 59
+      check runs, and the job this classifier hunts for was suite #30; a naively-small page
+      (queue_shepherd.py's OWN REARM_CANDIDATES_QUERY used `checkSuites(first:20)` for an
+      unrelated, lower-stakes lookup before its own S1 cure dropped it outright — see that
+      module's docstring) would silently never find it, misreading "not found" as "gate not
+      applicable" when it is really "gate hiding past page 1". That whole fan-out is GONE:
+      `fetch_check_runs_flat` now calls GitHub's REST "list check runs for a git reference"
+      endpoint (`commits/{sha}/check-runs`) with `check_name=<HARNESS_FLOOR_CHECK_NAME>` — the
+      exact server-side name filter the ledger item names ("check-runs filtered by name") — so
+      GitHub itself returns only check runs actually named "Harness floor recompute", never all
+      59. `per_page=100` is now headroom for a DUPLICATE workflow_dispatch rerun sharing that one
+      name (trap (h)), not for an unrelated suite/job the fetch never touches at all. The
+      `truncated` detection (`total_count` > entries actually returned) is kept anyway —
+      belt-and-braces, not because this endpoint is known to paginate past 100 same-named runs in
+      practice — and a truncated read still downgrades that PR's row to CANNOT-VERIFY rather than
+      silently defaulting to required-check-red, exactly as before.
 
   (e) The `harness/fable-gate` verdict is read the SAME way scripts/ci/harness_gate_read.py
       itself reads it — the combined `commits/{sha}/status` REST endpoint for the literal
@@ -82,9 +93,10 @@ CORRECTNESS TRAPS THIS SCRIPT RESPECTS (each already measured, live, in this rep
 
   (h) TWO checkRuns can share the exact name "Harness floor recompute" on the SAME commit — a
       `workflow_dispatch` rerun of the gate lands in a DIFFERENT check suite than the original
-      `pull_request` run (Agent PR Contract rule 3), so a naive first-match lookup is
-      order-dependent on GraphQL's unspecified checkSuites ordering and can misclassify in
-      EITHER direction (found by an independent second-opinion review, kimi-code/k3,
+      `pull_request` run (Agent PR Contract rule 3), and the name filter in trap (d) does not
+      collapse the two into one: GitHub returns BOTH entries for `check_name=...`, so a naive
+      first-match lookup is order-dependent on the REST endpoint's unspecified ordering and can
+      misclassify in EITHER direction (found by an independent second-opinion review, kimi-code/k3,
       2026-08-31). `find_named_check_conclusion` returns AMBIGUOUS_CHECK_CONCLUSION when
       matches disagree, and `_classify_one` reads that as CANNOT-VERIFY rather than guessing —
       the same discipline already applied to a truncated fetch in trap (d). The same review
@@ -99,6 +111,15 @@ the very report that exists to catch it. DEFAULT_MIN_AGE_MINUTES=30 is 3x
 queue_shepherd.py's own 10-minute tick cadence: long enough that ordinary CI/queue churn
 resolves itself, short enough to catch a same-night stall.
 
+S1 "MINI SIBLING OUT OF PERIMETER" (2026-09-11, PENDING-ARMS row "S1 BLUE, Pro — Mini sibling
+out of perimeter"): this module was the one member of the `checkSuites(first:N){checkRuns(...)}`
+fan-out family queue_shepherd.py's own S1 cure (2026-09-10) had NOT yet reached — it kept the
+exact shape that blinded that sibling for 1892 ticks (module docstring trap (d), pre-cure text
+preserved there for the archaeology). Put on the same diet here: see trap (d) for the full
+before/after. Output vocabulary (STALL_CAUSES / CANNOT_VERIFY, and every row's `cause`/`detail`
+keys) is UNCHANGED by this cure — queue_stall_notify.py and fleet mail readers consume it
+untouched; only the I/O this module performs to reach a verdict changed.
+
 Tests: scripts/tests/test_queue_stall_classifier.py.
 """
 
@@ -112,6 +133,7 @@ import logging
 import subprocess
 import sys
 from typing import Any
+from urllib.parse import quote as _urlquote
 
 REPO_DEFAULT = "Bali-Zero/Teman2"
 DEFAULT_MIN_AGE_MINUTES = 30
@@ -127,10 +149,10 @@ HARNESS_FLOOR_CHECK_NAME = "Harness floor recompute"  # the required WORKFLOW JO
 FABLE_GATE_STATUS_CONTEXT = "harness/fable-gate"  # duplicated from
 # scripts/ci/harness_gate_read.py::CONTEXT — see module docstring trap (e).
 
-CHECK_SUITES_PAGE_SIZE = 100  # see module docstring trap (d) — measured live 2026-08-31: a
-# real PR here carries 38 check suites.
-CHECK_RUNS_PAGE_SIZE = 20  # every suite sampled live carries exactly 1 checkRun; generous
-# headroom for a matrix job.
+CHECK_RUNS_REST_PAGE_SIZE = 100  # see module docstring trap (d), post-S1-diet: the REST
+# "list check runs for a git reference" read below is filtered server-side by check_name, so
+# this is headroom for a DUPLICATE run sharing that one name (trap (h)), never for an unrelated
+# suite/job — the fetch never sees those at all anymore.
 
 RED_ROLLUP_STATES = ("FAILURE", "ERROR")
 RED_CHECK_CONCLUSIONS = ("FAILURE", "TIMED_OUT")  # deliberately narrow: CANCELLED/NEUTRAL/
@@ -203,8 +225,8 @@ def find_named_check_conclusion(check_runs: list[dict[str, Any]], name: str) -> 
     so `fetch_check_runs_flat`'s flattened list can contain two (or more) entries named
     "Harness floor recompute" with potentially different conclusions (found by an independent
     second-opinion review, kimi-code/k3, 2026-08-31). Picking the textually-first one by list
-    order — which is what this function did before that review — is order-dependent on
-    GraphQL's unspecified checkSuites ordering, and can go wrong in BOTH directions: a stale
+    order — which is what this function did before that review — is order-dependent on the
+    REST check-runs endpoint's unspecified ordering, and can go wrong in BOTH directions: a stale
     FAILURE found first while the latest rerun is green fabricates a gate-verdict-missing; a
     stale SUCCESS found first while the latest run is red demotes a real gate-verdict-missing
     into required-check-red — exactly the swallow this module's docstring says must never
@@ -450,59 +472,48 @@ def fetch_fresh_merge_state(repo: str, number: int) -> str | None:
     return pr.get("mergeStateStatus")
 
 
-CHECK_RUNS_QUERY = """
-query($owner:String!, $repo:String!, $number:Int!) {
-  repository(owner:$owner, name:$repo) {
-    pullRequest(number:$number) {
-      commits(last:1) {
-        nodes {
-          commit {
-            checkSuites(first:100) {
-              totalCount
-              nodes { checkRuns(first:20) { totalCount nodes { name conclusion } } }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-"""
+def fetch_check_runs_flat(repo: str, sha: str) -> tuple[list[dict[str, Any]], bool]:
+    """S1 diet (2026-09-11, module docstring trap (d)): a plain REST GET, filtered SERVER-SIDE by
+    `check_name=<HARNESS_FLOOR_CHECK_NAME>` — GitHub's "list check runs for a git reference"
+    endpoint — never a GraphQL `checkSuites(first:N){checkRuns(first:M)}` fan-out over every
+    check suite on the commit. Mirrors queue_shepherd.py's own S1 cure in SHAPE only (that sibling
+    dropped its checkSuites lookup outright because harness/fable-gate is a commit STATUS
+    context, never a check-run, so it needed no replacement fetch at all; THIS module genuinely
+    needs the "Harness floor recompute" check-run's conclusion — a real GH Actions job, not a
+    status context — so its cure is filtering check-runs by name server-side, exactly what the
+    ledger item names, rather than dropping the read).
 
-
-def fetch_check_runs_flat(repo: str, number: int) -> tuple[list[dict[str, Any]], bool]:
-    """Returns (flattened [{"name":..,"conclusion":..}], truncated). `truncated` is True when
-    EITHER the checkSuites page or ANY individual suite's checkRuns page did not fit the
-    fetched window (module docstring trap (d)) — CHECK_SUITES_PAGE_SIZE/CHECK_RUNS_PAGE_SIZE
-    are sized against a LIVE measurement, not a guess, but a future PR could still exceed them;
-    the caller must never read a truncated 'not found' as a reliable absence. Raises on fetch
-    failure."""
-    owner, name = repo.split("/", 1)
-    data = _gh_graphql(CHECK_RUNS_QUERY, {"owner": owner, "repo": name, "number": number})
+    Returns (flattened [{"name":..,"conclusion":..}], truncated). `truncated` is True when
+    `total_count` exceeds what this one page actually returned — belt-and-braces (see trap (d)
+    for why this is not expected to fire in practice against a name-filtered read, but the caller
+    must still never read a truncated 'not found' as a reliable absence). Raises on fetch
+    failure, a non-dict response, or a missing/non-list `check_runs`."""
+    encoded_name = _urlquote(HARNESS_FLOOR_CHECK_NAME, safe="")
+    url = (
+        f"repos/{repo}/commits/{sha}/check-runs"
+        f"?check_name={encoded_name}&per_page={CHECK_RUNS_REST_PAGE_SIZE}"
+    )
+    rc, out, err = _run(["gh", "api", url], timeout=30)
+    if rc != 0:
+        raise RuntimeError(f"gh api commits/{sha}/check-runs failed rc={rc}: {err.strip()[:300]}")
     try:
-        pr = data["data"]["repository"]["pullRequest"]
-        if pr is None:
-            raise RuntimeError(f"PR #{number} not found (closed/merged mid-run?)")
-        commit_nodes = pr["commits"]["nodes"]
-    except (KeyError, TypeError) as exc:
-        raise RuntimeError(f"unexpected graphql shape: {exc}: {json.dumps(data)[:300]}") from exc
-    if not commit_nodes:
-        # CONFIRMED finding (gpt-5.6-sol, 2026-08-31): an open PR always has >=1 commit for real
-        # — an empty commits.nodes here is an anomalous GraphQL response, not "no check runs".
-        # Raising (-> CANNOT-VERIFY at the caller) beats silently returning ([], False), which
-        # would let a possibly-red gate hide behind a data anomaly instead of being flagged.
-        raise RuntimeError(f"PR #{number}: commits.nodes empty on an open PR (anomalous response)")
-    suites = (commit_nodes[0].get("commit") or {}).get("checkSuites") or {}
-    suite_nodes = suites.get("nodes") or []
-    truncated = (suites.get("totalCount") or 0) > len(suite_nodes)
-    flat: list[dict[str, Any]] = []
-    for suite in suite_nodes:
-        runs = suite.get("checkRuns") or {}
-        run_nodes = runs.get("nodes") or []
-        if (runs.get("totalCount") or 0) > len(run_nodes):
-            truncated = True
-        for run in run_nodes:
-            flat.append({"name": run.get("name"), "conclusion": run.get("conclusion")})
+        data = json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"commits/{sha}/check-runs returned unparseable JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(f"commits/{sha}/check-runs response is not a JSON object: {str(data)[:300]}")
+    check_runs = data.get("check_runs")
+    if not isinstance(check_runs, list):
+        raise RuntimeError(
+            f"commits/{sha}/check-runs response missing a 'check_runs' array: {str(data)[:300]}"
+        )
+    flat = [
+        {"name": run.get("name"), "conclusion": run.get("conclusion")}
+        for run in check_runs
+        if isinstance(run, dict)
+    ]
+    total_count = data.get("total_count")
+    truncated = isinstance(total_count, int) and total_count > len(flat)
     return flat, truncated
 
 
@@ -580,9 +591,9 @@ def _classify_one(repo: str, pr: dict[str, Any], now: _dt.datetime) -> dict[str,
     fable_gate_posted: bool | None = None
     if pr["status_rollup_state"] in RED_ROLLUP_STATES:
         try:
-            check_runs, truncated = fetch_check_runs_flat(repo, number)
+            check_runs, truncated = fetch_check_runs_flat(repo, pr["head_sha"])
         except RuntimeError as exc:
-            return {**base, "cause": CANNOT_VERIFY, "detail": f"checkSuites fetch failed: {exc}"}
+            return {**base, "cause": CANNOT_VERIFY, "detail": f"check-runs fetch failed: {exc}"}
         conclusion = find_named_check_conclusion(check_runs, HARNESS_FLOOR_CHECK_NAME)
         if conclusion is None and truncated:
             return {
@@ -591,8 +602,8 @@ def _classify_one(repo: str, pr: dict[str, Any], now: _dt.datetime) -> dict[str,
                 "detail": (
                     f"statusCheckRollup={pr['status_rollup_state']} but the "
                     f"'{HARNESS_FLOOR_CHECK_NAME}' check run could not be reliably located — "
-                    "checkSuites/checkRuns pagination truncated before reaching it (see module "
-                    "docstring trap (d)); silently reading 'not found' as 'not the gate' here "
+                    "the name-filtered check-runs read was truncated before reaching it (see "
+                    "module docstring trap (d)); silently reading 'not found' as 'not the gate' here "
                     "would risk misclassifying a possible gate-verdict-missing as "
                     "required-check-red"
                 ),

--- a/scripts/tests/test_queue_stall_classifier.py
+++ b/scripts/tests/test_queue_stall_classifier.py
@@ -351,7 +351,7 @@ def test_classify_one_red_gate_never_posted_is_gate_verdict_missing(monkeypatch)
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}], False),
+        lambda repo, sha: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}], False),
     )
     monkeypatch.setattr(sc, "read_fable_gate_state", lambda repo, sha: (None, None))
     row = sc._classify_one("Bali-Zero/Teman2", pr, NOW)
@@ -362,7 +362,7 @@ def test_classify_one_red_gate_with_real_verdict_is_required_check_red(monkeypat
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}], False),
+        lambda repo, sha: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}], False),
     )
     monkeypatch.setattr(sc, "read_fable_gate_state", lambda repo, sha: ("failure", "REWORK"))
     row = sc._classify_one("Bali-Zero/Teman2", pr, NOW)
@@ -374,7 +374,7 @@ def test_classify_one_red_other_check_not_the_gate_is_required_check_red(monkeyp
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: ([{"name": "Backend Tests", "conclusion": "FAILURE"}], False),
+        lambda repo, sha: ([{"name": "Backend Tests", "conclusion": "FAILURE"}], False),
     )
 
     def never_called(repo, sha):
@@ -386,13 +386,13 @@ def test_classify_one_red_other_check_not_the_gate_is_required_check_red(monkeyp
 
 
 def test_classify_one_truncated_and_gate_not_found_is_cannot_verify_never_guessed(monkeypatch):
-    """Module docstring trap (d), the live-measured checkSuites pagination bug: if the fetch
-    was truncated and 'Harness floor recompute' was not found among what WAS fetched, this must
-    never silently fall through to required-check-red -- it might be hiding past the page."""
+    """Module docstring trap (d): if the name-filtered check-runs fetch was truncated and
+    'Harness floor recompute' was not found among what WAS fetched, this must never silently
+    fall through to required-check-red -- it might be hiding past the page."""
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: ([{"name": "Some Other Check", "conclusion": "FAILURE"}], True),
+        lambda repo, sha: ([{"name": "Some Other Check", "conclusion": "FAILURE"}], True),
     )
 
     def never_called(repo, sha):
@@ -409,15 +409,15 @@ def test_classify_one_not_truncated_and_gate_not_found_falls_through_normally(mo
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: ([{"name": "Some Other Check", "conclusion": "FAILURE"}], False),
+        lambda repo, sha: ([{"name": "Some Other Check", "conclusion": "FAILURE"}], False),
     )
     row = sc._classify_one("Bali-Zero/Teman2", pr, NOW)
     assert row["cause"] == "required-check-red"
 
 
-def test_classify_one_checksuites_fetch_failure_is_cannot_verify(monkeypatch):
-    def boom(repo, number):
-        raise RuntimeError("gh api graphql failed rc=1")
+def test_classify_one_check_runs_fetch_failure_is_cannot_verify(monkeypatch):
+    def boom(repo, sha):
+        raise RuntimeError("gh api commits/.../check-runs failed rc=1")
 
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(sc, "fetch_check_runs_flat", boom)
@@ -429,7 +429,7 @@ def test_classify_one_fable_gate_read_failure_is_cannot_verify(monkeypatch):
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}], False),
+        lambda repo, sha: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}], False),
     )
 
     def boom(repo, sha):
@@ -441,9 +441,9 @@ def test_classify_one_fable_gate_read_failure_is_cannot_verify(monkeypatch):
 
 
 def test_classify_one_never_fetches_check_runs_when_rollup_is_green(monkeypatch):
-    # efficiency + correctness: the heavier per-candidate checkSuites fetch must only fire when
+    # efficiency + correctness: the heavier per-candidate check-runs fetch must only fire when
     # the cheap bulk rollup was already red.
-    def never_called(repo, number):
+    def never_called(repo, sha):
         raise AssertionError("must not fetch check runs for a green PR")
 
     monkeypatch.setattr(sc, "fetch_check_runs_flat", never_called)
@@ -726,77 +726,90 @@ def test_fetch_open_prs_innocence_stops_after_exhausted_first_page(monkeypatch):
     assert calls == 1
 
 
-def _check_runs_graphql_payload(*, suite_total: int, run_total: int) -> dict:
-    return {
-        "data": {
-            "repository": {
-                "pullRequest": {
-                    "commits": {
-                        "nodes": [
-                            {
-                                "commit": {
-                                    "checkSuites": {
-                                        "totalCount": suite_total,
-                                        "nodes": [
-                                            {
-                                                "checkRuns": {
-                                                    "totalCount": run_total,
-                                                    "nodes": [
-                                                        {
-                                                            "name": sc.HARNESS_FLOOR_CHECK_NAME,
-                                                            "conclusion": "FAILURE",
-                                                        }
-                                                    ],
-                                                }
-                                            }
-                                        ],
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-    }
+def _check_runs_rest_payload(*, total_count: int, check_runs: list[dict]) -> dict:
+    return {"total_count": total_count, "check_runs": check_runs}
 
 
-def test_fetch_check_runs_flat_guilt_marks_suite_level_truncation(monkeypatch):
-    monkeypatch.setattr(
-        sc,
-        "_gh_graphql",
-        lambda query, variables: _check_runs_graphql_payload(suite_total=2, run_total=1),
-    )
+def test_fetch_check_runs_flat_sends_no_checksuites_fan_out(monkeypatch):
+    """S1 diet pin (mandate, verbatim): the classifier must no longer send a
+    `checkSuites(first:N){checkRuns(first:M)}` GraphQL fan-out — it reads a plain REST GET,
+    filtered server-side by check_name, exactly like queue_shepherd.py's own status-context cure
+    in shape (never in mechanism -- see fetch_check_runs_flat's own docstring)."""
+    captured = {}
 
-    runs, truncated = sc.fetch_check_runs_flat("Bali-Zero/Teman2", 1)
+    def fake_run(cmd, timeout=30):
+        captured["cmd"] = cmd
+        return 0, json.dumps(_check_runs_rest_payload(
+            total_count=1,
+            check_runs=[{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}],
+        )), ""
+
+    monkeypatch.setattr(sc, "_run", fake_run)
+
+    def graphql_must_not_be_called(query, variables):
+        raise AssertionError("fetch_check_runs_flat must not use GraphQL at all")
+
+    monkeypatch.setattr(sc, "_gh_graphql", graphql_must_not_be_called)
+
+    runs, truncated = sc.fetch_check_runs_flat("Bali-Zero/Teman2", "a" * 40)
 
     assert runs == [{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}]
-    assert truncated is True
+    assert truncated is False
+    cmd = captured["cmd"]
+    assert "checkSuites" not in " ".join(cmd)
+    assert any("check-runs" in part for part in cmd)
+    assert any("check_name=" in part for part in cmd)
 
 
-def test_fetch_check_runs_flat_guilt_marks_check_run_level_truncation(monkeypatch):
+def test_fetch_check_runs_flat_requests_check_name_filter_and_per_page(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, timeout=30):
+        captured["cmd"] = cmd
+        return 0, json.dumps(_check_runs_rest_payload(total_count=0, check_runs=[])), ""
+
+    monkeypatch.setattr(sc, "_run", fake_run)
+    sc.fetch_check_runs_flat("Bali-Zero/Teman2", "a" * 40)
+    url = captured["cmd"][-1]
+    assert "Harness" in url and "floor" in url and "recompute" in url
+    assert f"per_page={sc.CHECK_RUNS_REST_PAGE_SIZE}" in url
+    assert f"commits/{'a' * 40}/check-runs" in url
+
+
+def test_fetch_check_runs_flat_guilt_total_count_exceeding_page_is_truncated(monkeypatch):
     monkeypatch.setattr(
-        sc,
-        "_gh_graphql",
-        lambda query, variables: _check_runs_graphql_payload(suite_total=1, run_total=2),
+        sc, "_run",
+        lambda cmd, timeout=30: (0, json.dumps(_check_runs_rest_payload(
+            total_count=2,
+            check_runs=[{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}],
+        )), ""),
     )
 
-    _runs, truncated = sc.fetch_check_runs_flat("Bali-Zero/Teman2", 1)
+    runs, truncated = sc.fetch_check_runs_flat("Bali-Zero/Teman2", "a" * 40)
 
+    assert len(runs) == 1
     assert truncated is True
 
 
 def test_fetch_check_runs_flat_innocence_complete_cardinality_is_not_truncated(monkeypatch):
     monkeypatch.setattr(
-        sc,
-        "_gh_graphql",
-        lambda query, variables: _check_runs_graphql_payload(suite_total=1, run_total=1),
+        sc, "_run",
+        lambda cmd, timeout=30: (0, json.dumps(_check_runs_rest_payload(
+            total_count=1,
+            check_runs=[{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"}],
+        )), ""),
     )
 
-    runs, truncated = sc.fetch_check_runs_flat("Bali-Zero/Teman2", 1)
+    runs, truncated = sc.fetch_check_runs_flat("Bali-Zero/Teman2", "a" * 40)
 
     assert len(runs) == 1
     assert truncated is False
+
+
+def test_fetch_check_runs_flat_gh_failure_raises(monkeypatch):
+    monkeypatch.setattr(sc, "_run", lambda cmd, timeout=30: (1, "", "gh: not found"))
+    with pytest.raises(RuntimeError):
+        sc.fetch_check_runs_flat("Bali-Zero/Teman2", "a" * 40)
 
 
 def test_render_table_escapes_markdown_pipe_in_detail():
@@ -954,15 +967,25 @@ def test_classify_one_innocence_commits_missing_false_proceeds_normally(monkeypa
     assert row["cause"] == "queued-and-advancing"
 
 
-def test_fetch_check_runs_flat_guilt_empty_commit_nodes_raises(monkeypatch):
+def test_fetch_check_runs_flat_guilt_missing_check_runs_key_raises(monkeypatch):
+    # REST-shape anomaly (post-S1-diet successor to the old GraphQL "empty commits.nodes" guard):
+    # a response body that parses as JSON but lacks a 'check_runs' list must never be read as
+    # "zero check runs" -- that would silently hide a real gate result behind a malformed read.
     monkeypatch.setattr(
-        sc, "_gh_graphql",
-        lambda query, variables: {
-            "data": {"repository": {"pullRequest": {"commits": {"nodes": []}}}}
-        },
+        sc, "_run",
+        lambda cmd, timeout=30: (0, json.dumps({"total_count": 0}), ""),
     )
     with pytest.raises(RuntimeError):
-        sc.fetch_check_runs_flat("Bali-Zero/Teman2", 1)
+        sc.fetch_check_runs_flat("Bali-Zero/Teman2", "a" * 40)
+
+
+def test_fetch_check_runs_flat_guilt_non_dict_response_raises(monkeypatch):
+    monkeypatch.setattr(
+        sc, "_run",
+        lambda cmd, timeout=30: (0, json.dumps([1, 2, 3]), ""),
+    )
+    with pytest.raises(RuntimeError):
+        sc.fetch_check_runs_flat("Bali-Zero/Teman2", "a" * 40)
 
 
 # ── fetch_open_prs MAX_PAGES (2026-08-31 fix #4, gpt-5.6-sol review): exhausting the page ─────
@@ -1046,7 +1069,7 @@ def test_classify_one_guilt_disagreeing_duplicate_gate_runs_is_cannot_verify(mon
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: (
+        lambda repo, sha: (
             [
                 {"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "SUCCESS"},
                 {"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"},
@@ -1068,7 +1091,7 @@ def test_classify_one_innocence_agreeing_duplicate_gate_runs_classifies_normally
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: (
+        lambda repo, sha: (
             [
                 {"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"},
                 {"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "FAILURE"},
@@ -1089,7 +1112,7 @@ def test_classify_one_guilt_timed_out_gate_run_is_gate_verdict_missing_not_swall
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "TIMED_OUT"}], False),
+        lambda repo, sha: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "TIMED_OUT"}], False),
     )
     monkeypatch.setattr(sc, "read_fable_gate_state", lambda repo, sha: (None, None))
     row = sc._classify_one("Bali-Zero/Teman2", pr, NOW)
@@ -1102,7 +1125,7 @@ def test_classify_one_innocence_skipped_gate_run_is_not_treated_as_red(monkeypat
     pr = _pr(1, status_rollup_state="FAILURE")
     monkeypatch.setattr(
         sc, "fetch_check_runs_flat",
-        lambda repo, number: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "SKIPPED"}], False),
+        lambda repo, sha: ([{"name": sc.HARNESS_FLOOR_CHECK_NAME, "conclusion": "SKIPPED"}], False),
     )
 
     def never_called(repo, sha):


### PR DESCRIPTION
Ledger row `S1 BLUE, Pro — Mini sibling out of perimeter`. `scripts/queue_stall_classifier.py` (runs on Mini, feeds `queue_stall_notify.py`) was the last member of the `checkSuites(first:100){checkRuns(first:20)}` family — the same fan-out that blinded `queue_shepherd.py` for 1892 ticks before its own S1 cure.

**It was still biting tonight.** The fleet mailbox received CANNOT-VERIFY messages for #5608, #5619 and #5835 whose stated cause was `checkSuites fetch failed … TLS handshake timeout`. On a real PR here that query enumerates 38 suites and 59 runs to find one check.

**The cure, and why it differs from the shepherd's.** The shepherd could *drop* its lookup outright because `harness/fable-gate` is a commit STATUS context. This classifier genuinely needs a check-run's conclusion, so it takes the ledger row's other option: GitHub's REST `commits/{sha}/check-runs` filtered **server-side** by `check_name=Harness floor recompute`. No suite enumeration at all. The signature moved from `(repo, number)` to `(repo, head_sha)` because the REST endpoint is keyed on the commit.

**What did NOT change**, checked rather than assumed: the output vocabulary. `STALL_CAUSES`, `CANNOT_VERIFY` and the row keys are untouched — the consumer `queue_stall_notify.py` was grepped first and reads `cause`/`detail`/`number` as opaque strings. CANNOT-VERIFY stays fail-closed and loud: a failed or malformed REST read still raises, and the truncation guard (`total_count` > returned) is kept.

**Bites:** the consumer is `queue_stall_notify.py` on **Mini**, which is where this file executes; the read it depends on ships in this PR. Verified here before shipping: `pytest test_queue_stall_classifier.py test_queue_stall_notify.py -q` → **117 passed** (classifier suite 81 → 84), `/usr/bin/python3 -m py_compile` rc=0, and `grep -n checkSuites` over the module returns 7 hits that are **all prose documenting the removal** — no live query. The new pin `test_fetch_check_runs_flat_sends_no_checksuites_fan_out` asserts the real argv carries `check-runs` + `check_name=` and monkeypatches `_gh_graphql` to raise if it is called at all, so a reintroduced fan-out cannot pass silently.

Post-merge observation, which belongs to Mini and not to this host: after Mini pulls, its queue-stall messages stop citing `checkSuites` fetch timeouts. The ledger row carries that 24 h window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)