### PR TITLE
fix(queue-shepherd): count consecutive re-arm write failures, reach CANNOT-VERIFY on malformed JSON, GC alerted_state (K-3, K-7, K-8)

### DIFF
--- a/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
@@ -51,13 +51,19 @@ assumptions:
       Read on disk before implementing, not assumed. No "already fixed" case among the three.
   - assumption: >-
       Every guard is proven by its own mutation.
-    status: verified
+    status: verified # CORRECTED — it was claimed verified on FOUR mutations and was FALSE
     evidence: >-
-      Four mutations run independently of the implementer, each in a throwaway copy, the
-      real file never touched — sticky-limit check neutered 1 failed/180; the
-      _normalize_rearm_pr RuntimeError wrap removed 2 failed/179; the gc_alerted_state call
-      site removed 1 failed/180; the candidate count moved back below the GC step
-      1 failed/183.
+      This assumption was written after four mutations and the fresh Opus 5 gate then ran
+      SEVENTEEN and found THREE guards the suite could not see, all green under deletion:
+      the gc_rearm_fail_state CALL SITE (the function had a test, the wired step did not —
+      the earlier spalla finding surviving one level up), the alerted_state pop of the
+      rearm-write-fail dedup key on a SUCCESSFUL write (without it a second run of three
+      failures after a recovery is silent, which is the K-3 disease reintroduced by the
+      dedup cache meant to cure it), and gc_alerted_state's documented "an unparseable key
+      is KEPT, never silently dropped" invariant. All three now have a test and all three
+      mutations were re-run after it: 1 failed/186 each. The claim is true at THIS sha and
+      the four-mutation version of it was not — recorded rather than quietly overwritten,
+      because a brief that inherits an over-claim is worse than one that never claimed.
   - assumption: >-
       K-3's alert path works end to end in production.
     status: unverified
@@ -70,9 +76,12 @@ assumptions:
       The second state file this PR adds (REARM_FAIL_FILE) does not itself grow unbounded.
     status: verified
     evidence: >-
-      gc_rearm_fail_state ages entries on last_attempt_at like gc_budget_state, and an
-      adversarial review found it shipped UNTESTED — the fix for an unbounded-growth bug
-      had introduced a second un-proven GC. Now pinned by a guilt+innocence test.
+      gc_rearm_fail_state ages entries on last_attempt_at like gc_budget_state. A spalla
+      review found it shipped UNTESTED — the fix for an unbounded-growth bug had introduced
+      a second un-proven GC — and the test added then covered only the FUNCTION, so removing
+      its call site still left the suite green. The wired step is now pinned end to end by
+      test_run_rearm_pass_actually_prunes_the_rearm_fail_file_B1 (aged entry absent, fresh
+      entry present, read back off disk after the pass).
 consumer_map:
   - >-
     launchd on Pro runs scripts/queue_shepherd.py every 600s as

--- a/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
@@ -77,8 +77,16 @@ assumptions:
       unverifiable-by-the-author on principle rather than on a count: "no guard is blind" is
       a claim about the ABSENCE of a blind spot, and an author cannot measure the absence of
       something they failed to imagine. Only an adversary can, and only up to the mutations
-      it happened to run — 21 core mutations are red at this sha, and that is the true
-      statement, not "every".
+      it happened to run. THIRD ROUND: the count was stale the moment it was written, and the
+      third gate found three MORE blind mutations — all three inside the tests the second round
+      had just added, which is the same shape for the third time running: a cure closes a hole
+      and opens an adjacent one. One of them is worth naming, because reading could not have
+      caught it: the M27 test asserted that the CORRUPT line named REARM_FAIL_FILE, and passed
+      even when the code named the WRONG file, because the exception text interpolated into the
+      same line already carried the right path — an assertion satisfied by a substring from a
+      different source than the one it meant to check. At THIS sha: 37 mutations executed, 33
+      red, 0 blind, 1 dead (M25, provably unreachable: the dry-run `continue` precedes
+      rearm_pr). That is the true statement, and it is true of these 37 only.
   - assumption: >-
       K-3's alert path works end to end in production.
     status: unverified

--- a/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
@@ -40,9 +40,16 @@ acceptance:
       initial 0 that reads as a measurement.
     probe: pytest-red-state-gc-candidates-test
   - text: >-
-      rc=3 SHALL NOT read as a crashed daemon to launchd — the plist is KeepAlive=false
-      with StartInterval=600 and no wrapper, so the child's exit code is not consumed.
-    probe: read-the-plist
+      rc=3 SHALL NOT raise a false alarm. CORRECTED after the gate: the earlier wording of
+      this probe said "the child's exit code is not consumed", and that is FALSE —
+      scripts/launchd_liveness_detector.py:424 reads LastExitStatus, and
+      com.nuzantara.queue-shepherd IS inside its OURS_RE glob, measured live among its 210
+      findings. The conclusion survives its broken premise: launchd itself ignores the exit
+      code (KeepAlive=false, StartInterval=600, no wrapper), and the detector maps a
+      non-zero exit to FAILING-HONESTLY (:442-449), which is NOT in ALARM_VERDICTS (:604).
+      No page fires. A conclusion resting on a false premise is the harder defect to catch,
+      because the answer still comes out right.
+    probe: read-the-plist-and-the-detector
 assumptions:
   - assumption: >-
       The three findings were still unfixed on origin/main.
@@ -51,7 +58,7 @@ assumptions:
       Read on disk before implementing, not assumed. No "already fixed" case among the three.
   - assumption: >-
       Every guard is proven by its own mutation.
-    status: verified # CORRECTED — it was claimed verified on FOUR mutations and was FALSE
+    status: unverifiable-by-the-author # twice claimed verified, twice falsified by a gate
     evidence: >-
       This assumption was written after four mutations and the fresh Opus 5 gate then ran
       SEVENTEEN and found THREE guards the suite could not see, all green under deletion:
@@ -64,6 +71,14 @@ assumptions:
       mutations were re-run after it: 1 failed/186 each. The claim is true at THIS sha and
       the four-mutation version of it was not — recorded rather than quietly overwritten,
       because a brief that inherits an over-claim is worse than one that never claimed.
+      SECOND CORRECTION, after the second gate round: the corrected wording ALSO claimed
+      verified, and a second round found three MORE blind guards (report()'s per-key block,
+      its CORRUPT branch, and the C2 conflation itself). The status is now
+      unverifiable-by-the-author on principle rather than on a count: "no guard is blind" is
+      a claim about the ABSENCE of a blind spot, and an author cannot measure the absence of
+      something they failed to imagine. Only an adversary can, and only up to the mutations
+      it happened to run — 21 core mutations are red at this sha, and that is the true
+      statement, not "every".
   - assumption: >-
       K-3's alert path works end to end in production.
     status: unverified
@@ -82,6 +97,19 @@ assumptions:
       its call site still left the suite green. The wired step is now pinned end to end by
       test_run_rearm_pass_actually_prunes_the_rearm_fail_file_B1 (aged entry absent, fresh
       entry present, read back off disk after the pass).
