### PR TITLE
feat(ops): Claude Seats — floating desk widget for the six seats, Pro and M5

### DIFF
--- a/evidence/2026-09/agent-nuzantara-infra-seat-widget-92a1cdbb/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-infra-seat-widget-92a1cdbb/brief.yml
@@ -1,0 +1,41 @@
+task_id: seat-widget
+gear: 2
+l_level: L1
+gate_class: opus
+grader: opus-gate-session
+objective: >-
+  Zero asked (2026-09-11, four rulings in one sitting): a desk widget showing quota used
+  and reset for the six Claude seats, refreshed by a button; in the real Claude colours
+  (orange card, white type); nailed to the desktop so it hides under app windows; collapsible
+  to a small square; draggable; installed on Pro and on M5. infra/seat-widget/ is one SwiftUI
+  file, a build script, an Info.plist and a README. Nothing else in the repo changes.
+
+  Gear 2 by SIZE, deterministically: 639 net lines across four new files. The path term is
+  1 (infra/seat-widget/ is not a hot zone); harness-floor.yml computed floor 2 on the first
+  push and failed for want of this brief. Declared 2, not argued down.
+constraints:
+  - >-
+    The widget never reads a token and never talks to the Anthropic endpoint. It shells out
+    to scripts/claude_seat_quota.py --json, the single measured source of quota on this
+    fleet, so the panel and the CLI table can never disagree. ANTHROPIC_API_KEY,
+    CLAUDE_CODE_OAUTH_TOKEN and CLAUDE_CONFIG_DIR are stripped from the child environment.
+  - >-
+    Quota is Keychain-backed and readable only where the logged-in profiles live (Pro).
+    M5's Keychain holds only stale Claude entries (measured 2026-09-11, every entry "no
+    access token"), so M5 runs the widget in remote mode: build.sh --remote pro, one host
+    name in ~/Library/Application Support/Claude Seats/remote, ssh -o BatchMode=yes.
+  - >-
+    The script and FLEET_TOPOLOGY.json are bundled into the .app at build time. The widget
+    must not depend on the state of any checkout; NUZANTARA_REPO is a development override.
+  - >-
+    Desktop level means CGWindowLevelForKey(.desktopIconWindow) + 1 with canJoinAllSpaces
+    and stationary: under every app window, on every Space, never in Mission Control.
+    Borderless, so quitting is a right-click menu item, not a close button.
+acceptance:
+  - ~/Library/Logs/SeatWidget.log on Pro carries an `ok … local seats=6` line stamped after the final build.
+  - ~/Library/Logs/SeatWidget.log on M5 carries an `ok … via pro seats=6` line stamped after the final build.
+  - A screenshot on Pro shows the orange card under an app window, and the collapsed square.
+budget:
+  hours: 3
+  adversarial_rounds: 1
+  tokens: 1500000

--- a/infra/seat-widget/Info.plist
+++ b/infra/seat-widget/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key><string>Claude Seats</string>
+  <key>CFBundleExecutable</key><string>ClaudeSeats</string>
+  <key>CFBundleIdentifier</key><string>com.balizero.claude-seats</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleName</key><string>Claude Seats</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>LSMinimumSystemVersion</key><string>13.0</string>
+  <key>LSUIElement</key><true/>
+  <key>NSHighResolutionCapable</key><true/>
+  <key>NSPrincipalClass</key><string>NSApplication</string>
+</dict>
+</plist>

--- a/infra/seat-widget/README.md
+++ b/infra/seat-widget/README.md
@@ -1,20 +1,23 @@
 # Claude Seats — desk widget
 
-Floating panel (no Dock icon) showing, for each of the six Claude seats, the 5h and the
-weekly usage with their resets. One button (↻) re-measures; it also refreshes itself
-every 30 minutes. Numbers come from `scripts/claude_seat_quota.py --json` — the widget
-never reads a token and never talks to the endpoint itself.
+Desktop widget for the six Claude seats: the 5h and the weekly usage of each, with their
+resets. It lives at the desktop-icon level — under every app window, on every Space — so it is
+there whenever the desktop is. ↻ re-measures; it also refreshes itself every 30 minutes.
+Closed it is a small square (six seats, 5h usage); open it is the full table. Numbers come
+from `scripts/claude_seat_quota.py --json` — the widget never reads a token and never talks
+to the endpoint itself.
 
 ```bash
 infra/seat-widget/build.sh                # Pro: measure locally (Keychain profiles live here)
 infra/seat-widget/build.sh --remote pro   # M5 / Mini: measure over `ssh pro`
 ```
 
