### PR TITLE
fix(portal): stop shipping invite and magic-link tokens to Google Analytics

### DIFF
--- a/apps/mouth/src/app/layout.tsx
+++ b/apps/mouth/src/app/layout.tsx
@@ -9,6 +9,7 @@ import {
   DynamicJsonLd,
 } from "@/components/seo";
 import { RouteChangeTracker } from "@/components/analytics/RouteChangeTracker";
+import { analyticsUrlRedactScript } from "@/lib/analytics-url";
 import { QueryProvider } from "@/components/providers/QueryProvider";
 import { ErrorBoundary } from "@/components/optimization";
 import { WebVitalsMonitor } from "@/components/providers/WebVitalsMonitor";
@@ -211,6 +212,17 @@ export default function RootLayout({
             __html:
               "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'denied','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});gtag('consent','update',{'analytics_storage':'granted'});",
           }}
+        />
+
+        {/* Redact credential-bearing query params from page_location BEFORE
+            gtag.js loads. Measured 2026-09-11: /portal/register?token=… and
+            /portal/magic?token=… shipped the raw single-use token to
+            google-analytics.com/g/collect as `dl=` (HTTP 204 — accepted).
+            GA's automatic page_view reads document.location.href, so this has
+            to be queued in dataLayer ahead of gtag('config'); see
+            src/lib/analytics-url.ts. */}
+        <script
+          dangerouslySetInnerHTML={{ __html: analyticsUrlRedactScript }}
         />
 
         {/* ⚡ Performance: Preconnect to critical domains */}

--- a/apps/mouth/src/components/analytics/RouteChangeTracker.test.tsx
+++ b/apps/mouth/src/components/analytics/RouteChangeTracker.test.tsx
@@ -45,6 +45,23 @@ describe("RouteChangeTracker", () => {
     );
   });
 
