### PR TITLE
fix(automations): format the generated doc in the worktree that commits it, and never push a failed commit

### DIFF
--- a/scripts/automations-reference-cron-wrapper.sh
+++ b/scripts/automations-reference-cron-wrapper.sh
@@ -96,6 +96,16 @@ PYTHON="${AUTOMATIONS_PYTHON:-python3}"
 RUN_RC=$?
 log "generate_automations_reference.py exit=$RUN_RC"
 
+# Belt and braces: the generator already formats the file itself (cwd=NUZANTARA_ROOT,
+# relative path — fixed 2026-09-1x after prettier's own .gitignore matching silently
+# no-op'd when it ran with the MAIN checkout's cwd, where .worktrees/ is gitignored).
+# This wrapper must not depend on that internal behaviour holding: run prettier again,
+# explicitly cd'd INTO the worktree, so a future regression in the generator's own cwd
+# handling still leaves the committed file formatted.
+(cd "$WT_PATH" && npx prettier --write docs/AUTOMATIONS_REFERENCE.md) >>"$LOG" 2>&1
+PRETTIER_RC=$?
+log "prettier (wrapper-side) rc=$PRETTIER_RC"
+
 CHANGED=$(git -C "$WT_PATH" status --porcelain -- docs/AUTOMATIONS_REFERENCE.md | wc -l | tr -d ' ')
 
 if [ "$RUN_RC" -ne 0 ] && [ "$CHANGED" -eq 0 ]; then
@@ -123,6 +133,19 @@ file is output (decision 2026-09-11).
 Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
 EOF
   )" >>"$LOG" 2>&1
+  COMMIT_RC=$?
+  if [ "$COMMIT_RC" -ne 0 ]; then
+    # Measured on Pro's first live run: husky's pre-commit lint failed on the
+    # unformatted file (prettier had silently no-op'd, see above) and this
+    # branch used to ignore that non-zero rc entirely — it pushed a branch
+    # IDENTICAL to main (nothing was ever committed) and `gh pr create` died
+    # with "No commits between main and branch", so the heartbeat went error
+    # for the wrong reason and only after a useless push. A failed commit must
+    # never reach push or gh at all.
+    log "ERROR: commit failed rc=$COMMIT_RC — worktree left for recovery"
+    heartbeat error "commit failed (pre-commit hook?) — worktree left for recovery"
+    exit 1
+  fi
 
   git -C "$WT_PATH" push -u origin "$BRANCH" >>"$LOG" 2>&1
   PUSH_RC=$?

--- a/scripts/generate_automations_reference.py
+++ b/scripts/generate_automations_reference.py
@@ -145,12 +145,53 @@ class Job:
     autonomy_action: str = "—"
 
 
-def _run(cmd: str, timeout: int = 10) -> str:
+def _run(cmd: str, timeout: int = 10, cwd: Path | None = None) -> str:
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout)
+        r = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=timeout, cwd=cwd
+        )
         return r.stdout.strip()
     except (subprocess.TimeoutExpired, Exception):
         return ""
+
+
+def _run_prettier(relative_path: str, cwd: Path = NUZANTARA_ROOT, timeout: int = 30) -> None:
+    """Format `relative_path` (relative to `cwd`) with prettier, running FROM `cwd`
+    explicitly.
+
+    First live run on Pro (2026-09-1x) measured the defect this exists to close:
+    the generator wrote the file inside an isolated worktree, but this call ran
+    with the CALLER's cwd — the main checkout, where `.worktrees/` is gitignored.
+    Prettier honours .gitignore, so it matched ZERO files against the absolute
+    worktree path and reported "All matched files use Prettier code style" in
+    ~1s — a lie of omission, not a real pass. From the worktree's own cwd the
+    same file showed real style warnings. Passing `cwd` explicitly and a path
+    RELATIVE to it removes the caller's cwd as a variable entirely.
+
+    stderr and the return code are NOT swallowed into /dev/null any more (the
+    previous call embedded `2>/dev/null` in the shell string): a caller with
+    its own stdout/stderr redirected to a log file needs to see WHY prettier
+    failed, not just silence. A failure here does not raise — prettier
+    formatting the generated doc is best-effort, same contract as before.
+    """
+    try:
+        result = subprocess.run(
+            ["npx", "prettier", "--write", relative_path],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"prettier rc=timeout ({timeout}s)")
+        return
+    except Exception as exc:  # npx missing, permissions, etc. — best-effort
+        print(f"prettier rc=exception: {exc}")
+        return
+    if result.returncode != 0:
+        print(f"prettier rc={result.returncode}")
+        if result.stderr:
+            print(result.stderr.strip())
 
 
 def _codex_state_key_for_job(job: Job) -> str | None:
@@ -1057,8 +1098,10 @@ def generate(dry_run: bool = False) -> str:
 
     OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT_FILE.write_text(content)
-    # Applica prettier per rispettare le regole di formatting del monorepo
-    _run(f"npx prettier --write {OUTPUT_FILE} 2>/dev/null", timeout=30)
+    # Applica prettier per rispettare le regole di formatting del monorepo — da
+    # NUZANTARA_ROOT, su un path relativo (see _run_prettier's docstring for why
+    # the caller's own cwd cannot be trusted here).
+    _run_prettier(str(OUTPUT_FILE.relative_to(NUZANTARA_ROOT)), cwd=NUZANTARA_ROOT)
     print(f"Written: {OUTPUT_FILE} ({total} jobs, {len(lines)} lines)")
     return content
 

--- a/scripts/tests/test_automations_reference_cron_wrapper.sh
+++ b/scripts/tests/test_automations_reference_cron_wrapper.sh
@@ -60,8 +60,8 @@ new_world() {
   # own, same as translate-articles-cron-wrapper.sh — so the fixture must
   # match that pre-existing production state, not paper over a real gap.
   mkdir -p "$W/bin" "$W/fgh" "$W/fpy" "$W/home/nuzantara/scripts" "$W/home/logs" "$W/wtbase"
-  GHLOG="$W/ghlog"; PYLOG="$W/pylog"
-  : > "$GHLOG"; : > "$PYLOG"
+  GHLOG="$W/ghlog"; PYLOG="$W/pylog"; NPXLOG="$W/npxlog"
+  : > "$GHLOG"; : > "$PYLOG"; : > "$NPXLOG"
   : > "$W/home/nuzantara/scripts/agent_start.py"
 
   cat > "$W/bin/gh" <<'FAKEGH'
@@ -133,6 +133,19 @@ case "${1:-}" in
         git -C "$WT" config user.name "Test"
         mkdir -p "$WT/scripts" "$WT/docs"
         : > "$WT/scripts/generate_automations_reference.py"
+        # Real pre-commit hook, real git — flips on $FAKE_PY_STATE/commit_fail
+        # so the "commit fails" scenario below exercises the wrapper's actual
+        # `git commit` rc handling, not a git shim standing in for it.
+        mkdir -p "$WT/.git/hooks"
+        cat > "$WT/.git/hooks/pre-commit" <<HOOK
+#!/usr/bin/env bash
+if [ -f "${FAKE_PY_STATE}/commit_fail" ]; then
+  echo "pre-commit: simulated style errors (unformatted file)" >&2
+  exit 1
+fi
+exit 0
+HOOK
+        chmod +x "$WT/.git/hooks/pre-commit"
         if [ -n "${FAKE_BROKEN_REMOTE:-}" ]; then
           git -C "$WT" remote set-url origin "$W_DOES_NOT_EXIST"
         fi
@@ -155,6 +168,18 @@ exit 97
 FAKEPY
   chmod +x "$W/bin/python3"
 
+  # Fake npx — records cwd + args for every invocation, so the wrapper-side
+  # `(cd "$WT_PATH" && npx prettier --write docs/AUTOMATIONS_REFERENCE.md)`
+  # belt-and-braces call can be asserted to run FROM the worktree, on the
+  # RELATIVE path (the exact defect: it used to run from the main checkout's
+  # cwd against an absolute path prettier's own .gitignore silently ignored).
+  cat > "$W/bin/npx" <<'FAKENPX'
+#!/usr/bin/env bash
+printf 'PWD=%s ARGS=%s\n' "$(pwd)" "$*" >> "$FAKE_NPX_LOG"
+exit 0
+FAKENPX
+  chmod +x "$W/bin/npx"
+
   # Real bare "origin" + a real seed clone with one commit on main.
   git init --quiet --bare "$W/origin.git"
   git init --quiet "$W/seed"
@@ -176,6 +201,7 @@ run() {
              PATH="$W/bin:$PATH" \
              FAKE_GH_LOG="$GHLOG" FAKE_GH_STATE="$W/fgh" \
              FAKE_PY_LOG="$PYLOG" FAKE_PY_STATE="$W/fpy" \
+             FAKE_NPX_LOG="$NPXLOG" \
              FAKE_ORIGIN="$W/origin.git" FAKE_WT_BASE="$W/wtbase" \
              W_DOES_NOT_EXIST="$W/does-not-exist.git" \
              "$@" \
@@ -188,8 +214,9 @@ run() {
 new_world
 resolved_gh="$(env PATH="$W/bin:$PATH" command -v gh)"
 resolved_py="$(env PATH="$W/bin:$PATH" command -v python3)"
-if [ "$resolved_gh" != "$W/bin/gh" ] || [ "$resolved_py" != "$W/bin/python3" ]; then
-  echo "HARNESS TOO POOR TO JUDGE: PATH did not resolve to the fakes (gh=$resolved_gh python3=$resolved_py)" >&2
+resolved_npx="$(env PATH="$W/bin:$PATH" command -v npx)"
+if [ "$resolved_gh" != "$W/bin/gh" ] || [ "$resolved_py" != "$W/bin/python3" ] || [ "$resolved_npx" != "$W/bin/npx" ]; then
+  echo "HARNESS TOO POOR TO JUDGE: PATH did not resolve to the fakes (gh=$resolved_gh python3=$resolved_py npx=$resolved_npx)" >&2
   exit 2
 fi
 
@@ -267,6 +294,36 @@ run
 check "exit 0" "$(yesno test "$RC" -eq 0)"
 check "gh pr merge WAS attempted" "$(yesno eval 'grep -q "pr merge" "$GHLOG"')"
 check "heartbeat sidecar status=degraded" "$(yesno eval 'grep -q "\"status\": *\"degraded\"" "$W/home/.organism/last_seen/pro.automations_reference.json"')"
+
+echo "commit fails (pre-commit hook) -> no push, no gh pr create, heartbeat error:"
+new_world
+: > "$W/fpy/gen_change"
+: > "$W/fpy/commit_fail"
+run
+check "exit 1" "$(yesno test "$RC" -eq 1)"
+check "log names commit failure" "$(yesno eval 'grep -q "commit failed" "$W/home/logs/automations-reference-wrapper.log"')"
+check "origin gained NO new ref (never pushed)" "$(yesno eval '! git -C "$W/origin.git" for-each-ref --format="%(refname)" | grep -q "agent/testhost/docs/automations-"')"
+check "gh never invoked" "$(yesno eval '[ ! -s "$GHLOG" ]')"
+check "heartbeat sidecar status=error" "$(yesno eval 'grep -q "\"status\": *\"error\"" "$W/home/.organism/last_seen/pro.automations_reference.json"')"
+check "heartbeat note mentions commit failed" "$(yesno eval 'grep -q "commit failed" "$W/home/.organism/last_seen/pro.automations_reference.json"')"
+
+echo "prettier (wrapper-side belt-and-braces) runs FROM the worktree, on the relative path:"
+new_world
+: > "$W/fpy/gen_change"
+run
+check "exit 0" "$(yesno test "$RC" -eq 0)"
+check "npx WAS invoked" "$(yesno eval '[ -s "$NPXLOG" ]')"
+# Canonicalize $W before comparing — mktemp under TMPDIRs with a trailing slash
+# (macOS: /var/folders/.../T/) can leave a double slash baked into the shell
+# variable's string form, which a real `pwd` inside the subprocess normalises
+# away; comparing the raw strings would be a harness false negative, not a
+# defect in the wrapper.
+WNORM="$(cd "$W" && pwd)"
+check "npx ran with PWD inside the worktree (not the fake \$HOME/nuzantara placeholder)" \
+  "$(yesno eval 'grep -q "PWD=$WNORM/wtbase/" "$NPXLOG"')"
+check "npx was given the RELATIVE path, not an absolute one" \
+  "$(yesno eval 'grep -q "ARGS=prettier --write docs/AUTOMATIONS_REFERENCE.md" "$NPXLOG"')"
+check "npx was NOT given an absolute worktree path" "$(yesno eval '! grep -q "ARGS=prettier --write $WNORM/wtbase" "$NPXLOG"')"
 
 echo
 if [ "$failures" -eq 0 ]; then echo "PASS (all checks)"; exit 0; fi

--- a/scripts/tests/test_generate_automations_reference.py
+++ b/scripts/tests/test_generate_automations_reference.py
@@ -1,0 +1,113 @@
+"""Tests for scripts/generate_automations_reference.py's prettier call.
+
+Module is imported via importlib.util.spec_from_file_location (not a package
+import) because scripts/ is a flat bag of standalone tools, not a Python
+package (mirrors scripts/tests/test_adversarial_review_gate.py convention).
+
+Pins the defect measured on Pro's first live run of
+scripts/automations-reference-cron-wrapper.sh (2026-09-1x): the generator
+wrote docs/AUTOMATIONS_REFERENCE.md inside an isolated worktree, then ran
+`npx prettier --write <absolute worktree path>` with the CALLER's cwd — the
+main checkout, where `.worktrees/` is gitignored. Prettier honours
+.gitignore, so it matched ZERO files and reported success in ~1s while the
+file itself, from the worktree's own cwd, showed real style warnings. The
+husky pre-commit hook in the worktree then failed on the unformatted file,
+and the wrapper (fixed separately) ignored that non-zero commit rc.
+
+Fix pinned here: run prettier with `cwd=NUZANTARA_ROOT` explicitly and a path
+RELATIVE to it, so the caller's cwd cannot make prettier silently skip the
+file, and surface rc/stderr instead of swallowing them into /dev/null.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "generate_automations_reference.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("generate_automations_reference", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gen = _load_module()
+
+
+def _fake_completed(returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["npx", "prettier"], returncode=returncode, stdout="", stderr=stderr)
+
+
+def test_run_prettier_uses_nuzantara_root_cwd_and_relative_path(capsys):
+    with mock.patch("subprocess.run", return_value=_fake_completed(0)) as mock_run:
+        gen._run_prettier("docs/AUTOMATIONS_REFERENCE.md", cwd=gen.NUZANTARA_ROOT)
+
+    mock_run.assert_called_once()
+    _args, kwargs = mock_run.call_args
+    called_cmd = _args[0] if _args else kwargs.get("args")
+    assert called_cmd == ["npx", "prettier", "--write", "docs/AUTOMATIONS_REFERENCE.md"]
+    assert kwargs["cwd"] == gen.NUZANTARA_ROOT
+    # No absolute path anywhere in the invoked command — that is precisely the
+    # shape that let prettier's own .gitignore matching silently no-op.
+    assert not any(str(gen.NUZANTARA_ROOT) in str(a) for a in called_cmd)
+    out = capsys.readouterr().out
+    assert "prettier rc=" not in out  # success path prints nothing
+
+
+def test_run_prettier_prints_rc_and_stderr_on_failure(capsys):
+    with mock.patch("subprocess.run", return_value=_fake_completed(2, "some style error\n")):
+        gen._run_prettier("docs/AUTOMATIONS_REFERENCE.md", cwd=gen.NUZANTARA_ROOT)
+
+    out = capsys.readouterr().out
+    assert "prettier rc=2" in out
+    assert "some style error" in out
+
+
+def test_run_prettier_timeout_does_not_raise(capsys):
+    with mock.patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["npx", "prettier"], timeout=30),
+    ):
+        gen._run_prettier("docs/AUTOMATIONS_REFERENCE.md", cwd=gen.NUZANTARA_ROOT, timeout=30)
+
+    out = capsys.readouterr().out
+    assert "prettier rc=timeout" in out
+
+
+def test_generate_calls_run_prettier_with_relative_path_from_nuzantara_root(tmp_path, monkeypatch):
+    """`generate()` must hand _run_prettier a path relative to NUZANTARA_ROOT,
+    not the caller's cwd — this is the exact call site the live-run defect
+    was found in."""
+    fake_root = tmp_path / "worktree-checkout"
+    (fake_root / "docs").mkdir(parents=True)
+    monkeypatch.setattr(gen, "NUZANTARA_ROOT", fake_root)
+    monkeypatch.setattr(gen, "OUTPUT_FILE", fake_root / "docs" / "AUTOMATIONS_REFERENCE.md")
+    monkeypatch.setattr(gen, "_check_output_safety", lambda path: None)
+    # Every external state source degrades to empty/graceful, so generate()
+    # runs end to end without touching the real machine.
+    monkeypatch.setattr(gen, "_run", lambda *a, **k: "")
+    monkeypatch.setattr(gen, "_ssh_mini", lambda *a, **k: "")
+    monkeypatch.setattr(gen, "_load_registry", lambda *a, **k: {})
+    monkeypatch.setattr(gen, "_load_sentinel_state", lambda *a, **k: ({}, {}))
+
+    captured: dict = {}
+
+    def fake_run_prettier(relative_path, cwd=gen.NUZANTARA_ROOT, timeout=30):
+        captured["relative_path"] = relative_path
+        captured["cwd"] = cwd
+
+    monkeypatch.setattr(gen, "_run_prettier", fake_run_prettier)
+
+    gen.generate(dry_run=False)
+
+    assert captured["cwd"] == fake_root
+    assert captured["relative_path"] == "docs/AUTOMATIONS_REFERENCE.md"
+    assert not Path(captured["relative_path"]).is_absolute()


### PR DESCRIPTION
## Why

The first live run of `com.nuzantara.automations-reference` on Pro (2026-09-11 07:15 WITA, after #6169/#6171) failed with `gh pr create: No commits between main and branch`. Root cause, measured on Pro: `scripts/generate_automations_reference.py` ran `npx prettier --write <absolute path>` with cwd = the main checkout, where `.worktrees/` is gitignored (`.gitignore:864`); prettier honours `.gitignore` by default, matched zero files and reported "All matched files use Prettier code style" (`npx prettier --file-info` from the repo root: `"ignored": true`; from the worktree: `"ignored": false`). The husky pre-commit in the worktree then rejected the unformatted doc, and the wrapper ignored the commit's non-zero rc, pushed a branch identical to main and tried to open a PR.

## What

- `scripts/generate_automations_reference.py`: `_run_prettier(relative_path, cwd=NUZANTARA_ROOT)` via `subprocess.run` with rc/stderr surfaced (timeout and missing `npx` caught, never raised); the call site passes `docs/AUTOMATIONS_REFERENCE.md` relative to the script's own repo root, so the caller's cwd no longer matters. 4 tests in `scripts/tests/test_generate_automations_reference.py`.
- `scripts/automations-reference-cron-wrapper.sh`: explicit `(cd "$WT_PATH" && npx prettier --write docs/AUTOMATIONS_REFERENCE.md)` before the change detection, logged; `git commit` rc captured — non-zero → heartbeat `error` "commit failed (pre-commit hook?)", worktree left for recovery, exit 1, no push, no `gh`.
- Shell test: a real pre-commit hook in the fixture toggled to fail, a fake `npx` on PATH recording cwd + args. 43 asserts PASS.

Floor 1 (no hot-zone path, no size trigger) — no evidence pack required. Independent Opus 5 gate on disk: SIGN (confirms cause via `git check-ignore -v .worktrees` + prettier's documented `--ignore-path` default; 65 existing generator tests still green; the gate also retracted its earlier "prettier runs in the worktree" claim, which had rested on the same vacuous `--check` output).

Bites: `com.nuzantara.automations-reference` on Pro, kickstarted by this session after Pro pulls this merge: `~/logs/automations-reference-wrapper.log` shows the prettier step, a successful commit, and a PR `docs(automations): promote nightly automations snapshot (2026-09-11)` with auto-merge armed; heartbeat `pro.automations_reference` = ok. After that PR merges, `python3 scripts/docs_sync.py --json | jq .automation_coverage` on `origin/main` reports 136/136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)