-- App: `~/Applications/Claude Seats.app` (ad-hoc signed, local use). Close the panel to quit.
+- App: `~/Applications/Claude Seats.app` (ad-hoc signed, local use). Drag it anywhere; the
+  position is remembered. Right-click → Aggiorna / Riduci / Esci.
 - Config: `~/Library/Application Support/Claude Seats/remote` — one host name, or absent for local.
 - Log: `~/Library/Logs/SeatWidget.log` — one line per refresh (`ok 32s local seats=6 hidden=3`).
 - Login item: System Settings → General → Login Items → add the app (GUI action, owner's call).
 
-The script and `FLEET_TOPOLOGY.json` are copied into the bundle at build time; rebuild
-after either changes. Colours follow the claude.ai palette (ivory card, clay accent, kraft →
-clay → ember as a window fills).
+The script and `FLEET_TOPOLOGY.json` are copied into the bundle at build time; rebuild after
+either changes. Colours: Claude orange card (`#D97757` → `#C96442`), white type, white bars
+that turn ink once a window is at 85 % or more.

--- a/infra/seat-widget/README.md
+++ b/infra/seat-widget/README.md
@@ -1,0 +1,20 @@
+# Claude Seats — desk widget
+
+Floating panel (no Dock icon) showing, for each of the six Claude seats, the 5h and the
+weekly usage with their resets. One button (↻) re-measures; it also refreshes itself
+every 30 minutes. Numbers come from `scripts/claude_seat_quota.py --json` — the widget
+never reads a token and never talks to the endpoint itself.
+
+```bash
+infra/seat-widget/build.sh                # Pro: measure locally (Keychain profiles live here)
+infra/seat-widget/build.sh --remote pro   # M5 / Mini: measure over `ssh pro`
+```
+
+- App: `~/Applications/Claude Seats.app` (ad-hoc signed, local use). Close the panel to quit.
+- Config: `~/Library/Application Support/Claude Seats/remote` — one host name, or absent for local.
+- Log: `~/Library/Logs/SeatWidget.log` — one line per refresh (`ok 32s local seats=6 hidden=3`).
+- Login item: System Settings → General → Login Items → add the app (GUI action, owner's call).
+
+The script and `FLEET_TOPOLOGY.json` are copied into the bundle at build time; rebuild
+after either changes. Colours follow the claude.ai palette (ivory card, clay accent, kraft →
+clay → ember as a window fills).

--- a/infra/seat-widget/build.sh
+++ b/infra/seat-widget/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Build "Claude Seats.app" into ~/Applications and (re)launch it.
+#
+#   build.sh                 build from this checkout, launch
+#   build.sh --remote pro    also make the widget measure over `ssh pro` (machines
+#                            without the logged-in profiles: M5, Mini)
+#   build.sh --local         drop a previous --remote setting
+#   build.sh --no-launch     build only
+#
+# Bundles scripts/claude_seat_quota.py and FLEET_TOPOLOGY.json into the app so the widget
+# never depends on the state of a checkout. Needs swiftc (Xcode or Command Line Tools).
+# Ad-hoc signed: local use only.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${SEAT_WIDGET_REPO:-$HERE/../..}"
+APP="${SEAT_WIDGET_APP:-$HOME/Applications/Claude Seats.app}"
+SUPPORT="$HOME/Library/Application Support/Claude Seats"
+LAUNCH=1
+REMOTE=""
+LOCAL=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-launch) LAUNCH=0 ;;
+        --remote) REMOTE="$2"; shift ;;
+        --local) LOCAL=1 ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+[[ -f "$ROOT/scripts/claude_seat_quota.py" ]] || { echo "no scripts/claude_seat_quota.py under $ROOT" >&2; exit 2; }
+[[ -f "$ROOT/FLEET_TOPOLOGY.json" ]] || { echo "no FLEET_TOPOLOGY.json under $ROOT" >&2; exit 2; }
+
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources/scripts"
+swiftc -O -target arm64-apple-macos13.0 \
+    -framework AppKit -framework SwiftUI \
+    "$HERE/main.swift" -o "$APP/Contents/MacOS/ClaudeSeats"
+cp "$HERE/Info.plist" "$APP/Contents/Info.plist"
+cp "$ROOT/scripts/claude_seat_quota.py" "$APP/Contents/Resources/scripts/claude_seat_quota.py"
+cp "$ROOT/FLEET_TOPOLOGY.json" "$APP/Contents/Resources/FLEET_TOPOLOGY.json"
+codesign --force --sign - "$APP" >/dev/null 2>&1
+
+mkdir -p "$SUPPORT"
+if [[ -n "$REMOTE" ]]; then
+    printf '%s\n' "$REMOTE" > "$SUPPORT/remote"
+    echo "source: via ssh $REMOTE"
+elif [[ $LOCAL -eq 1 ]]; then
+    rm -f "$SUPPORT/remote"
+    echo "source: local"
+elif [[ -f "$SUPPORT/remote" ]]; then
+    echo "source: via ssh $(cat "$SUPPORT/remote") (kept)"
+else
+    echo "source: local"
+fi
+
+if [[ $LAUNCH -eq 1 ]]; then
+    pkill -x ClaudeSeats 2>/dev/null || true
+    open "$APP"
+fi
+echo "built: $APP"

--- a/infra/seat-widget/main.swift
+++ b/infra/seat-widget/main.swift
@@ -15,20 +15,25 @@
 import AppKit
 import SwiftUI
 
