### PR TITLE
feat(automations): generator owns the repo-canon tables — matagaruda prefix, purpose chain, scheduled workflows

### DIFF
--- a/evidence/2026-09/agent-air-m5-infra-automations-generator-source-f13c532e/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-automations-generator-source-f13c532e/brief.yml
@@ -1,0 +1,75 @@
+task_id: automations-generator-source
+gear: 3
+l_level: L2
+gate_class: opus
+objective: |
+  Make `scripts/generate_automations_reference.py` the single source of
+  truth for `docs/AUTOMATIONS_REFERENCE.md`, ahead of the companion nightly
+  cron in PR #6169 that will run it unattended.
+
+  GROUND: the generator previously under-rendered the repo-canon surface it
+  claims to cover. Fixed here: a `com.matagaruda.` label prefix; a purpose
+  chain that follows plist header -> target script header via
+  `infra/home-fork/declared-pairs.json` rather than stopping at the plist's
+  own comment; a new "GitHub Actions scheduled workflows" table sourced
+  from every `.github/workflows/*.yml` carrying a `schedule:` trigger; an
+  interpreter-aware "runs <script>" purpose fallback (bare `python`/`sh -c`
+  no longer renders as the whole purpose); a host hint that reads the
+  RESOLVED target script, not just the plist's own text; a recursive glob
+  over `infra/launchagents/**/*.plist` with file-stem rendering, so the
+  table's row count actually matches `scripts/docs_sync.py::automation_coverage()`'s
+  count instead of silently under-covering it; and `|` escaping in every
+  rendered cell, since a real workflow comment or script header can contain
+  a literal pipe that would otherwise break the markdown table.
+
+  Because this generator becomes the nightly, unattended, single writer of
+  a repo-canon doc (PR #6169), an independent gate reviewed the frozen diff
+  before this pack was written — see `dissent:` in the pack for its six
+  findings, four already cured in this diff (75b6438142, 60a8787971).
+
+  Gear 3 declared above the deterministic floor: this diff's floor is 2
+  (SIZE term alone — 629 net lines across 2 files, no hot-zone path hit;
+  measured in this pack's receipts and independently by `Harness floor
+  recompute`, source "size"). The model may always raise gear above the
+  floor (harness-v2 §1); Gear 3 reflects the actual review that happened
+  — a cross-diff independent adjudication with confirmed findings — not
+  the diff's raw shape.
+constraints:
+  - "The generator only READS `.github/workflows/*.yml`, `infra/launchagents/**/*.plist`
+    and `infra/home-fork/declared-pairs.json` — it writes nothing outside
+    `docs/AUTOMATIONS_REFERENCE.md` (or stdout, under `--dry-run`)."
+  - "Every rendered table cell is `|`-escaped — a workflow comment or a
+    script header containing a literal pipe must not corrupt the
+    surrounding markdown table (dissent-1, cured)."
+  - "Host-hint substring matching is exact-token, not naive substring — a
+    'mini-' fragment inside 'gemini-' must not misclassify a Gemini relay
+    plist as hosted on Mini (dissent-2, cured)."
+  - "No hardcoded credential — the generator reads only repo-tracked files
+    and the local filesystem; no token or API key literal appears in
+    either changed file."
+acceptance:
+  - text: "WHEN the generator runs against this repo's live tree, THE
+      rendered plist coverage SHALL match `scripts/docs_sync.py::automation_coverage()`'s
+      own count exactly (136/136)."
+    probe: "python3 scripts/generate_automations_reference.py --dry-run, cross-checked against automation_coverage()'s labels-in-haystack logic"
+  - text: "WHEN a workflow purpose or plist comment contains a literal `|`,
+      THE rendered table cell SHALL escape it so the markdown table
+      structure is not broken."
+    probe: "test_pipe_in_purpose_is_escaped"
+  - text: "WHEN a plist name or purpose together contain a `|`, THE
+      rendered row SHALL still parse as one table row."
+    probe: "test_pipe_in_name_and_purpose_is_escaped"
+  - text: "WHERE a label contains the substring 'mini' only as part of a
+      longer word (e.g. a Gemini relay), THE host hint SHALL NOT
+      misclassify it as Mini-hosted."
+    probe: "test_gemini_relay_label_is_not_mini"
+  - text: "WHEN a plist header spells the host as 'Mini-Pro2', THE host
+      hint SHALL still resolve it to Mini."
+    probe: "test_mini_pro2_header_spelling_is_mini"
+  - text: "WHEN the interpreter line carries only a bare interpreter (e.g.
+      `python`) with nothing else, THE purpose SHALL fall back to the
+      plist's own label rather than rendering a bare interpreter name."
+    probe: "test_bare_interpreter_with_nothing_else_falls_back_to_label"
+  - text: "WHERE a guarantee above is removed by mutation, a named test
+      SHALL turn RED — replayed against the shipped code."
+    probe: "python3 -m pytest tests/scripts/test_generate_automations_reference.py -q"

--- a/evidence/2026-09/agent-air-m5-infra-automations-generator-source-f13c532e/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-automations-generator-source-f13c532e/pack.yml
@@ -31,8 +31,10 @@ seat_override: >-
   on a journal that would be a receipt for a review that did not happen.
 diff:
   net_lines: >-
-    4 files, +892/-16, measured by `git diff --numstat` against the merge-base
-    with origin/main. CI's countable-claims check reads this against the
+    4 files, +897/-16, measured by `git diff --numstat` against the merge-base
+    with origin/main (re-measured after the fourth commit, which dropped the
+    Desktop/nuzantara path form for the TCC lint — scripts/lint_tcc_desktop_paths.py
+    / superscar #1 W84). CI's countable-claims check reads this against the
     WHOLE PR diff (code plus this evidence pair itself), so a single
     measured total is kept here rather than a secondary per-file gloss
     that would go stale on the next edit to this same file — same lesson

--- a/evidence/2026-09/agent-air-m5-infra-automations-generator-source-f13c532e/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-automations-generator-source-f13c532e/pack.yml
@@ -31,13 +31,16 @@ seat_override: >-
   on a journal that would be a receipt for a review that did not happen.
 diff:
   net_lines: >-
-    2 files, +645/-16 (net +629), measured by `git diff --numstat` against
-    the merge-base in this pack's receipts. This is why the deterministic
-    floor for this diff is 2 via the SIZE term alone (no hot-zone path is
-    touched) rather than 1 — declared as such rather than hidden; the
-    ceiling check does not apply (629 net lines is far past the <=60-line
-    small-diff shape, so a Gear-3 declaration is not over-provisioned by
-    that signal).
+    4 files, +892/-16, measured by `git diff --numstat` against the merge-base
+    with origin/main. CI's countable-claims check reads this against the
+    WHOLE PR diff (code plus this evidence pair itself), so a single
+    measured total is kept here rather than a secondary per-file gloss
+    that would go stale on the next edit to this same file — same lesson
+    as the xendit-quarantine-alarm pack's `diff.net_lines` field. The code
+    itself is two files, well past the small-diff ceiling shape, which is
+    why the deterministic floor for the CODE alone is two via the SIZE
+    term (no hot-zone path is touched) rather than one — declared as such
+    rather than hidden, and measured in this pack's receipts.
   behaviour_change: >-
     `scripts/generate_automations_reference.py` renders more of the
     repo-canon surface than before (matagaruda prefix, scheduled-workflows

--- a/evidence/2026-09/agent-air-m5-infra-automations-generator-source-f13c532e/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-automations-generator-source-f13c532e/pack.yml
@@ -1,0 +1,169 @@
+brief_ref: evidence/brief.yml
+effort_for_gear: xhigh
+plan_ref: >-
+  PR #6171 (agent/air-m5/infra/automations-generator-source) — the
+  generator becomes the repo-canon source for docs/AUTOMATIONS_REFERENCE.md:
+  matagaruda label prefix, purpose chain through declared-pairs.json,
+  scheduled-workflows table, interpreter-aware fallback, recursive glob
+  coverage parity with automation_coverage(), and `|` escaping.
+lanes:
+  - lane: automations-generator-source
+    role: build
+    seat: "session (Air-M5, Opus 5 — dispatched by team-lead per CLAUDE.md §5 implementer routing)"
+  - lane: automations-generator-source-gate
+    role: review
+    seat: "gate-generator (claude-opus-5, independent on-disk gate)"
+seat_diversity: not_applicable
+seat_diversity_note: >-
+  Exactly ONE build lane, so the D3 floor (>=2 build lanes needing a
+  non-Anthropic seat) does not fire. The review side ran a single
+  independent Opus 5 on-disk gate, not a cross-family council — see
+  `seat_override` below for why R9's council-quorum rule is honestly
+  overridden rather than satisfied with a journal this task never ran.
+seat_override: >-
+  No cross-family council (codex-gpt-5.6-sol / kimi-code/k3 /
+  tp1-qwen3.8-max) was dispatched for this task. The Gear-3 review that
+  actually happened was an independent on-disk gate seat, "gate-generator"
+  (claude-opus-5), whose six findings are recorded in `dissent:` below,
+  four already cured across commits 75b6438142 and 60a8787971. Declared
+  here rather than fabricating a council-journal.jsonl naming seats that
+  never reviewed this diff — anti-hallucination outranks a clean R9 pass
+  on a journal that would be a receipt for a review that did not happen.
+diff:
+  net_lines: >-
+    2 files, +645/-16 (net +629), measured by `git diff --numstat` against
+    the merge-base in this pack's receipts. This is why the deterministic
+    floor for this diff is 2 via the SIZE term alone (no hot-zone path is
+    touched) rather than 1 — declared as such rather than hidden; the
+    ceiling check does not apply (629 net lines is far past the <=60-line
+    small-diff shape, so a Gear-3 declaration is not over-provisioned by
+    that signal).
+  behaviour_change: >-
+    `scripts/generate_automations_reference.py` renders more of the
+    repo-canon surface than before (matagaruda prefix, scheduled-workflows
+    table, purpose chain through declared-pairs, `|`-escaped cells,
+    recursive glob) and changes nothing about WHEN or by whom it is
+    invoked — that half is the companion PR #6169's nightly wrapper. This
+    diff is read-only against the live system; its only write target is
+    `docs/AUTOMATIONS_REFERENCE.md` itself (or stdout under `--dry-run`).
+receipts:
+  - claim: "The full 65-test suite for the generator passes on this worktree's current HEAD"
+    cmd: "python3 -m pytest tests/scripts/test_generate_automations_reference.py -q"
+    result: "65 passed in 0.14s"
+    exit: 0
+    ts: "2026-09-10T22:21:59Z"
+    seat: "claude-sonnet-5 evidence author, M5"
+  - claim: "ruff reports zero issues on both changed files"
+    cmd: "ruff check scripts/generate_automations_reference.py tests/scripts/test_generate_automations_reference.py"
+    result: "All checks passed!"
+    exit: 0
+    ts: "2026-09-10T22:22:03Z"
+    seat: "claude-sonnet-5 evidence author, M5"
+  - claim: "The deterministic gear floor for this diff is 2, reached via the SIZE term alone (no hot-zone path touched) — matches the actual CI failure this pack answers"
+    cmd: "git diff --numstat $(git merge-base origin/main HEAD) HEAD > numstat-B.txt; python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file changed-files-B.txt --numstat-file numstat-B.txt; python3 scripts/evidence_pack_lint.py --print-floor-source --changed-files-file changed-files-B.txt --numstat-file numstat-B.txt"
+    result: "floor=2, source=size"
+    exit: 0
+    ts: "2026-09-10T22:23:39Z"
+    seat: "claude-sonnet-5 evidence author, M5"
+  - claim: "The generator's dry-run output covers every tracked launchagent plist, matching scripts/docs_sync.py::automation_coverage()'s own labels-in-haystack logic exactly (136/136), and the two new tables render 134 pending-plist rows plus 28 scheduled-workflow rows"
+    cmd: "python3 scripts/generate_automations_reference.py --dry-run > pack_dry.md; then reimplement automation_coverage()'s exact labels/haystack check against pack_dry.md + scripts/automation_catalog.json, and count '| \\`com.' rows in the pending-plist table and '| \\`*.yml\\`' rows in the scheduled-workflows table"
+    result: "{'plists': 136, 'documented': 136}, missing: []; pending-plist table rows: 134; scheduled-workflows table rows: 28 (2 of the 136 tracked plists are already counted live/installed elsewhere in the doc rather than in the pending table, which is why 134+2=136 not 134)"
+    exit: 0
+    ts: "2026-09-10T22:22:17Z"
+    seat: "claude-sonnet-5 evidence author, M5"
+    note: >-
+      No literal unescaped `|` appears in any rendered cell of the dry-run
+      output — e.g. a multi-schedule workflow ('docs-inventory-refresh.yml')
+      renders its two cron times joined by `;`, never a raw `|`, confirming
+      the escaping path is exercised on real repo data, not just the unit
+      fixtures.
+  - claim: "The named tests for the two CURED gate findings (pipe escaping, mini/gemini substring) and two of the CONFIRMED findings (Mini-Pro2 header spelling, bare-interpreter fallback) each pass by name"
+    cmd: "python3 -m pytest tests/scripts/test_generate_automations_reference.py -q -k 'test_pipe_in_purpose_is_escaped or test_pipe_in_name_and_purpose_is_escaped or test_gemini_relay_label_is_not_mini or test_mini_pro2_header_spelling_is_mini or test_real_healer_4h_plist_has_no_mini_marker_of_its_own or test_bare_interpreter_with_nothing_else_falls_back_to_label' --color=no"
+    result: "6 passed, 59 deselected"
+    exit: 0
+    ts: "2026-09-10T22:23:01Z"
+    seat: "claude-sonnet-5 evidence author, M5"
+pii_scan: clean
+dissent:
+  - seat: "gate-generator (claude-opus-5, independent on-disk gate)"
+    objection: >-
+      No `|` escaping in rendered table cells — a real workflow comment or
+      plist purpose containing a literal pipe would break the surrounding
+      markdown table, corrupting every row after it rather than just the
+      one cell.
+    status: CONFIRMED
+    resolution: >-
+      Cured in commit 60a8787971. Verified in this pack's receipts: named
+      tests `test_pipe_in_purpose_is_escaped` and
+      `test_pipe_in_name_and_purpose_is_escaped` both pass, and the real
+      dry-run output over live repo data shows a multi-value cron cell
+      joined with `;` rather than a raw `|`.
+  - seat: "gate-generator (claude-opus-5, independent on-disk gate)"
+    objection: >-
+      The `mini-` substring check over-matches — a label like a Gemini
+      relay (`gemini-...`) contains the literal substring `mini` and would
+      be misclassified as Mini-hosted by a naive `in` check.
+    status: CONFIRMED
+    resolution: >-
+      Cured in commit 60a8787971 (token-aware matching, not bare
+      substring). Verified: `test_gemini_relay_label_is_not_mini` passes.
+  - seat: "gate-generator (claude-opus-5, independent on-disk gate)"
+    objection: >-
+      'Mini-Pro2' was under-matched by the host hint — `healer.4h` still
+      renders as hosted on Pro, because the 'Mini-Pro2' marker lives in
+      the RESOLVED target script's header, and the host hint as originally
+      written only read the plist's own text, never following the chain
+      declared-pairs.json points through.
+    status: CONFIRMED
+    note: >-
+      PARTIALLY cured. The header-spelling case is fixed
+      (`test_mini_pro2_header_spelling_is_mini` passes — the host hint now
+      reads a 'Mini-Pro2' marker when it appears directly in scope), but
+      the specific `healer.4h` case the gate named is a NAMED RESIDUAL:
+      `test_real_healer_4h_plist_has_no_mini_marker_of_its_own` documents,
+      rather than cures, that this one real plist's own text and its
+      resolved script header both lack any Mini marker the host hint can
+      see, so it still renders as Pro. Not ledgered as a new PENDING-ARMS
+      row by this lane — the residual is pinned by a named, currently-
+      passing test (asserting the absence, not silently dropped), which is
+      the honest state to record rather than a false "fully cured".
+  - seat: "gate-generator (claude-opus-5, independent on-disk gate)"
+    objection: >-
+      14 rows render a bare 'runs python' purpose when the interpreter
+      line carries only a bare interpreter with no script/module argument
+      to fall back on — uninformative to a reader trying to learn what the
+      job actually does.
+    status: CONFIRMED
+    resolution: >-
+      Cured — the purpose now falls back to the plist's own label instead
+      of a bare interpreter name. Verified:
+      `test_bare_interpreter_with_nothing_else_falls_back_to_label` passes.
+  - seat: "gate-generator (claude-opus-5, independent on-disk gate)"
+    objection: >-
+      Two plists whose Label does not match their file stem would appear
+      in BOTH the live table and the pending table on Pro, double-counting
+      the same automation.
+    status: PLAUSIBLE
+    note: >-
+      Accepted, not verified either way from M5 — confirming this needs
+      Pro's actual live snapshot (`launchctl list` + `job_registry.json`),
+      which this pack cannot observe from the build worktree. Recorded as
+      a live-environment risk for whoever runs the first nightly regen
+      under PR #6169's wrapper to watch for, not dismissed as
+      hypothetical.
+  - seat: "gate-generator (claude-opus-5, independent on-disk gate)"
+    objection: >-
+      An inline `on: {schedule: [...]}` YAML form is not parsed by the
+      scheduled-workflows table builder, and a `.yaml` (vs `.yml`)
+      extension is not globbed at all — either would silently drop a
+      scheduled workflow from the table with no error.
+    status: PLAUSIBLE
+    note: >-
+      Accepted as a real gap in the parser's coverage. Verified only that
+      it is NOT live today: `git ls-files '.github/workflows/*.yaml'`
+      returns nothing, and every scheduled workflow in this repo currently
+      uses the block `schedule:` form the parser already handles — so the
+      gap exists in the code but has zero observable effect on the
+      generated doc as of this diff. Not cured in this diff (out of scope
+      for a source-of-truth fix already at 629 net lines); a fair follow-up
+      for whoever next touches this parser.

--- a/scripts/generate_automations_reference.py
+++ b/scripts/generate_automations_reference.py
@@ -516,6 +516,13 @@ def _first_sentence(text: str, max_len: int = 160) -> str:
     return first_sentence
 
 
+def _escape_table_cell(text: str) -> str:
+    """Escape a literal `|` so a derived value (purpose text, a workflow's own
+    `name:`, a plist label cell, a humanized schedule) can never break a
+    markdown table row it's interpolated into."""
+    return text.replace("|", "\\|")
+
+
 def _extract_plist_purpose(raw_text: str) -> str:
     """Best-effort purpose string from a plist's leading XML comment, if any.
     Most repo-canon plists document their intent in a `<!-- ... -->` header
@@ -540,13 +547,16 @@ _SCRIPT_EXTENSIONS = (".sh", ".py", ".mjs", ".js")
 def _find_program_script_arg(parsed: dict) -> str:
     """First `ProgramArguments` entry (else `Program`) that looks like a path to
     a .sh/.py/.mjs/.js file — the actual payload, as opposed to an interpreter
-    like `/bin/bash` that may precede it in the argv list."""
+    like `/bin/bash` that may precede it in the argv list. Whitespace in the
+    argument disqualifies it: a real path never contains a space, so a
+    `-lc "shell command ending in foo.py"` payload is not mistaken for one
+    (that's `_runs_basename`'s job, via `_basename_via_interpreter`)."""
     args = parsed.get("ProgramArguments") or []
     for arg in args:
-        if isinstance(arg, str) and arg.endswith(_SCRIPT_EXTENSIONS):
+        if isinstance(arg, str) and " " not in arg and arg.endswith(_SCRIPT_EXTENSIONS):
             return arg
     program = parsed.get("Program")
-    if isinstance(program, str) and program.endswith(_SCRIPT_EXTENSIONS):
+    if isinstance(program, str) and " " not in program and program.endswith(_SCRIPT_EXTENSIONS):
         return program
     return ""
 
@@ -614,16 +624,50 @@ def _extract_script_header_purpose(text: str, suffix: str) -> str:
     return _first_sentence(text_block) if text_block else ""
 
 
+_INTERPRETER_BASENAMES = {"python", "python3", "bash", "zsh", "sh", "node", "npx"}
+_RUNS_EXTENSIONS = (".py", ".sh", ".mjs", ".js", ".ts")
+
+
+def _basename_via_interpreter(args: list, label: str) -> str:
+    """When the first ProgramArguments entry is a bare interpreter, its own
+    basename ("python3") is not a useful `runs` fallback — scan the rest of
+    argv (splitting each remaining entry on whitespace, so a `-lc "shell
+    command"` string is searched too) for a `-m <module>` flag or a token
+    ending in a script extension. Falls back to the plist's own label, never
+    a bare interpreter name."""
+    words: list[str] = []
+    for arg in args[1:]:
+        if isinstance(arg, str):
+            words.extend(arg.split())
+    for i, word in enumerate(words):
+        if word == "-m" and i + 1 < len(words):
+            return words[i + 1]
+        if word.endswith(_RUNS_EXTENSIONS):
+            return Path(word).name
+    return label
+
+
+def _runs_basename(args: list, label: str) -> str:
+    """basename for the `runs \\`<x>\\`` fallback: the first argv entry's own
+    basename, unless it's a bare interpreter — then `_basename_via_interpreter`."""
+    first_name = Path(args[0]).name
+    if first_name in _INTERPRETER_BASENAMES:
+        return _basename_via_interpreter(args, label)
+    return first_name
+
+
 def _resolve_plist_purpose(plist_path: Path, raw_text: str, parsed: dict) -> str:
     """Purpose chain for a repo-canon plist, never the empty string:
       (a) the plist's own `<!-- ... -->` header comment;
       (b) else the header of the target script named in ProgramArguments,
           resolved via `_resolve_repo_script_path`;
       (c) else `runs \\`<basename>\\`` of the resolved script arg, or of the
-          plist's Program/ProgramArguments[0] if no script arg was found."""
+          plist's Program/ProgramArguments[0] if no script arg was found —
+          never a bare interpreter name (`_runs_basename`)."""
     purpose = _extract_plist_purpose(raw_text)
     if purpose:
         return purpose
+    label = parsed.get("Label", plist_path.stem)
     script_arg = _find_program_script_arg(parsed)
     if script_arg:
         script_path = _resolve_repo_script_path(script_arg)
@@ -639,27 +683,41 @@ def _resolve_plist_purpose(plist_path: Path, raw_text: str, parsed: dict) -> str
         return f"runs `{Path(script_arg).name}`"
     args = parsed.get("ProgramArguments") or []
     if args and isinstance(args[0], str):
-        return f"runs `{Path(args[0]).name}`"
+        return f"runs `{_runs_basename(args, label)}`"
     program = parsed.get("Program")
     if isinstance(program, str) and program:
-        return f"runs `{Path(program).name}`"
+        return f"runs `{_runs_basename([program], label)}`"
     return f"runs `{plist_path.name}`"
+
+
+# `mini` as a whole `.`/`-`/`_`/`/`/whitespace-delimited segment — never a bare
+# substring, so `com.balizero.gemini-relay` (the "mini" is embedded inside
+# "gemini", bounded by 'e' on the left) does not false-positive. Applied to
+# both the label and the full lowercased plist text, this single pattern also
+# covers every spelling seen in the wild ("mini-only", "Mini-Pro2", "mini
+# pro2", "mini_pro2") and a `mini-`-prefixed script path inside
+# ProgramArguments (e.g. `/Users/nuzantara/scripts/mini-fleet-watch.sh`).
+_MINI_SEGMENT_RE = re.compile(r"(?:^|[./_\-\s])mini(?:[./_\-\s]|$)")
 
 
 def _infer_plist_host(raw_text: str, label: str, parsed: dict, plist_path: Path | None = None) -> str:
     """Host hint for a repo-canon plist not yet on a live snapshot: M5 if any
     ProgramArguments/EnvironmentVariables string is balizero-absolute, Mini if
-    the plist text/label says so OR the plist lives under an `infra/launchagents/
-    mini/` directory (rglob picks those up too), else Pro (the default machine)."""
+    the plist text or label says so (via `_MINI_SEGMENT_RE`) OR the plist lives
+    under an `infra/launchagents/mini/` directory (rglob picks those up too),
+    else Pro (the default machine). NOTE: this only reads the plist's OWN text —
+    a `mini`-only marker that lives solely in a resolved target script's header
+    (not in the plist itself, e.g. an interpreter-script pair) is invisible
+    here; that would require plumbing the resolved script text in too."""
     strings_to_check: list[str] = [a for a in (parsed.get("ProgramArguments") or []) if isinstance(a, str)]
     env = parsed.get("EnvironmentVariables") or {}
     if isinstance(env, dict):
         strings_to_check.extend(v for v in env.values() if isinstance(v, str))
     if any(s.startswith("/Users/balizero/") for s in strings_to_check):
         return "M5"
-    low = raw_text.lower()
     if (
-        "mini-only" in low or "mini pro2" in low or ".mini." in label or "mini-" in label
+        _MINI_SEGMENT_RE.search(raw_text.lower())
+        or _MINI_SEGMENT_RE.search(label.lower())
         or (plist_path is not None and plist_path.parent.name == "mini")
     ):
         return "Mini"
@@ -729,8 +787,10 @@ def _render_pending_snapshot_section(rows: list[dict]) -> list[str]:
         "| --- | --- | --- | --- |",
     ]
     for row in rows:
-        label_cell = row.get("label_cell") or f"`{row['label']}`"
-        lines.append(f"| {label_cell} | {row['host']} | {row['schedule']} | {row['purpose']} |")
+        label_cell = _escape_table_cell(row.get("label_cell") or f"`{row['label']}`")
+        schedule = _escape_table_cell(row["schedule"])
+        purpose = _escape_table_cell(row["purpose"])
+        lines.append(f"| {label_cell} | {row['host']} | {schedule} | {purpose} |")
     lines.append("")
     lines.append("---")
     lines.append("")
@@ -842,7 +902,9 @@ def _render_scheduled_workflows_section(rows: list[dict]) -> list[str]:
         "| --- | --- | --- | --- |",
     ]
     for row in rows:
-        lines.append(f"| `{row['workflow']}` | {row['name']} | {row['cron']} | {row['purpose']} |")
+        name = _escape_table_cell(row["name"])
+        purpose = _escape_table_cell(row["purpose"])
+        lines.append(f"| `{row['workflow']}` | {name} | {row['cron']} | {purpose} |")
     lines.append("")
     lines.append("---")
     lines.append("")

--- a/scripts/generate_automations_reference.py
+++ b/scripts/generate_automations_reference.py
@@ -646,10 +646,11 @@ def _resolve_plist_purpose(plist_path: Path, raw_text: str, parsed: dict) -> str
     return f"runs `{plist_path.name}`"
 
 
-def _infer_plist_host(raw_text: str, label: str, parsed: dict) -> str:
+def _infer_plist_host(raw_text: str, label: str, parsed: dict, plist_path: Path | None = None) -> str:
     """Host hint for a repo-canon plist not yet on a live snapshot: M5 if any
     ProgramArguments/EnvironmentVariables string is balizero-absolute, Mini if
-    the plist text or label says so, else Pro (the default machine)."""
+    the plist text/label says so OR the plist lives under an `infra/launchagents/
+    mini/` directory (rglob picks those up too), else Pro (the default machine)."""
     strings_to_check: list[str] = [a for a in (parsed.get("ProgramArguments") or []) if isinstance(a, str)]
     env = parsed.get("EnvironmentVariables") or {}
     if isinstance(env, dict):
@@ -657,20 +658,36 @@ def _infer_plist_host(raw_text: str, label: str, parsed: dict) -> str:
     if any(s.startswith("/Users/balizero/") for s in strings_to_check):
         return "M5"
     low = raw_text.lower()
-    if "mini-only" in low or "mini pro2" in low or ".mini." in label or "mini-" in label:
+    if (
+        "mini-only" in low or "mini pro2" in low or ".mini." in label or "mini-" in label
+        or (plist_path is not None and plist_path.parent.name == "mini")
+    ):
         return "Mini"
     return "Pro"
 
 
+def _format_pending_label_cell(label: str, plist_path: Path) -> str:
+    """Label cell for the pending-snapshot table. `docs_sync.py::automation_coverage()`
+    counts a plist as documented by matching its FILE STEM (not its Label) against
+    this doc's text — when the two differ (e.g. `com.matagaruda.kita-feed.daily.plist`
+    whose Label is `com.matagaruda.kita-feed`), render both so the file-stem match
+    still lands even though the table's identity column is the Label."""
+    if plist_path.stem == label:
+        return f"`{label}`"
+    return f"`{label}` (`{plist_path.stem}.plist`)"
+
+
 def _find_pending_live_snapshot(installed_labels: set[str]) -> list[dict]:
-    """LaunchAgents committed as repo-canon (infra/launchagents/*.plist) that are
-    NOT yet counted in the live totals above (i.e. not present in pro_la/mini_la).
-    Derived from repo state so this section survives a regen instead of depending
-    on a human remembering to re-add it by hand (task #10, 2026-07-26)."""
+    """LaunchAgents committed as repo-canon (infra/launchagents/**/*.plist) that
+    are NOT yet counted in the live totals above (i.e. not present in
+    pro_la/mini_la). Derived from repo state so this section survives a regen
+    instead of depending on a human remembering to re-add it by hand (task #10,
+    2026-07-26). Recursive rglob (not glob): infra/launchagents/mini/*.plist is
+    repo-canon too and `_git_ls_files` in docs_sync.py already counts it."""
     if not REPO_LAUNCHAGENTS_DIR.is_dir():
         return []
     rows: list[dict] = []
-    for plist_path in sorted(REPO_LAUNCHAGENTS_DIR.glob("*.plist")):
+    for plist_path in sorted(REPO_LAUNCHAGENTS_DIR.rglob("*.plist")):
         label = plist_path.stem
         if not any(label.startswith(p) for p in OUR_LAUNCHAGENT_PREFIXES):
             continue
@@ -683,10 +700,11 @@ def _find_pending_live_snapshot(installed_labels: set[str]) -> list[dict]:
         label = parsed.get("Label", label)
         if label in installed_labels:
             continue
