### PR TITLE
feat(ops): claude_seat_quota names the seat and both resets with a countdown

### DIFF
--- a/scripts/claude_seat_quota.py
+++ b/scripts/claude_seat_quota.py
@@ -36,7 +36,11 @@ stale: every report carries `generated_at`, and a reader refuses one older than
 they were now. A cached report that outlives its truth is the same disease as the watcher
 this file replaced — it just fails one layer further out.
 
-Output: a table by default, `--json` for machines. Exit codes are the alerting surface:
+Output: a table by default, `--json` for machines. Each row carries the SEAT label
+(`A2/_5` = slot A2 in FLEET_TOPOLOGY.json, token CLAUDE_CODE_OAUTH_TOKEN_5) so the answer
+to "which of the six is free?" does not need a second lookup, and BOTH resets — the 5h
+session window and the weekly one — in local time with a countdown, because a percentage
+without its reset is half a number. Exit codes are the alerting surface:
   0 = every discovered profile reported a number (or a FRESH published report was read)
   1 = at least one named seat could not be read (expired/revoked/no scope) — NEVER silent
   2 = zero profiles discovered, endpoint unreachable for all of them, or the only report
@@ -67,6 +71,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -78,6 +83,50 @@ UA = "claude-cli (external, cli)"
 OAUTH_BETA = "oauth-2025-04-20"
 KEYCHAIN_SERVICE_PREFIX = "Claude Code-credentials"
 HTTP_TIMEOUT = 25
+TOPOLOGY_PATH = Path(__file__).resolve().parent.parent / "FLEET_TOPOLOGY.json"
+
+
+def seat_labels(path: Path = TOPOLOGY_PATH) -> dict[str, str]:
+    """email -> 'A2/_5' from FLEET_TOPOLOGY.json accounts.anthropic.slots.
+
+    The topology is the ONLY registry that ties an account to its token slot (see its
+    oauth_slot_note); an unreadable or unexpected file degrades to no labels, never to a
+    crash — the percentages are the payload, the label is the convenience.
+    """
+    try:
+        slots = json.loads(path.read_text())["accounts"]["anthropic"]["slots"]
+    except (OSError, ValueError, KeyError, TypeError):
+        return {}
+    out: dict[str, str] = {}
+    for label, slot in slots.items():
+        if not isinstance(slot, dict) or not slot.get("email"):
+            continue
+        num = str(slot.get("oauth_token_slot") or "").rsplit("_", 1)[-1]
+        out[str(slot["email"]).lower()] = f"{label}/_{num}" if num.isdigit() else str(label)
+    return out
+
+
+def when(iso: str | None, now: datetime | None = None) -> str:
+    """'Fri 11 11:40 (in 4h47m)' in LOCAL time, or 'passed' — a reset is a countdown."""
+    if not iso:
+        return "-"
+    try:
+        t = datetime.fromisoformat(iso)
+    except ValueError:
+        return iso[:16]
+    if t.tzinfo is None:
+        t = t.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    mins = int((t - now).total_seconds() // 60)
+    if mins <= 0:
+        rel = "passed"
+    elif mins < 60:
+        rel = f"in {mins}m"
+    elif mins < 24 * 60:
+        rel = f"in {mins // 60}h{mins % 60:02d}m"
+    else:
+        rel = f"in {mins // (24 * 60)}d{(mins // 60) % 24:02d}h"
+    return f"{t.astimezone():%a %d %H:%M} ({rel})"
 
 
 def keychain_services() -> list[str]:
@@ -371,6 +420,10 @@ def main() -> int:
               "python3 scripts/claude_seat_quota.py --publish", file=sys.stderr)
         return 2
 
+    labels = seat_labels()
+    for r in rows:
+        r["seat"] = labels.get(str(r.get("account") or "").lower())
+
     readable = [r for r in rows if r.get("weekly_pct") is not None]
     # A stale Keychain leftover has no account name and no live credential: it is noise
     # from an old login, not a seat that failed. Only a NAMED account that could not be
@@ -383,17 +436,23 @@ def main() -> int:
     else:
         if source != "live":
             print(f"source: {source}")
-        print(f"{'account':34s} | {'5h':>5} | {'weekly':>6} | weekly resets at")
-        print("-" * 34 + "-+-" + "-" * 5 + "-+-" + "-" * 6 + "-+-" + "-" * 20)
+        now = datetime.now(timezone.utc)
+        print(f"{'seat':6s} | {'account':30s} | {'5h':>4} | {'5h resets':26s} | "
+              f"{'week':>4} | week resets")
+        print("-" * 6 + "-+-" + "-" * 30 + "-+-" + "-" * 4 + "-+-" + "-" * 26 + "-+-"
+              + "-" * 4 + "-+-" + "-" * 26)
         for r in rows:
+            seat = r.get("seat") or "?"
             if r.get("error"):
                 label = r.get("account") or "(stale keychain entry)"
-                print(f"{label:34s} | {'-':>5} | {'-':>6} | {r['error']}")
+                print(f"{seat:6s} | {label:30s} | {'-':>4} | {'-':26s} | {'-':>4} | "
+                      f"{r['error']}")
                 continue
-            reset = (r.get("weekly_resets_at") or "")[:16].replace("T", " ")
             flag = " <<<" if (r.get("weekly_pct") or 0) >= 85 else ""
-            print(f"{r['account']:34s} | {fmt(r.get('session_pct')):>5} | "
-                  f"{fmt(r.get('weekly_pct')):>6} | {reset}{flag}")
+            print(f"{seat:6s} | {r['account']:30s} | {fmt(r.get('session_pct')):>4} | "
+                  f"{when(r.get('session_resets_at'), now):26s} | "
+                  f"{fmt(r.get('weekly_pct')):>4} | "
+                  f"{when(r.get('weekly_resets_at'), now)}{flag}")
         if stale:
             print(f"\n{len(stale)} stale keychain entr{'y' if len(stale) == 1 else 'ies'} "
                   f"(old logins, no live credential) — informational, not a seat failure")


### PR DESCRIPTION
## What

`scripts/claude_seat_quota.py` already read the real weekly/session quota from `/api/oauth/usage`, but its table answered only "how much?". Zero's question this morning was "quota used AND when does each of the six seats reset". Two gaps: no seat label (which of `_1.._6` is this account?) and no 5h reset at all (only the weekly one, raw ISO, UTC).

- each row now carries the seat label from `FLEET_TOPOLOGY.json` `accounts.anthropic.slots` — `A2/_5` = slot A2, token `CLAUDE_CODE_OAUTH_TOKEN_5`
- both resets (5h window and weekly) in local time with a countdown: `in 25m` / `in 4h45m` / `in 4d01h` / `passed`
- `--json` gains a `seat` field; rows read from a published report on Mini/M5 get labelled the same way
- an unreadable topology degrades to no label (`?`), never to a crash — the percentages are the payload

One file, +69/-7. No behaviour change to warm-up, exit codes, `--publish` or `--from-report`.

## Bites

**Consumer:** Zero on Pro, `python3 scripts/claude_seat_quota.py` (the machine holding the six logged-in profiles).
**Observation, measured 2026-09-11 06:54 WITA on this branch:** 6/6 seats readable in 32 s, exit 0, table shows `A3/_3 … 100% | Fri 11 07:19 (in 25m)` for the 5h window — the seat the R1 Dux died on at 05:34 WITA, whose reset memory 16085 records as 07:20 WITA. The number and the reset now agree with the scar, from one command.

Prove-live after merge: run the `origin/main` blob of the script on Pro and get the same six labelled rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