-// MARK: - Palette (claude.ai tones)
+// MARK: - Palette (Claude orange card, white type)
 
 enum Palette {
-    static let ivory = Color(red: 0.980, green: 0.976, blue: 0.961)   // #FAF9F5 card
-    static let cloud = Color(red: 0.910, green: 0.902, blue: 0.863)   // #E8E6DC track/border
-    static let ink = Color(red: 0.078, green: 0.078, blue: 0.075)     // #141413 text
-    static let slate = Color(red: 0.420, green: 0.412, blue: 0.400)   // #6B6966 secondary
-    static let kraft = Color(red: 0.831, green: 0.635, blue: 0.498)   // #D4A27F calm
-    static let clay = Color(red: 0.851, green: 0.467, blue: 0.341)    // #D97757 Claude orange
-    static let ember = Color(red: 0.690, green: 0.255, blue: 0.243)   // #B0413E saturated
+    static let clay = Color(red: 0.851, green: 0.467, blue: 0.341)     // #D97757 Claude orange
+    static let clayDeep = Color(red: 0.788, green: 0.392, blue: 0.259) // #C96442 claude.ai button
+    static let ink = Color(red: 0.078, green: 0.078, blue: 0.075)      // #141413 "full" bar
+    static let text = Color.white
+    static let muted = Color.white.opacity(0.85)
+    static let track = Color.white.opacity(0.28)
+    static let line = Color.white.opacity(0.35)
 
+    static var card: LinearGradient {
+        LinearGradient(colors: [clay, clayDeep], startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+
+    /// White while a window fills; ink once it is effectively gone (≥ 85 %).
     static func usage(_ v: Double?) -> Color {
-        guard let v else { return cloud }
-        return v >= 85 ? ember : v >= 50 ? clay : kraft
+        guard let v else { return track }
+        return v >= 85 ? ink : text
     }
 }
 
@@ -201,6 +206,12 @@ final class Model: ObservableObject {
     @Published var updatedAt: Date?
     @Published var loading = false
     @Published var source = ""
+    @Published var expanded: Bool = UserDefaults.standard.object(forKey: "expanded") as? Bool ?? true {
+        didSet {
+            UserDefaults.standard.set(expanded, forKey: "expanded")
+            onChange?()
+        }
+    }
     var onChange: (() -> Void)?
     private var timer: Timer?
 
@@ -298,17 +309,17 @@ struct QuotaBar: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 5) {
-                Text(label).font(.system(size: 10, weight: .bold)).foregroundStyle(Palette.slate)
+                Text(label).font(.system(size: 10, weight: .bold)).foregroundStyle(Palette.muted)
                 Text(Fmt.pct(pct))
                     .font(.system(size: 12, weight: .semibold, design: .rounded))
-                    .foregroundStyle(pct == nil ? Palette.slate : Palette.usage(pct))
+                    .foregroundStyle(pct == nil ? Palette.muted : Palette.usage(pct))
                 Spacer(minLength: 2)
                 Text("↻ " + Fmt.reset(reset, weekly: weekly))
-                    .font(.system(size: 10)).foregroundStyle(Palette.slate).lineLimit(1)
+                    .font(.system(size: 10)).foregroundStyle(Palette.muted).lineLimit(1)
             }
             GeometryReader { g in
                 ZStack(alignment: .leading) {
-                    Capsule().fill(Palette.cloud)
+                    Capsule().fill(Palette.track)
                     Capsule().fill(Palette.usage(pct))
                         .frame(width: g.size.width * CGFloat(min(max(pct ?? 0, 0), 100)) / 100)
                 }
@@ -327,13 +338,13 @@ struct SeatRow: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(seat.seat ?? "?")
                     .font(.system(size: 13, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(Palette.ink)
+                    .foregroundStyle(Palette.text)
                 Text(seat.shortAccount)
-                    .font(.system(size: 10)).foregroundStyle(Palette.slate).lineLimit(1)
+                    .font(.system(size: 10)).foregroundStyle(Palette.muted).lineLimit(1)
             }
             .frame(width: 118, alignment: .leading)
             if let e = seat.error {
-                Text(e).font(.system(size: 11)).foregroundStyle(Palette.ember).lineLimit(2)
+                Text(e).font(.system(size: 11)).foregroundStyle(Palette.text).lineLimit(2)
                 Spacer()
             } else {
                 QuotaBar(label: "5h", pct: seat.sessionPct, reset: seat.sessionResetsAt, weekly: false)
@@ -344,94 +355,169 @@ struct SeatRow: View {
     }
 }
 
+struct SeatChip: View {
+    let seat: Seat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Text((seat.seat ?? "?").split(separator: "/").first.map(String.init) ?? "?")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(Palette.muted)
+                Spacer(minLength: 0)
+                Text(seat.error == nil ? Fmt.pct(seat.sessionPct) : "!")
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundStyle(Palette.usage(seat.sessionPct))
+            }
+            GeometryReader { g in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Palette.track)
+                    Capsule().fill(Palette.usage(seat.sessionPct))
+                        .frame(width: g.size.width * CGFloat(min(max(seat.sessionPct ?? 0, 0), 100)) / 100)
+                }
+            }
+            .frame(height: 3)
+        }
+        .frame(width: 62)
+        .help("\(seat.seat ?? "?") \(seat.shortAccount) — 5h \(Fmt.pct(seat.sessionPct)) ↻ \(Fmt.reset(seat.sessionResetsAt, weekly: false)) · 7g \(Fmt.pct(seat.weeklyPct))")
+    }
+}
+
 struct RootView: View {
     @ObservedObject var model: Model
 
+    var header: some View {
+        HStack(spacing: 6) {
+            Circle().fill(Palette.text).frame(width: 8, height: 8)
+            Text(model.expanded ? "Claude seats" : "Claude")
+                .font(.system(size: model.expanded ? 15 : 13, weight: .medium, design: .serif))
+                .foregroundStyle(Palette.text)
+                .onTapGesture { model.expanded.toggle() }
+            Spacer(minLength: 4)
+            if model.expanded, let t = model.updatedAt {
+                Text("agg. " + Fmt.hm.string(from: t) + (model.source == "local" ? "" : " · " + model.source))
+                    .font(.system(size: 10)).foregroundStyle(Palette.muted)
+            }
+            if model.loading {
+                ProgressView().controlSize(.mini).tint(.white)
+            } else {
+                Button { model.refresh() } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Palette.text)
+                }
+                .buttonStyle(.borderless)
+                .help("Aggiorna adesso")
+            }
+            Button { model.expanded.toggle() } label: {
+                Image(systemName: model.expanded ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(Palette.text)
+            }
+            .buttonStyle(.borderless)
+            .help(model.expanded ? "Riduci" : "Espandi")
+        }
+        .frame(minHeight: 22)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
-                Circle().fill(Palette.clay).frame(width: 10, height: 10)
-                Text("Claude seats")
-                    .font(.system(size: 16, weight: .medium, design: .serif))
-                    .foregroundStyle(Palette.ink)
-                Spacer()
-                if let t = model.updatedAt {
-                    Text("agg. " + Fmt.hm.string(from: t) + (model.source == "local" ? "" : " · " + model.source))
-                        .font(.system(size: 10)).foregroundStyle(Palette.slate)
-                }
-                if model.loading {
-                    ProgressView().controlSize(.small)
+            header
+            if model.expanded {
+                Rectangle().fill(Palette.line).frame(height: 1)
+                if model.seats.isEmpty {
+                    Text(model.loading ? "misuro i sei seat…" : (model.note ?? "nessun dato"))
+                        .font(.system(size: 12)).foregroundStyle(Palette.muted)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 40)
                 } else {
-                    Button { model.refresh() } label: {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(Palette.clay)
-                    }
-                    .buttonStyle(.borderless)
-                    .help("Aggiorna adesso")
+                    ForEach(model.seats) { SeatRow(seat: $0) }
                 }
-            }
-            Rectangle().fill(Palette.cloud).frame(height: 1)
-            if model.seats.isEmpty {
-                Text(model.loading ? "misuro i sei seat…" : (model.note ?? "nessun dato"))
-                    .font(.system(size: 12)).foregroundStyle(Palette.slate)
+                if !model.seats.isEmpty, let n = model.note {
+                    Text(n).font(.system(size: 10)).foregroundStyle(Palette.text).lineLimit(2)
+                }
+                if model.hidden > 0 {
+                    Text("\(model.hidden) vecchi login ignorati")
+                        .font(.system(size: 10)).foregroundStyle(Palette.muted.opacity(0.8))
+                }
+            } else if model.seats.isEmpty {
+                Text(model.loading ? "misuro…" : "nessun dato")
+                    .font(.system(size: 11)).foregroundStyle(Palette.muted)
                     .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, 40)
+                    .padding(.vertical, 24)
             } else {
-                ForEach(model.seats) { SeatRow(seat: $0) }
-            }
-            if !model.seats.isEmpty, let n = model.note {
-                Text(n).font(.system(size: 10)).foregroundStyle(Palette.ember).lineLimit(2)
-            }
-            if model.hidden > 0 {
-                Text("\(model.hidden) vecchi login ignorati")
-                    .font(.system(size: 10)).foregroundStyle(Palette.slate.opacity(0.7))
+                LazyVGrid(columns: [GridItem(.fixed(62), spacing: 10), GridItem(.fixed(62), spacing: 0)],
+                          alignment: .leading, spacing: 9) {
+                    ForEach(model.seats) { SeatChip(seat: $0) }
+                }
+                .padding(.top, 2)
             }
         }
