### PR TITLE
fix(harness): exclude the nightly-generated docs/AUTOMATIONS_REFERENCE.md from the size term

### DIFF
--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -873,9 +873,23 @@ SIZE_TERM_EXCLUDE_FILENAMES: tuple[str, ...] = (
 #: means exempting by FULL PATH, not name. Only these two exact,
 #: currently-real paths are exempted; a genuine future sibling (e.g. a
 #: split requirements-dev.lock.txt) needs its own literal added here.
+#:
+#: `docs/AUTOMATIONS_REFERENCE.md` (2026-09-11, measured on PR #6184, the FIRST
+#: PR the nightly promote job — `scripts/automations-reference-cron-wrapper.sh`
+#: → `scripts/generate_automations_reference.py` — ever opened): a full
+#: machine regeneration from live launchd/cron state churned 483 lines
+#: (240+/243-) in that ONE file, net -3, floor==2 via the SIZE term alone,
+#: and the job by construction carries no evidence/brief.yml — so the very
+#: first promote PR was BLOCKED on "Harness floor recompute" and every
+#: nightly after it would be too. Same class as the translations below: a
+#: GENERATED artifact of the system state (the generator is the reviewable
+#: object, and it lives under scripts/ where it counts in full). Exact
+#: path, never a basename: a hand-written `AUTOMATIONS_REFERENCE.md`
+#: anywhere else in the tree still counts.
 SIZE_TERM_EXCLUDE_EXACT_PATHS: tuple[str, ...] = (
     "apps/backend-rag/requirements.lock.txt",
     "apps/backend-rag/requirements-prod.lock.txt",
+    "docs/AUTOMATIONS_REFERENCE.md",
 )
 SIZE_TERM_EXCLUDE_SUFFIXES: tuple[str, ...] = (
     ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico", ".bmp",

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -899,6 +899,33 @@ def test_size_term_net_lines_pip_compile_lockfile_excluded_2026_09_02():
     assert _size_term_net_lines(numstat) == 102
 
 
+def test_size_term_net_lines_generated_automations_reference_excluded_2026_09_11():
+    """GUILT->INNOCENCE (2026-09-11): the nightly-regenerated
+    `docs/AUTOMATIONS_REFERENCE.md` is a machine artifact of live
+    launchd/cron state (scripts/generate_automations_reference.py). This
+    is the ACTUAL numstat of PR #6184, the first PR the promote job ever
+    opened: 483 churned lines in one file, net -3, no brief by
+    construction — BLOCKED at floor==2 via the SIZE term alone. The
+    generated doc is excluded; a change to the generator itself, in the
+    same PR, still counts in full."""
+    numstat = (
+        "240\t243\tdocs/AUTOMATIONS_REFERENCE.md\n"
+        "12\t3\tscripts/generate_automations_reference.py\n"
+    )
+    assert _size_term_net_lines(numstat) == 15
+
+
+def test_size_term_net_lines_guilt_automations_reference_basename_elsewhere_counts_2026_09_11():
+    """GUILT (guard-over-match, superscar #3): the exemption is the exact
+    repo-relative path the generator writes, not the basename — a
+    same-named hand-written file in another directory counts in full."""
+    numstat = (
+        "240\t243\tresearch/AUTOMATIONS_REFERENCE.md\n"
+        "240\t243\tdocs/archive/AUTOMATIONS_REFERENCE.md\n"
+    )
+    assert _size_term_net_lines(numstat) == 966
+
+
 def test_size_term_net_lines_innocence_similarly_named_file_not_matched():
     """INNOCENCE (guard-over-match, superscar #3): the exemption is two
     EXACT literals, not a `requirements*` prefix or `.lock.txt` suffix


### PR DESCRIPTION
## Why
PR #6184 is the first PR the nightly promote job (`scripts/automations-reference-cron-wrapper.sh`, live since #6169/#6180) ever opened. It regenerates `docs/AUTOMATIONS_REFERENCE.md` from live launchd/cron state: 483 churned lines (240+/243-), net -3, floor==2 via the SIZE term alone, no `evidence/brief.yml` by construction. "Harness floor recompute" BLOCKED it, and would block every nightly after it.

## What
- `SIZE_TERM_EXCLUDE_EXACT_PATHS` gains `docs/AUTOMATIONS_REFERENCE.md` — exact repo-relative path, never a basename. Same class as the generated translations and pip-compile lockfiles already excluded: the reviewable object is the generator under `scripts/`, which still counts in full.
- Tests: innocence (the actual #6184 numstat + a generator edit → 15 lines counted, floor 1) and guilt (same basename under `research/` or `docs/archive/` → counts in full).

## Bites
Consumer: the `Harness floor recompute` required check on PR #6184. Observation: after this merges, `gh pr update-branch 6184` and the check goes green with floor==1 (locally on #6184's numstat: `size_term=0 floor=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)