### PR TITLE
docs(runbook): second drill aborted by its own guard — arm on an empty queue instead

### DIFF
--- a/docs/runbooks/queue-shepherd-live-fire.md
+++ b/docs/runbooks/queue-shepherd-live-fire.md
@@ -38,6 +38,15 @@ write path exists for.
    If the branch name carries a PR number that is not yours, **stop and wait** for a batch that
    is yours alone. This is the one step of the drill that can hurt somebody else.
 
+   In practice a busy queue almost never hands you a batch of one, and two drills died here.
+   Do not loosen the rule — change WHEN you arm: wait for the queue to hold no PR but yours,
+   arm the subject only then, and it enters as its own batch. The guard still runs and still
+   stops the drill if somebody armed in the same second.
+
+   The rule is OWNERSHIP, not arithmetic: a batch of several PRs that are ALL yours is fine —
+   the ejection costs only your own work and the shepherd re-arms it. A batch of one that
+   belongs to another lane is not.
+
 4. **Cancel the run**, not the PR — and do it FAST. A merge_group batch here finishes in
    minutes but most of its runs finish in SECONDS (change-map skips), so a poll loop that
    sleeps 12 s arrives after the fact. Poll every few seconds and cancel the moment the batch
@@ -90,4 +99,5 @@ One line per execution. A drill that was aborted is worth recording too: the abo
 | Date       | Subject PR | Outcome                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 2026-09-11 | #6160      | MISSED — the cancel came 28 s after the group was created and 11 of the 13 runs had already completed; `gh run cancel` answered `Cannot cancel a workflow run that is completed` and the PR merged normally. Two lessons, both in the procedure below: cancel within seconds, and never discard the cancel's own output. |
+| 2026-09-11 | #6163      | ABORTED BY THE GUARD — the batch carried 2 commits, so step 3 stopped the drill and cancelled nothing. Correct behaviour, and the reason the drill is hard to land: a busy queue almost never gives a batch of one.                                                                                                      |
 | 2026-09-11 | this PR    | pending                                                                                                                                                                                                                                                                                                                  |


### PR DESCRIPTION
The second live-fire attempt (#6163) stopped at step 3: the merge_group batch carried two commits, so the guard refused to cancel. That is the guard working. It is also why the drill is hard to land — a busy queue rarely hands out a batch of one, and two attempts have now died on this step for two different reasons (#6160 missed its window, #6163 was correctly refused).

The runbook change is not a loosening:

- **Arm on an empty queue.** The subject enters as its own batch, instead of hoping to be alone in someone else's.
- **The rule is OWNERSHIP, not arithmetic.** A batch of several PRs that are all yours is acceptable — the ejection costs only your own work and the shepherd re-arms it. A batch of one that belongs to another lane is not.

**Bites:** the consumer is `scripts/queue_shepherd.py`'s WRITE path, still un-exercised in production twelve ticks after #6127 shipped. This PR is the third drill's subject, armed only once the queue is empty. The observation to report is the shepherd's next tick logging `class=INFRA allowed=True` and `rearmed=1` for this number; if it misses again, that row is written too. Three rows of honest failure are worth more than one row of "pending" that never resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)