-        .padding(.horizontal, 14)
-        .padding(.top, 26)
-        .padding(.bottom, 12)
-        .frame(width: 560, alignment: .top)
-        .background(Palette.ivory)
-        .environment(\.colorScheme, .light)
+        .padding(.horizontal, 12)
+        .padding(.top, 9)
+        .padding(.bottom, model.expanded ? 12 : 11)
+        .frame(width: model.expanded ? 560 : 158, alignment: .top)
+        .background(Palette.card)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .environment(\.colorScheme, .dark)
+        .contextMenu {
+            Button("Aggiorna adesso") { model.refresh() }
+            Button(model.expanded ? "Riduci" : "Espandi") { model.expanded.toggle() }
+            Divider()
+            Button("Esci") { NSApp.terminate(nil) }
+        }
     }
 }
 
 // MARK: - App
 
+/// Borderless panels refuse key status by default; the ↻ button needs it for a first click.
+final class WidgetPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     let model = Model()
-    var panel: NSPanel!
+    var panel: WidgetPanel!
     var host: NSHostingView<RootView>!
 
-    /// Keep the panel exactly as tall as its content, anchored at the top edge.
+    /// Size the panel to its content. The top edge stays put; the horizontal anchor is the
+    /// screen edge the panel is nearer to, so a corner widget collapses into its corner.
     func fit() {
-        let h = host.fittingSize.height
-        guard h > 0, abs(panel.frame.height - h) > 1 else { return }
+        let size = host.fittingSize
+        guard size.width > 0, size.height > 0 else { return }
         var f = panel.frame
-        f.origin.y = f.maxY - h
-        f.size.height = h
+        if abs(f.width - size.width) < 1, abs(f.height - size.height) < 1 { return }
+        let screen = panel.screen ?? NSScreen.main
+        let anchorRight = screen.map { f.midX > $0.frame.midX } ?? false
+        let maxX = f.maxX, maxY = f.maxY
+        f.size = size
+        f.origin.y = maxY - size.height
+        if anchorRight { f.origin.x = maxX - size.width }
         panel.setFrame(f, display: true, animate: false)
     }
 
     func applicationDidFinishLaunching(_ note: Notification) {
         host = NSHostingView(rootView: RootView(model: model))
         host.sizingOptions = [.intrinsicContentSize]
-        model.onChange = { [weak self] in DispatchQueue.main.async { self?.fit() } }
-        panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 560, height: 320),
-                        styleMask: [.titled, .closable, .nonactivatingPanel, .utilityWindow, .fullSizeContentView],
-                        backing: .buffered, defer: false)
+        model.onChange = { [weak self] in
+            DispatchQueue.main.async { self?.fit() }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { self?.fit() }
+        }
+        panel = WidgetPanel(contentRect: NSRect(x: 0, y: 0, width: 560, height: 320),
+                            styleMask: [.borderless, .nonactivatingPanel],
+                            backing: .buffered, defer: false)
         panel.title = "Claude seats"
