### PR TITLE
fix(mouth): translate-hourly supersede search matched nothing — drop the type(scope): prefix

### DIFF
--- a/scripts/translate-articles-cron-wrapper.sh
+++ b/scripts/translate-articles-cron-wrapper.sh
@@ -151,7 +151,7 @@ EOF
   # empty diff. Scope: same title prefix AND same branch prefix (entity, not
   # substring). A PR already occupying a merge-queue slot is left alone: it is
   # about to land and closing it would evict it (queue_unstick.py's rule 1).
-  OLDER=$(gh pr list --state open --search "chore(mouth): promote hourly-translated in:title" \
+  OLDER=$(gh pr list --state open --search "promote hourly-translated in:title" \
       --json number,headRefName \
       --jq ".[] | select(.number != $PR_NUM) | select(.headRefName | startswith(\"agent/nuzantara/mouth/hourly-\")) | .number" 2>>"$LOG")
   for old in ${(f)OLDER}; do


### PR DESCRIPTION
## Why

`scripts/translate-articles-cron-wrapper.sh` closes older open promote PRs so the hourly translation batch does not pile up identical copies (the 68-copies scar of 2026-09-09). Its `gh pr list --search "chore(mouth): promote hourly-translated in:title"` matched nothing: GitHub search ignores the `type(scope):` prefix.

Evidence, run read-only on 2026-09-11:

```
gh pr list --state merged --limit 5 --search "chore(mouth): promote hourly-translated in:title" --json number
[]
gh pr list --state merged --limit 5 --search "promote hourly-translated in:title" --json number
[6129, 6018, 6010, 5663, 5375]
```

## What

One line: the search is now `"promote hourly-translated in:title"`; the entity filter stays the jq `headRefName | startswith("agent/nuzantara/mouth/hourly-")`. No dedicated test harness exists for this wrapper (checked); the equivalent assertion is pinned in `scripts/tests/test_automations_reference_cron_wrapper.sh` for the sibling wrapper where the bug was found (#6169).

Independent Opus 5 gate on disk: SIGN (`zsh -n` clean; the words-only query returns the historical promote PRs, the prefixed one returns none).

Bites: `com.balizero.translate.hourly` on Pro runs this script from the repo checkout (auto-pulled every 15 min). Observation: the next run that opens a promote PR while an older one is still open logs `closed superseded promote PR #<n>` in `~/logs/translate-hourly-wrapper.log` on Pro and the older PR shows the "Superseded by" close comment; today there are 0 open promote PRs, so the first observation comes at the first overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXAENUo2iNkKyHT48GJWc3