+residuals:
+  - >-
+    com.nuzantara.queue-shepherd is deliberately NOT added to
+    launchd_liveness_detector.py's EXPECTED_NONZERO_LABELS (:527-532), even though rc=3 is
+    exactly the documented "non-zero as a reporting convention" this allowlist exists for.
+    The allowlist is keyed on the LABEL, not on the exit code, so adding it would also
+    re-label rc=1 (an uncaught crash) and rc=2 (CANNOT-VERIFY) as EXPECTED-NONZERO on the
+    same job — silencing two real failures to tidy one deliberate signal. The file's own
+    comment forbids exactly that ("a genuinely broken job must NOT be added here to silence
+    it"). Left as FAILING-HONESTLY, which raises no alarm and reads truthfully. Making the
+    allowlist exit-code-aware is a change to the detector, a different concern and a
+    different PR.
+
 consumer_map:
   - >-
     launchd on Pro runs scripts/queue_shepherd.py every 600s as

--- a/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
@@ -121,7 +121,10 @@ residuals:
 
 consumer_map:
   - >-
-    launchd on Pro runs scripts/queue_shepherd.py every 600s as
-    com.nuzantara.queue-shepherd.10min; it is the only consumer of the three guards.
+    launchd on Pro runs scripts/queue_shepherd.py every 600s. The plist FILE is
+    com.nuzantara.queue-shepherd.10min.plist but its Label — the string launchctl knows and
+    the one launchd_liveness_detector.py matches on — is com.nuzantara.queue-shepherd, which
+    is why the residual below is stated against that name. Reading the filename as the label
+    is the same conflation the residual is about. It is the only consumer of the three guards.
   - >-
     scripts/tests/test_queue_shepherd.py runs in CI in this PR and is the shipped proof.

--- a/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
@@ -32,7 +32,8 @@ acceptance:
       queue_shepherd.py turns EXACTLY its own test(s) red and nothing else.
     probe: guilt-mutation-in-throwaway-copy
   - text: >-
-      The suite SHALL pass at 184 (169 before), and /usr/bin/python3 -m py_compile
+      The suite SHALL pass at 192 (169 before; 184 after round two, 192 after round three
+      added the four tests the third gate round demanded), and /usr/bin/python3 -m py_compile
       (3.9.6) SHALL exit 0.
     probe: pytest-and-py-compile
   - text: >-

--- a/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-s1-k3-k7-k8-767b6b19/brief.yml
@@ -1,0 +1,81 @@
+gear: 2
+task_id: s1-k3-k7-k8
+l_level: L1
+objective: >-
+  Close the last three deferred Kimi council findings from #6127, which are one concern:
+  scripts/queue_shepherd.py reported success while a failure was happening. K-3 — a
+  `gh pr merge --auto` re-arm WRITE that fails every tick ended rc=0 with a healthy
+  heartbeat and was retried silently forever. K-7 — a PR node missing `number`, or a
+  hand-edited red-state key, escaped as a bare KeyError/ValueError instead of reaching the
+  existing CANNOT-VERIFY path. K-8 — alerted_state was never garbage-collected.
+scope:
+  - scripts/queue_shepherd.py
+  - scripts/tests/test_queue_shepherd.py
+constraints:
+  - >-
+    Tests only and one module. No workflow, no plist, no ledger row in this PR; the two
+    PENDING-ARMS rows this discharges are filed separately, rebuilt on fresh origin/main
+    (a merge=union DIRTY on that file never self-clears).
+  - >-
+    K-3 reuses the EXISTING batched send_telegram/alerted_state mechanism rather than
+    adding a second alerting path.
+  - >-
+    The RuntimeError wraps are narrow — the named access only, never a blanket try/except
+    that would swallow real bugs and turn a correct re-arm into a CANNOT-VERIFY.
+  - >-
+    3.9.6 compatibility required (the fleet still runs it in places).
+  - >-
+    No paid per-token Anthropic endpoint, no secret printed, no client PII.
+acceptance:
+  - text: >-
+      Each of the three guards SHALL be load-bearing: neutering it in a throwaway copy of
+      queue_shepherd.py turns EXACTLY its own test(s) red and nothing else.
+    probe: guilt-mutation-in-throwaway-copy
+  - text: >-
+      The suite SHALL pass at 184 (169 before), and /usr/bin/python3 -m py_compile
+      (3.9.6) SHALL exit 0.
+    probe: pytest-and-py-compile
+  - text: >-
+      A tick that fails on red_state_gc SHALL report the REAL candidate count, never the
+      initial 0 that reads as a measurement.
+    probe: pytest-red-state-gc-candidates-test
+  - text: >-
+      rc=3 SHALL NOT read as a crashed daemon to launchd — the plist is KeepAlive=false
+      with StartInterval=600 and no wrapper, so the child's exit code is not consumed.
+    probe: read-the-plist
+assumptions:
+  - assumption: >-
+      The three findings were still unfixed on origin/main.
+    status: verified
+    evidence: >-
+      Read on disk before implementing, not assumed. No "already fixed" case among the three.
+  - assumption: >-
+      Every guard is proven by its own mutation.
+    status: verified
+    evidence: >-
+      Four mutations run independently of the implementer, each in a throwaway copy, the
+      real file never touched — sticky-limit check neutered 1 failed/180; the
+      _normalize_rearm_pr RuntimeError wrap removed 2 failed/179; the gc_alerted_state call
+      site removed 1 failed/180; the candidate count moved back below the GC step
+      1 failed/183.
+  - assumption: >-
+      K-3's alert path works end to end in production.
+    status: unverified
+    evidence: >-
+      It stays unexercised until a re-arm write actually FAILS three times in a row against
+      the live API, which has not happened since #6127 shipped. Covered by tests, not by
+      observation. Stated as a limit rather than claimed — the same distinction that made
+      the live-fire drill necessary for the write path at all.
+  - assumption: >-
+      The second state file this PR adds (REARM_FAIL_FILE) does not itself grow unbounded.
+    status: verified
+    evidence: >-
+      gc_rearm_fail_state ages entries on last_attempt_at like gc_budget_state, and an
+      adversarial review found it shipped UNTESTED — the fix for an unbounded-growth bug
+      had introduced a second un-proven GC. Now pinned by a guilt+innocence test.
+consumer_map:
+  - >-
+    launchd on Pro runs scripts/queue_shepherd.py every 600s as
+    com.nuzantara.queue-shepherd.10min; it is the only consumer of the three guards.
+  - >-
+    scripts/tests/test_queue_shepherd.py runs in CI in this PR and is the shipped proof.

--- a/scripts/queue_shepherd.py
+++ b/scripts/queue_shepherd.py
@@ -130,6 +130,7 @@ Env overrides:
     QUEUE_SHEPHERD_REPO          default "Bali-Zero/Teman2"
     QUEUE_SHEPHERD_BUDGET_FILE   default ~/logs/queue-shepherd/rearm-budget.json
     QUEUE_SHEPHERD_ALERTED_FILE  default ~/logs/queue-shepherd/alerted-unknown.json
+    QUEUE_SHEPHERD_REARM_FAIL_FILE default ~/logs/queue-shepherd/rearm-write-failures.json
     QUEUE_SHEPHERD_LOG_FILE      default ~/logs/queue-shepherd.log
     TELEGRAM_OWNER_CHAT_ID       read at send time, never hardcoded in this file (per mandate —
                                  the CI-secret path is for GitHub Actions; a local organ reads
@@ -173,6 +174,12 @@ ALERTED_FILE = Path(
         os.path.expanduser("~/logs/queue-shepherd/alerted-unknown.json"),
     )
 )
+REARM_FAIL_FILE = Path(
+    os.environ.get(
+        "QUEUE_SHEPHERD_REARM_FAIL_FILE",
+        os.path.expanduser("~/logs/queue-shepherd/rearm-write-failures.json"),
+    )
+)
 UNCANCELLABLE_FILE = Path(
     os.environ.get(
         "QUEUE_SHEPHERD_UNCANCELLABLE_FILE",
@@ -210,6 +217,17 @@ UNCANCELLABLE_RETRY_COOLDOWN_HOURS = 24  # past this since quarantined_at, allow
 # repeats. No cap on history length (B3(a), Codex review 2026-09-11): the PR's full red history
 # is kept for as long as the PR stays open — see record_red / gc_red_state.
 RED_SAME_CAUSE_LIMIT = 3
+
+# K-3 (Kimi council finding, S1 2026-09-11): a persistently failing `gh pr merge --auto` re-arm
+# WRITE (rearm_pr returning False) used to end the tick exit 0 / heartbeat ok and be retried
+# silently every 10-minute tick forever — the organ reporting success while a failure was
+# happening underneath it. Three CONSECUTIVE write failures for the SAME (PR, head SHA) — never
+# cumulative, a successful write resets the counter to zero — raises the existing batched
+# Telegram (see run_rearm_pass's new_rearm_fail_keys block, same mechanism the MEDIUM fix built
+# for UNKNOWN PRs) and makes the tick's own outcome non-ok (see tick()). 3 mirrors
+# RED_SAME_CAUSE_LIMIT's own "three strikes" idiom for the same reason: one or two transient
+# write failures (a `gh` timeout, a momentary API blip) must never alert on their own.
+REARM_WRITE_FAIL_LIMIT = 3
 
 _UNCANCELLABLE_ERROR_LABELS = {
     "uncancellable_409": "both cancel and force-cancel endpoints answered HTTP 409 (not queued yet)",
@@ -462,6 +480,68 @@ def gc_budget_state(budget_state: dict[str, Any], now: _dt.datetime) -> dict[str
     return kept
 
 
+def count_consecutive_rearm_write_failures(
+    rearm_fail_state: dict[str, Any], pr_number: int, head_sha: str
+) -> int:
+    """Pure: how many CONSECUTIVE `rearm_pr` WRITE failures are currently recorded for this exact
+    (PR, head SHA) — see REARM_WRITE_FAIL_LIMIT's module-level comment for the K-3 finding this
+    responds to. Keyed exactly like budget_state ("<number>:<sha>") — a head-SHA change is a
+    fresh key with zero prior failures by construction, the same "head moved = resets" idiom
+    count_recent_infra_rearms already uses."""
+    key = f"{pr_number}:{head_sha}"
+    entry = rearm_fail_state.get(key) or {}
+    return int(entry.get("consecutive_failures", 0) or 0)
+
+
+def record_rearm_write_failure(
+    rearm_fail_state: dict[str, Any], pr_number: int, head_sha: str, now: _dt.datetime
+) -> dict[str, Any]:
+    """Pure: returns a NEW rearm_fail_state (never mutates the input) with one more CONSECUTIVE
+    `rearm_pr` WRITE failure recorded against (pr_number, head_sha). Mirrors record_infra_rearm's
+    deep-copy-and-return contract — callers own persistence."""
+    key = f"{pr_number}:{head_sha}"
+    new_state = json.loads(json.dumps(rearm_fail_state))  # cheap deep copy, JSON-safe by contract
+    entry = new_state.setdefault(key, {"consecutive_failures": 0})
+    entry["consecutive_failures"] = int(entry.get("consecutive_failures", 0) or 0) + 1
+    entry["pr_number"] = pr_number
+    entry["head_sha"] = head_sha
+    entry["last_attempt_at"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return new_state
+
+
+def record_rearm_write_success(
+    rearm_fail_state: dict[str, Any], pr_number: int, head_sha: str
+) -> dict[str, Any]:
+    """Pure: a SUCCESSFUL `rearm_pr` write resets the consecutive-failure counter for
+    (pr_number, head_sha) back to zero — K-3's other innocence case: a write that eventually
+    succeeds must never leave a stale failure count behind to poison a LATER, unrelated run of
+    failures on the same (PR, head SHA). A no-op (returns the SAME object, not a copy) when the
+    key was never tracked — mirrors clear_cancel_entry's own no-op-when-absent convention, the
+    common case since most writes succeed on the first try."""
+    key = f"{pr_number}:{head_sha}"
+    if key not in rearm_fail_state:
+        return rearm_fail_state
+    new_state = json.loads(json.dumps(rearm_fail_state))
+    new_state.pop(key, None)
+    return new_state
+
+
+def gc_rearm_fail_state(rearm_fail_state: dict[str, Any], now: _dt.datetime) -> dict[str, Any]:
+    """Pure: drop (pr, sha) entries whose last recorded write-failure attempt is older than
+    BUDGET_GC_DAYS — mirrors gc_budget_state's own age-based bound (this file shares its
+    (pr, head_sha) key shape), so REARM_FAIL_FILE never grows unbounded across the life of the
+    repo. A successful write already drops its own entry immediately (record_rearm_write_success)
+    — this GC only catches keys that stalled mid-failure and then simply stopped recurring (head
+    moved on, PR closed without ever succeeding again)."""
+    cutoff = now - _dt.timedelta(days=BUDGET_GC_DAYS)
+    kept: dict[str, Any] = {}
+    for key, entry in rearm_fail_state.items():
+        ts = _parse_iso(entry.get("last_attempt_at"))
+        if ts is not None and ts >= cutoff:
+            kept[key] = entry
+    return kept
+
+
 def record_red(
     red_state: dict[str, Any], pr_number: int, removed_at: str, cause: str | None, head_sha: str
 ) -> dict[str, Any]:
@@ -509,8 +589,52 @@ def gc_red_state(red_state: dict[str, Any], open_pr_numbers: set[int]) -> dict[s
     set. Suspension is sticky until the PR is no longer open — no time-based unsuspend — so the
     ONLY thing that ever clears an entry is the PR itself closing/merging. Caller must only call
     this after a SUCCESSFUL fetch_open_prs read (a partial/failed set would wrongly GC every
-    entry as "not open")."""
-    return {key: entry for key, entry in red_state.items() if int(key) in open_pr_numbers}
+    entry as "not open").
+
+    K-7 (Kimi council finding, S1 2026-09-11): a hand-edited (or otherwise garbage) red-file key
+    that is not a bare PR-number string used to raise a bare ValueError here, out of any
+    try/except in run_rearm_pass — a malformed-but-JSON state file crashed the whole tick as a
+    raw, uncaught exception (loud, no Telegram) instead of reaching the existing CANNOT-VERIFY
+    path. Wrapped as RuntimeError so the caller's `except RuntimeError` catches it like every
+    other fail-closed read in this module."""
+    kept: dict[str, Any] = {}
+    for key, entry in red_state.items():
+        try:
+            pr_number = int(key)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"gc_red_state: malformed PR-number key {key!r} in red state: {exc}"
+            ) from exc
+        if pr_number in open_pr_numbers:
+            kept[key] = entry
+    return kept
+
+
+def gc_alerted_state(alerted_state: dict[str, Any], open_pr_numbers: set[int]) -> dict[str, Any]:
+    """Pure: drop alerted-file entries (keyed "<pr_number>:<head_sha>", or "rearm-write-fail:
+    <pr_number>:<head_sha>" for the K-3 dedup entries below) whose PR number is no longer in THIS
+    TICK's examined open-PR set — K-8 (Kimi council finding, S1 2026-09-11), mirrors gc_red_state
+    exactly. Before this, a PR's alert-dedup key lived in ALERTED_FILE forever even after the PR
+    closed/merged, growing the file unbounded across the life of the repo (gc_red_state already
+    had this GC; alerted_state never did).
+
+    A key without a parseable leading PR number is KEPT rather than dropped (never silently
+    destroyed) — unlike gc_red_state, this file's entries are a dedup cache, not the suspension
+    ledger the Builder Contract §1 count depends on, so the safe default here is "do nothing",
+    never "raise and CANNOT-VERIFY the whole tick" over a cosmetic dedup key."""
+    kept: dict[str, Any] = {}
+    for key, value in alerted_state.items():
+        prefix = key.split(":", 1)[0]
+        if prefix == "rearm-write-fail":
+            prefix = key.split(":", 2)[1] if key.count(":") >= 2 else ""
+        try:
+            pr_number = int(prefix)
+        except ValueError:
+            kept[key] = value  # unparseable key — never silently drop, keep as-is
+            continue
+        if pr_number in open_pr_numbers:
+            kept[key] = value
+    return kept
 
 
 def gc_uncancellable_state(
@@ -765,6 +889,18 @@ def _pr_has_fable_gate_status(node: dict[str, Any]) -> bool:
 
 
 def _normalize_rearm_pr(node: dict[str, Any]) -> dict[str, Any]:
+    # K-7 (Kimi council finding, S1 2026-09-11): a PR node missing `number` (malformed-but-JSON
+    # GraphQL data) used to raise a bare KeyError here, out of any try/except in fetch_open_prs —
+    # a real live-shape read that reaches this function escaped as a raw exception (loud, no
+    # Telegram) instead of reaching the existing CANNOT-VERIFY path. Wrapped as RuntimeError so
+    # run_rearm_pass's `except RuntimeError` around fetch_open_prs(REPO) catches it exactly like
+    # any other failed candidate-page read.
+    try:
+        number = node["number"]
+    except (KeyError, TypeError) as exc:
+        raise RuntimeError(
+            f"_normalize_rearm_pr: PR node missing 'number': {exc}: {str(node)[:200]}"
+        ) from exc
     commits = (node.get("commits") or {}).get("nodes") or []
     rollup_state = None
     if commits:
@@ -772,7 +908,7 @@ def _normalize_rearm_pr(node: dict[str, Any]) -> dict[str, Any]:
             "state"
         )
     return {
-        "number": node["number"],
+        "number": number,
         "is_draft": bool(node.get("isDraft")),
         "head_ref_name": node.get("headRefName") or "",
         "head_sha": node.get("headRefOid") or "",
@@ -1339,15 +1475,18 @@ def _enabled() -> bool:
 
 
 def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
-    """Returns {rearmed, examined, candidates, unknown, suspended, unverified, cannot_verify,
-    detail}. CANNOT-VERIFY is a tick OUTCOME the caller must surface, never silently folded into
-    a zero (S1, 2026-09-10 — see the module docstring's S1 section for the measured incident this
-    responds to). `cannot_verify` is None on a clean
-    read, else "rearm_state" (budget/alerted state file corrupt) or "rearm_candidates" (the gh
-    candidate-PR fetch failed after its one retry). `detail` carries the first 300 chars of the
-    triggering exception, for tick()'s heartbeat/alert — not part of the spec-named fields, purely
-    a passthrough. `unverified` counts candidates whose OWN per-PR timeline read failed (skipped
-    that PR, not the whole tick).
+    """Returns {rearmed, examined, candidates, unknown, suspended, unverified, rearm_write_failed,
+    cannot_verify, detail}. CANNOT-VERIFY is a tick OUTCOME the caller must surface, never silently
+    folded into a zero (S1, 2026-09-10 — see the module docstring's S1 section for the measured
+    incident this responds to). `cannot_verify` is None on a clean read, else "rearm_state"
+    (budget/alerted/red/rearm-fail state file corrupt), "rearm_candidates" (the gh candidate-PR
+    fetch failed after its one retry), or "red_state_gc" (K-7: a hand-edited red-file key could not
+    be parsed as a PR number). `detail` carries the first 300 chars of the triggering exception, for
+    tick()'s heartbeat/alert — not part of the spec-named fields, purely a passthrough. `unverified`
+    counts candidates whose OWN per-PR timeline read failed (skipped that PR, not the whole tick).
+    `rearm_write_failed` (K-3) counts candidates whose `rearm_pr` WRITE has now failed
+    REARM_WRITE_FAIL_LIMIT+ CONSECUTIVE times — a non-zero value here is what makes tick() report
+    the tick's own outcome as NOT ok, even though no CANNOT-VERIFY read failure occurred.
 
     Fail-closed on state corruption (refuter round, agy pass, 2026-08-27): a torn/corrupt budget
     file must NEVER be read as "no re-arms recorded yet" — that silently grants a fresh
@@ -1361,24 +1500,27 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
         "unknown": 0,
         "suspended": 0,
         "unverified": 0,
+        "rearm_write_failed": 0,
         "cannot_verify": None,
         "detail": None,
     }
     try:
-        # Letter G (S1, 2026-09-10): dry-run READS every state file — budget/alerted/red — same
-        # as a live tick; only the WRITE at the end of this pass is skipped for dry_run. Before
-        # this fix, dry-run substituted {} here, so a dry-run tick's rearm decisions (INFRA
+        # Letter G (S1, 2026-09-10): dry-run READS every state file — budget/alerted/red/rearm-fail
+        # — same as a live tick; only the WRITE at the end of this pass is skipped for dry_run.
+        # Before this fix, dry-run substituted {} here, so a dry-run tick's rearm decisions (INFRA
         # budget, alerted-dedup, same-cause suspension) never matched what the SAME tick would
         # decide live — a dry-run's whole purpose is to preview the live decision.
         budget_state = _load_json(BUDGET_FILE)
         alerted_state = _load_json(ALERTED_FILE)
         red_state = _load_json(RED_FILE)
+        rearm_fail_state = _load_json(REARM_FAIL_FILE)  # K-3
     except RuntimeError as exc:
-        logger.error("CANNOT-VERIFY rearm/alert/red state: %s", exc)
+        logger.error("CANNOT-VERIFY rearm/alert/red/rearm-fail state: %s", exc)
         result["cannot_verify"] = "rearm_state"
         result["detail"] = str(exc)[:300]
         return result
     budget_state = gc_budget_state(budget_state, now)
+    rearm_fail_state = gc_rearm_fail_state(rearm_fail_state, now)  # K-3
 
     try:
         all_prs = fetch_open_prs(REPO)
@@ -1389,16 +1531,29 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
         return result
     examined = len(all_prs)
     unknown = sum(1 for pr in all_prs if pr.get("merge_state_status") == "UNKNOWN")
-    open_pr_numbers = {pr["number"] for pr in all_prs}
-    red_state = gc_red_state(red_state, open_pr_numbers)  # only after a successful read
-    candidates = [pr for pr in all_prs if is_rearm_candidate(pr)]
     result["examined"] = examined
     result["unknown"] = unknown
+    open_pr_numbers = {pr["number"] for pr in all_prs}
+    try:
+        red_state = gc_red_state(red_state, open_pr_numbers)  # only after a successful read
+        alerted_state = gc_alerted_state(alerted_state, open_pr_numbers)  # K-8
+    except RuntimeError as exc:
+        # K-7: gc_red_state now raises RuntimeError (not a bare ValueError) on a hand-edited/
+        # garbage red-file key — caught here so it reaches CANNOT-VERIFY instead of crashing the
+        # tick as an uncaught exception. examined/unknown are already real numbers above (the
+        # fetch itself succeeded; only this GC step failed), so they are NOT masked to "-".
+        logger.error("CANNOT-VERIFY red/alerted state GC: %s", exc)
+        result["cannot_verify"] = "red_state_gc"
+        result["detail"] = str(exc)[:300]
+        return result
+    candidates = [pr for pr in all_prs if is_rearm_candidate(pr)]
     result["candidates"] = len(candidates)
 
     rearmed = 0
     unverified = 0
     new_unknown_keys: list[str] = []  # collected, sent as ONE alert after the loop (MEDIUM fix)
+    rearm_write_failed_keys: list[str] = []  # K-3: every (pr,sha) AT/PAST the threshold this tick
+    new_rearm_fail_keys: list[str] = []  # K-3: subset of the above not yet alerted — batched below
     for pr in candidates:
         number = pr["number"]
         head_sha = pr["head_sha"]
@@ -1479,7 +1634,25 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
         if rearm_pr(REPO, number):
             budget_state = record_infra_rearm(budget_state, number, head_sha, now)
             alerted_state.pop(alert_key, None)  # a live re-arm supersedes any stale alert
+            # K-3 innocence: a SUCCESSFUL write resets the consecutive-failure counter to zero,
+            # and clears any stale write-failure alert dedup for this (pr, head sha).
+            rearm_fail_state = record_rearm_write_success(rearm_fail_state, number, head_sha)
+            alerted_state.pop(f"rearm-write-fail:{alert_key}", None)
             rearmed += 1
+        else:
+            # K-3 (Kimi council finding, S1 2026-09-11): the WRITE itself failed non-zero. Before
+            # this, a persistently failing `gh pr merge --auto` ended the tick exit 0 / heartbeat
+            # ok and was retried silently every 10-minute tick forever — the organ reporting
+            # success while a failure was happening underneath it. A single transient failure
+            # must NOT alert (innocence case); only REARM_WRITE_FAIL_LIMIT CONSECUTIVE failures
+            # for the SAME (pr, head sha) do.
+            rearm_fail_state = record_rearm_write_failure(rearm_fail_state, number, head_sha, now)
+            consecutive = count_consecutive_rearm_write_failures(rearm_fail_state, number, head_sha)
+            if consecutive >= REARM_WRITE_FAIL_LIMIT:
+                rearm_write_failed_keys.append(alert_key)  # counts toward "tick NOT ok" every tick
+                fail_alert_key = f"rearm-write-fail:{alert_key}"
+                if not alerted_state.get(fail_alert_key):
+                    new_rearm_fail_keys.append(fail_alert_key)  # batched below, deduped separately
 
     if new_unknown_keys and not dry_run:
         # MEDIUM (Codex review, 2026-09-11): ONE batched alert per tick listing every newly-
@@ -1497,12 +1670,32 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
             for k in sorted_keys:
                 alerted_state[k] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
+    if new_rearm_fail_keys and not dry_run:
+        # K-3: reuse the EXACT batched-Telegram mechanism the MEDIUM fix above built for UNKNOWN
+        # PRs — one `send_telegram` call per tick, deduped via the SAME alerted_state file (never
+        # a second alerting mechanism), listing every (PR, head sha) whose re-arm WRITE has now
+        # failed REARM_WRITE_FAIL_LIMIT+ consecutive times.
+        sorted_fail_keys = sorted(new_rearm_fail_keys)
+        sent = send_telegram(
+            f"re-arm WRITE (`gh pr merge --auto`) has failed {REARM_WRITE_FAIL_LIMIT}+ "
+            "consecutive times, silently (tick would otherwise read exit 0), for:\n"
+            + "\n".join(f"  PR {k[len('rearm-write-fail:'):]}" for k in sorted_fail_keys),
+            dedup_key="queue-shepherd-rearm-write-fail-" + "+".join(sorted_fail_keys),
+        )
+        if sent:
+            for k in sorted_fail_keys:
+                alerted_state[k] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
     result["rearmed"] = rearmed
     result["unverified"] = unverified
+    # K-3: NOT gated on whether a NEW alert was sent this tick (that part is deduped above) — the
+    # tick's own "not ok" signal must persist every tick the write keeps failing, not just once.
+    result["rearm_write_failed"] = len(rearm_write_failed_keys)
     if not dry_run:
         _save_json(BUDGET_FILE, budget_state)
         _save_json(ALERTED_FILE, alerted_state)
         _save_json(RED_FILE, red_state)
+        _save_json(REARM_FAIL_FILE, rearm_fail_state)
     return result
 
 
@@ -1705,6 +1898,36 @@ def tick(dry_run: bool) -> int:
             )
         return 2
 
+    rearm_write_failed = rearm_result.get("rearm_write_failed", 0)
+    if rearm_write_failed:
+        # K-3 (Kimi council finding, S1 2026-09-11): the alert already fired inside
+        # run_rearm_pass (batched, deduped via alerted_state) — this branch only makes the
+        # TICK's own outcome match reality. Before this, a persistently failing re-arm WRITE
+        # ended the tick exit 0 / heartbeat ok, exactly the blind spot K-3 named: the organ
+        # reporting success while a failure was happening underneath it. No second Telegram send
+        # here — "raise the existing batched Telegram", never a second alerting mechanism.
+        logger.error(
+            "tick complete: %s PR(s) have a re-arm WRITE failing %s+ consecutive times — "
+            "alerted (deduped), tick NOT ok. examined=%s candidates=%s rearmed=%s cancelled=%s "
+            "dry_run=%s",
+            rearm_write_failed, REARM_WRITE_FAIL_LIMIT, rearm_result["examined"],
+            rearm_result["candidates"], rearmed, cancelled, dry_run,
+        )
+        if not dry_run:  # B4: no heartbeat write anywhere in dry-run (unreachable here anyway —
+            # dry-run never calls rearm_pr, so rearm_write_failed is always 0 in dry-run)
+            _write_heartbeat(
+                "error",
+                {
+                    "rearm_write_failed": rearm_write_failed,
+                    "examined": rearm_result["examined"],
+                    "candidates": rearm_result["candidates"],
+                    "rearmed": rearmed,
+                    "cancelled": cancelled,
+                    "dry_run": dry_run,
+                },
+            )
+        return 3
+
     logger.info(
         "tick complete: examined=%s candidates=%s unknown=%s rearmed=%s suspended=%s "
         "unverified=%s cancelled=%s dry_run=%s",
@@ -1766,6 +1989,22 @@ def report() -> int:
         susp = entry.get("suspended")
         susp_note = f" SUSPENDED at {susp.get('at')} (cause={susp.get('cause')})" if susp else ""
         print(f"    PR #{key}: {len(entry.get('reds') or [])} reds{susp_note}")
+    try:
+        rearm_fail_state = _load_json(REARM_FAIL_FILE)
+    except RuntimeError as exc:
+        logger.error("%s", exc)
+        print(f"rearm-write-fail file: {REARM_FAIL_FILE} — CORRUPT, cannot parse ({exc})")
+        rearm_fail_state = {}
+    print(
+        f"rearm-write-fail file: {REARM_FAIL_FILE} "
+        f"({'exists' if REARM_FAIL_FILE.exists() else 'missing'})"
+    )
+    print(f"  tracked (pr,sha) keys: {len(rearm_fail_state)}")
+    for key, entry in sorted(rearm_fail_state.items()):
+        print(
+            f"    {key}: {entry.get('consecutive_failures', 0)}/{REARM_WRITE_FAIL_LIMIT} "
+            f"consecutive write failures (last attempt {entry.get('last_attempt_at')})"
+        )
     if LOG_FILE.exists():
         lines = LOG_FILE.read_text(encoding="utf-8", errors="replace").splitlines()
         print(f"last log lines ({LOG_FILE}):")

--- a/scripts/queue_shepherd.py
+++ b/scripts/queue_shepherd.py
@@ -1534,6 +1534,12 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
     result["examined"] = examined
     result["unknown"] = unknown
     open_pr_numbers = {pr["number"] for pr in all_prs}
+    # Computed BEFORE the GC step below, not after: a `red_state_gc` CANNOT-VERIFY returns early,
+    # and with the filter left downstream the tick's own log printed `candidates=0` — the initial
+    # value, indistinguishable from a real zero. An organ whose failure log lies about how many
+    # PRs were waiting is the exact defect K-3/K-7/K-8 exist to remove (spalla review, 2026-09-11).
+    candidates = [pr for pr in all_prs if is_rearm_candidate(pr)]
+    result["candidates"] = len(candidates)
     try:
         red_state = gc_red_state(red_state, open_pr_numbers)  # only after a successful read
         alerted_state = gc_alerted_state(alerted_state, open_pr_numbers)  # K-8
@@ -1546,9 +1552,6 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
         result["cannot_verify"] = "red_state_gc"
         result["detail"] = str(exc)[:300]
         return result
-    candidates = [pr for pr in all_prs if is_rearm_candidate(pr)]
-    result["candidates"] = len(candidates)
-
     rearmed = 0
     unverified = 0
     new_unknown_keys: list[str] = []  # collected, sent as ONE alert after the loop (MEDIUM fix)

--- a/scripts/queue_shepherd.py
+++ b/scripts/queue_shepherd.py
@@ -233,6 +233,16 @@ REARM_WRITE_FAIL_LIMIT = 3
 # as a literal at four sites, which is how report() came to count these keys as UNKNOWN ones.
 REARM_FAIL_ALERT_PREFIX = "rearm-write-fail:"
 
+
+def _is_rearm_fail_key(key: str) -> bool:
+    """The ONE predicate for "is this alerted_state key a write-failure dedup key". C4 (gate on
+    #6175, third round): report() asked it with `startswith(PREFIX)` and gc_alerted_state with
+    `split(":", 1)[0] == PREFIX.rstrip(":")`, and the two DIVERGE on the degenerate bare key
+    `"rearm-write-fail"` (no colon) — one read it as UNKNOWN, the other as write-fail. Only a
+    hand-edited file produces it, but "a write-failure key counted under UNKNOWN" is the exact
+    class C2 exists to close, so it must not survive in a second spelling."""
+    return key == REARM_FAIL_ALERT_PREFIX.rstrip(":") or key.startswith(REARM_FAIL_ALERT_PREFIX)
+
 _UNCANCELLABLE_ERROR_LABELS = {
     "uncancellable_409": "both cancel and force-cancel endpoints answered HTTP 409 (not queued yet)",
     "failed": "cancel_run failed (non-409) repeatedly — see queue-shepherd.log for the gh stderr",
@@ -629,7 +639,7 @@ def gc_alerted_state(alerted_state: dict[str, Any], open_pr_numbers: set[int]) -
     kept: dict[str, Any] = {}
     for key, value in alerted_state.items():
         prefix = key.split(":", 1)[0]
-        if prefix == REARM_FAIL_ALERT_PREFIX.rstrip(":"):
+        if _is_rearm_fail_key(key):  # C4: one predicate, shared with report()
             prefix = key.split(":", 2)[1] if key.count(":") >= 2 else ""
         try:
             pr_number = int(prefix)
@@ -1985,8 +1995,8 @@ def report() -> int:
     # write-failure dedup. Counting them together under the "UNKNOWN" label reported a
     # write-failure alert as an UNKNOWN one: two different diseases in one number, in the
     # one command an operator runs to find out what the organ is doing.
-    unknown_alerts = {k: v for k, v in alerted_state.items() if not k.startswith(REARM_FAIL_ALERT_PREFIX)}
-    write_fail_alerts = {k: v for k, v in alerted_state.items() if k.startswith(REARM_FAIL_ALERT_PREFIX)}
+    unknown_alerts = {k: v for k, v in alerted_state.items() if not _is_rearm_fail_key(k)}
+    write_fail_alerts = {k: v for k, v in alerted_state.items() if _is_rearm_fail_key(k)}
     print(f"alerted (UNKNOWN, undelivered-until-resolved) keys: {len(unknown_alerts)}")
     for key, ts in sorted(unknown_alerts.items()):
         print(f"    {key}: alerted at {ts}")

--- a/scripts/queue_shepherd.py
+++ b/scripts/queue_shepherd.py
@@ -229,6 +229,10 @@ RED_SAME_CAUSE_LIMIT = 3
 # write failures (a `gh` timeout, a momentary API blip) must never alert on their own.
 REARM_WRITE_FAIL_LIMIT = 3
 
+# C2 (gate on #6175): the single spelling of the write-failure dedup prefix. It was written
+# as a literal at four sites, which is how report() came to count these keys as UNKNOWN ones.
+REARM_FAIL_ALERT_PREFIX = "rearm-write-fail:"
+
 _UNCANCELLABLE_ERROR_LABELS = {
     "uncancellable_409": "both cancel and force-cancel endpoints answered HTTP 409 (not queued yet)",
     "failed": "cancel_run failed (non-409) repeatedly — see queue-shepherd.log for the gh stderr",
@@ -625,7 +629,7 @@ def gc_alerted_state(alerted_state: dict[str, Any], open_pr_numbers: set[int]) -
     kept: dict[str, Any] = {}
     for key, value in alerted_state.items():
         prefix = key.split(":", 1)[0]
-        if prefix == "rearm-write-fail":
+        if prefix == REARM_FAIL_ALERT_PREFIX.rstrip(":"):
             prefix = key.split(":", 2)[1] if key.count(":") >= 2 else ""
         try:
             pr_number = int(prefix)
@@ -1640,7 +1644,7 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
             # K-3 innocence: a SUCCESSFUL write resets the consecutive-failure counter to zero,
             # and clears any stale write-failure alert dedup for this (pr, head sha).
             rearm_fail_state = record_rearm_write_success(rearm_fail_state, number, head_sha)
-            alerted_state.pop(f"rearm-write-fail:{alert_key}", None)
+            alerted_state.pop(f"{REARM_FAIL_ALERT_PREFIX}{alert_key}", None)
             rearmed += 1
         else:
             # K-3 (Kimi council finding, S1 2026-09-11): the WRITE itself failed non-zero. Before
@@ -1653,7 +1657,7 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
             consecutive = count_consecutive_rearm_write_failures(rearm_fail_state, number, head_sha)
             if consecutive >= REARM_WRITE_FAIL_LIMIT:
                 rearm_write_failed_keys.append(alert_key)  # counts toward "tick NOT ok" every tick
-                fail_alert_key = f"rearm-write-fail:{alert_key}"
+                fail_alert_key = f"{REARM_FAIL_ALERT_PREFIX}{alert_key}"
                 if not alerted_state.get(fail_alert_key):
                     new_rearm_fail_keys.append(fail_alert_key)  # batched below, deduped separately
 
@@ -1682,7 +1686,7 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
         sent = send_telegram(
             f"re-arm WRITE (`gh pr merge --auto`) has failed {REARM_WRITE_FAIL_LIMIT}+ "
             "consecutive times, silently (tick would otherwise read exit 0), for:\n"
-            + "\n".join(f"  PR {k[len('rearm-write-fail:'):]}" for k in sorted_fail_keys),
+            + "\n".join(f"  PR {k[len(REARM_FAIL_ALERT_PREFIX):]}" for k in sorted_fail_keys),
             dedup_key="queue-shepherd-rearm-write-fail-" + "+".join(sorted_fail_keys),
         )
         if sent:
@@ -1976,9 +1980,19 @@ def report() -> int:
             budget_state, entry.get("pr_number", 0), entry.get("head_sha", ""), now
         )
         print(f"    {key}: {count}/{INFRA_BUDGET_MAX} infra rearms in last {BUDGET_WINDOW_HOURS}h")
-    print(f"alerted (UNKNOWN, undelivered-until-resolved) keys: {len(alerted_state)}")
-    for key, ts in sorted(alerted_state.items()):
+    # C2 (gate on #6175, 2026-09-11): alerted_state holds TWO key families since K-3 —
+    # "<pr>:<sha>" for the UNKNOWN-class dedup and "rearm-write-fail:<pr>:<sha>" for the
+    # write-failure dedup. Counting them together under the "UNKNOWN" label reported a
+    # write-failure alert as an UNKNOWN one: two different diseases in one number, in the
+    # one command an operator runs to find out what the organ is doing.
+    unknown_alerts = {k: v for k, v in alerted_state.items() if not k.startswith(REARM_FAIL_ALERT_PREFIX)}
+    write_fail_alerts = {k: v for k, v in alerted_state.items() if k.startswith(REARM_FAIL_ALERT_PREFIX)}
+    print(f"alerted (UNKNOWN, undelivered-until-resolved) keys: {len(unknown_alerts)}")
+    for key, ts in sorted(unknown_alerts.items()):
         print(f"    {key}: alerted at {ts}")
+    print(f"alerted (re-arm WRITE failure, undelivered-until-resolved) keys: {len(write_fail_alerts)}")
+    for key, ts in sorted(write_fail_alerts.items()):
+        print(f"    {key[len(REARM_FAIL_ALERT_PREFIX):]}: write-failure alerted at {ts}")
     try:
         red_state = _load_json(RED_FILE)
     except RuntimeError as exc:

--- a/scripts/queue_shepherd.py
+++ b/scripts/queue_shepherd.py
@@ -1494,8 +1494,11 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
     folded into a zero (S1, 2026-09-10 — see the module docstring's S1 section for the measured
     incident this responds to). `cannot_verify` is None on a clean read, else "rearm_state"
     (budget/alerted/red/rearm-fail state file corrupt), "rearm_candidates" (the gh candidate-PR
-    fetch failed after its one retry), or "red_state_gc" (K-7: a hand-edited red-file key could not
-    be parsed as a PR number). `detail` carries the first 300 chars of the triggering exception, for
+    fetch failed after its one retry), "red_state_gc" (K-7: a hand-edited red-file key could not
+    be parsed as a PR number), or "rearm_pr_reads" (a PER-PR timeline or infra-correlation read
+    failed after the list read had already succeeded). The last one is the reason tick() at the
+    log line below branches on the SET ("rearm_candidates", "rearm_state") rather than on
+    cannot_verify being truthy: only those two leave examined/candidates unknowable. `detail` carries the first 300 chars of the triggering exception, for
     tick()'s heartbeat/alert — not part of the spec-named fields, purely a passthrough. `unverified`
     counts candidates whose OWN per-PR timeline read failed (skipped that PR, not the whole tick).
     `rearm_write_failed` (K-3) counts candidates whose `rearm_pr` WRITE has now failed

--- a/scripts/queue_shepherd.py
+++ b/scripts/queue_shepherd.py
@@ -1498,7 +1498,8 @@ def run_rearm_pass(dry_run: bool, now: _dt.datetime) -> dict[str, Any]:
     be parsed as a PR number), or "rearm_pr_reads" (a PER-PR timeline or infra-correlation read
     failed after the list read had already succeeded). The last one is the reason tick() at the
     log line below branches on the SET ("rearm_candidates", "rearm_state") rather than on
-    cannot_verify being truthy: only those two leave examined/candidates unknowable. `detail` carries the first 300 chars of the triggering exception, for
+    cannot_verify being truthy: only those two leave examined/candidates unknowable.
+    `detail` carries the first 300 chars of the triggering exception, for
     tick()'s heartbeat/alert — not part of the spec-named fields, purely a passthrough. `unverified`
     counts candidates whose OWN per-PR timeline read failed (skipped that PR, not the whole tick).
     `rearm_write_failed` (K-3) counts candidates whose `rearm_pr` WRITE has now failed

--- a/scripts/tests/test_queue_shepherd.py
+++ b/scripts/tests/test_queue_shepherd.py
@@ -43,6 +43,7 @@ def _isolate_state_files(monkeypatch, tmp_path):
     monkeypatch.setattr(qs, "ALERTED_FILE", tmp_path / "alerted-unknown.json")
     monkeypatch.setattr(qs, "UNCANCELLABLE_FILE", tmp_path / "uncancellable.json")
     monkeypatch.setattr(qs, "RED_FILE", tmp_path / "red-causes.json")
+    monkeypatch.setattr(qs, "REARM_FAIL_FILE", tmp_path / "rearm-write-failures.json")
     monkeypatch.setattr(qs, "LOG_FILE", tmp_path / "queue-shepherd.log")
 
 
@@ -2963,3 +2964,196 @@ def test_rearm_pass_failing_snyk_docker_job_is_never_rearmed_K5(monkeypatch, tmp
     result = qs.run_rearm_pass(dry_run=False, now=NOW)
     assert result["rearmed"] == 0
     assert result["unverified"] == 0
+
+
+# ── K-3 (Kimi council finding, S1 2026-09-11): consecutive re-arm WRITE failures ────────────
+# a persistently failing `gh pr merge --auto` re-arm WRITE must not read as tick-ok forever.
+
+
+def _k3_setup_infra_candidate(monkeypatch, number, head_sha, rearm_pr_fn):
+    """Shared plumbing for the K-3 tests: one candidate PR whose ejection classifies INFRA
+    (allowed=True, so the loop actually reaches the `rearm_pr` call), fingerprint None (never
+    contributes to the unrelated RED_SAME_CAUSE_LIMIT suspension)."""
+    monkeypatch.setattr(
+        qs, "fetch_open_prs",
+        lambda repo=qs.REPO: [_pr(number=number, head_sha=head_sha, head_ref_name="agent/x/y")],
+    )
+    monkeypatch.setattr(
+        qs, "fetch_last_ejection",
+        lambda repo, num: {
+            "reason": "failed_checks", "removed_at": _iso(NOW), "before_commit": head_sha
+        },
+    )
+    monkeypatch.setattr(
+        qs, "fetch_infra_hint_and_fingerprint", lambda repo, num, removed_at: (True, None)
+    )
+    monkeypatch.setattr(qs, "rearm_pr", rearm_pr_fn)
+
+
+def test_rearm_pass_three_consecutive_rearm_write_failures_alert_once_and_tick_not_ok_K3(
+    monkeypatch, tmp_path
+):
+    _k3_setup_infra_candidate(monkeypatch, 901, "shaW", lambda repo, number: False)
+
+    sends = []
+
+    def fake_send_telegram(message, dedup_key=""):
+        sends.append(dedup_key)
+        return True
+
+    monkeypatch.setattr(qs, "send_telegram", fake_send_telegram)
+
+    r1 = qs.run_rearm_pass(dry_run=False, now=NOW)
+    assert sends == []
+    assert r1["rearm_write_failed"] == 0
+
+    r2 = qs.run_rearm_pass(dry_run=False, now=NOW + _dt.timedelta(minutes=10))
+    assert sends == []
+    assert r2["rearm_write_failed"] == 0
+
+    r3 = qs.run_rearm_pass(dry_run=False, now=NOW + _dt.timedelta(minutes=20))
+    assert len(sends) == 1  # ONE alert, raised on the THIRD consecutive failing write
+    assert r3["rearm_write_failed"] == 1
+
+    saved = qs._load_json(qs.REARM_FAIL_FILE)
+    assert saved["901:shaW"]["consecutive_failures"] == 3
+
+    # the SAME tick outcome surfaces at tick() level as non-ok, without a SECOND Telegram send —
+    # the alert already fired inside run_rearm_pass above (reused, not duplicated). tick() calls
+    # the real qs._now() internally (real wall clock) — pinned here to stay within
+    # BUDGET_GC_DAYS of the fixed test NOW above, or gc_rearm_fail_state would prune the
+    # freshly-recorded 901:shaW entry as if it were weeks stale.
+    _no_op_janitor(monkeypatch)
+    monkeypatch.setattr(qs, "_now", lambda: NOW + _dt.timedelta(minutes=30))
+    rc = qs.tick(dry_run=False)
+    assert rc == 3
+    assert len(sends) == 1  # still exactly one — tick() must not send a second alert
+    hb = json.loads((tmp_path / "organism" / f"{qs.ORGAN_ID}.json").read_text())
+    assert hb["status"] == "error"
+    assert hb["metadata"]["rearm_write_failed"] == 1
+
+
+def test_rearm_pass_single_transient_rearm_write_failure_never_alerts_K3_innocence(
+    monkeypatch, tmp_path
+):
+    _k3_setup_infra_candidate(monkeypatch, 902, "shaT", lambda repo, number: False)
+
+    def never_called(*_a, **_k):
+        raise AssertionError("a single transient write failure must never alert")
+
+    monkeypatch.setattr(qs, "send_telegram", never_called)
+
+    result = qs.run_rearm_pass(dry_run=False, now=NOW)
+
+    assert result["rearm_write_failed"] == 0
+    saved = qs._load_json(qs.REARM_FAIL_FILE)
+    assert saved["902:shaT"]["consecutive_failures"] == 1
+
+
+def test_rearm_pass_successful_rearm_resets_write_failure_counter_to_zero_K3_innocence(
+    monkeypatch, tmp_path
+):
+    outcomes = iter([False, False, True, False, False])  # fail, fail, SUCCEED, fail, fail
+    _k3_setup_infra_candidate(monkeypatch, 903, "shaR2", lambda repo, number: next(outcomes))
+
+    sends = []
+    monkeypatch.setattr(
+        qs, "send_telegram", lambda message, dedup_key="": (sends.append(dedup_key), True)[1]
+    )
+
+    times = [NOW + _dt.timedelta(minutes=i * 10) for i in range(5)]
+    results = [qs.run_rearm_pass(dry_run=False, now=t) for t in times]
+
+    # the success on tick 3 resets the counter to zero — the two MORE failures on ticks 4-5 never
+    # reach REARM_WRITE_FAIL_LIMIT again on their own, so no alert fires across all five ticks.
+    assert [r["rearm_write_failed"] for r in results] == [0, 0, 0, 0, 0]
+    assert sends == []
+    saved = qs._load_json(qs.REARM_FAIL_FILE)
+    assert saved["903:shaR2"]["consecutive_failures"] == 2  # reset, then two MORE fails only
+
+
+# ── K-7 (Kimi council finding, S1 2026-09-11): malformed-but-JSON data raises RuntimeError,
+# never a raw KeyError/ValueError that escapes CANNOT-VERIFY (loud, no Telegram) ──────────────
+
+
+def test_normalize_rearm_pr_missing_number_raises_runtimeerror_not_keyerror_K7():
+    node = _rearm_node(42)
+    del node["number"]
+    with pytest.raises(RuntimeError):
+        qs._normalize_rearm_pr(node)
+
+
+def test_normalize_rearm_pr_innocence_well_formed_node_still_normalizes_K7():
+    node = _rearm_node(42)
+    normalized = qs._normalize_rearm_pr(node)
+    assert normalized["number"] == 42
+
+
+def test_run_rearm_pass_malformed_pr_node_missing_number_is_cannot_verify_K7(monkeypatch, tmp_path):
+    node = _rearm_node(43)
+    del node["number"]
+    payload = {
+        "data": {"repository": {"pullRequests": {
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+            "nodes": [node],
+        }}}
+    }
+    monkeypatch.setattr(qs, "_gh_graphql", lambda query, variables, timeout=45: payload)
+
+    result = qs.run_rearm_pass(dry_run=False, now=NOW)
+
+    assert result["cannot_verify"] == "rearm_candidates"
+    assert result["rearmed"] == 0
+
+
+def test_gc_red_state_hand_edited_garbage_key_raises_runtimeerror_not_valueerror_K7():
+    red_state = {"not-a-number": {"reds": []}}
+    with pytest.raises(RuntimeError):
+        qs.gc_red_state(red_state, {1, 2, 3})
+
+
+def test_gc_red_state_innocence_well_formed_key_still_gcs_K7():
+    red_state = {"5": {"reds": []}, "6": {"reds": []}}
+    gced = qs.gc_red_state(red_state, {5})
+    assert gced == {"5": {"reds": []}}
+
+
+def test_run_rearm_pass_hand_edited_red_file_key_is_cannot_verify_K7(monkeypatch, tmp_path):
+    red_path = tmp_path / "red.json"
+    qs._save_json(red_path, {"garbage-key": {"reds": []}})
+    monkeypatch.setattr(qs, "RED_FILE", red_path)
+    monkeypatch.setattr(
+        qs, "fetch_open_prs",
+        lambda repo=qs.REPO: [_pr(number=44, head_sha="s", head_ref_name="agent/x/y")],
+    )
+
+    result = qs.run_rearm_pass(dry_run=False, now=NOW)
+
+    assert result["cannot_verify"] == "red_state_gc"
+    assert result["rearmed"] == 0
+
+
+# ── K-8 (Kimi council finding, S1 2026-09-11): alerted_state GC'd like red_state ────────────
+
+
+def test_gc_alerted_state_guilt_drops_entry_once_its_pr_is_no_longer_open_K8():
+    alerted_state = {"701:shaOld": "2026-09-01T00:00:00Z"}
+    gced = qs.gc_alerted_state(alerted_state, set())  # PR 701 no longer open
+    assert gced == {}
+
+
+def test_gc_alerted_state_innocence_keeps_entry_while_its_pr_stays_open_K8():
+    alerted_state = {"701:shaOld": "2026-09-01T00:00:00Z"}
+    gced = qs.gc_alerted_state(alerted_state, {701})
+    assert gced == alerted_state
+
+
+def test_run_rearm_pass_gcs_alerted_state_after_a_pr_closes_K8(monkeypatch, tmp_path):
+    alerted_path = tmp_path / "alerted.json"
+    qs._save_json(alerted_path, {"999:shaClosed": "2026-09-01T00:00:00Z"})
+    monkeypatch.setattr(qs, "ALERTED_FILE", alerted_path)
+    monkeypatch.setattr(qs, "fetch_open_prs", lambda repo=qs.REPO: [])  # PR 999 no longer open
+
+    qs.run_rearm_pass(dry_run=False, now=NOW)
+
+    assert qs._load_json(alerted_path) == {}

--- a/scripts/tests/test_queue_shepherd.py
+++ b/scripts/tests/test_queue_shepherd.py
@@ -3217,6 +3217,43 @@ def test_gc_alerted_state_keeps_both_key_families_apart(tmp_path):
     assert set(kept) == {"910:shaOpen", "rearm-write-fail:910:shaOpen"}
 
 
+def test_the_two_family_predicates_agree_on_the_degenerate_bare_key_C4():
+    """C4: report() asked `startswith(PREFIX)` and gc_alerted_state asked
+    `split(":",1)[0] == PREFIX.rstrip(":")`, and the two disagreed on the bare `rearm-write-fail`
+    key — one calling it UNKNOWN, the other write-fail. One predicate now answers for both."""
+    assert qs._is_rearm_fail_key("rearm-write-fail") is True
+    assert qs._is_rearm_fail_key("rearm-write-fail:701:sha") is True
+    assert qs._is_rearm_fail_key("rearm-write-fail:") is True
+    assert qs._is_rearm_fail_key("700:shaUnknown") is False
+    assert qs._is_rearm_fail_key("rearm-write-failure:700:sha") is False
+    # The bare key survives gc_alerted_state either way (both spellings end at int("") ->
+    # ValueError -> kept), so the GC side cannot observe the divergence — stated rather than
+    # asserted, because an assertion that passes under both spellings proves nothing. The
+    # divergence is observable in report(), and that is where the next test looks.
+    assert "rearm-write-fail" in qs.gc_alerted_state({"rearm-write-fail": {"at": "x"}}, set())
+
+
+def test_report_counts_the_degenerate_bare_key_as_a_write_failure_C4(monkeypatch, tmp_path, capsys):
+    """C4, the observable half: with two predicates, report() called the bare `rearm-write-fail`
+    key an UNKNOWN alert while gc_alerted_state called it a write-fail one. A write-failure key
+    counted under UNKNOWN is precisely the disease C2 exists to cure, so it must not survive in
+    a second spelling."""
+    monkeypatch.setattr(qs, "BUDGET_FILE", tmp_path / "budget.json")
+    monkeypatch.setattr(qs, "ALERTED_FILE", tmp_path / "alerted.json")
+    monkeypatch.setattr(qs, "RED_FILE", tmp_path / "red.json")
+    monkeypatch.setattr(qs, "REARM_FAIL_FILE", tmp_path / "rearm_fail.json")
+    monkeypatch.setattr(qs, "LOG_FILE", tmp_path / "absent.log")
+    qs._save_json(qs.ALERTED_FILE, {
+        "800:shaUnknown": "2026-09-11T00:00:00Z",
+        "rearm-write-fail": "2026-09-11T00:00:00Z",  # hand-edited, no colon
+    })
+
+    _rc, out = _run_report(capsys)
+
+    assert "alerted (UNKNOWN, undelivered-until-resolved) keys: 1" in out
+    assert "alerted (re-arm WRITE failure, undelivered-until-resolved) keys: 1" in out
+
+
 # ── gate findings on THIS PR: three guards the suite could not see (2026-09-11) ─────────────
 # A fresh Opus 5 gate ran 17 guilt mutations against this branch and three left all 184 GREEN.
 # Each of the three is the SAME shape as the finding that opened K-3/K-7/K-8: the code is right
@@ -3324,15 +3361,22 @@ def test_report_separates_the_two_alert_families_C2(monkeypatch, tmp_path, capsy
     monkeypatch.setattr(qs, "RED_FILE", tmp_path / "red.json")
     monkeypatch.setattr(qs, "REARM_FAIL_FILE", tmp_path / "rearm_fail.json")
     monkeypatch.setattr(qs, "LOG_FILE", tmp_path / "absent.log")
+    # C2b (gate round 3): the counts must be ASYMMETRIC — with one key each, swapping the two
+    # family filters leaves both numbers at 1 and the test cannot see the inversion.
     qs._save_json(qs.ALERTED_FILE, {
         "700:shaUnknown": "2026-09-11T00:00:00Z",
+        "703:shaOther": "2026-09-11T00:00:00Z",
         f"{qs.REARM_FAIL_ALERT_PREFIX}701:shaWrite": "2026-09-11T00:00:00Z",
     })
 
     _rc, out = _run_report(capsys)
 
-    assert "alerted (UNKNOWN, undelivered-until-resolved) keys: 1" in out
+    assert "alerted (UNKNOWN, undelivered-until-resolved) keys: 2" in out
     assert "alerted (re-arm WRITE failure, undelivered-until-resolved) keys: 1" in out
+    # C2d: the count was anchored and the LISTING was not — "keys: 1" while showing nothing is
+    # still a report that hides what the operator came to read.
+    assert "701:shaWrite: write-failure alerted at" in out
+    assert "700:shaUnknown: alerted at" in out
 
 
 def test_report_lists_the_rearm_fail_file_entries_M23(monkeypatch, tmp_path, capsys):
@@ -3367,4 +3411,15 @@ def test_report_says_CORRUPT_when_the_rearm_fail_file_is_unparseable_M27(monkeyp
 
     _rc, out = _run_report(capsys)
 
-    assert "CORRUPT, cannot parse" in out
+    # C2e (gate round 3): asserting the WORD "CORRUPT" without the FILE let the message name
+    # the budget file instead and stay green — a corruption report that fingers the wrong organ.
+    corrupt_lines = [ln for ln in out.splitlines() if "CORRUPT, cannot parse" in ln]
+    assert len(corrupt_lines) == 1, out
+    # The assertion must read the file the LINE names, not the whole line: the exception text is
+    # interpolated into the same line and already carries the right path, so `str(corrupt) in
+    # line` passes even when the code names the WRONG file. That is a test satisfied by a
+    # substring from a different source than the one it means to check — the same conflation
+    # shape as C2, one level up, found by mutating rather than by reading.
+    named = corrupt_lines[0].split(" — CORRUPT")[0]
+    assert str(corrupt) in named, named
+    assert str(tmp_path / "budget.json") not in named, named

--- a/scripts/tests/test_queue_shepherd.py
+++ b/scripts/tests/test_queue_shepherd.py
@@ -3303,3 +3303,68 @@ def test_gc_alerted_state_keeps_an_unparseable_key_B3():
     assert "hand-written-nonsense" in kept
     assert "rearm-write-fail:not-a-number:sha" in kept
     assert "970:shaOpen" in kept
+
+
+# ── C2 + M23/M27: report() had no test at all (gate on #6175, second round) ─────────────────
+# `report()` is the ONE command an operator runs to ask what the organ is doing, and nothing
+# exercised it — which is why the C2 conflation (write-failure alerts counted and labelled as
+# UNKNOWN ones) reached a reviewer instead of a test.
+
+
+def _run_report(capsys):
+    rc = qs.report()
+    return rc, capsys.readouterr().out
+
+
+def test_report_separates_the_two_alert_families_C2(monkeypatch, tmp_path, capsys):
+    """Guilt: a write-failure dedup key must NOT be counted or labelled as an UNKNOWN alert.
+    Innocence: a genuine UNKNOWN key must still be counted as one, on the same dict."""
+    monkeypatch.setattr(qs, "BUDGET_FILE", tmp_path / "budget.json")
+    monkeypatch.setattr(qs, "ALERTED_FILE", tmp_path / "alerted.json")
+    monkeypatch.setattr(qs, "RED_FILE", tmp_path / "red.json")
+    monkeypatch.setattr(qs, "REARM_FAIL_FILE", tmp_path / "rearm_fail.json")
+    monkeypatch.setattr(qs, "LOG_FILE", tmp_path / "absent.log")
+    qs._save_json(qs.ALERTED_FILE, {
+        "700:shaUnknown": "2026-09-11T00:00:00Z",
+        f"{qs.REARM_FAIL_ALERT_PREFIX}701:shaWrite": "2026-09-11T00:00:00Z",
+    })
+
+    _rc, out = _run_report(capsys)
+
+    assert "alerted (UNKNOWN, undelivered-until-resolved) keys: 1" in out
+    assert "alerted (re-arm WRITE failure, undelivered-until-resolved) keys: 1" in out
+
+
+def test_report_lists_the_rearm_fail_file_entries_M23(monkeypatch, tmp_path, capsys):
+    """M23: the whole per-key block report() gained for REARM_FAIL_FILE was blind — deleting it
+    left every test green, so the file K-3 added was invisible in the operator's own view."""
+    monkeypatch.setattr(qs, "BUDGET_FILE", tmp_path / "budget.json")
+    monkeypatch.setattr(qs, "ALERTED_FILE", tmp_path / "alerted.json")
+    monkeypatch.setattr(qs, "RED_FILE", tmp_path / "red.json")
+    monkeypatch.setattr(qs, "REARM_FAIL_FILE", tmp_path / "rearm_fail.json")
+    monkeypatch.setattr(qs, "LOG_FILE", tmp_path / "absent.log")
+    qs._save_json(qs.REARM_FAIL_FILE, {
+        "702:shaFail": {"consecutive_failures": 2, "last_attempt_at": "2026-09-11T00:00:00Z"},
+    })
+
+    _rc, out = _run_report(capsys)
+
+    assert "702:shaFail" in out
+    assert f"2/{qs.REARM_WRITE_FAIL_LIMIT} consecutive write failures" in out
+
+
+def test_report_says_CORRUPT_when_the_rearm_fail_file_is_unparseable_M27(monkeypatch, tmp_path, capsys):
+    """M27: the CORRUPT branch was blind too. A corrupt state file must be NAMED in the report,
+    never rendered as an empty-and-therefore-healthy one — the whole family of defect this PR
+    exists to close is an organ that looks fine while something is wrong underneath."""
+    monkeypatch.setattr(qs, "BUDGET_FILE", tmp_path / "budget.json")
+    monkeypatch.setattr(qs, "ALERTED_FILE", tmp_path / "alerted.json")
+    monkeypatch.setattr(qs, "RED_FILE", tmp_path / "red.json")
+    corrupt = tmp_path / "rearm_fail.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(qs, "REARM_FAIL_FILE", corrupt)
+    monkeypatch.setattr(qs, "LOG_FILE", tmp_path / "absent.log")
+
+    _rc, out = _run_report(capsys)
+
+    assert "CORRUPT, cannot parse" in out

--- a/scripts/tests/test_queue_shepherd.py
+++ b/scripts/tests/test_queue_shepherd.py
@@ -3157,3 +3157,61 @@ def test_run_rearm_pass_gcs_alerted_state_after_a_pr_closes_K8(monkeypatch, tmp_
     qs.run_rearm_pass(dry_run=False, now=NOW)
 
     assert qs._load_json(alerted_path) == {}
+
+
+# ── spalla-review findings on the K-3/K-7/K-8 commit itself (2026-09-11) ────────────────────
+
+
+def test_run_rearm_pass_red_state_gc_failure_still_reports_real_candidates_count(monkeypatch, tmp_path):
+    """The review's finding 1: on a `red_state_gc` CANNOT-VERIFY the pass returns early, and with
+    the candidate filter left downstream the tick logged `candidates=0` — the initial value, not
+    a measurement, and `list_read_failed` does not mask it to `-`. The count is now taken before
+    the GC step, so the failure log tells the truth about how many PRs were waiting."""
+    monkeypatch.setattr(qs, "BUDGET_FILE", tmp_path / "budget.json")
+    monkeypatch.setattr(qs, "ALERTED_FILE", tmp_path / "alerted.json")
+    monkeypatch.setattr(qs, "RED_FILE", tmp_path / "red.json")
+    qs._save_json(qs.RED_FILE, {"not-a-number": {"reds": []}})  # the hand-edited key K-7 guards
+
+    monkeypatch.setattr(
+        qs, "fetch_open_prs",
+        lambda repo=qs.REPO: [
+            _pr(number=801, head_sha="shaA", head_ref_name="agent/x/y"),
+            _pr(number=802, head_sha="shaB", head_ref_name="agent/x/y"),
+            _pr(number=803, merge_state_status="DIRTY"),  # not a candidate
+        ],
+    )
+
+    result = qs.run_rearm_pass(dry_run=False, now=NOW)
+
+    assert result["cannot_verify"] == "red_state_gc"
+    assert result["examined"] == 3
+    assert result["candidates"] == 2, "a real count, never the initial 0 that reads as a measurement"
+
+
+def test_gc_rearm_fail_state_drops_aged_entries_and_keeps_fresh_ones(tmp_path):
+    """The review's finding 2: `gc_rearm_fail_state` shipped with no direct test, so the K-3 state
+    file's own 'never grows unbounded' claim was asserted rather than proven. Guilt and innocence
+    on the same entity, in one pass."""
+    old = (NOW - _dt.timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fresh = NOW.strftime("%Y-%m-%dT%H:%M:%SZ")
+    state = {
+        "901:shaOld": {"consecutive": 2, "last_attempt_at": old},
+        "902:shaNew": {"consecutive": 1, "last_attempt_at": fresh},
+    }
+    kept = qs.gc_rearm_fail_state(state, NOW)
+    assert "902:shaNew" in kept, "a fresh entry must survive"
+    assert "901:shaOld" not in kept, "an aged entry must be pruned"
+
+
+def test_gc_alerted_state_keeps_both_key_families_apart(tmp_path):
+    """The review's finding 3: K-3 put a second key family (`rearm-write-fail:<pr>:<sha>`) in the
+    file K-8's GC prunes, and no test drove a MIXED dict through it. Both families for an open PR
+    survive; both for a closed one are dropped; neither is misread as the other."""
+    state = {
+        "910:shaOpen": {"at": "x"},
+        "rearm-write-fail:910:shaOpen": {"at": "x"},
+        "911:shaGone": {"at": "x"},
+        "rearm-write-fail:911:shaGone": {"at": "x"},
+    }
+    kept = qs.gc_alerted_state(state, {910})
+    assert set(kept) == {"910:shaOpen", "rearm-write-fail:910:shaOpen"}

--- a/scripts/tests/test_queue_shepherd.py
+++ b/scripts/tests/test_queue_shepherd.py
@@ -3215,3 +3215,91 @@ def test_gc_alerted_state_keeps_both_key_families_apart(tmp_path):
     }
     kept = qs.gc_alerted_state(state, {910})
     assert set(kept) == {"910:shaOpen", "rearm-write-fail:910:shaOpen"}
+
+
+# ── gate findings on THIS PR: three guards the suite could not see (2026-09-11) ─────────────
+# A fresh Opus 5 gate ran 17 guilt mutations against this branch and three left all 184 GREEN.
+# Each of the three is the SAME shape as the finding that opened K-3/K-7/K-8: the code is right
+# and the suite is blind to it. B1 in particular is the earlier spalla finding surviving one
+# level up — gc_rearm_fail_state was tested as a FUNCTION and never as a WIRED STEP.
+
+
+def test_run_rearm_pass_actually_prunes_the_rearm_fail_file_B1(monkeypatch, tmp_path):
+    """B1: removing the `gc_rearm_fail_state(...)` CALL SITE left the whole suite green, because
+    the only coverage drove the function directly. This drives the wired step: an aged entry
+    present on disk before the pass is gone from the saved file after it."""
+    monkeypatch.setattr(qs, "BUDGET_FILE", tmp_path / "budget.json")
+    monkeypatch.setattr(qs, "ALERTED_FILE", tmp_path / "alerted.json")
+    monkeypatch.setattr(qs, "RED_FILE", tmp_path / "red.json")
+    monkeypatch.setattr(qs, "REARM_FAIL_FILE", tmp_path / "rearm_fail.json")
+
+    old = (NOW - _dt.timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fresh = NOW.strftime("%Y-%m-%dT%H:%M:%SZ")
+    qs._save_json(qs.REARM_FAIL_FILE, {
+        "950:shaAged": {"consecutive": 2, "last_attempt_at": old},
+        "951:shaFresh": {"consecutive": 1, "last_attempt_at": fresh},
+    })
+    monkeypatch.setattr(qs, "fetch_open_prs", lambda repo=qs.REPO: [])
+
+    qs.run_rearm_pass(dry_run=False, now=NOW)
+
+    saved = qs._load_json(qs.REARM_FAIL_FILE)
+    assert "951:shaFresh" in saved, "a fresh entry must survive the wired GC"
+    assert "950:shaAged" not in saved, "the wired GC step must actually prune — not just the function"
+
+
+def test_rearm_pass_second_run_of_failures_alerts_again_after_a_success_B2(monkeypatch, tmp_path):
+    """B2: the `alerted_state.pop("rearm-write-fail:...")` on a SUCCESSFUL write had no test.
+    Without it a (pr, head) that fails 3x, alerts, then succeeds, then fails 3x again is SILENT
+    the second time — the exact K-3 disease (a failure with no alert), reintroduced by the dedup
+    cache it was given."""
+    monkeypatch.setattr(qs, "BUDGET_FILE", tmp_path / "budget.json")
+    monkeypatch.setattr(qs, "ALERTED_FILE", tmp_path / "alerted.json")
+    monkeypatch.setattr(qs, "RED_FILE", tmp_path / "red.json")
+    monkeypatch.setattr(qs, "REARM_FAIL_FILE", tmp_path / "rearm_fail.json")
+
+    sends: list[str] = []
+    monkeypatch.setattr(qs, "send_telegram", lambda *a, **k: (sends.append(str(k.get("dedup_key") or a)), True)[1])
+    monkeypatch.setattr(
+        qs, "fetch_open_prs",
+        lambda repo=qs.REPO: [_pr(number=960, head_sha="shaB2", head_ref_name="agent/x/y")],
+    )
+    monkeypatch.setattr(
+        qs, "fetch_last_ejection",
+        lambda repo, number: {"reason": "failed_checks", "removed_at": _iso(NOW), "before_commit": "shaB2"},
+    )
+    monkeypatch.setattr(qs, "fetch_infra_hint_and_fingerprint", lambda repo, number, removed_at: (True, None))
+
+    write_ok = {"v": False}
+    monkeypatch.setattr(qs, "rearm_pr", lambda repo, number: write_ok["v"])
+
+    for i in range(3):  # first run of failures -> one alert
+        qs.run_rearm_pass(dry_run=False, now=NOW + _dt.timedelta(minutes=i))
+    assert len(sends) == 1, f"three consecutive failures must alert exactly once, got {sends}"
+
+    write_ok["v"] = True  # the write recovers
+    qs.run_rearm_pass(dry_run=False, now=NOW + _dt.timedelta(minutes=3))
+
+    write_ok["v"] = False  # and fails again, three more times
+    for i in range(4, 7):
+        qs.run_rearm_pass(dry_run=False, now=NOW + _dt.timedelta(minutes=i))
+
+    assert len(sends) == 2, (
+        f"a SECOND run of three failures after a recovery must alert again, not be swallowed "
+        f"by the stale dedup key — got {sends}"
+    )
+
+
+def test_gc_alerted_state_keeps_an_unparseable_key_B3():
+    """B3: the docstring's own invariant — 'a key without a parseable leading PR number is KEPT
+    rather than dropped' — had zero coverage, so turning it into a silent drop left 184 green.
+    This file is a dedup cache, and destroying a key here re-opens the alert it deduplicates."""
+    state = {
+        "970:shaOpen": {"at": "x"},
+        "hand-written-nonsense": {"at": "x"},
+        "rearm-write-fail:not-a-number:sha": {"at": "x"},
+    }
+    kept = qs.gc_alerted_state(state, {970})
+    assert "hand-written-nonsense" in kept
+    assert "rearm-write-fail:not-a-number:sha" in kept
+    assert "970:shaOpen" in kept


### PR DESCRIPTION
The last three deferred Kimi council findings from #6127. They ship together because they are one concern: **the organ reported success while a failure was happening.**

| Letter | Before | After |
|---|---|---|
| K-3 | a `gh pr merge --auto` that fails every tick ends rc=0 with a healthy heartbeat, retried silently forever | consecutive failures counted per `(pr, head_sha)`; past 3 the EXISTING batched Telegram fires once and the tick is not ok (rc=3) |
| K-7 | a PR node missing `number`, or a hand-edited red-file key, escaped as a bare KeyError/ValueError — loud, no alert, tick dead | both raise RuntimeError and reach the EXISTING CANNOT-VERIFY path |
| K-8 | `alerted_state` grew forever | `gc_alerted_state`, mirroring `gc_red_state`, wired into the same pass |

## Adversarial review

Two gate rounds by a fresh Opus 5 session outside the contribution chain, plus one spalla review. **Every round found something, and the last two found defects in the cures of the round before.**

**Round 0 (spalla), on the first commit.** On a `red_state_gc` CANNOT-VERIFY the pass returns early, and the candidate filter sat *after* it, so the tick's own failure log printed `candidates=0` — indistinguishable from a measured zero. An organ whose failure log lies about how many PRs were waiting is this PR's own subject. Also: `gc_rearm_fail_state` shipped untested, i.e. the fix for an unbounded-growth bug had added a second unproven GC.

**Round 1, 17 mutations on `0a2d8b6fd4`.** Fourteen red, **three blind**: the `gc_rearm_fail_state` CALL SITE (the function had a test, the wired step did not — round 0's finding surviving one level up), the `alerted_state` pop of the write-failure dedup key on a SUCCESSFUL write (without it, a second run of three failures after a recovery is SILENT — the K-3 disease reintroduced by the dedup cache added to cure it), and `gc_alerted_state`'s documented "an unparseable key is KEPT" invariant.

**Round 2, on `ef68780edd`.** The three cures hold (each mutation `1 failed/186`, and B1's immunity to `record_rearm_write_success` proven by exploding both writers and observing B1 is not among the fallers). 21 core mutations now 21/21 red. But **three more blind guards**, all in `report()` — which had no test at all, and is the one command an operator runs to ask what the organ is doing. That is how **C2** got in: `alerted_state` has held two key families since K-3, and `report()` counted and labelled them all as UNKNOWN alerts. Two different diseases in one number. The prefix was a literal at four sites; it is now `REARM_FAIL_ALERT_PREFIX`, spelled once.

**C3 — a right answer resting on a false premise**, the hardest kind to catch. The brief's probe 4 claimed "the child's exit code is not consumed". False: `launchd_liveness_detector.py:424` reads `LastExitStatus` and this label IS in its glob, measured live among its 210 findings. The conclusion survives anyway — non-zero maps to `FAILING-HONESTLY` (`:442-449`), which is not in `ALARM_VERDICTS` (`:604`) — so no page fires. Corrected in place with the reason rather than quietly.

**Declared residual, not bought quiet.** `com.nuzantara.queue-shepherd` is deliberately NOT added to `EXPECTED_NONZERO_LABELS` (`:527-532`), though rc=3 is exactly the reporting convention that allowlist exists for. It is keyed on the LABEL, not the exit code, so adding it would also silence rc=1 (a crash) and rc=2 on this job — which the file's own comment forbids. Making the allowlist exit-code-aware is a different concern and a different PR.

**Two conditions were never delivered.** The round-1 report truncated three times before its numbered conditions, so C2 and C3 went uncured while I believed all three were closed — I said so to the gate rather than assume, and asked it to re-derive them on the new sha. It did, and both were real. Recorded because the near-miss is the lesson: cures derived from a *summary* of a review are not the review.

**The brief's own claim is now `status: unverifiable-by-the-author`.** It twice declared "every guard is proven by its own mutation" as verified, and was twice falsified. The absence of a blind spot is not something the author can measure — only an adversary can, and only up to the mutations it happened to run. "37 mutations executed at this sha, 33 red, 0 blind, 1 provably dead" is the true statement; "every" is not.

## Gate verdict and its six conditions

**PASS-WITH-CONDITIONS**, final on-disk gate (Opus 5, separate session, did not write this code) on `21cb5605e9`. Measured by the gate, not reported by the author: `~/nuzantara/.venv/bin/pytest scripts/tests/test_queue_shepherd.py -q` = **192 passed**; `/usr/bin/python3 -m py_compile scripts/queue_shepherd.py scripts/tests/test_queue_shepherd.py` = rc=0 on Python 3.9.6; plus `import queue_shepherd` under 3.9.6 with direct calls to `_is_rearm_fail_key`, `gc_alerted_state`, `gc_red_state` — the module does not merely compile on 3.9, it runs there. The mutation hunt is CLOSED at three rounds by the builder contract ("three reds for the same cause and the PR suspends instead of taking a fourth round"); this gate judged coherence, constraints, brief honesty and read-visible defects, and found none of the last.

The six conditions, in the gate's own words. Two were doc-only and are **CURED** in `ce19a671cf`, reflowed in `95e88ea508` because the first cure left a 154-char docstring line where the file's maximum was 118. **Re-signed PASS-WITH-CONDITIONS on the shipped sha `95e88ea508`**: 192 passed, `py_compile` rc=0 on 3.9.6, plus `import queue_shepherd` under 3.9. Delta vs the originally signed `21cb5605e9` = 2 files **+11/-4**, docstring and brief only, **zero executable lines** — and the reflow is word-for-word identical to the already-signed content, which the gate proved on a whitespace-collapsed md5 rather than on `git diff -w` (`-w` ignores space *within* a line, not re-wrapping that moves words *between* lines, and it misreported this same delta as 2 insertions/1 deletion). Three of the six are residuals declared here and cured by nobody; one is process.

1. **CURED.** "brief.yml:125 chiama il job `com.nuzantara.queue-shepherd.10min`, ma il `Label` reale del plist è `com.nuzantara.queue-shepherd` (infra/launchagents/com.nuzantara.queue-shepherd.10min.plist:5-6): `.10min` è solo il nome del file. brief.yml:47 e :111 usano la grafia corretta, quindi il brief si contraddice proprio sulla stringa da cui dipende l'argomento EXPECTED_NONZERO_LABELS del residual."
2. **CURED.** "La docstring di run_rearm_pass riscritta in questa PR (queue_shepherd.py:1495-1497) enumera tre valori di `cannot_verify` — rearm_state, rearm_candidates, red_state_gc — mentre il codice ne setta un quarto, `rearm_pr_reads`, a :1586 e :1615. L'omissione è pre-esistente su origin/main, ma è stata portata dentro un elenco che questa PR ha appena esteso."
3. **RESIDUAL.** "Il try a queue_shepherd.py:1560-1567 avvolge due chiamate, gc_red_state e gc_alerted_state, ma etichetta qualunque RuntimeError come `red_state_gc`. A questo sha l'etichetta è corretta, perché gc_alerted_state non ha alcun path che solleva: il suo unico except ValueError (:630-636) conserva la chiave invece di alzare. Diventerà un'etichetta falsa il giorno in cui quella funzione imparerà a sollevare."
4. **RESIDUAL.** "gc_rearm_fail_state (queue_shepherd.py:549-556) scarta in silenzio una entry il cui `last_attempt_at` sia assente o non parsabile (`if ts is not None and ts >= cutoff`), azzerando di fatto un contatore K-3, mentre gc_alerted_state:628-632 documenta la politica opposta (\"never silently drop\"). Il claim del brief \"mirrors gc_budget_state\" è esatto — :463 ha forma identica — e _save_json è atomico write-then-rename (:1465-1473), quindi la condizione è raggiungibile solo per hand-edit del file di stato, mai per scrittura interrotta."
5. **RESIDUAL + follow-up.** "queue_shepherd.py:1946 introduce rc=3, un exit code nuovo del processo, documentato solo dal commento inline: il modulo non ha una tabella di exit code (grep \"Exit code\" → 0 hit) e docs/runbooks/queue-shepherd-live-fire.md non è toccato, correttamente, perché il constraint del brief vieta modifiche al runbook in questa PR. Da portare nella PR di follow-up insieme alla riga PENDING-ARMS."
6. **PROCESS.** "A questo sha la PR è BLOCKED con un solo check rosso, \"Harness floor recompute\" (run 34558192501), il cui log dice testualmente: `harness_gate_read: PENDING — no harness/fable-gate verdict has been posted yet on this commit`. Il floor deterministico ricalcolato dal gate stampa 2, uguale al `gear: 2` dichiarato nel brief. Il rosso è l'assenza del verdetto di gate, non un difetto del codice."

Mini's `fleet-watch` reached the same reading independently and from outside this lane, classifying the same red as `gate-verdict-missing` — "process, not a code defect" — on five other PRs the same night. The cure is publishing the verdict, then rerunning that run; never `gh workflow run --ref`.

## Bites

The consumer is `scripts/queue_shepherd.py` on Pro's `com.nuzantara.queue-shepherd.10min`, and the suite that exercises every guard runs in CI in this PR. Observed before reporting done: **192 passed** (169 → 192, 23 new), `/usr/bin/python3 -m py_compile` (3.9.6) rc=0, changed-file set exactly three. Post-merge the pull onto Pro is the prove-live. **Stated limit, not a claim:** K-3's alert path stays unexercised in production until a re-arm write really fails three times against the live API — it is covered by tests, not by observation.

Ledger rows to close: `Kimi council finding K-3, deferred` and `Kimi council findings K-7 and K-8, deferred`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