-        panel.titleVisibility = .hidden
-        panel.titlebarAppearsTransparent = true
         panel.isMovableByWindowBackground = true
-        panel.level = .floating
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        // Nailed to the desktop: one notch above the Finder icons, under every app window.
+        panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.desktopIconWindow)) + 1)
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
         panel.hidesOnDeactivate = false
         panel.isReleasedWhenClosed = false
         panel.isOpaque = false
         panel.backgroundColor = .clear
+        panel.hasShadow = true
         panel.delegate = self
         panel.contentView = host
         panel.setFrameAutosaveName("ClaudeSeatsPanel")
@@ -439,7 +525,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             let v = screen.visibleFrame
             panel.setFrameOrigin(NSPoint(x: v.maxX - 560 - 24, y: v.maxY - 320 - 24))
         }
-        panel.makeKeyAndOrderFront(nil)
+        panel.orderFrontRegardless()
         fit()
         model.start(every: 30 * 60)
     }

--- a/infra/seat-widget/main.swift
+++ b/infra/seat-widget/main.swift
@@ -383,6 +383,17 @@ struct SeatChip: View {
     }
 }
 
+/// Drag the widget from any point of the card; buttons keep their clicks.
+struct DragAnywhere: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 15, *) {
+            content.gesture(WindowDragGesture())
+        } else {
+            content
+        }
+    }
+}
+
 struct RootView: View {
     @ObservedObject var model: Model
 
@@ -460,6 +471,7 @@ struct RootView: View {
         .background(Palette.card)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .environment(\.colorScheme, .dark)
+        .modifier(DragAnywhere())
         .contextMenu {
             Button("Aggiorna adesso") { model.refresh() }
             Button(model.expanded ? "Riduci" : "Espandi") { model.expanded.toggle() }

--- a/infra/seat-widget/main.swift
+++ b/infra/seat-widget/main.swift
@@ -1,0 +1,454 @@
+// Claude Seats — a floating desk widget for the six Claude seats.
+//
+// One button, one number per window: it runs claude_seat_quota.py --json (the only
+// measured source of quota on this fleet) and draws each seat's 5h and weekly usage with
+// its reset. The widget never talks to the endpoint itself and never sees a token; it
+// shells out to the script exactly as a human would, so the two can never disagree.
+//
+// The script and FLEET_TOPOLOGY.json are bundled into the .app at build time, so the
+// widget does not depend on the state of any checkout. Quota is Keychain-backed and only
+// readable on the machine that holds the logged-in profiles (Pro); on any other machine
+// build.sh --remote pro writes a one-line config and the widget measures over ssh.
+//
+// Build: infra/seat-widget/build.sh [--remote HOST] [--no-launch]
+
+import AppKit
+import SwiftUI
+
+// MARK: - Palette (claude.ai tones)
+
+enum Palette {
+    static let ivory = Color(red: 0.980, green: 0.976, blue: 0.961)   // #FAF9F5 card
+    static let cloud = Color(red: 0.910, green: 0.902, blue: 0.863)   // #E8E6DC track/border
+    static let ink = Color(red: 0.078, green: 0.078, blue: 0.075)     // #141413 text
+    static let slate = Color(red: 0.420, green: 0.412, blue: 0.400)   // #6B6966 secondary
+    static let kraft = Color(red: 0.831, green: 0.635, blue: 0.498)   // #D4A27F calm
+    static let clay = Color(red: 0.851, green: 0.467, blue: 0.341)    // #D97757 Claude orange
+    static let ember = Color(red: 0.690, green: 0.255, blue: 0.243)   // #B0413E saturated
+
+    static func usage(_ v: Double?) -> Color {
+        guard let v else { return cloud }
+        return v >= 85 ? ember : v >= 50 ? clay : kraft
+    }
+}
+
+// MARK: - Data
+
+struct Seat: Decodable, Identifiable {
+    let account: String?
+    var seat: String?
+    let sessionPct: Double?
+    let weeklyPct: Double?
+    let sessionResetsAt: String?
+    let weeklyResetsAt: String?
+    let error: String?
+    let stale: Bool?
+
+    var id: String { (seat ?? "?") + "|" + (account ?? "?") }
+
+    enum CodingKeys: String, CodingKey {
+        case account, seat, error, stale
+        case sessionPct = "session_pct"
+        case weeklyPct = "weekly_pct"
+        case sessionResetsAt = "session_resets_at"
+        case weeklyResetsAt = "weekly_resets_at"
+    }
+
+    var shortAccount: String {
+        guard let account else { return "?" }
+        let parts = account.split(separator: "@", maxSplits: 1).map(String.init)
+        if parts.count == 2, parts[1] == "gmail.com" { return parts[0] }
+        return account
+    }
+}
+
+enum Paths {
+    static let support = NSHomeDirectory() + "/Library/Application Support/Claude Seats"
+    static let remoteConfig = support + "/remote"
+    static let log = NSHomeDirectory() + "/Library/Logs/SeatWidget.log"
+
+    static var repo: String? {
+        let home = NSHomeDirectory()
+        let roots = [ProcessInfo.processInfo.environment["NUZANTARA_REPO"],
+                     home + "/nuzantara", home + "/Desktop/nuzantara"].compactMap { $0 }
+        return roots.first { FileManager.default.fileExists(atPath: $0 + "/scripts/claude_seat_quota.py") }
+    }
+
+    /// Bundled copy first (frozen at build time), a checkout only when explicitly named.
+    static var script: String? {
+        if let r = ProcessInfo.processInfo.environment["NUZANTARA_REPO"] {
+            return r + "/scripts/claude_seat_quota.py"
+        }
+        if let res = Bundle.main.resourcePath,
+           FileManager.default.fileExists(atPath: res + "/scripts/claude_seat_quota.py") {
+            return res + "/scripts/claude_seat_quota.py"
+        }
+        return repo.map { $0 + "/scripts/claude_seat_quota.py" }
+    }
+
+    static var topology: String? {
+        if let res = Bundle.main.resourcePath,
+           FileManager.default.fileExists(atPath: res + "/FLEET_TOPOLOGY.json") {
+            return res + "/FLEET_TOPOLOGY.json"
+        }
+        return repo.map { $0 + "/FLEET_TOPOLOGY.json" }
+    }
+
+    static var remoteHost: String? {
+        guard let s = try? String(contentsOfFile: remoteConfig, encoding: .utf8) else { return nil }
+        let host = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        return host.isEmpty ? nil : host
+    }
+}
+
+enum Labels {
+    /// email -> "A2/_5" from FLEET_TOPOLOGY.json accounts.anthropic.slots (same rule as the script).
+    static let byEmail: [String: String] = {
+        guard let p = Paths.topology, let data = FileManager.default.contents(atPath: p),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accounts = root["accounts"] as? [String: Any],
+              let anthropic = accounts["anthropic"] as? [String: Any],
+              let slots = anthropic["slots"] as? [String: Any]
+        else { return [:] }
+        var out: [String: String] = [:]
+        for (label, raw) in slots {
+            guard let slot = raw as? [String: Any], let email = slot["email"] as? String else { continue }
+            let tok = (slot["oauth_token_slot"] as? String ?? "").split(separator: "_").last.map(String.init) ?? ""
+            out[email.lowercased()] = Int(tok) != nil ? "\(label)/_\(tok)" : label
+        }
+        return out
+    }()
+}
+
+enum Quota {
+    struct Outcome {
+        var seats: [Seat] = []
+        var hidden = 0
+        var note: String?
+        var failure: String?
+        var source = "local"
+    }
+
+    static func measure() -> Outcome {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        var env = ProcessInfo.processInfo.environment
+        let home = NSHomeDirectory()
+        env["PATH"] = "/opt/homebrew/bin:\(home)/.local/bin:" + (env["PATH"] ?? "/usr/bin:/bin")
+        for k in ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR"] {
+            env.removeValue(forKey: k)
+        }
+        proc.environment = env
+        var source = "local"
+        if let host = Paths.remoteHost {
+            source = "via \(host)"
+            let remote = "export PATH=/opt/homebrew/bin:$HOME/.local/bin:$PATH; "
+                + "for r in $HOME/nuzantara $HOME/Desktop/nuzantara; do "
+                + "[ -f $r/scripts/claude_seat_quota.py ] && exec python3 $r/scripts/claude_seat_quota.py --json; "
+                + "done; echo 'claude_seat_quota.py non trovato sul peer' >&2; exit 2"
+            proc.arguments = ["-lc", "exec ssh -o BatchMode=yes -o ConnectTimeout=10 '\(host)' '\(remote)'"]
+        } else if let script = Paths.script {
+            proc.arguments = ["-lc", "exec python3 '\(script)' --json"]
+        } else {
+            return Outcome(failure: "claude_seat_quota.py non trovato (imposta NUZANTARA_REPO)")
+        }
+        let out = Pipe(), err = Pipe()
+        proc.standardOutput = out
+        proc.standardError = err
+        proc.standardInput = FileHandle.nullDevice
+        do { try proc.run() } catch {
+            return Outcome(failure: "avvio fallito: \(error.localizedDescription)", source: source)
+        }
+        let watchdog = DispatchWorkItem { if proc.isRunning { proc.terminate() } }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 300, execute: watchdog)
+        var errData = Data()
+        let errThread = Thread { errData = err.fileHandleForReading.readDataToEndOfFile() }
+        errThread.start()
+        let outData = out.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        while errThread.isExecuting { usleep(10_000) }
+        watchdog.cancel()
+
+        let stderr = String(decoding: errData, as: UTF8.self)
+            .split(separator: "\n").last.map(String.init) ?? ""
+        let stdout = String(decoding: outData, as: UTF8.self)
+        guard let a = stdout.firstIndex(of: "["), let b = stdout.lastIndex(of: "]"),
+              let rows = try? JSONDecoder().decode([Seat].self, from: Data(stdout[a...b].utf8)),
+              !rows.isEmpty
+        else {
+            let why = stderr.isEmpty ? "exit \(proc.terminationStatus), nessun JSON" : stderr
+            return Outcome(failure: why, source: source)
+        }
+        var o = Outcome(source: source)
+        o.seats = rows.filter { $0.account != nil }.map { row in
+            var r = row
+            if r.seat == nil, let e = r.account { r.seat = Labels.byEmail[e.lowercased()] }
+            return r
+        }.sorted { ($0.seat ?? "~") < ($1.seat ?? "~") }
+        o.hidden = rows.count - o.seats.count
+        if proc.terminationStatus != 0, !stderr.isEmpty { o.note = stderr }
+        return o
+    }
+}
+
+// MARK: - Model
+
+@MainActor
+final class Model: ObservableObject {
+    @Published var seats: [Seat] = []
+    @Published var hidden = 0
+    @Published var note: String?
+    @Published var updatedAt: Date?
+    @Published var loading = false
+    @Published var source = ""
+    var onChange: (() -> Void)?
+    private var timer: Timer?
+
+    func start(every seconds: TimeInterval) {
+        refresh()
+        timer = Timer.scheduledTimer(withTimeInterval: seconds, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+    }
+
+    func refresh() {
+        guard !loading else { return }
+        loading = true
+        let started = Date()
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome = Quota.measure()
+            DispatchQueue.main.async { self.apply(outcome, started: started) }
+        }
+    }
+
+    private func apply(_ o: Quota.Outcome, started: Date) {
+        loading = false
+        source = o.source
+        defer { onChange?() }
+        let secs = Int(Date().timeIntervalSince(started))
+        if let f = o.failure {
+            note = f
+            log("err \(secs)s \(o.source): \(f)")
+            return
+        }
+        seats = o.seats
+        hidden = o.hidden
+        note = o.note
+        updatedAt = Date()
+        log("ok \(secs)s \(o.source) seats=\(o.seats.count) hidden=\(o.hidden)"
+            + (o.note.map { " note=\($0)" } ?? ""))
+    }
+
+    private func log(_ line: String) {
+        let data = Data("\(ISO8601DateFormatter().string(from: Date())) \(line)\n".utf8)
+        if let h = FileHandle(forWritingAtPath: Paths.log) {
+            h.seekToEndOfFile()
+            h.write(data)
+            h.closeFile()
+        } else {
+            FileManager.default.createFile(atPath: Paths.log, contents: data)
+        }
+    }
+}
+
+// MARK: - Formatting
+
+enum Fmt {
+    static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    static let isoPlain: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+    static func clock(_ pattern: String) -> DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "it_IT")
+        f.dateFormat = pattern
+        return f
+    }
+    static let hm = clock("HH:mm")
+    static let dayHm = clock("EEE d HH:mm")
+
+    static func reset(_ s: String?, weekly: Bool, now: Date = Date()) -> String {
+        guard let s, let d = iso.date(from: s) ?? isoPlain.date(from: s) else { return "–" }
+        let mins = Int(d.timeIntervalSince(now) / 60)
+        let rel: String
+        if mins <= 0 { rel = "passato" }
+        else if mins < 60 { rel = "\(mins)m" }
+        else if mins < 1440 { rel = String(format: "%dh%02d", mins / 60, mins % 60) }
+        else { rel = String(format: "%dg%02dh", mins / 1440, (mins / 60) % 24) }
+        return "\((weekly ? dayHm : hm).string(from: d)) · \(rel)"
+    }
+
+    static func pct(_ v: Double?) -> String { v.map { "\(Int($0.rounded()))%" } ?? "–" }
+}
+
+// MARK: - Views
+
+struct QuotaBar: View {
+    let label: String
+    let pct: Double?
+    let reset: String?
+    let weekly: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 5) {
+                Text(label).font(.system(size: 10, weight: .bold)).foregroundStyle(Palette.slate)
+                Text(Fmt.pct(pct))
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundStyle(pct == nil ? Palette.slate : Palette.usage(pct))
+                Spacer(minLength: 2)
+                Text("↻ " + Fmt.reset(reset, weekly: weekly))
+                    .font(.system(size: 10)).foregroundStyle(Palette.slate).lineLimit(1)
+            }
+            GeometryReader { g in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Palette.cloud)
+                    Capsule().fill(Palette.usage(pct))
+                        .frame(width: g.size.width * CGFloat(min(max(pct ?? 0, 0), 100)) / 100)
+                }
+            }
+            .frame(height: 6)
+        }
+        .frame(width: 190)
+    }
+}
+
+struct SeatRow: View {
+    let seat: Seat
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(seat.seat ?? "?")
+                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(Palette.ink)
+                Text(seat.shortAccount)
+                    .font(.system(size: 10)).foregroundStyle(Palette.slate).lineLimit(1)
+            }
+            .frame(width: 118, alignment: .leading)
+            if let e = seat.error {
+                Text(e).font(.system(size: 11)).foregroundStyle(Palette.ember).lineLimit(2)
+                Spacer()
+            } else {
+                QuotaBar(label: "5h", pct: seat.sessionPct, reset: seat.sessionResetsAt, weekly: false)
+                QuotaBar(label: "7g", pct: seat.weeklyPct, reset: seat.weeklyResetsAt, weekly: true)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct RootView: View {
+    @ObservedObject var model: Model
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Circle().fill(Palette.clay).frame(width: 10, height: 10)
+                Text("Claude seats")
+                    .font(.system(size: 16, weight: .medium, design: .serif))
+                    .foregroundStyle(Palette.ink)
+                Spacer()
+                if let t = model.updatedAt {
+                    Text("agg. " + Fmt.hm.string(from: t) + (model.source == "local" ? "" : " · " + model.source))
+                        .font(.system(size: 10)).foregroundStyle(Palette.slate)
+                }
+                if model.loading {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Button { model.refresh() } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Palette.clay)
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Aggiorna adesso")
+                }
+            }
+            Rectangle().fill(Palette.cloud).frame(height: 1)
+            if model.seats.isEmpty {
+                Text(model.loading ? "misuro i sei seat…" : (model.note ?? "nessun dato"))
+                    .font(.system(size: 12)).foregroundStyle(Palette.slate)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 40)
+            } else {
+                ForEach(model.seats) { SeatRow(seat: $0) }
+            }
+            if !model.seats.isEmpty, let n = model.note {
+                Text(n).font(.system(size: 10)).foregroundStyle(Palette.ember).lineLimit(2)
+            }
+            if model.hidden > 0 {
+                Text("\(model.hidden) vecchi login ignorati")
+                    .font(.system(size: 10)).foregroundStyle(Palette.slate.opacity(0.7))
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 26)
+        .padding(.bottom, 12)
+        .frame(width: 560, alignment: .top)
+        .background(Palette.ivory)
+        .environment(\.colorScheme, .light)
+    }
+}
+
+// MARK: - App
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    let model = Model()
+    var panel: NSPanel!
+    var host: NSHostingView<RootView>!
+
+    /// Keep the panel exactly as tall as its content, anchored at the top edge.
+    func fit() {
+        let h = host.fittingSize.height
+        guard h > 0, abs(panel.frame.height - h) > 1 else { return }
+        var f = panel.frame
+        f.origin.y = f.maxY - h
+        f.size.height = h
+        panel.setFrame(f, display: true, animate: false)
+    }
+
+    func applicationDidFinishLaunching(_ note: Notification) {
+        host = NSHostingView(rootView: RootView(model: model))
+        host.sizingOptions = [.intrinsicContentSize]
+        model.onChange = { [weak self] in DispatchQueue.main.async { self?.fit() } }
+        panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 560, height: 320),
+                        styleMask: [.titled, .closable, .nonactivatingPanel, .utilityWindow, .fullSizeContentView],
+                        backing: .buffered, defer: false)
+        panel.title = "Claude seats"
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.isMovableByWindowBackground = true
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.delegate = self
+        panel.contentView = host
+        panel.setFrameAutosaveName("ClaudeSeatsPanel")
+        if !panel.setFrameUsingName("ClaudeSeatsPanel"), let screen = NSScreen.main {
+            let v = screen.visibleFrame
+            panel.setFrameOrigin(NSPoint(x: v.maxX - 560 - 24, y: v.maxY - 320 - 24))
+        }
+        panel.makeKeyAndOrderFront(nil)
+        fit()
+        model.start(every: 30 * 60)
+    }
+
+    func windowWillClose(_ notification: Notification) { NSApp.terminate(nil) }
+}
+
+let app = NSApplication.shared
+let delegate = MainActor.assumeIsolated { AppDelegate() }
+app.delegate = delegate
+app.setActivationPolicy(.accessory)
+app.run()