+  it("never sends a credential-bearing query string as page_location", () => {
+    // Portal audit L-GA (2026-09-11): the raw href reached
+    // google-analytics.com/g/collect with the single-use token in `dl=`.
+    window.history.replaceState({}, "", "/portal/magic?token=LEAKME");
+    usePathnameMock.mockReturnValue("/portal/magic");
+    const { rerender } = render(<RouteChangeTracker />);
+
+    window.history.replaceState({}, "", "/portal/register?token=LEAKMETOO");
+    usePathnameMock.mockReturnValue("/portal/register");
+    rerender(<RouteChangeTracker />);
+
+    expect(gtag).toHaveBeenCalledTimes(1);
+    const payload = gtag.mock.calls[0][2] as { page_location: string };
+    expect(payload.page_location).not.toContain("LEAKMETOO");
+    expect(payload.page_location).toContain("/portal/register");
+  });
+
   it("is a no-op when gtag is not loaded", () => {
     delete (window as typeof window & { gtag?: unknown }).gtag;
     usePathnameMock.mockReturnValue("/a");

--- a/apps/mouth/src/components/analytics/RouteChangeTracker.tsx
+++ b/apps/mouth/src/components/analytics/RouteChangeTracker.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 
+import { redactSensitiveQueryParams } from "@/lib/analytics-url";
+
 type GtagWindow = typeof window & { gtag?: (...args: unknown[]) => void };
 
 /**
@@ -29,7 +31,9 @@ export function RouteChangeTracker() {
     if (typeof win.gtag !== "function") return;
     win.gtag("event", "page_view", {
       page_path: pathname,
-      page_location: window.location.href,
+      // Never the raw href: a credential-bearing query string reached
+      // Google verbatim through this field (portal audit L-GA, 2026-09-11).
+      page_location: redactSensitiveQueryParams(window.location.href),
       page_title: document.title,
     });
   }, [pathname]);

--- a/apps/mouth/src/lib/analytics-url.test.ts
+++ b/apps/mouth/src/lib/analytics-url.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+
+import {
+  REDACTED,
+  SENSITIVE_QUERY_PARAMS,
+  analyticsUrlRedactScript,
+  redactSensitiveQueryParams,
+} from "./analytics-url";
+
+describe("redactSensitiveQueryParams", () => {
+  it("redacts the invite token measured leaking to GA (portal audit L-GA)", () => {
+    const out = redactSensitiveQueryParams(
+      "https://my.balizero.com/portal/register?token=AUDITPROBE1234567890",
+    );
+    expect(out).not.toContain("AUDITPROBE1234567890");
+    expect(out).toBe(
+      `https://my.balizero.com/portal/register?token=${encodeURIComponent(REDACTED)}`,
+    );
+  });
+
+  it("redacts the magic-link token", () => {
+    const out = redactSensitiveQueryParams(
+      "https://my.balizero.com/portal/magic?token=AUDITPROBE0987654321",
+    );
+    expect(out).not.toContain("AUDITPROBE0987654321");
+  });
+
+  it("redacts a token nested inside another parameter (the second leak)", () => {
+    // The exact shape of the expired-magic-link redirect that leaked the token
+    // a second time as dl=/dr=.
+    const out = redactSensitiveQueryParams(
+      "https://my.balizero.com/portal/login-upgraded?expired=true&reason=token_expired" +
+        "&redirect=%2Fportal%2Fmagic%3Ftoken%3DAUDITPROBE0987654321",
+    );
+    expect(out).not.toContain("AUDITPROBE0987654321");
+    expect(out).toContain("expired=true");
+    expect(out).toContain("reason=token_expired");
+  });
+
+  it("redacts every declared parameter", () => {
+    for (const param of SENSITIVE_QUERY_PARAMS) {
+      const out = redactSensitiveQueryParams(
+        `https://my.balizero.com/x?${param}=SUPERSECRETVALUE`,
+      );
+      expect(out, param).not.toContain("SUPERSECRETVALUE");
+    }
+  });
+
+  it("leaves an ordinary URL byte-identical", () => {
+    const clean = "https://balizero.com/kbli/56303?ref=newsletter&page=2";
+    expect(redactSensitiveQueryParams(clean)).toBe(clean);
+  });
+
+  it("returns an unparseable value unchanged instead of throwing", () => {
+    expect(redactSensitiveQueryParams("not a url")).toBe("not a url");
+    expect(redactSensitiveQueryParams("")).toBe("");
+  });
+});
+
+describe("analyticsUrlRedactScript", () => {
+  it("is generated from the same parameter list (no drift between the two copies)", () => {
+    for (const param of SENSITIVE_QUERY_PARAMS) {
+      expect(analyticsUrlRedactScript).toContain(`"${param}"`);
+    }
+  });
+
+  it("only overrides page_location when the URL actually carries a credential", () => {
+    // Real jsdom window/document: the script sets the GLOBAL dataLayer and
+    // reads the browser's own location, exactly as it does in the browser.
+    const win = window as typeof window & { dataLayer?: unknown[] };
+
+    const run = (path: string, referrer: string): unknown[] => {
+      delete win.dataLayer;
+      window.history.replaceState({}, "", path);
+      Object.defineProperty(document, "referrer", {
+        value: referrer,
+        configurable: true,
+      });
+      new Function(analyticsUrlRedactScript)();
+      return win.dataLayer ?? [];
+    };
+
+    expect(run("/kbli/56303?ref=newsletter", "")).toEqual([]);
+
+    const pushed = run(
+      "/portal/magic?token=LEAKME",
+      "https://my.balizero.com/portal/register?token=LEAKMETOO",
+    );
+    expect(pushed).toHaveLength(1);
+    const args = Array.from(pushed[0] as IArguments);
+    expect(args[0]).toBe("set");
+    const payload = args[1] as { page_location: string; page_referrer: string };
+    expect(payload.page_location).not.toContain("LEAKME");
+    expect(payload.page_referrer).not.toContain("LEAKMETOO");
+  });
+});
+
+describe("root layout wiring", () => {
+  // The scrub only works if it is queued in dataLayer BEFORE gtag.js loads.
+  // @next/third-parties' <GoogleAnalytics> injects the gtag('config', …)
+  // whose automatic page_view is the beacon that leaked, so ordering is the
+  // whole mechanism — not a style preference.
+  const layout = readFileSync("src/app/layout.tsx", "utf8");
+
+  it("mounts the redact script in <head>, before <GoogleAnalytics>", () => {
+    const scrubAt = layout.indexOf("__html: analyticsUrlRedactScript");
+    const headEndsAt = layout.indexOf("</head>");
+    const gaAt = layout.indexOf("<GoogleAnalytics");
+    expect(scrubAt).toBeGreaterThan(-1);
+    expect(gaAt).toBeGreaterThan(-1);
+    expect(scrubAt).toBeLessThan(headEndsAt);
+    expect(scrubAt).toBeLessThan(gaAt);
+  });
+});

--- a/apps/mouth/src/lib/analytics-url.ts
+++ b/apps/mouth/src/lib/analytics-url.ts
@@ -1,0 +1,107 @@
+/**
+ * Credential-bearing query parameters must never reach a third-party
+ * analytics endpoint.
+ *
+ * Measured 2026-09-11 (live network capture on my.balizero.com, portal audit
+ * finding L-GA / ux F8): opening `/portal/register?token=…` or
+ * `/portal/magic?token=…` produced
+ * `POST https://www.google-analytics.com/g/collect?…&dl=<the full URL, token
+ * included>` → **HTTP 204**. Google accepted the single-use invite token and
+ * the single-use magic-link token verbatim, in `page_location`, before the
+ * client had touched anything. The invalid-token case leaked a second time as
+ * `dr=` (referrer) after the auto-redirect to `/portal/login-upgraded?…
+ * redirect=%2Fportal%2Fmagic%3Ftoken%3D…`. `www.google-analytics.com` is
+ * whitelisted in the portal's `connect-src`, so nothing on the page blocked it.
+ *
+ * GA reads `document.location.href`, not the page's props, so no per-page code
+ * can prevent this — the value has to be overridden before the first beacon
+ * fires. `analyticsUrlRedactScript` does that in `<head>` (before gtag.js
+ * loads) and `redactSensitiveQueryParams` does it for every explicit
+ * `page_view` this app sends itself.
+ *
+ * This is defence in depth, not a substitute for keeping tokens out of URLs:
+ * `src/app/visa/voa/auth/route.ts` shows the structural fix (a route handler
+ * that moves the token into an HttpOnly cookie and redirects to a URL that
+ * carries nothing). A scrub here also covers Google's own automatic
+ * `page_view`, any future tag, and any token route added later.
+ */
+
+/**
+ * Query parameters whose VALUE is a credential or a personal identifier.
+ * The key is kept (so the shape of the funnel is still measurable) and the
+ * value is replaced — dropping the key entirely would hide that a
+ * token-bearing URL was visited at all.
+ */
+export const SENSITIVE_QUERY_PARAMS = [
+  "token",
+  "magic_token",
+  "invite",
+  "invitation",
+  "invite_token",
+  "access_token",
+  "id_token",
+  "refresh_token",
+  "code",
+  "pin",
+  "otp",
+  "secret",
+  "key",
+  "api_key",
+  "password",
+  "email",
+] as const;
+
+export const REDACTED = "[redacted]";
+
+/**
+ * Replace the value of every credential-bearing query parameter in `href`.
+ *
+ * Returns `href` unchanged when it holds none of them (the overwhelmingly
+ * common case) and when it cannot be parsed — a scrubber must never be the
+ * reason a page stops reporting.
+ */
+export function redactSensitiveQueryParams(href: string): string {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return href;
+  }
+
+  let touched = false;
+  for (const param of SENSITIVE_QUERY_PARAMS) {
+    if (url.searchParams.has(param)) {
+      url.searchParams.set(param, REDACTED);
+      touched = true;
+    }
+  }
+
+  // A token can also ride inside another parameter's value, which is how the
+  // magic-link redirect leaked it a second time:
+  // `?redirect=%2Fportal%2Fmagic%3Ftoken%3D<token>`. Redact any value that
+  // embeds one of the sensitive keys as a nested query parameter.
+  for (const [param, value] of Array.from(url.searchParams.entries())) {
+    if (
+      SENSITIVE_QUERY_PARAMS.some((p) => new RegExp(`[?&]${p}=`).test(value))
+    ) {
+      url.searchParams.set(param, REDACTED);
+      touched = true;
+    }
+  }
+
+  return touched ? url.href : href;
+}
+
+/**
+ * The same redaction, as an inline `<head>` script, generated from the SAME
+ * parameter list so the two copies cannot drift.
+ *
+ * It runs before `@next/third-parties`' gtag.js is loaded, so the
+ * `gtag('set', …)` lands in `dataLayer` ahead of the `gtag('config', …)`
+ * whose automatic `page_view` is the beacon that leaked. It only calls `set`
+ * when the URL actually carries a credential: on every ordinary page GA keeps
+ * its default behaviour untouched.
+ */
+export const analyticsUrlRedactScript = `(function(){try{var S=${JSON.stringify(
+  SENSITIVE_QUERY_PARAMS,
+)};var R=${JSON.stringify(REDACTED)};function scrub(h){if(!h)return h;var u;try{u=new URL(h);}catch(e){return h;}var t=false;S.forEach(function(p){if(u.searchParams.has(p)){u.searchParams.set(p,R);t=true;}});u.searchParams.forEach(function(v,k){for(var i=0;i<S.length;i++){if(new RegExp('[?&]'+S[i]+'=').test(v)){u.searchParams.set(k,R);t=true;break;}}});return t?u.href:h;}var loc=window.location.href;var ref=document.referrer;var sl=scrub(loc);var sr=scrub(ref);if(sl!==loc||sr!==ref){window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('set',{page_location:sl,page_referrer:sr});}}catch(e){}})();`;


### PR DESCRIPTION
## What

Measured live on my.balizero.com, 2026-09-11, with no login: opening
`/portal/register?token=<invite token>` or `/portal/magic?token=<magic-link token>` produced

```
POST https://www.google-analytics.com/g/collect?...&dl=https%3A%2F%2Fmy.balizero.com
     %2Fportal%2Fregister%3Ftoken%3DAUDITPROBE1234567890&...   → HTTP 204
```

Google **accepted** both single-use credentials verbatim, in `page_location`, before the client touched anything. An invalid magic token leaked a second time as `dr=` after the auto-redirect to `/portal/login-upgraded?…&redirect=%2Fportal%2Fmagic%3Ftoken%3D…`. `www.google-analytics.com` is whitelisted in the portal's `connect-src`, so nothing on the page blocked it — only the `www.google.com/g/collect` variant is CSP-blocked, which is the wrong one.

Portal audit findings **L-GA (live, P0)** and **ux F8**. This is the §4 output boundary: a credential-bearing URL reaching a third-party cloud in the clear.

## How

GA reads `document.location.href`, not the page's props, so no per-page code can prevent this — the value has to be overridden before the first beacon fires.

- `src/lib/analytics-url.ts` — one parameter list, two consumers **generated from it** so the copies cannot drift. Values are replaced, keys kept, so the funnel stays measurable. A token nested inside another parameter's value (the `redirect=` second leak) is redacted too.
- Root layout: the redaction runs as an inline `<head>` script **before** `@next/third-parties` loads gtag.js, so the `gtag('set', …)` is queued in `dataLayer` ahead of the `gtag('config', …)` whose automatic `page_view` is the beacon that leaked. It fires `set` **only when the URL actually carries a credential** — every ordinary page keeps GA's default behaviour byte for byte.
- `RouteChangeTracker` scrubs the href it sends explicitly.

## Adversarial review

- *Isn't the real fix to keep tokens out of URLs?* Yes, and this repo already has that pattern, adversarially reviewed: `src/app/visa/voa/auth/route.ts` is a route handler that moves the token into an HttpOnly cookie and redirects to a URL carrying nothing — its own header explains that a *page* at a token URL leaks precisely this way. The portal's two token pages should follow it. **Filed as the follow-up, not done here**, because it restructures live auth flows while the confirmed leak is open today; a scrub also covers Google's automatic hit, the client Sentry SDK's breadcrumb URLs, any future tag, and any token route added later — which the per-route fix does not.
- *Why `set` and not `config`?* We do not own the `config` call — `@next/third-parties` injects it. `set` queued earlier in `dataLayer` applies to it.
- *Why keep the key?* Dropping `?token` entirely would hide that a token-bearing URL was visited at all, which is exactly the funnel signal the team needs.
- *Not addressed:* the layout forces `analytics_storage: 'granted'` immediately after defaulting it to `'denied'`, regardless of any consent choice. Real, separate concern, out of scope here.

## Bites

**Consumers:** the root layout's GA bootstrap (Google's automatic `page_view`) and `RouteChangeTracker`'s explicit one — the two beacons the capture caught.

**Observation (run now, on this branch):** `npx vitest run src/lib/analytics-url.test.ts src/components/analytics/RouteChangeTracker.test.tsx` → **13 passed**; `npx tsc --noEmit` clean. Guilt-proof: restoring the raw `window.location.href` in `RouteChangeTracker` **and** blanking the `<head>` script turns exactly the two wiring tests red —
```
FAIL src/lib/analytics-url.test.ts > root layout wiring >
     mounts the redact script in <head>, before <GoogleAnalytics>
FAIL src/components/analytics/RouteChangeTracker.test.tsx >
     never sends a credential-bearing query string as page_location
```
The URL-shape tests keep the exact `AUDITPROBE…` strings from the live capture, so a regression in the redactor itself fails on the measured payload, not a paraphrase of it.

Live proof after Vercel deploy: re-run the network capture on `/portal/register?token=…` and confirm `dl=` carries `token=%5Bredacted%5D` — recorded as a comment on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