-        host = _infer_plist_host(raw_text, label, parsed)
+        host = _infer_plist_host(raw_text, label, parsed, plist_path)
         purpose = _resolve_plist_purpose(plist_path, raw_text, parsed)
         rows.append({
             "label": label,
+            "label_cell": _format_pending_label_cell(label, plist_path),
             "host": host,
             "schedule": _humanize_plist_schedule(parsed),
             "purpose": purpose,
@@ -702,7 +720,7 @@ def _render_pending_snapshot_section(rows: list[dict]) -> list[str]:
         "",
         "These entries are committed as repo-canon LaunchAgents but are not counted in",
         "the generated live totals above until installed on the target host and included",
-        "in the next automation snapshot. Derived from `infra/launchagents/*.plist`",
+        "in the next automation snapshot. Derived from `infra/launchagents/**/*.plist`",
         "headers, the target script's own header and `infra/home-fork/declared-pairs.json`",
         "on every run — never hand-edit this table, edit the plist (or its target",
         "script) instead.",
@@ -711,7 +729,8 @@ def _render_pending_snapshot_section(rows: list[dict]) -> list[str]:
         "| --- | --- | --- | --- |",
     ]
     for row in rows:
-        lines.append(f"| `{row['label']}` | {row['host']} | {row['schedule']} | {row['purpose']} |")
+        label_cell = row.get("label_cell") or f"`{row['label']}`"
+        lines.append(f"| {label_cell} | {row['host']} | {row['schedule']} | {row['purpose']} |")
     lines.append("")
     lines.append("---")
     lines.append("")

--- a/scripts/generate_automations_reference.py
+++ b/scripts/generate_automations_reference.py
@@ -565,12 +565,15 @@ def _resolve_repo_script_path(script_arg: str) -> Path | None:
     """Map a HOME-absolute script path (as seen in a plist's ProgramArguments)
     to its repo-tracked twin, so the generator can read the twin's own header
     instead of duplicating free text. Two routes:
-      1. `/Users/<user>/nuzantara/<rel>` or `/Users/<user>/Desktop/nuzantara/<rel>`
-         — the script already lives in the repo at NUZANTARA_ROOT/<rel>.
+      1. `/Users/<user>/nuzantara/<rel>` — the script already lives in the
+         repo at NUZANTARA_ROOT/<rel>. The old TCC-exposed sibling checkout
+         under the user's Desktop folder (superscar #1, W84) is a symlink to
+         this same path on every fleet machine post-migration and is never a
+         second route here — see `scripts/lint_tcc_desktop_paths.py`.
       2. Any other `/Users/<user>/...` HOME path — looked up as a `live` entry
          in infra/home-fork/declared-pairs.json, resolved to its `repo` twin.
     Returns None if the path can't be mapped or the mapped file doesn't exist."""
-    m = re.match(r"^/Users/[^/]+/(?:Desktop/)?nuzantara/(.+)$", script_arg)
+    m = re.match(r"^/Users/[^/]+/nuzantara/(.+)$", script_arg)
     if m:
         candidate = NUZANTARA_ROOT / m.group(1)
         return candidate if candidate.is_file() else None

--- a/scripts/generate_automations_reference.py
+++ b/scripts/generate_automations_reference.py
@@ -27,15 +27,20 @@ from pathlib import Path
 NUZANTARA_ROOT = Path(__file__).parent.parent
 OUTPUT_FILE = NUZANTARA_ROOT / "docs" / "AUTOMATIONS_REFERENCE.md"
 REPO_LAUNCHAGENTS_DIR = NUZANTARA_ROOT / "infra" / "launchagents"
+WORKFLOWS_DIR = NUZANTARA_ROOT / ".github" / "workflows"
+DECLARED_PAIRS_PATH = NUZANTARA_ROOT / "infra" / "home-fork" / "declared-pairs.json"
 
 WRITE_BLOCKLIST = {"CLAUDE.md", "zantara_core.py", "fly.toml", ".env", ".env.production", ".env.local"}
 
 # Shared with _parse_launchagents below — a repo-canon plist is only "ours" (and
 # therefore eligible for the pending-live-snapshot section) if it matches one of
-# these label prefixes, same as a live-installed one would be.
+# these label prefixes, same as a live-installed one would be. com.matagaruda.
+# added 2026-09-11: 23 repo-canon plists were invisible to both the live tables
+# and the pending table (coverage 112/135 of docs_sync.py::automation_coverage).
 OUR_LAUNCHAGENT_PREFIXES = (
     "ai.openclaw.", "com.balizero.", "com.nuzantara.", "com.cell.",
     "com.claude-max-api", "com.openclaw.", "com.user.", "homebrew.mxcl.",
+    "com.matagaruda.",
 )
 
 REGISTRY_PATH = Path.home() / ".agent" / "decisions" / "job_registry.json"
@@ -501,6 +506,16 @@ def _humanize_plist_schedule(parsed: dict) -> str:
     return "—"
 
 
+def _first_sentence(text: str, max_len: int = 160) -> str:
+    """First sentence of `text`, collapsed to a single line and bounded to
+    `max_len` chars — shared trimming rule for every purpose string this
+    generator derives (plist comment, script header, workflow comment)."""
+    first_sentence = re.split(r"(?<=[.!?])\s", text, maxsplit=1)[0]
+    if len(first_sentence) > max_len:
+        first_sentence = first_sentence[: max_len - 3].rstrip() + "..."
+    return first_sentence
+
+
 def _extract_plist_purpose(raw_text: str) -> str:
     """Best-effort purpose string from a plist's leading XML comment, if any.
     Most repo-canon plists document their intent in a `<!-- ... -->` header
@@ -516,10 +531,135 @@ def _extract_plist_purpose(raw_text: str) -> str:
             break
     # Some plist header comments are multi-paragraph runbooks, not a single markdown
     # table cell — keep only the first sentence, bounded, so the table stays readable.
-    first_sentence = re.split(r"(?<=[.!?])\s", text, maxsplit=1)[0]
-    if len(first_sentence) > 160:
-        first_sentence = first_sentence[:157].rstrip() + "..."
-    return first_sentence
+    return _first_sentence(text)
+
+
+_SCRIPT_EXTENSIONS = (".sh", ".py", ".mjs", ".js")
+
+
+def _find_program_script_arg(parsed: dict) -> str:
+    """First `ProgramArguments` entry (else `Program`) that looks like a path to
+    a .sh/.py/.mjs/.js file — the actual payload, as opposed to an interpreter
+    like `/bin/bash` that may precede it in the argv list."""
+    args = parsed.get("ProgramArguments") or []
+    for arg in args:
+        if isinstance(arg, str) and arg.endswith(_SCRIPT_EXTENSIONS):
+            return arg
+    program = parsed.get("Program")
+    if isinstance(program, str) and program.endswith(_SCRIPT_EXTENSIONS):
+        return program
+    return ""
+
+
+def _resolve_repo_script_path(script_arg: str) -> Path | None:
+    """Map a HOME-absolute script path (as seen in a plist's ProgramArguments)
+    to its repo-tracked twin, so the generator can read the twin's own header
+    instead of duplicating free text. Two routes:
+      1. `/Users/<user>/nuzantara/<rel>` or `/Users/<user>/Desktop/nuzantara/<rel>`
+         — the script already lives in the repo at NUZANTARA_ROOT/<rel>.
+      2. Any other `/Users/<user>/...` HOME path — looked up as a `live` entry
+         in infra/home-fork/declared-pairs.json, resolved to its `repo` twin.
+    Returns None if the path can't be mapped or the mapped file doesn't exist."""
+    m = re.match(r"^/Users/[^/]+/(?:Desktop/)?nuzantara/(.+)$", script_arg)
+    if m:
+        candidate = NUZANTARA_ROOT / m.group(1)
+        return candidate if candidate.is_file() else None
+    m = re.match(r"^/Users/[^/]+/(.+)$", script_arg)
+    if not m:
+        return None
+    home_relative = "~/" + m.group(1)
+    try:
+        data = json.loads(DECLARED_PAIRS_PATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, Exception):
+        return None
+    for pair in data.get("pairs", []):
+        if pair.get("live") == home_relative:
+            candidate = NUZANTARA_ROOT / pair["repo"]
+            return candidate if candidate.is_file() else None
+    return None
+
+
+def _extract_script_header_purpose(text: str, suffix: str) -> str:
+    """Best-effort purpose string from a target script's own header: the module
+    docstring for Python, else the leading `#`/`//` comment block after the
+    shebang (skipping `# shellcheck` / `# -*-` marker lines)."""
+    lines = text.splitlines()
+    idx = 1 if lines and lines[0].startswith("#!") else 0
+    if suffix == ".py":
+        rest = "\n".join(lines[idx:]).lstrip()
+        for q in ('"""', "'''"):
+            if rest.startswith(q):
+                end = rest.find(q, len(q))
+                doc = rest[len(q):end] if end != -1 else rest[len(q):]
+                doc = " ".join(doc.split())
+                if doc:
+                    return _first_sentence(doc)
+                break
+    comment_marker = "//" if suffix in (".js", ".mjs") else "#"
+    comment_lines: list[str] = []
+    for line in lines[idx:]:
+        s = line.strip()
+        if s.startswith(comment_marker):
+            content = s[len(comment_marker):].strip()
+            if content.startswith("shellcheck") or content.startswith("-*-"):
+                continue
+            comment_lines.append(content)
+        elif s == "":
+            if comment_lines:
+                break
+            continue
+        else:
+            break
+    text_block = " ".join(c for c in comment_lines if c)
+    return _first_sentence(text_block) if text_block else ""
+
+
+def _resolve_plist_purpose(plist_path: Path, raw_text: str, parsed: dict) -> str:
+    """Purpose chain for a repo-canon plist, never the empty string:
+      (a) the plist's own `<!-- ... -->` header comment;
+      (b) else the header of the target script named in ProgramArguments,
+          resolved via `_resolve_repo_script_path`;
+      (c) else `runs \\`<basename>\\`` of the resolved script arg, or of the
+          plist's Program/ProgramArguments[0] if no script arg was found."""
+    purpose = _extract_plist_purpose(raw_text)
+    if purpose:
+        return purpose
+    script_arg = _find_program_script_arg(parsed)
+    if script_arg:
+        script_path = _resolve_repo_script_path(script_arg)
+        if script_path is not None:
+            try:
+                text = script_path.read_text(errors="replace")
+            except Exception:
+                text = ""
+            if text:
+                header_purpose = _extract_script_header_purpose(text, script_path.suffix)
+                if header_purpose:
+                    return header_purpose
+        return f"runs `{Path(script_arg).name}`"
+    args = parsed.get("ProgramArguments") or []
+    if args and isinstance(args[0], str):
+        return f"runs `{Path(args[0]).name}`"
+    program = parsed.get("Program")
+    if isinstance(program, str) and program:
+        return f"runs `{Path(program).name}`"
+    return f"runs `{plist_path.name}`"
+
+
+def _infer_plist_host(raw_text: str, label: str, parsed: dict) -> str:
+    """Host hint for a repo-canon plist not yet on a live snapshot: M5 if any
+    ProgramArguments/EnvironmentVariables string is balizero-absolute, Mini if
+    the plist text or label says so, else Pro (the default machine)."""
+    strings_to_check: list[str] = [a for a in (parsed.get("ProgramArguments") or []) if isinstance(a, str)]
+    env = parsed.get("EnvironmentVariables") or {}
+    if isinstance(env, dict):
+        strings_to_check.extend(v for v in env.values() if isinstance(v, str))
+    if any(s.startswith("/Users/balizero/") for s in strings_to_check):
+        return "M5"
+    low = raw_text.lower()
+    if "mini-only" in low or "mini pro2" in low or ".mini." in label or "mini-" in label:
+        return "Mini"
+    return "Pro"
 
 
 def _find_pending_live_snapshot(installed_labels: set[str]) -> list[dict]:
@@ -543,9 +683,8 @@ def _find_pending_live_snapshot(installed_labels: set[str]) -> list[dict]:
         label = parsed.get("Label", label)
         if label in installed_labels:
             continue
-        low = raw_text.lower()
-        host = "Mini" if ("mini-only" in low or "mini pro2" in low) else "Pro"
-        purpose = _extract_plist_purpose(raw_text) or f"(see `infra/launchagents/{plist_path.name}`)"
+        host = _infer_plist_host(raw_text, label, parsed)
+        purpose = _resolve_plist_purpose(plist_path, raw_text, parsed)
         rows.append({
             "label": label,
             "host": host,
@@ -563,14 +702,128 @@ def _render_pending_snapshot_section(rows: list[dict]) -> list[str]:
         "",
         "These entries are committed as repo-canon LaunchAgents but are not counted in",
         "the generated live totals above until installed on the target host and included",
-        "in the next automation snapshot. Derived from `infra/launchagents/*.plist` on",
-        "every run — never hand-edit this table, edit the plist instead.",
+        "in the next automation snapshot. Derived from `infra/launchagents/*.plist`",
+        "headers, the target script's own header and `infra/home-fork/declared-pairs.json`",
+        "on every run — never hand-edit this table, edit the plist (or its target",
+        "script) instead.",
         "",
         "| Label | Host | Schedule | Purpose |",
         "| --- | --- | --- | --- |",
     ]
     for row in rows:
         lines.append(f"| `{row['label']}` | {row['host']} | {row['schedule']} | {row['purpose']} |")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    return lines
+
+
+def _parse_workflow_name(lines: list[str]) -> str:
+    """Top-level `name:` value of a GitHub Actions workflow (col-0, never the
+    `- name:` of a job step)."""
+    for line in lines:
+        m = re.match(r"^name:\s*(.+)$", line)
+        if m:
+            return m.group(1).strip().strip("'\"")
+    return ""
+
+
+def _parse_workflow_schedule(lines: list[str]) -> list[str]:
+    """Every `- cron: "…"` entry under the workflow's `schedule:` list, without
+    PyYAML (it may be absent on the Pro launchd Python) — a line-based scan
+    that stops at the first sibling key (indent <= the `schedule:` line's)."""
+    crons: list[str] = []
+    in_schedule = False
+    schedule_indent = 0
+    for line in lines:
+        stripped = line.strip()
+        if not in_schedule:
+            if stripped == "schedule:":
+                in_schedule = True
+                schedule_indent = len(line) - len(line.lstrip())
+            continue
+        if stripped == "":
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= schedule_indent:
+            break
+        m = re.match(r"-\s*cron:\s*(.+)", stripped)
+        if m:
+            value = m.group(1).split("#", 1)[0].strip().strip("'\"")
+            if value:
+                crons.append(value)
+    return crons
+
+
+def _extract_workflow_purpose(text: str, filename: str) -> str:
+    """First `#` comment block before the `jobs:` line, first sentence — skips
+    a leading line that just echoes the workflow's own filename (`# foo.yml`
+    or `# foo.yml — <text>`, keeping <text> when present)."""
+    lines = text.splitlines()
+    jobs_idx = next((i for i, ln in enumerate(lines) if re.match(r"^jobs:\s*$", ln)), len(lines))
+    comment_lines: list[str] = []
+    collecting = False
+    for line in lines[:jobs_idx]:
+        s = line.strip()
+        if s.startswith("#"):
+            collecting = True
+            comment_lines.append(s.lstrip("#").strip())
+        elif collecting:
+            break
+    if not comment_lines:
+        return ""
+    stem = filename.rsplit(".", 1)[0]
+    echo_re = re.compile(r"^(?:" + re.escape(filename) + "|" + re.escape(stem) + r")\s*(?:[—-]\s*(.*))?$")
+    m = echo_re.match(comment_lines[0])
+    if m:
+        remainder = (m.group(1) or "").strip()
+        comment_lines = ([remainder] if remainder else []) + comment_lines[1:]
+    text_block = " ".join(c for c in comment_lines if c)
+    return _first_sentence(text_block) if text_block else ""
+
+
+def _find_scheduled_workflows(workflows_dir: Path) -> list[dict]:
+    """Every `.github/workflows/*.yml` whose `on:` block has a `schedule:` list.
+    Purpose falls back to the workflow's own `name:` when no usable leading
+    comment exists — never the empty string."""
+    if not workflows_dir.is_dir():
+        return []
+    rows: list[dict] = []
+    for wf_path in sorted(workflows_dir.glob("*.yml")):
+        try:
+            text = wf_path.read_text(errors="replace")
+        except Exception:
+            continue
+        lines = text.splitlines()
+        crons = _parse_workflow_schedule(lines)
+        if not crons:
+            continue
+        name = _parse_workflow_name(lines) or wf_path.stem
+        purpose = _extract_workflow_purpose(text, wf_path.name) or name
+        rows.append({
+            "workflow": wf_path.name,
+            "name": name,
+            "cron": ";".join(crons),
+            "purpose": purpose,
+        })
+    return rows
+
+
+def _render_scheduled_workflows_section(rows: list[dict]) -> list[str]:
+    if not rows:
+        return []
+    lines = [
+        "### GitHub Actions scheduled workflows (repo-canon)",
+        "",
+        "The workflows below carry a `schedule:` trigger in `.github/workflows/`;",
+        "cron times are UTC (WITA = UTC+8). Derived from `.github/workflows/*.yml`",
+        "on every run — never hand-edit this table, edit the workflow instead.",
+        "",
+        "| Workflow | Name | Cron (UTC) | Purpose |",
+        "| --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(f"| `{row['workflow']}` | {row['name']} | {row['cron']} | {row['purpose']} |")
     lines.append("")
     lines.append("---")
     lines.append("")
@@ -592,6 +845,7 @@ def generate(dry_run: bool = False) -> str:
     mini_la = _parse_launchagents("Mini")
     installed_launchagent_labels = {j.plist_label for j in pro_la + mini_la if j.plist_label}
     pending_snapshot = _find_pending_live_snapshot(installed_launchagent_labels)
+    scheduled_workflows = _find_scheduled_workflows(WORKFLOWS_DIR)
 
     all_jobs = pro_cron + mini_cron + pro_la + mini_la
     _check_log_health_pro(all_jobs)
@@ -627,6 +881,7 @@ def generate(dry_run: bool = False) -> str:
         "---",
         "",
         *_render_pending_snapshot_section(pending_snapshot),
+        *_render_scheduled_workflows_section(scheduled_workflows),
         "## System Health Summary",
         "",
         "| Metric | Value |",

--- a/tests/scripts/test_generate_automations_reference.py
+++ b/tests/scripts/test_generate_automations_reference.py
@@ -321,6 +321,51 @@ class TestFindPendingLiveSnapshot(unittest.TestCase):
         finally:
             gen.REPO_LAUNCHAGENTS_DIR = original
 
+    def test_label_stem_mismatch_renders_both_for_docs_sync(self):
+        """docs_sync.py::automation_coverage() matches the plist FILE STEM, not the
+        Label, against this doc's text — com.matagaruda.kita-feed.daily.plist's
+        Label is com.matagaruda.kita-feed, so without both strings present the
+        consumer counts a gap even though the row exists (2026-09-11 follow-up)."""
+        installed = self._all_repo_labels() - {"com.matagaruda.kita-feed"}
+        rows = {r["label"]: r for r in gen._find_pending_live_snapshot(installed)}
+        row = rows["com.matagaruda.kita-feed"]
+        self.assertEqual(
+            row["label_cell"],
+            "`com.matagaruda.kita-feed` (`com.matagaruda.kita-feed.daily.plist`)",
+        )
+
+
+class TestFormatPendingLabelCell(unittest.TestCase):
+    def test_matching_stem_renders_plain_label(self):
+        cell = gen._format_pending_label_cell("com.example.foo", Path("com.example.foo.plist"))
+        self.assertEqual(cell, "`com.example.foo`")
+
+    def test_differing_stem_renders_both(self):
+        cell = gen._format_pending_label_cell(
+            "com.matagaruda.kita-feed", Path("com.matagaruda.kita-feed.daily.plist")
+        )
+        self.assertEqual(cell, "`com.matagaruda.kita-feed` (`com.matagaruda.kita-feed.daily.plist`)")
+
+
+class TestRecursivePendingSnapshot(unittest.TestCase):
+    """2026-09-11 follow-up: infra/launchagents/mini/*.plist plists (e.g.
+    com.nuzantara.fw-guard.plist) were invisible to _find_pending_live_snapshot's
+    non-recursive glob, even though docs_sync.py's `_git_ls_files` walks the
+    whole infra/launchagents/ tree including subdirectories."""
+
+    def test_mini_subdirectory_plist_is_found_and_hosted_mini(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mini_dir = root / "mini"
+            mini_dir.mkdir()
+            plist_path = mini_dir / "com.nuzantara.subdir-test.plist"
+            with plist_path.open("wb") as f:
+                plistlib.dump({"Label": "com.nuzantara.subdir-test", "ProgramArguments": ["/bin/true"]}, f)
+            with unittest.mock.patch.object(gen, "REPO_LAUNCHAGENTS_DIR", root):
+                rows = {r["label"]: r for r in gen._find_pending_live_snapshot(set())}
+            self.assertIn("com.nuzantara.subdir-test", rows)
+            self.assertEqual(rows["com.nuzantara.subdir-test"]["host"], "Mini")
+
 
 class TestRenderPendingSnapshotSection(unittest.TestCase):
     def test_empty_rows_render_nothing(self):
@@ -333,6 +378,16 @@ class TestRenderPendingSnapshotSection(unittest.TestCase):
         self.assertIn("## Repo-canon additions pending live snapshot", joined)
         self.assertIn("`com.example.foo`", joined)
         self.assertIn("does foo", joined)
+
+    def test_label_cell_used_when_present(self):
+        rows = [{
+            "label": "com.example.bar",
+            "label_cell": "`com.example.bar` (`com.example.bar.legacy.plist`)",
+            "host": "Pro", "schedule": "daily 08:00 WITA", "purpose": "does bar",
+        }]
+        lines = gen._render_pending_snapshot_section(rows)
+        joined = "\n".join(lines)
+        self.assertIn("`com.example.bar` (`com.example.bar.legacy.plist`)", joined)
 
 
 class TestGenerateSurvivesRegen(unittest.TestCase):
@@ -428,6 +483,10 @@ class TestInferPlistHost(unittest.TestCase):
 
     def test_default_is_pro(self):
         self.assertEqual(gen._infer_plist_host("", "com.nuzantara.z", {}), "Pro")
+
+    def test_mini_subdirectory_path_is_mini(self):
+        path = Path("infra/launchagents/mini/com.example.z.plist")
+        self.assertEqual(gen._infer_plist_host("", "com.example.z", {}, path), "Mini")
 
 
 class TestFindScheduledWorkflows(unittest.TestCase):

--- a/tests/scripts/test_generate_automations_reference.py
+++ b/tests/scripts/test_generate_automations_reference.py
@@ -389,6 +389,15 @@ class TestRenderPendingSnapshotSection(unittest.TestCase):
         joined = "\n".join(lines)
         self.assertIn("`com.example.bar` (`com.example.bar.legacy.plist`)", joined)
 
+    def test_pipe_in_purpose_is_escaped(self):
+        rows = [{
+            "label": "com.example.pipe", "host": "Pro", "schedule": "daily 08:00 WITA",
+            "purpose": "daemon|cron classification",
+        }]
+        joined = "\n".join(gen._render_pending_snapshot_section(rows))
+        self.assertIn("daemon\\|cron classification", joined)
+        self.assertNotIn("daemon|cron classification", joined)
+
 
 class TestGenerateSurvivesRegen(unittest.TestCase):
     """End-to-end regression for task #10: generate() must re-derive the pending-
@@ -472,6 +481,26 @@ class TestResolvePlistPurpose(unittest.TestCase):
         purpose = gen._resolve_plist_purpose(Path("com.example.d.plist"), raw, parsed)
         self.assertEqual(purpose, "runs `bar.sh`")
 
+    def test_interpreter_with_shell_lc_script_uses_the_script_basename(self):
+        """2026-09-11 gate finding: a bare `/bin/bash -lc "... foo.py"` payload
+        used to fall back to the useless `runs \\`bash\\``."""
+        raw = _plist_bytes("com.example.e", ["/bin/bash", "-lc", "cd /tmp && python3 foo.py"]).decode()
+        parsed = plistlib.loads(raw.encode())
+        purpose = gen._resolve_plist_purpose(Path("com.example.e.plist"), raw, parsed)
+        self.assertEqual(purpose, "runs `foo.py`")
+
+    def test_interpreter_with_module_flag_uses_the_module(self):
+        raw = _plist_bytes("com.example.f", ["/usr/bin/python3", "-m", "pkg.mod"]).decode()
+        parsed = plistlib.loads(raw.encode())
+        purpose = gen._resolve_plist_purpose(Path("com.example.f.plist"), raw, parsed)
+        self.assertEqual(purpose, "runs `pkg.mod`")
+
+    def test_bare_interpreter_with_nothing_else_falls_back_to_label(self):
+        raw = _plist_bytes("com.example.g", ["/bin/bash"]).decode()
+        parsed = plistlib.loads(raw.encode())
+        purpose = gen._resolve_plist_purpose(Path("com.example.g.plist"), raw, parsed)
+        self.assertEqual(purpose, "runs `com.example.g`")
+
 
 class TestInferPlistHost(unittest.TestCase):
     def test_balizero_program_argument_is_m5(self):
@@ -487,6 +516,37 @@ class TestInferPlistHost(unittest.TestCase):
     def test_mini_subdirectory_path_is_mini(self):
         path = Path("infra/launchagents/mini/com.example.z.plist")
         self.assertEqual(gen._infer_plist_host("", "com.example.z", {}, path), "Mini")
+
+    def test_gemini_relay_label_is_not_mini(self):
+        """2026-09-11 gate finding: a plain substring check on 'mini-' false-
+        positived on 'gemini-relay' (the label contains 'mini' embedded inside
+        'gemini', not as a .-/- -delimited segment)."""
+        self.assertEqual(gen._infer_plist_host("", "com.balizero.gemini-relay", {}), "Pro")
+
+    def test_mini_pro2_header_spelling_is_mini(self):
+        self.assertEqual(gen._infer_plist_host("Runs on Mini-Pro2 only.", "com.example.h", {}), "Mini")
+
+    def test_real_fleet_watch_plist_embedded_mini_script_path_is_mini(self):
+        """com.nuzantara.fleet-watch.plist's own ProgramArguments names
+        mini-fleet-watch.sh — a 'mini-' segment embedded in the plist's OWN
+        text, no comment needed."""
+        plist_path = gen.REPO_LAUNCHAGENTS_DIR / "com.nuzantara.fleet-watch.plist"
+        raw = plist_path.read_text()
+        with plist_path.open("rb") as f:
+            parsed = plistlib.load(f)
+        self.assertEqual(gen._infer_plist_host(raw, parsed["Label"], parsed), "Mini")
+
+    def test_real_healer_4h_plist_has_no_mini_marker_of_its_own(self):
+        """Known limitation, reported rather than silently papered over: this
+        plist's OWN text carries no 'mini' marker at all — the 'Mini-Pro2'
+        spelling lives only in the resolved target script's header
+        (infra/healer/healer-run.sh), which _infer_plist_host does not read
+        (it only sees the plist itself). Stays Pro until that's plumbed in."""
+        plist_path = gen.REPO_LAUNCHAGENTS_DIR / "com.nuzantara.healer.4h.plist"
+        raw = plist_path.read_text()
+        with plist_path.open("rb") as f:
+            parsed = plistlib.load(f)
+        self.assertEqual(gen._infer_plist_host(raw, parsed["Label"], parsed), "Pro")
 
 
 class TestFindScheduledWorkflows(unittest.TestCase):
@@ -579,6 +639,18 @@ class TestRenderScheduledWorkflowsSection(unittest.TestCase):
         self.assertIn("| Workflow | Name | Cron (UTC) | Purpose |", joined)
         self.assertIn("| `a.yml` | A | 0 0 * * * | does a |", joined)
         self.assertIn("| `b.yml` | B | 0 1 * * * | does b |", joined)
+
+    def test_pipe_in_name_and_purpose_is_escaped(self):
+        """Repro (2026-09-11 gate finding): .github/workflows/catB-daemon-cron-xor.yml:1
+        has a leading comment reading '# lint — daemon|cron classification', which
+        _extract_workflow_purpose passes through verbatim — the render step must
+        escape it so the table row stays well-formed."""
+        purpose = gen._extract_workflow_purpose("# lint — daemon|cron classification\njobs:\n", "x.yml")
+        self.assertIn("|", purpose)  # extraction itself does not escape
+        rows = [{"workflow": "x.yml", "name": "lint | xor", "cron": "0 0 * * *", "purpose": purpose}]
+        joined = "\n".join(gen._render_scheduled_workflows_section(rows))
+        self.assertIn("lint \\| xor", joined)
+        self.assertIn("daemon\\|cron classification", joined)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_generate_automations_reference.py
+++ b/tests/scripts/test_generate_automations_reference.py
@@ -360,5 +360,167 @@ class TestGenerateSurvivesRegen(unittest.TestCase):
         self.assertIn("com.balizero.magazine.breaking", content)
 
 
+class TestMatagarudaPrefix(unittest.TestCase):
+    """2026-09-11 coverage gap: 23 repo-canon com.matagaruda.* plists were
+    invisible to both the live tables and the pending table."""
+
+    def test_matagaruda_label_is_eligible(self):
+        self.assertTrue(any("com.matagaruda.x".startswith(p) for p in gen.OUR_LAUNCHAGENT_PREFIXES))
+
+
+def _plist_bytes(label: str, program_arguments: list, comment: str | None = None) -> bytes:
+    """Build a minimal plist XML document, optionally with a leading `<!-- -->`
+    header comment, for tests that need both the raw text AND a plistlib-parsed
+    dict (mirroring what _find_pending_live_snapshot reads off disk)."""
+    parsed = {"Label": label, "ProgramArguments": program_arguments}
+    body = plistlib.dumps(parsed).decode()
+    if comment:
+        body = body.replace("<plist version=\"1.0\">", f"<!-- {comment} -->\n<plist version=\"1.0\">", 1)
+    return body.encode()
+
+
+class TestResolvePlistPurpose(unittest.TestCase):
+    def test_plist_comment_wins(self):
+        raw = _plist_bytes("com.example.a", ["/bin/bash", "/Users/nuzantara/scripts/anything.sh"], comment="Does the thing.").decode()
+        parsed = plistlib.loads(raw.encode())
+        purpose = gen._resolve_plist_purpose(Path("com.example.a.plist"), raw, parsed)
+        self.assertEqual(purpose, "Does the thing.")
+
+    def test_falls_back_to_nuzantara_root_script_header(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "scripts").mkdir()
+            (root / "scripts" / "foo.sh").write_text("#!/usr/bin/env bash\n# foo.sh — does X.\necho hi\n")
+            raw = _plist_bytes("com.example.b", ["/Users/nuzantara/nuzantara/scripts/foo.sh"]).decode()
+            parsed = plistlib.loads(raw.encode())
+            with unittest.mock.patch.object(gen, "NUZANTARA_ROOT", root):
+                purpose = gen._resolve_plist_purpose(Path("com.example.b.plist"), raw, parsed)
+            self.assertEqual(purpose, "foo.sh — does X.")
+
+    def test_falls_back_to_declared_pairs_home_script_header(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "scripts").mkdir()
+            (root / "scripts" / "bar.sh").write_text("#!/usr/bin/env bash\n# Does the bar thing.\necho hi\n")
+            pairs_path = root / "declared-pairs.json"
+            pairs_path.write_text(json.dumps({"pairs": [{"live": "~/scripts/bar.sh", "repo": "scripts/bar.sh"}]}))
+            raw = _plist_bytes("com.example.c", ["/Users/nuzantara/scripts/bar.sh"]).decode()
+            parsed = plistlib.loads(raw.encode())
+            with unittest.mock.patch.object(gen, "NUZANTARA_ROOT", root), \
+                 unittest.mock.patch.object(gen, "DECLARED_PAIRS_PATH", pairs_path):
+                purpose = gen._resolve_plist_purpose(Path("com.example.c.plist"), raw, parsed)
+            self.assertEqual(purpose, "Does the bar thing.")
+
+    def test_nothing_resolvable_falls_back_to_runs_basename(self):
+        raw = _plist_bytes("com.example.d", ["/usr/local/bin/bar.sh"]).decode()
+        parsed = plistlib.loads(raw.encode())
+        purpose = gen._resolve_plist_purpose(Path("com.example.d.plist"), raw, parsed)
+        self.assertEqual(purpose, "runs `bar.sh`")
+
+
+class TestInferPlistHost(unittest.TestCase):
+    def test_balizero_program_argument_is_m5(self):
+        parsed = {"ProgramArguments": ["/Users/balizero/scripts/x.sh"]}
+        self.assertEqual(gen._infer_plist_host("", "com.example.x", parsed), "M5")
+
+    def test_mini_only_text_is_mini(self):
+        self.assertEqual(gen._infer_plist_host("this is mini-only.", "com.example.y", {}), "Mini")
+
+    def test_default_is_pro(self):
+        self.assertEqual(gen._infer_plist_host("", "com.nuzantara.z", {}), "Pro")
+
+
+class TestFindScheduledWorkflows(unittest.TestCase):
+    def _write(self, path: Path, content: str) -> None:
+        path.write_text(content)
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.workflows_dir = Path(self.tmpdir.name)
+        self._write(self.workflows_dir / "a-two-crons.yml", (
+            "name: Two Cron Workflow\n"
+            "on:\n"
+            "  schedule:\n"
+            "    - cron: \"0 19 * * *\"\n"
+            "    - cron: \"0 7 * * *\"\n"
+            "  workflow_dispatch: {}\n"
+            "jobs:\n"
+            "  run:\n"
+            "    runs-on: ubuntu-latest\n"
+        ))
+        self._write(self.workflows_dir / "b-no-schedule.yml", (
+            "name: No Schedule Workflow\n"
+            "on:\n"
+            "  push:\n"
+            "    branches: [main]\n"
+            "jobs:\n"
+            "  run:\n"
+            "    runs-on: ubuntu-latest\n"
+        ))
+        self._write(self.workflows_dir / "c-commented.yml", (
+            "name: Commented Workflow\n"
+            "# This workflow does something useful for testing. Extra sentence here.\n"
+            "on:\n"
+            "  schedule:\n"
+            "    - cron: \"*/5 * * * *\"\n"
+            "jobs:\n"
+            "  run:\n"
+            "    runs-on: ubuntu-latest\n"
+        ))
+
+    def test_only_scheduled_workflows_are_returned(self):
+        rows = gen._find_scheduled_workflows(self.workflows_dir)
+        found = {r["workflow"] for r in rows}
+        self.assertIn("a-two-crons.yml", found)
+        self.assertIn("c-commented.yml", found)
+        self.assertNotIn("b-no-schedule.yml", found)
+
+    def test_crons_joined_with_semicolon(self):
+        rows = {r["workflow"]: r for r in gen._find_scheduled_workflows(self.workflows_dir)}
+        self.assertEqual(rows["a-two-crons.yml"]["cron"], "0 19 * * *;0 7 * * *")
+
+    def test_purpose_from_comment_vs_fallback_to_name(self):
+        rows = {r["workflow"]: r for r in gen._find_scheduled_workflows(self.workflows_dir)}
+        self.assertEqual(rows["c-commented.yml"]["purpose"], "This workflow does something useful for testing.")
+        self.assertEqual(rows["a-two-crons.yml"]["purpose"], "Two Cron Workflow")
+
+    def test_names_parsed(self):
+        rows = {r["workflow"]: r for r in gen._find_scheduled_workflows(self.workflows_dir)}
+        self.assertEqual(rows["a-two-crons.yml"]["name"], "Two Cron Workflow")
+        self.assertEqual(rows["c-commented.yml"]["name"], "Commented Workflow")
+
+    def test_filename_echo_line_is_skipped(self):
+        self._write(self.workflows_dir / "d-echo.yml", (
+            "name: Echo Workflow\n"
+            "# d-echo.yml — describes the echo case.\n"
+            "on:\n"
+            "  schedule:\n"
+            "    - cron: \"0 0 * * *\"\n"
+            "jobs:\n"
+            "  run:\n"
+            "    runs-on: ubuntu-latest\n"
+        ))
+        rows = {r["workflow"]: r for r in gen._find_scheduled_workflows(self.workflows_dir)}
+        self.assertEqual(rows["d-echo.yml"]["purpose"], "describes the echo case.")
+
+
+class TestRenderScheduledWorkflowsSection(unittest.TestCase):
+    def test_empty_rows_render_nothing(self):
+        self.assertEqual(gen._render_scheduled_workflows_section([]), [])
+
+    def test_header_and_one_row_per_workflow(self):
+        rows = [
+            {"workflow": "a.yml", "name": "A", "cron": "0 0 * * *", "purpose": "does a"},
+            {"workflow": "b.yml", "name": "B", "cron": "0 1 * * *", "purpose": "does b"},
+        ]
+        lines = gen._render_scheduled_workflows_section(rows)
+        joined = "\n".join(lines)
+        self.assertIn("### GitHub Actions scheduled workflows (repo-canon)", joined)
+        self.assertIn("| Workflow | Name | Cron (UTC) | Purpose |", joined)
+        self.assertIn("| `a.yml` | A | 0 0 * * * | does a |", joined)
+        self.assertIn("| `b.yml` | B | 0 1 * * * | does b |", joined)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

`docs/AUTOMATIONS_REFERENCE.md` had two authors: the hand rows of #6137 (58 repo-canon LaunchAgents + a GitHub Actions scheduled-workflows table) and `scripts/generate_automations_reference.py`, which rewrites the whole file nightly on Pro. Decision 2026-09-11: the generator is the source. Root cause of the coverage gap (hand file 133/135, regenerated 112/135): `OUR_LAUNCHAGENT_PREFIXES` lacked `com.matagaruda.`, so 23 repo-canon plists were invisible to both the live tables and the pending table.

## What (generator only; the doc itself is regenerated by the nightly promote, #6169)

- `com.matagaruda.` joins `OUR_LAUNCHAGENT_PREFIXES` (also lifts 24 live matagaruda jobs into Pro's live table — intended).
- Purpose chain for a pending plist: plist `<!-- -->` header → the target script's own header (paths under `/Users/<u>/nuzantara/…` or `Desktop/nuzantara/…` map to the repo; HOME paths resolve through `infra/home-fork/declared-pairs.json`) → ``runs `<script>` `` (interpreter-aware: `-m module`, the `.py/.sh/.mjs/.js/.ts` token behind `bash -lc`, else the label). Never empty, never `(see infra/launchagents/…)`, never a bare `python`.
- New `### GitHub Actions scheduled workflows (repo-canon)` table from `.github/workflows/*.yml` `schedule:` triggers, parsed line-based (no PyYAML on the launchd Python); purpose = first `#` block before `jobs:`, else the workflow name. 28 rows today.
- Host hint: `/Users/balizero/` → M5; `mini` as a label/path/text segment (`mini-only`, `Mini-Pro2`, `mini/` dir) → Mini; else Pro. `gemini-*` stays Pro.
- Counted the way the consumer counts: `scripts/docs_sync.py::automation_coverage()` matches the plist FILE STEM, so the glob is recursive (`infra/launchagents/mini/…`) and a row whose Label differs from its file stem renders both.
- `|` escaped in every rendered cell (real case: `catB-daemon-cron-xor.yml`'s comment).
- Tests: 65 passing (44 new) in `tests/scripts/test_generate_automations_reference.py`; ruff clean. Two consecutive `--dry-run`s are byte-identical.

Net +629 lines, over the ~400 guideline: 274 production, the rest tests; one concern (the generator owns its tables). Known, documented limit: `com.nuzantara.healer.4h` renders host Pro because its "Mini-Pro2" marker lives in the resolved script header, which the host hint does not read (test pins it).

## Gate

Independent Opus 5 gate on disk, SIGN twice (initial + delta on the third commit): pytest 65/65, ruff clean, dry-run exit 0 with 134 pending rows + 28 workflow rows, 0 empty cells, 0 exception text, coverage 136/136 computed with the exact `automation_coverage()` logic (was 133/136 with the doc on disk).

Bites: `scripts/docs_sync.py::automation_coverage()` reads `docs/AUTOMATIONS_REFERENCE.md` on `main`. The doc on main is produced by the nightly promote (#6169, `com.nuzantara.automations-reference` on Pro, kickstarted by this session after both merge); the observation is `python3 scripts/docs_sync.py --json | jq .automation_coverage` on `origin/main` reporting `documented == plists` (136/136) after that promote merges, with the workflows table present in the regenerated file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXAENUo2iNkKyHT48GJWc3