### PR DESCRIPTION
## What

Zero asked, in one sitting, for "a nice widget on the desk that refreshes with a button", then: the real Claude colours (orange card, white type), nailed to the desktop and hidden under app windows, collapsible to a small square, draggable, and installed on M5 too. `infra/seat-widget/` — four new files, plus the Gear-2 brief. Nothing else in the repo changes.

- `main.swift`: SwiftUI panel, borderless, at the desktop-icon level (`CGWindowLevelForKey(.desktopIconWindow) + 1`, all Spaces, stationary) — under every app window, there whenever the desktop is. Header with ↻ and "agg. HH:MM"; **open** = one row per seat with the label from `FLEET_TOPOLOGY.json` (`A2/_5`), a 5h bar and a weekly bar, each with its percentage and reset (local time + countdown); **closed** = 158-px square with a 2×3 grid of the six seats' 5h usage. `WindowDragGesture` on the card (drag from anywhere, buttons keep their clicks), position and open/closed state remembered. Right-click → Aggiorna / Riduci / Esci. Self-refresh every 30 min. Palette: card `#D97757 → #C96442`, white type, white bars that turn ink at 85 %.
- The widget never reads a token and never calls the endpoint: it runs `claude_seat_quota.py --json` exactly as a human would, with `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` / `CLAUDE_CONFIG_DIR` stripped from the child env. Script + topology are **bundled into the .app** at build time; `NUZANTARA_REPO` overrides for development.
- Remote mode: `build.sh --remote pro` writes one host name under `~/Library/Application Support/Claude Seats/remote` and the widget measures over `ssh -o BatchMode=yes pro …`. Needed on M5, whose Keychain holds only stale Claude entries (measured today: every entry "no access token").
- `build.sh`: swiftc one-file build → `~/Applications/Claude Seats.app`, ad-hoc signed, `--remote HOST` / `--local` / `--no-launch`. `README.md` for the two commands and the log path.
- `evidence/2026-09/agent-nuzantara-infra-seat-widget-92a1cdbb/brief.yml`: Gear 2 by SIZE (639 net lines, four new files; path term 1) — the floor check computed 2 on the first push and asked for it.

## Bites

**Consumer:** Zero on Pro and on M5, looking at the desktop.
**Observations, from `~/Library/Logs/SeatWidget.log` written by the running app (one line per refresh, never a token), all on the `main.swift` of this head (`f1a9e0f9d47c988a…`):**

| machine | build | refresh line |
|---|---|---|
| Pro (`nuzantara@Nuzantara`) | `build.sh --local`, local Keychain profiles | `2026-09-10T23:55:46Z ok 32s local seats=6 hidden=3` |
| M5 (`balizero@Air-M5`) | `build.sh --remote pro` from a staged copy of this exact tree (sha16 verified on both hosts), rebuilt 23:59:15Z, new pid | `2026-09-10T23:59:29Z ok 17s via pro seats=6 hidden=3` |

Pro screenshots at 07:50–07:51 WITA: the collapsed square on the desktop with the six chips (A1 2% · A2 51% · A3 5% · A4 0% · A5 17% · AZ 39%), and the open card sitting UNDER the terminal window with all six rows in white on orange. M5's screen cannot be captured over ssh (TCC); its log line is the proof there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
