### PR TITLE
fix(portal): portal uploads land in the client's own Drive folder, not the global root

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -929,6 +929,7 @@ class PortalDocumentsMixin:
                     return result
                 # Use Service Account for upload
                 return await self._upload_with_service_account(
+                    conn,
                     client_id,
                     client_name,
                     document_type,
@@ -1034,8 +1035,71 @@ class PortalDocumentsMixin:
 
         return result
 
+    async def _resolve_client_drive_folder(
+        self,
+        conn: asyncpg.Connection,
+        sa_drive: Any,
+        client_id: int,
+        client_name: str,
+        category_folder: str,
+    ) -> str:
+        """Resolve the client's OWN Drive folder + category subfolder id.
+
+        Same tree the CRM upload path files into
+        (`crm_enhanced_documents.py`: `clients.google_drive_folder_id` +
+        a `CATEGORY_TO_FOLDER`-named subfolder), so a team member browsing a
+        client's Drive folder from the CRM sees portal uploads too.
+
+        Root creation goes through the idempotent
+        `ensure_client_folder` chokepoint (advisory lock, one root per
+        client). Raises on failure — filing a client document into a folder
+        that is not that client's is worse than refusing the upload.
+        """
+        row = await conn.fetchrow(
+            "SELECT google_drive_folder_id, client_type FROM clients WHERE id = $1",
+            client_id,
+        )
+        root_folder_id = row["google_drive_folder_id"] if row else None
+        if not root_folder_id:
+            ensure_result = await sa_drive.ensure_client_folder(
+                client_id=client_id,
+                client_name=client_name,
+                client_type=(row["client_type"] if row else None) or "individual",
+                db_pool=self.pool,
+            )
+            root_folder_id = ensure_result["root_folder_id"]
+        if not root_folder_id:
+            raise RuntimeError(f"No Drive root folder for client {client_id}")
+
+        # The subfolder ids created by ensure_client_folder are persisted in
+        # client_drive_subfolders (that is how DrivePollService matches a
+        # dropped file back to a client) — prefer that read over a Drive list.
+        subfolder_id = await conn.fetchval(
+            """
+            SELECT subfolder_id
+              FROM client_drive_subfolders
+             WHERE client_id = $1 AND subfolder_name = $2
+             LIMIT 1
+            """,
+            client_id,
+            category_folder,
+        )
+        if subfolder_id:
+            return subfolder_id
+
+        found = await sa_drive.find_folder(category_folder, root_folder_id)
+        if found:
+            return found["id"]
+
+        created = await sa_drive.create_folder(
+            name=category_folder,
+            parent_id=root_folder_id,
+        )
+        return created["id"]
+
     async def _upload_with_service_account(
         self,
+        conn: asyncpg.Connection,
         client_id: int,
         client_name: str,
         document_type: str,
@@ -1053,32 +1117,48 @@ class PortalDocumentsMixin:
         `team_drive.drive_service` attribute TeamDriveService never defined.
         That attribute meant this branch raised AttributeError on every real
         invocation (production and test alike); see cicatrix BUG C.
+
+        Files into the CLIENT's own Drive folder. Until 2026-09-11 this
+        branch — the one live in production — passed
+        `folder_id=settings.google_drive_root_folder_id`, the flat global
+        root shared by every client, while computing a `folder_path` string
+        it never handed to the API: a team member opening a client's Drive
+        folder from the CRM could not see anything that client had uploaded
+        through the portal.
         """
         try:
             from datetime import datetime
 
-            from backend.app.core.config import settings
             from backend.services.integrations.service_account_drive_service import (
                 ServiceAccountDriveService,
             )
 
-            # Create folder structure
             timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
-            safe_client_name = "".join(
-                c for c in client_name if c.isalnum() or c in (" ", "_")
-            ).rstrip()[:30]
-            folder_path = f"Zantara Portal Uploads/{client_id}_{safe_client_name}/{document_type.replace('_', ' ').title()}"
             drive_file_name = f"{timestamp}_{file_name}"
+
+            # The SAME category folder the OCR dispatch already tells the
+            # pipeline this file lives in (`folder_hint`, STEP 6b) — so the
+            # hint and the physical location can no longer disagree.
+            category_folder = self._get_drive_folder_for_category(
+                self._classify_document_category(document_type, file_name),
+            )
 
             # Upload using Service Account. ServiceAccountDriveService wraps
             # the (synchronous) googleapiclient .execute() call in
             # asyncio.to_thread internally, so this does not block the
             # event loop the way the old team_drive.drive_service.files()...
             # .execute() call would have (never reached in practice).
-            root_folder_id = settings.google_drive_root_folder_id or "root"
-            sa_drive = ServiceAccountDriveService(root_folder_id=root_folder_id)
+            sa_drive = ServiceAccountDriveService()
+            target_folder_id = await self._resolve_client_drive_folder(
+                conn=conn,
+                sa_drive=sa_drive,
+                client_id=client_id,
+                client_name=client_name,
+                category_folder=category_folder,
+            )
+            folder_path = f"{client_id}_{client_name}/{category_folder}"
             uploaded_file = await sa_drive.upload_file_to_folder(
-                folder_id=root_folder_id,
+                folder_id=target_folder_id,
                 file_content=file_content,
                 file_name=drive_file_name,
                 mime_type=mime_type,

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -1097,11 +1097,21 @@ async def test_upload_with_service_account_routes_through_service_account_drive_
         }
     )
 
+    mock_conn = AsyncMock()
+    # client already has its CRM root folder; 00_Profile subfolder id is in
+    # client_drive_subfolders, so no Drive list call is needed
+    mock_conn.fetchrow.return_value = {
+        "google_drive_folder_id": "crm_root_1",
+        "client_type": "individual",
+    }
+    mock_conn.fetchval.return_value = "profile_subfolder_1"
+
     with patch(
         "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
         return_value=mock_sa_instance,
     ) as sa_cls:
         out = await service._upload_with_service_account(
+            conn=mock_conn,
             client_id=1,
             client_name="Client One!",
             document_type="passport_scan",
@@ -1117,12 +1127,15 @@ async def test_upload_with_service_account_routes_through_service_account_drive_
     assert call_kwargs["file_content"] == b"PDF"
     assert call_kwargs["file_name"].endswith("_passport.pdf")
     assert call_kwargs["mime_type"] == "application/pdf"
+    # THE finding: the file lands in the client's own category subfolder,
+    # never in the global root the old body passed.
+    assert call_kwargs["folder_id"] == "profile_subfolder_1"
 
     assert out["success"] is True
     assert out["file_id"] == "sa_file_1"
     assert out["file_url"] == "https://drive.google.com/file/d/sa_file_1/view"
     assert out["method"] == "service_account"
-    assert out["folder_path"] == "Zantara Portal Uploads/1_Client One/Passport Scan"
+    assert out["folder_path"] == "1_Client One!/00_Profile"
 
 
 @pytest.mark.asyncio
@@ -1145,6 +1158,7 @@ async def test_upload_with_service_account_surfaces_drive_errors_without_raising
         side_effect=ValueError("GOOGLE_SERVICE_ACCOUNT_JSON not configured in settings"),
     ):
         out = await service._upload_with_service_account(
+            conn=AsyncMock(),
             client_id=1,
             client_name="Client One",
             document_type="passport",
@@ -1157,6 +1171,138 @@ async def test_upload_with_service_account_surfaces_drive_errors_without_raising
     assert out["success"] is False
     assert "Service Account upload failed" in out["error"]
     assert "GOOGLE_SERVICE_ACCOUNT_JSON" in out["error"]
+
+
+# =============================================================================
+# F2 (2026-09-11 portal↔CRM bridge audit) — the live Service Account branch
+# uploaded flat into settings.google_drive_root_folder_id, the global root
+# shared by EVERY client, so no portal upload was ever visible from the
+# client's Drive folder in the CRM. These pin the per-client destination.
+# =============================================================================
+
+
+def _sa_service_and_conn(
+    *,
+    root: str | None,
+    subfolder_row: str | None,
+) -> tuple[PortalService, AsyncMock, MagicMock]:
+    service = PortalService(MagicMock())
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow.return_value = (
+        {"google_drive_folder_id": root, "client_type": "individual"} if root is not None else None
+    )
+    mock_conn.fetchval.return_value = subfolder_row
+
+    sa = MagicMock()
+    sa.upload_file_to_folder = AsyncMock(
+        return_value={"id": "sa_file_2", "webViewLink": "https://drive.google.com/x"}
+    )
+    sa.ensure_client_folder = AsyncMock(return_value={"root_folder_id": "made_root_9"})
+    sa.find_folder = AsyncMock(return_value=None)
+    sa.create_folder = AsyncMock(return_value={"id": "made_subfolder_9"})
+    return service, mock_conn, sa
+
+
+def _blank_result() -> dict[str, Any]:
+    return {
+        "success": False,
+        "file_id": None,
+        "file_url": None,
+        "folder_path": "",
+        "error": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_service_account_upload_creates_client_root_and_category_subfolder() -> None:
+    """No root on the client row and no persisted subfolder: go through the
+    idempotent ensure_client_folder chokepoint, then create the category
+    subfolder under THAT root — not under the global one."""
+    service, mock_conn, sa = _sa_service_and_conn(root=None, subfolder_row=None)
+
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
+    ):
+        out = await service._upload_with_service_account(
+            conn=mock_conn,
+            client_id=42,
+            client_name="Client Two",
+            document_type="kitas",
+            file_content=b"PDF",
+            file_name="kitas.pdf",
+            mime_type="application/pdf",
+            result=_blank_result(),
+        )
+
+    sa.ensure_client_folder.assert_awaited_once()
+    assert sa.ensure_client_folder.call_args.kwargs["client_id"] == 42
+    sa.find_folder.assert_awaited_once_with("01_Immigration", "made_root_9")
+    assert sa.create_folder.call_args.kwargs == {
+        "name": "01_Immigration",
+        "parent_id": "made_root_9",
+    }
+    assert sa.upload_file_to_folder.call_args.kwargs["folder_id"] == "made_subfolder_9"
+    assert out["success"] is True
+    assert out["folder_path"] == "42_Client Two/01_Immigration"
+
+
+@pytest.mark.asyncio
+async def test_service_account_upload_reuses_existing_category_subfolder_from_drive() -> None:
+    """Root known, no client_drive_subfolders row, but the folder exists in
+    Drive: reuse it instead of creating a twin."""
+    service, mock_conn, sa = _sa_service_and_conn(root="crm_root_7", subfolder_row=None)
+    sa.find_folder = AsyncMock(return_value={"id": "found_tax_7"})
+
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
+    ):
+        out = await service._upload_with_service_account(
+            conn=mock_conn,
+            client_id=7,
+            client_name="Client Three",
+            document_type="spt_tahunan",
+            file_content=b"PDF",
+            file_name="spt.pdf",
+            mime_type="application/pdf",
+            result=_blank_result(),
+        )
+
+    sa.ensure_client_folder.assert_not_awaited()
+    sa.create_folder.assert_not_awaited()
+    assert sa.upload_file_to_folder.call_args.kwargs["folder_id"] == "found_tax_7"
+    assert out["folder_path"] == "7_Client Three/03_Tax"
+
+
+@pytest.mark.asyncio
+async def test_service_account_upload_fails_closed_when_folder_unresolvable() -> None:
+    """Guilt-proof for the regression shape: if the client folder cannot be
+    resolved, REFUSE — never fall back to the shared global root, which is
+    what silently swallowed every portal upload before this fix. The caller
+    turns an unsuccessful drive_result into 'Document storage is
+    unavailable', so the client is told rather than misled."""
+    service, mock_conn, sa = _sa_service_and_conn(root=None, subfolder_row=None)
+    sa.ensure_client_folder = AsyncMock(side_effect=RuntimeError("Drive 404"))
+
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
+    ):
+        out = await service._upload_with_service_account(
+            conn=mock_conn,
+            client_id=8,
+            client_name="Client Four",
+            document_type="passport",
+            file_content=b"PDF",
+            file_name="p.pdf",
+            mime_type="application/pdf",
+            result=_blank_result(),
+        )
+
+    sa.upload_file_to_folder.assert_not_awaited()
+    assert out["success"] is False
+    assert "Drive 404" in out["error"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

The live Service Account upload branch passed `folder_id=settings.google_drive_root_folder_id` — the flat root shared by **every** client — while computing a `folder_path` string it never handed to the Drive API (`_upload_with_service_account`, `services/portal/_mixins/documents.py`). Every document a client uploaded through my.balizero.com was filed outside that client's own folder tree, so a team member opening the client's Drive folder from the CRM could not see it. This is very likely the recurring "the client says they uploaded X but I don't see it".

Portal audit finding **F2 (P0)**, 2026-09-11 bridge pass.

## How

Resolve the SAME destination the CRM upload path uses (`crm_enhanced_documents.py`): `clients.google_drive_folder_id` + a category-named subfolder.

- Root creation goes through the idempotent `ensure_client_folder` chokepoint (advisory lock, one root per client) — not an inline create, which is the shape that produced twin root folders before.
- The category subfolder id is read from `client_drive_subfolders` first (the table `DrivePollService` already matches dropped files against), then Drive find-or-create.
- The category is the one `_get_drive_folder_for_category` **already** reports to the OCR dispatch as `folder_hint` (STEP 6b), so the hint and the physical location can no longer disagree.
- **Fails closed.** If the client folder cannot be resolved the upload is refused (the caller surfaces "Document storage is unavailable") instead of falling back to the shared root — the fallback is what silently swallowed the documents.

## Adversarial review

- *Why not keep a flat-root fallback so an upload never fails?* Because the flat root is not a degraded destination, it is a lost one: nothing in the CRM ever looks there. A refused upload is a client who retries; a "successful" upload into the global root is a document nobody finds. The CRM path already fails closed on the same step.
- *Race on the subfolder find-then-create?* Same exposure the CRM upload path has had; the root — the part that mattered, and the one with a scar — is serialized by `ensure_client_folder`'s advisory lock. Not widened here.
- *Does this move existing files?* No. Documents already uploaded into the global root stay there; this changes where new ones land. Relocating the existing ones is a separate, data-touching job.

## Bites

**Consumer:** `_upload_to_drive`'s service-account branch — the path production actually takes (OAuth is disabled; `apps/backend-rag/CLAUDE.md` records the live traffic going through `ServiceAccountDriveService`).

**Observation (run now, on this branch):** `pytest backend/tests/unit/app/services/portal/test_documents_mixin.py` → **48 passed**. Guilt-proof: replacing `folder_id=target_folder_id` with a global-root literal turns 3 of them red —
```
FAILED test_upload_with_service_account_routes_through_service_account_drive_service
  - AssertionError: assert 'GLOBAL_ROOT' == 'profile_subfolder_1'
FAILED test_service_account_upload_creates_client_root_and_category_subfolder
  - AssertionError: assert 'GLOBAL_ROOT' == 'made_subfolder_9'
FAILED test_service_account_upload_reuses_existing_category_subfolder_from_drive
  - AssertionError: assert 'GLOBAL_ROOT' == 'found_tax_7'
```
Live proof after deploy: upload a document from the portal as the synthetic audit client and open that client's Drive folder from kita — recorded in the follow-up comment on this PR before the audit client is cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
