### PR TITLE
fix(automations): humanize Weekday, Day and multi-fire StartCalendarInterval schedules

### DIFF
--- a/scripts/generate_automations_reference.py
+++ b/scripts/generate_automations_reference.py
@@ -485,8 +485,42 @@ def _humanize_single(sched: str) -> str:
     return sched
 
 
+_LAUNCHD_WEEKDAY_NAMES = {0: "Sun", 1: "Mon", 2: "Tue", 3: "Wed", 4: "Thu", 5: "Fri", 6: "Sat", 7: "Sun"}
+
+
+def _humanize_single_calendar_interval(interval: dict) -> str:
+    """One StartCalendarInterval dict -> a human string. Honors `Weekday` and
+    `Day`, not just `Hour`/`Minute` — a plist scheduled weekly or monthly used
+    to read as `daily HH:MM`, silently wrong (e.g. com.balizero.curiosity.weekly
+    and com.balizero.codex-spalla-calibrate both carry `Weekday: 0` (Sunday)
+    and used to render as "daily", contradicting their own header-comment
+    purpose text, which already said "Sunday HH:MM"). Only promotes to
+    weekly/monthly when a full HH:MM is also present — an hourly-minute-only
+    entry combined with Weekday/Day is not a shape any plist in this repo
+    uses, so it is left as the pre-existing hourly/dash fallback rather than
+    guessed at."""
+    hr, mi = interval.get("Hour"), interval.get("Minute")
+    if hr is not None and mi is not None:
+        time_str = f"{hr:02d}:{mi:02d}"
+        weekday = interval.get("Weekday")
+        day = interval.get("Day")
+        if weekday is not None:
+            name = _LAUNCHD_WEEKDAY_NAMES.get(weekday, f"weekday{weekday}")
+            return f"weekly {name} {time_str} WITA"
+        if day is not None:
+            return f"monthly day {day} {time_str} WITA"
+        return f"daily {time_str} WITA"
+    if mi is not None:
+        return f"hourly :{mi:02d}"
+    return "—"
+
+
+
 def _humanize_plist_schedule(parsed: dict) -> str:
-    """Humanize a parsed plist's StartInterval / StartCalendarInterval / RunAtLoad."""
+    """Humanize a parsed plist's StartInterval / StartCalendarInterval / RunAtLoad.
+    StartCalendarInterval may be a single dict OR a list of dicts (multiple
+    fire times) — e.g. com.matagaruda.public-channel.plist fires 6x/day via a
+    6-entry list; each entry is humanized independently and joined."""
     if "StartInterval" in parsed:
         secs = parsed["StartInterval"]
         if isinstance(secs, int) and secs % 3600 == 0:
@@ -495,12 +529,17 @@ def _humanize_plist_schedule(parsed: dict) -> str:
             return f"every {secs // 60}m"
         return f"every {secs}s"
     interval = parsed.get("StartCalendarInterval")
-    if isinstance(interval, dict):
-        hr, mi = interval.get("Hour"), interval.get("Minute")
-        if hr is not None and mi is not None:
-            return f"daily {hr:02d}:{mi:02d} WITA"
-        if mi is not None:
-            return f"hourly :{mi:02d}"
+    if isinstance(interval, list):
+        parts = [
+            _humanize_single_calendar_interval(i) for i in interval if isinstance(i, dict)
+        ]
+        parts = [p for p in parts if p and p != "—"]
+        if parts:
+            return "; ".join(parts)
+    elif isinstance(interval, dict):
+        result = _humanize_single_calendar_interval(interval)
+        if result != "—":
+            return result
     if parsed.get("RunAtLoad"):
         return "RunAtLoad"
     return "—"

--- a/scripts/tests/test_plist_schedule_humanizer.py
+++ b/scripts/tests/test_plist_schedule_humanizer.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""`_humanize_plist_schedule` honors Weekday / Day / list-of-intervals.
+
+WHY THIS EXISTS: the generated automations reference rendered
+com.balizero.curiosity.weekly and com.balizero.codex-spalla-calibrate (both
+`StartCalendarInterval.Weekday: 0` = Sunday) as "daily HH:MM WITA", contradicting
+their own header-comment purpose ("Sunday HH:MM"). Weekly, monthly and multi-fire
+schedules now read as what launchd will actually do; plain daily / hourly /
+StartInterval / RunAtLoad outputs are pinned unchanged. Salvaged 2026-09-11 from
+the abandoned split-design branch (agent/air-m5/infra/automations-one-author).
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+gen = pytest.importorskip("generate_automations_reference")
+
+
+def test_humanize_plist_schedule_weekly_sunday_weekday_zero():
+    # launchd convention: Weekday 0 (and 7) both mean Sunday.
+    parsed = {"StartCalendarInterval": {"Hour": 6, "Minute": 0, "Weekday": 0}}
+    assert gen._humanize_plist_schedule(parsed) == "weekly Sun 06:00 WITA"
+
+
+def test_humanize_plist_schedule_weekly_other_weekday():
+    parsed = {"StartCalendarInterval": {"Hour": 8, "Minute": 0, "Weekday": 3}}
+    assert gen._humanize_plist_schedule(parsed) == "weekly Wed 08:00 WITA"
+
+
+def test_humanize_plist_schedule_monthly_day():
+    parsed = {"StartCalendarInterval": {"Day": 1, "Hour": 4, "Minute": 30}}
+    assert gen._humanize_plist_schedule(parsed) == "monthly day 1 04:30 WITA"
+
+
+def test_humanize_plist_schedule_list_of_intervals_joined():
+    parsed = {
+        "StartCalendarInterval": [
+            {"Hour": 2, "Minute": 15},
+            {"Hour": 6, "Minute": 15},
+            {"Hour": 10, "Minute": 15},
+        ]
+    }
+    assert gen._humanize_plist_schedule(parsed) == (
+        "daily 02:15 WITA; daily 06:15 WITA; daily 10:15 WITA"
+    )
+
+
+def test_humanize_plist_schedule_list_of_weekly_intervals_joined():
+    parsed = {
+        "StartCalendarInterval": [
+            {"Hour": 8, "Minute": 0, "Weekday": 3},
+            {"Hour": 8, "Minute": 0, "Weekday": 6},
+        ]
+    }
+    assert gen._humanize_plist_schedule(parsed) == "weekly Wed 08:00 WITA; weekly Sat 08:00 WITA"
+
+
+def test_humanize_plist_schedule_plain_daily_unchanged():
+    # No Weekday/Day present -> unchanged "daily HH:MM WITA" behavior.
+    parsed = {"StartCalendarInterval": {"Hour": 8, "Minute": 15}}
+    assert gen._humanize_plist_schedule(parsed) == "daily 08:15 WITA"
+
+
+def test_humanize_plist_schedule_start_interval_unchanged():
+    # StartInterval path is untouched by the Weekday/Day rework.
+    assert gen._humanize_plist_schedule({"StartInterval": 3600}) == "every 1h"
+    assert gen._humanize_plist_schedule({"StartInterval": 600}) == "every 10m"
+    assert gen._humanize_plist_schedule({"StartInterval": 90}) == "every 90s"
+
+
+def test_humanize_plist_schedule_run_at_load_and_dash_unchanged():
+    assert gen._humanize_plist_schedule({"RunAtLoad": True}) == "RunAtLoad"
+    assert gen._humanize_plist_schedule({}) == "—"


### PR DESCRIPTION
## Why

`_humanize_plist_schedule` in `scripts/generate_automations_reference.py` read only `Hour`/`Minute`, so every weekly or monthly LaunchAgent rendered as `daily HH:MM WITA` in the generated automations reference. Measured on the current generator with `--dry-run`: `com.balizero.curiosity.weekly` and `com.balizero.codex-spalla-calibrate` (both `Weekday: 0` = Sunday) said "daily" while their own purpose column said "Sunday 06:00"; `com.balizero.sota.m13-monthly` (`Day: 1`) said "daily"; `com.matagaruda.public-channel` (six fire times as a list) fell through to the dash.

## What

- New `_humanize_single_calendar_interval` honours `Weekday` (0/7 = Sun … 6 = Sat → `weekly Sun 06:00 WITA`) and `Day` (→ `monthly day 1 04:30 WITA`); `_humanize_plist_schedule` accepts a list of intervals and joins them with `; `. Plain daily / hourly / `StartInterval` / `RunAtLoad` outputs are unchanged.
- `scripts/tests/test_plist_schedule_humanizer.py`: 8 tests — weekly (Sunday and another weekday), monthly, list of intervals, list of weekly intervals, and three pins on the unchanged shapes.
- No doc regenerated here: the nightly promote organ from #6169 owns `docs/AUTOMATIONS_REFERENCE.md` and will carry the corrected schedules on its next successful run.

Salvaged from the abandoned split-design branch `agent/air-m5/infra/automations-one-author` (superseded by #6169 + #6171, branch deleted); nothing else from it is carried.

## Bites

Consumer: `scripts/generate_automations_reference.py` as run by `com.nuzantara.automations-reference` on Pro (nightly 23:15, promotes the doc via PR since #6169). Observation, run on this branch:

```
$ python3 scripts/generate_automations_reference.py --dry-run | grep -E "curiosity.weekly|codex-spalla-calibrate|sota.m13-monthly"
| `com.balizero.codex-spalla-calibrate` | Pro | weekly Sun 06:00 WITA | Sunday 06:00 Asia/Makassar ...
| `com.balizero.curiosity.weekly`       | Pro | weekly Sun 20:00 WITA | curiosity-batch.sh ...
| `com.balizero.sota.m13-monthly`       | Pro | monthly day 1 04:30 WITA | wr2-cron-wrapper.sh ...
```

Before: all three rows read `daily HH:MM WITA`. Tests: 8/8 new pass; `tests/scripts/test_generate_automations_reference.py` green; `scripts/tests/test_sentinel_v33.py::TestDocGeneratorBlocklist::test_format_schedule` fails identically on `origin/main` (calls a `_format_schedule` that does not exist) and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)