### PR TITLE
fix(portal): every download proxy uses the Service Account, not the dead SYSTEM OAuth token

### DIFF
--- a/apps/backend-rag/backend/services/compliance/lkpm_service.py
+++ b/apps/backend-rag/backend/services/compliance/lkpm_service.py
@@ -11,7 +11,6 @@ from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import asyncpg
-import httpx
 
 from backend.app.models.lkpm import (
     DataSource,
@@ -408,48 +407,21 @@ class LKPMService:
         if not file_id:
             return None
 
-        from backend.services.integrations.google_drive_service import GoogleDriveService
+        from backend.services.portal._drive_fetch import fetch_drive_file
 
-        drive_service = GoogleDriveService(self.db_pool)
-        access_token = await drive_service.get_valid_token(GoogleDriveService.SYSTEM_USER_ID)
-        if not access_token:
-            raise RuntimeError("Receipt storage is not connected")
-
-        headers = {"Authorization": f"Bearer {access_token}"}
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            metadata_response = await client.get(
-                f"https://www.googleapis.com/drive/v3/files/{file_id}",
-                params={"fields": "mimeType,name,size"},
-                headers=headers,
-            )
-            if metadata_response.status_code == 404:
-                return None
-            if metadata_response.status_code != 200:
-                logger.error(
-                    "LKPM receipt metadata fetch failed: status=%s",
-                    metadata_response.status_code,
-                )
-                raise RuntimeError("Failed to fetch receipt metadata")
-
-            metadata = metadata_response.json()
-            download_response = await client.get(
-                f"https://www.googleapis.com/drive/v3/files/{file_id}",
-                params={"alt": "media"},
-                headers=headers,
-            )
-            if download_response.status_code == 404:
-                return None
-            if download_response.status_code != 200:
-                logger.error(
-                    "LKPM receipt download failed: status=%s",
-                    download_response.status_code,
-                )
-                raise RuntimeError("Failed to download receipt")
+        drive_file = await fetch_drive_file(
+            file_id,
+            fallback_file_name=row["file_name"] or "lkpm-receipt.pdf",
+            fallback_mime_type="application/pdf",
+            what="receipt",
+        )
+        if drive_file is None:
+            return None
 
         return {
-            "content": download_response.content,
-            "file_name": metadata.get("name") or row["file_name"] or "lkpm-receipt.pdf",
-            "mime_type": metadata.get("mimeType") or "application/pdf",
+            "content": drive_file.content,
+            "file_name": drive_file.file_name,
+            "mime_type": drive_file.mime_type,
         }
 
     async def submit_form_data(self, submission: LKPMClientSubmission) -> LKPMDraft:

--- a/apps/backend-rag/backend/services/integrations/service_account_drive_service.py
+++ b/apps/backend-rag/backend/services/integrations/service_account_drive_service.py
@@ -181,6 +181,21 @@ class ServiceAccountDriveService:
         )
         return await asyncio.to_thread(request.execute)
 
+    async def download_file_content(self, file_id: str) -> bytes:
+        """Fetch a file's bytes via Drive API v3 `alt=media`.
+
+        The Service Account is the only Drive credential this backend still
+        has: the SYSTEM OAuth token has been deliberately dead since
+        2026-05-10 (`GoogleDriveService._refresh_token` returns None for
+        SYSTEM by design). Every download proxy therefore has to come
+        through here.
+        """
+        request = self.service.files().get_media(
+            fileId=file_id,
+            supportsAllDrives=True,
+        )
+        return await asyncio.to_thread(request.execute)
+
     async def get_file_metadata_detailed(self, file_id: str) -> dict[str, Any]:
         """Fetch read-only metadata needed by CRM Guardian evidence scans."""
         fields = (

--- a/apps/backend-rag/backend/services/portal/_drive_fetch.py
+++ b/apps/backend-rag/backend/services/portal/_drive_fetch.py
@@ -1,0 +1,82 @@
+"""One Drive read path for every portal download proxy.
+
+WHY THIS EXISTS — the portal's vault download, invoice-PDF download and LKPM
+receipt download each opened `GoogleDriveService(...).get_valid_token(SYSTEM)`
+and refused when it came back empty. It always comes back empty:
+`GoogleDriveService._refresh_token` returns None for `SYSTEM` **by design**
+since 2026-05-10 ("OAuth SYSTEM disabled — Drive operations use
+ServiceAccountDriveService"), and the stored SYSTEM token expired
+2026-06-15. So all three proxies raised, and the routers turned that into a
+generic HTTP 500 — measured live 2026-09-11 on a client's own document:
+`GET /api/portal/documents/<id>/download` → 500
+`{"detail":"Failed to download document"}`, with the vault's DOWNLOAD button
+failing silently (portal audit finding F-01).
+
+Uploads had already moved to the Service Account, which is also the identity
+that owns the files it wrote — so the reads have to use the same credential,
+not merely a working one.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DriveFile:
+    content: bytes
+    file_name: str
+    mime_type: str
+
+
+def _is_not_found(exc: Exception) -> bool:
+    """True when Drive answered 404/410 — the file is gone, not broken."""
+    status = getattr(getattr(exc, "resp", None), "status", None)
+    if status is None:
+        status = getattr(exc, "status_code", None)
+    return status in (404, 410)
+
+
+async def fetch_drive_file(
+    file_id: str,
+    *,
+    fallback_file_name: str,
+    fallback_mime_type: str,
+    what: str,
+) -> DriveFile | None:
+    """Read a Drive file through the Service Account.
+
+    Returns None when Drive reports the file as missing (the caller turns
+    that into a 404, not a 500). Raises RuntimeError on any other failure so
+    a real outage is not misreported as "your document does not exist".
+    """
+    from backend.services.integrations.service_account_drive_service import (
+        ServiceAccountDriveService,
+    )
+
+    sa_drive = ServiceAccountDriveService()
+
+    try:
+        metadata = await sa_drive.get_file_metadata(file_id)
+    except Exception as e:
+        if _is_not_found(e):
+            return None
+        logger.error("Portal %s metadata fetch failed: %s", what, e)
+        raise RuntimeError(f"Failed to fetch {what} metadata") from e
+
+    try:
+        content = await sa_drive.download_file_content(file_id)
+    except Exception as e:
+        if _is_not_found(e):
+            return None
+        logger.error("Portal %s download failed: %s", what, e)
+        raise RuntimeError(f"Failed to download {what}") from e
+
+    return DriveFile(
+        content=content,
+        file_name=metadata.get("name") or fallback_file_name,
+        mime_type=metadata.get("mimeType") or fallback_mime_type,
+    )

--- a/apps/backend-rag/backend/services/portal/_mixins/billing.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/billing.py
@@ -9,12 +9,12 @@ fields are whitelisted here (PROFILE_EDITABLE_FIELDS).
 from typing import Any
 
 import asyncpg
-import httpx
 
 from backend.app.services.crm.audit_logger import audit_logger
 from backend.app.utils.logging_utils import get_logger
 from backend.phone_lock import lock_phone_cores, phone_core
 from backend.services.common.cache import cache_invalidating
+from backend.services.portal._drive_fetch import fetch_drive_file
 from backend.services.portal._rbac import ClientContext, require_client_access
 from backend.services.portal.qa_document_sink import QADocumentSinkClient
 
@@ -212,45 +212,19 @@ class PortalBillingMixin:
                 "mime_type": "application/pdf",
             }
 
-        from backend.services.integrations.google_drive_service import GoogleDriveService
-
-        drive_service = GoogleDriveService(self.pool)
-        access_token = await drive_service.get_valid_token(GoogleDriveService.SYSTEM_USER_ID)
-        if not access_token:
-            raise RuntimeError("Google Drive is not connected")
-
-        headers = {"Authorization": f"Bearer {access_token}"}
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            meta_response = await client.get(
-                f"https://www.googleapis.com/drive/v3/files/{file_id}",
-                params={"fields": "mimeType,name,size"},
-                headers=headers,
-            )
-            if meta_response.status_code == 404:
-                return None
-            if meta_response.status_code != 200:
-                logger.error("Portal invoice metadata fetch failed: %s", meta_response.status_code)
-                raise RuntimeError("Failed to fetch invoice metadata")
-
-            metadata = meta_response.json()
-            mime_type = metadata.get("mimeType") or "application/pdf"
-            file_name = metadata.get("name") or f"{row['invoice_number']}.pdf"
-
-            download_response = await client.get(
-                f"https://www.googleapis.com/drive/v3/files/{file_id}",
-                params={"alt": "media"},
-                headers=headers,
-            )
-            if download_response.status_code == 404:
-                return None
-            if download_response.status_code != 200:
-                logger.error("Portal invoice download failed: %s", download_response.status_code)
-                raise RuntimeError("Failed to download invoice")
+        drive_file = await fetch_drive_file(
+            file_id,
+            fallback_file_name=f"{row['invoice_number']}.pdf",
+            fallback_mime_type="application/pdf",
+            what="invoice",
+        )
+        if drive_file is None:
+            return None
 
         return {
-            "content": download_response.content,
-            "file_name": file_name,
-            "mime_type": mime_type,
+            "content": drive_file.content,
+            "file_name": drive_file.file_name,
+            "mime_type": drive_file.mime_type,
         }
 
     # ================================================

--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -24,13 +24,13 @@ from datetime import datetime, timezone
 from typing import Any
 
 import asyncpg
-import httpx
 
 from backend.app.utils.logging_utils import get_logger
 from backend.services.common.background import spawn
 from backend.services.common.cache import cache_invalidating
 from backend.services.pii.violation_store import hash_subject
 from backend.services.portal._document_visibility import document_visibility_clause
+from backend.services.portal._drive_fetch import fetch_drive_file
 from backend.services.portal._rbac import ClientContext, require_client_access
 from backend.services.portal.document_processing import (
     DocumentOCR,
@@ -279,45 +279,19 @@ class PortalDocumentsMixin:
         if not file_id:
             return None
 
-        from backend.services.integrations.google_drive_service import GoogleDriveService
-
-        drive_service = GoogleDriveService(self.pool)
-        access_token = await drive_service.get_valid_token(GoogleDriveService.SYSTEM_USER_ID)
-        if not access_token:
-            raise RuntimeError("Google Drive is not connected")
-
-        headers = {"Authorization": f"Bearer {access_token}"}
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            meta_response = await client.get(
-                f"https://www.googleapis.com/drive/v3/files/{file_id}",
-                params={"fields": "mimeType,name,size"},
-                headers=headers,
-            )
-            if meta_response.status_code == 404:
-                return None
-            if meta_response.status_code != 200:
-                logger.error("Portal document metadata fetch failed: %s", meta_response.status_code)
-                raise RuntimeError("Failed to fetch document metadata")
-
-            metadata = meta_response.json()
-            mime_type = metadata.get("mimeType") or row["mime_type"] or "application/octet-stream"
-            file_name = metadata.get("name") or row["file_name"] or "document"
-
-            download_response = await client.get(
-                f"https://www.googleapis.com/drive/v3/files/{file_id}",
-                params={"alt": "media"},
-                headers=headers,
-            )
-            if download_response.status_code == 404:
-                return None
-            if download_response.status_code != 200:
-                logger.error("Portal document download failed: %s", download_response.status_code)
-                raise RuntimeError("Failed to download document")
+        drive_file = await fetch_drive_file(
+            file_id,
+            fallback_file_name=row["file_name"] or "document",
+            fallback_mime_type=row["mime_type"] or "application/octet-stream",
+            what="document",
+        )
+        if drive_file is None:
+            return None
 
         return {
-            "content": download_response.content,
-            "file_name": file_name,
-            "mime_type": mime_type,
+            "content": drive_file.content,
+            "file_name": drive_file.file_name,
+            "mime_type": drive_file.mime_type,
         }
 
     async def _record_timeline_event(

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_lkpm_receipt_client_safe.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_lkpm_receipt_client_safe.py
@@ -13,9 +13,11 @@ from fastapi import HTTPException, Request
 
 from backend.app.routers import lkpm as lkpm_router
 from backend.app.routers import portal as portal_router
-from backend.services.compliance import lkpm_service as service_module
 from backend.services.compliance.lkpm_service import LKPMService
 from backend.services.integrations import google_drive_service
+from backend.services.integrations import (
+    service_account_drive_service as sa_drive_module,
+)
 
 
 class _AcquireContext:
@@ -332,8 +334,26 @@ async def test_service_proxy_fetches_tenant_owned_drive_file_server_side(
     }
     service = object.__new__(LKPMService)
     service.db_pool = pool
-    monkeypatch.setattr(google_drive_service, "GoogleDriveService", _FakeDriveService)
-    monkeypatch.setattr(service_module.httpx, "AsyncClient", _FakeHTTPClient)
+
+    # Service Account, not the SYSTEM OAuth token: `_refresh_token` returns
+    # None for SYSTEM by design since 2026-05-10, so the old credential path
+    # could only 500 in production (portal audit F-01). Guilt-proof: put
+    # GoogleDriveService back and `get_valid_token` gets awaited, which the
+    # assertion below refuses.
+    sa = MagicMock()
+    sa.get_file_metadata = AsyncMock(
+        return_value={"name": "receipt.pdf", "mimeType": "application/pdf"}
+    )
+    sa.download_file_content = AsyncMock(return_value=b"synthetic-pdf")
+    oauth_cls = MagicMock()
+    oauth_cls.SYSTEM_USER_ID = "SYSTEM"
+    oauth_cls.return_value.get_valid_token = AsyncMock(return_value=None)
+    monkeypatch.setattr(google_drive_service, "GoogleDriveService", oauth_cls)
+    monkeypatch.setattr(
+        sa_drive_module,
+        "ServiceAccountDriveService",
+        MagicMock(return_value=sa),
+    )
 
     result = await service.download_receipt_for_portal_client(101, 81)
 
@@ -342,12 +362,9 @@ async def test_service_proxy_fetches_tenant_owned_drive_file_server_side(
         "file_name": "receipt.pdf",
         "mime_type": "application/pdf",
     }
-    assert len(_FakeHTTPClient.calls) == 2
-    assert all(raw_file_id in str(call["url"]) for call in _FakeHTTPClient.calls)
-    assert all(
-        call["headers"] == {"Authorization": "Bearer synthetic-access-token"}
-        for call in _FakeHTTPClient.calls
-    )
+    sa.get_file_metadata.assert_awaited_once_with(raw_file_id)
+    sa.download_file_content.assert_awaited_once_with(raw_file_id)
+    oauth_cls.return_value.get_valid_token.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -785,63 +785,94 @@ async def test_download_document_returns_none_without_drive_file_id() -> None:
     assert result is None
 
 
+# =============================================================================
+# F-01 (2026-09-11 portal live audit) — every portal download proxy asked
+# GoogleDriveService for the SYSTEM OAuth token, which `_refresh_token`
+# returns None for BY DESIGN since 2026-05-10 ("OAuth SYSTEM disabled — Drive
+# operations use ServiceAccountDriveService"). So the vault DOWNLOAD button
+# 500'd on every click, for every document, since that date.
+#
+# The tests that guarded this path passed by mocking `get_valid_token` to
+# return "access-token" — a value production could not obtain. That is
+# superscar #2 (esiste≠armato) inside the test suite: green, and guarding
+# nothing. They are replaced, not extended.
+# =============================================================================
+
+
+class _DriveHttpError(Exception):
+    """The shape of googleapiclient.errors.HttpError that matters here."""
+
+    def __init__(self, status: int) -> None:
+        super().__init__(f"drive returned {status}")
+        self.resp = MagicMock(status=status)
+
+
+def _sa_drive_mock(
+    *,
+    metadata: Any,
+    content: Any = b"PDF_BYTES",
+) -> MagicMock:
+    def _mock(value: Any) -> AsyncMock:
+        if isinstance(value, Exception):
+            return AsyncMock(side_effect=value)
+        return AsyncMock(return_value=value)
+
+    sa = MagicMock()
+    sa.get_file_metadata = _mock(metadata)
+    sa.download_file_content = _mock(content)
+    return sa
+
+
+def _download_row() -> dict[str, Any]:
+    return {
+        "id": 10,
+        "file_name": "passport.pdf",
+        "file_id": "drive_file_10",
+        "file_url": None,
+        "mime_type": "application/pdf",
+        "status": "received",
+    }
+
+
 @pytest.mark.asyncio
-async def test_download_document_raises_when_drive_not_connected() -> None:
-    service, _mock_conn = _make_service_with_fetchrow(
-        {
-            "id": 10,
-            "file_name": "passport.pdf",
-            "file_id": "drive_file_10",
-            "file_url": None,
-            "mime_type": "application/pdf",
-            "status": "received",
-        }
-    )
+async def test_download_document_never_consults_the_dead_oauth_token() -> None:
+    """Guilt-proof: restore `get_valid_token(SYSTEM)` as the credential and
+    this fails — production always gets None there, which is the 500."""
+    service, _mock_conn = _make_service_with_fetchrow(_download_row())
+    sa = _sa_drive_mock(metadata={"name": "passport.pdf", "mimeType": "application/pdf"})
 
-    with patch(
-        "backend.services.integrations.google_drive_service.GoogleDriveService"
-    ) as drive_cls:
-        drive_cls.SYSTEM_USER_ID = "SYSTEM"
-        drive_cls.return_value.get_valid_token = AsyncMock(return_value=None)
+    with (
+        patch(
+            "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+            return_value=sa,
+        ),
+        patch("backend.services.integrations.google_drive_service.GoogleDriveService") as oauth_cls,
+    ):
+        oauth_cls.SYSTEM_USER_ID = "SYSTEM"
+        oauth_cls.return_value.get_valid_token = AsyncMock(return_value=None)
 
-        with pytest.raises(RuntimeError, match="Google Drive is not connected"):
-            await service.download_document(
-                client_id=1,
-                document_id=10,
-                current_user={"client_id": 1, "email": "client@example.com"},
-            )
+        result = await service.download_document(
+            client_id=1,
+            document_id=10,
+            current_user={"client_id": 1, "email": "client@example.com"},
+        )
+
+    assert result is not None
+    oauth_cls.return_value.get_valid_token.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_download_document_streams_drive_file() -> None:
-    service, mock_conn = _make_service_with_fetchrow(
-        {
-            "id": 10,
-            "file_name": "passport.pdf",
-            "file_id": "drive_file_10",
-            "file_url": None,
-            "mime_type": "application/pdf",
-            "status": "received",
-        }
+    service, mock_conn = _make_service_with_fetchrow(_download_row())
+    sa = _sa_drive_mock(
+        metadata={"name": "passport-renamed.pdf", "mimeType": "application/pdf"},
+        content=b"PDF_BYTES",
     )
-    meta_response = MagicMock(status_code=200)
-    meta_response.json.return_value = {
-        "name": "passport-renamed.pdf",
-        "mimeType": "application/pdf",
-    }
-    download_response = MagicMock(status_code=200, content=b"PDF_BYTES")
-    async_http = MagicMock()
-    async_http.get = AsyncMock(side_effect=[meta_response, download_response])
 
-    with (
-        patch("backend.services.integrations.google_drive_service.GoogleDriveService") as drive_cls,
-        patch("httpx.AsyncClient") as client_cls,
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
     ):
-        drive_cls.SYSTEM_USER_ID = "SYSTEM"
-        drive_cls.return_value.get_valid_token = AsyncMock(return_value="access-token")
-        client_cls.return_value.__aenter__ = AsyncMock(return_value=async_http)
-        client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
         result = await service.download_document(
             client_id=1,
             document_id=10,
@@ -853,53 +884,70 @@ async def test_download_document_streams_drive_file() -> None:
         "file_name": "passport-renamed.pdf",
         "mime_type": "application/pdf",
     }
+    sa.download_file_content.assert_awaited_once_with("drive_file_10")
     fetch_sql = mock_conn.fetchrow.call_args.args[0]
     assert "deleted_at IS NULL" in fetch_sql
     assert "COALESCE(is_archived, FALSE) = FALSE" in fetch_sql
 
 
 @pytest.mark.asyncio
+async def test_download_document_falls_back_to_stored_name_and_mime() -> None:
+    service, _mock_conn = _make_service_with_fetchrow(_download_row())
+    sa = _sa_drive_mock(metadata={}, content=b"BYTES")
+
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
+    ):
+        result = await service.download_document(
+            client_id=1,
+            document_id=10,
+            current_user={"client_id": 1, "email": "client@example.com"},
+        )
+
+    assert result == {
+        "content": b"BYTES",
+        "file_name": "passport.pdf",
+        "mime_type": "application/pdf",
+    }
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("meta_status", "download_status", "expected_error"),
+    ("metadata", "content", "expected_error"),
     [
-        (404, None, None),
-        (503, None, "Failed to fetch document metadata"),
-        (200, 404, None),
-        (200, 500, "Failed to download document"),
+        ("__404_META__", b"", None),
+        ("__503_META__", b"", "Failed to fetch document metadata"),
+        ("__OK_META__", "__404_MEDIA__", None),
+        ("__OK_META__", "__500_MEDIA__", "Failed to download document"),
     ],
 )
 async def test_download_document_handles_drive_failures(
-    meta_status: int,
-    download_status: int | None,
+    metadata: str,
+    content: Any,
     expected_error: str | None,
 ) -> None:
-    service, _mock_conn = _make_service_with_fetchrow(
-        {
-            "id": 10,
-            "file_name": "passport.pdf",
-            "file_id": "drive_file_10",
-            "file_url": None,
-            "mime_type": "application/pdf",
-            "status": "received",
-        }
-    )
-    meta_response = MagicMock(status_code=meta_status)
-    meta_response.json.return_value = {"name": "passport.pdf", "mimeType": "application/pdf"}
-    responses = [meta_response]
-    if download_status is not None:
-        responses.append(MagicMock(status_code=download_status, content=b""))
-    async_http = MagicMock()
-    async_http.get = AsyncMock(side_effect=responses)
+    """A missing file is a 404 for the client; anything else must stay a
+    failure — never a silent "your document does not exist"."""
+    resolved_meta: Any = {"name": "p.pdf", "mimeType": "application/pdf"}
+    if metadata == "__404_META__":
+        resolved_meta = _DriveHttpError(404)
+    elif metadata == "__503_META__":
+        resolved_meta = _DriveHttpError(503)
 
-    with (
-        patch("backend.services.integrations.google_drive_service.GoogleDriveService") as drive_cls,
-        patch("httpx.AsyncClient") as client_cls,
+    resolved_content: Any = content
+    if content == "__404_MEDIA__":
+        resolved_content = _DriveHttpError(404)
+    elif content == "__500_MEDIA__":
+        resolved_content = _DriveHttpError(500)
+
+    service, _mock_conn = _make_service_with_fetchrow(_download_row())
+    sa = _sa_drive_mock(metadata=resolved_meta, content=resolved_content)
+
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
     ):
-        drive_cls.SYSTEM_USER_ID = "SYSTEM"
-        drive_cls.return_value.get_valid_token = AsyncMock(return_value="access-token")
-        client_cls.return_value.__aenter__ = AsyncMock(return_value=async_http)
-        client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
         if expected_error:
             with pytest.raises(RuntimeError, match=expected_error):
                 await service.download_document(

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_portal_service.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_portal_service.py
@@ -483,27 +483,19 @@ class TestPortalServiceDocumentDownload:
             "status": "verified",
         }
 
-        meta_response = MagicMock(status_code=200)
-        meta_response.json.return_value = {
-            "name": "passport.pdf",
-            "mimeType": "application/pdf",
-        }
-        download_response = MagicMock(status_code=200, content=b"PDF_CONTENT")
+        # Service Account, not the SYSTEM OAuth token: that token has been
+        # dead by design since 2026-05-10, which is why every portal download
+        # 500'd until 2026-09-11 (audit F-01).
+        sa = MagicMock()
+        sa.get_file_metadata = AsyncMock(
+            return_value={"name": "passport.pdf", "mimeType": "application/pdf"}
+        )
+        sa.download_file_content = AsyncMock(return_value=b"PDF_CONTENT")
 
-        async_http = MagicMock()
-        async_http.get = AsyncMock(side_effect=[meta_response, download_response])
-
-        with (
-            patch(
-                "backend.services.integrations.google_drive_service.GoogleDriveService"
-            ) as drive_cls,
-            patch("httpx.AsyncClient") as client_cls,
+        with patch(
+            "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+            return_value=sa,
         ):
-            drive_cls.SYSTEM_USER_ID = "SYSTEM"
-            drive_cls.return_value.get_valid_token = AsyncMock(return_value="access-token")
-            client_cls.return_value.__aenter__ = AsyncMock(return_value=async_http)
-            client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
             result = await portal_service.download_document(
                 1,
                 10,
@@ -516,16 +508,8 @@ class TestPortalServiceDocumentDownload:
             "mime_type": "application/pdf",
         }
         mock_conn.fetchrow.assert_called_once()
-        async_http.get.assert_any_call(
-            "https://www.googleapis.com/drive/v3/files/drive_file_123",
-            params={"fields": "mimeType,name,size"},
-            headers={"Authorization": "Bearer access-token"},
-        )
-        async_http.get.assert_any_call(
-            "https://www.googleapis.com/drive/v3/files/drive_file_123",
-            params={"alt": "media"},
-            headers={"Authorization": "Bearer access-token"},
-        )
+        sa.get_file_metadata.assert_awaited_once_with("drive_file_123")
+        sa.download_file_content.assert_awaited_once_with("drive_file_123")
 
 
 # ============================================================================

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal_billing.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal_billing.py
@@ -317,6 +317,35 @@ async def test_get_invoice_pdf_url():
     assert result == {"download_url": "/api/portal/billing/1/pdf"}
 
 
+class _DriveHttpError(Exception):
+    """The shape of googleapiclient.errors.HttpError that matters here."""
+
+    def __init__(self, status: int) -> None:
+        super().__init__(f"drive returned {status}")
+        self.resp = MagicMock(status=status)
+
+
+def _sa_drive_mock(*, metadata: object, content: object = b"PDF_INVOICE") -> MagicMock:
+    """Mock the Service Account Drive client.
+
+    The download proxies used to ask GoogleDriveService for the SYSTEM OAuth
+    token; `_refresh_token` returns None for SYSTEM BY DESIGN since
+    2026-05-10, so those calls could only ever 500 in production. The tests
+    that guarded them mocked the token to a value production cannot obtain
+    (superscar #2, esiste≠armato — inside the suite). Audit finding F-01.
+    """
+
+    def _mock(value: object) -> AsyncMock:
+        if isinstance(value, Exception):
+            return AsyncMock(side_effect=value)
+        return AsyncMock(return_value=value)
+
+    sa = MagicMock()
+    sa.get_file_metadata = _mock(metadata)
+    sa.download_file_content = _mock(content)
+    return sa
+
+
 @pytest.mark.asyncio
 async def test_download_invoice_pdf_streams_owned_invoice_drive_file():
     """download_invoice_pdf streams an invoice PDF through the portal proxy."""
@@ -331,26 +360,16 @@ async def test_download_invoice_pdf_streams_owned_invoice_drive_file():
     mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
     mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
 
-    meta_response = MagicMock(status_code=200)
-    meta_response.json.return_value = {
-        "name": "invoice.pdf",
-        "mimeType": "application/pdf",
-    }
-    download_response = MagicMock(status_code=200, content=b"PDF_INVOICE")
-
-    async_http = MagicMock()
-    async_http.get = AsyncMock(side_effect=[meta_response, download_response])
+    sa = _sa_drive_mock(
+        metadata={"name": "invoice.pdf", "mimeType": "application/pdf"},
+        content=b"PDF_INVOICE",
+    )
 
     service = PortalService(mock_pool)
-    with (
-        patch("backend.services.integrations.google_drive_service.GoogleDriveService") as drive_cls,
-        patch("httpx.AsyncClient") as client_cls,
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
     ):
-        drive_cls.SYSTEM_USER_ID = "SYSTEM"
-        drive_cls.return_value.get_valid_token = AsyncMock(return_value="access-token")
-        client_cls.return_value.__aenter__ = AsyncMock(return_value=async_http)
-        client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
         result = await service.download_invoice_pdf(
             client_id=1,
             invoice_id=1,
@@ -500,18 +519,28 @@ async def test_download_invoice_pdf_raises_when_drive_not_connected() -> None:
         }
     )
 
-    with patch(
-        "backend.services.integrations.google_drive_service.GoogleDriveService"
-    ) as drive_cls:
-        drive_cls.SYSTEM_USER_ID = "SYSTEM"
-        drive_cls.return_value.get_valid_token = AsyncMock(return_value=None)
+    sa = _sa_drive_mock(metadata={"name": "invoice.pdf", "mimeType": "application/pdf"})
 
-        with pytest.raises(RuntimeError, match="Google Drive is not connected"):
-            await service.download_invoice_pdf(
-                client_id=1,
-                invoice_id=1,
-                current_user={"client_id": 1, "email": "c1@example.com"},
-            )
+    with (
+        patch(
+            "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+            return_value=sa,
+        ),
+        patch("backend.services.integrations.google_drive_service.GoogleDriveService") as oauth_cls,
+    ):
+        oauth_cls.SYSTEM_USER_ID = "SYSTEM"
+        oauth_cls.return_value.get_valid_token = AsyncMock(return_value=None)
+
+        result = await service.download_invoice_pdf(
+            client_id=1,
+            invoice_id=1,
+            current_user={"client_id": 1, "email": "c1@example.com"},
+        )
+
+    # Guilt-proof: put `get_valid_token(SYSTEM)` back in the credential path
+    # and this fails — that token is always None, which was the 500.
+    assert result is not None
+    oauth_cls.return_value.get_valid_token.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -524,18 +553,12 @@ async def test_download_invoice_pdf_returns_none_when_metadata_is_404() -> None:
             "drive_file_id": "invoice_drive_123",
         }
     )
-    meta_response = MagicMock(status_code=404)
-    async_http = MagicMock()
-    async_http.get = AsyncMock(return_value=meta_response)
+    sa = _sa_drive_mock(metadata=_DriveHttpError(404))
 
-    with (
-        patch("backend.services.integrations.google_drive_service.GoogleDriveService") as drive_cls,
-        patch("httpx.AsyncClient") as client_cls,
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
     ):
-        drive_cls.SYSTEM_USER_ID = "SYSTEM"
-        drive_cls.return_value.get_valid_token = AsyncMock(return_value="access-token")
-        client_cls.return_value.__aenter__ = AsyncMock(return_value=async_http)
-        client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         result = await service.download_invoice_pdf(
             client_id=1,
@@ -556,18 +579,12 @@ async def test_download_invoice_pdf_raises_when_metadata_fetch_fails() -> None:
             "drive_file_id": "invoice_drive_123",
         }
     )
-    meta_response = MagicMock(status_code=503)
-    async_http = MagicMock()
-    async_http.get = AsyncMock(return_value=meta_response)
+    sa = _sa_drive_mock(metadata=_DriveHttpError(503))
 
-    with (
-        patch("backend.services.integrations.google_drive_service.GoogleDriveService") as drive_cls,
-        patch("httpx.AsyncClient") as client_cls,
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
     ):
-        drive_cls.SYSTEM_USER_ID = "SYSTEM"
-        drive_cls.return_value.get_valid_token = AsyncMock(return_value="access-token")
-        client_cls.return_value.__aenter__ = AsyncMock(return_value=async_http)
-        client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with pytest.raises(RuntimeError, match="Failed to fetch invoice metadata"):
             await service.download_invoice_pdf(
@@ -587,20 +604,15 @@ async def test_download_invoice_pdf_returns_none_when_download_is_404() -> None:
             "drive_file_id": "invoice_drive_123",
         }
     )
-    meta_response = MagicMock(status_code=200)
-    meta_response.json.return_value = {"name": "invoice.pdf", "mimeType": "application/pdf"}
-    download_response = MagicMock(status_code=404)
-    async_http = MagicMock()
-    async_http.get = AsyncMock(side_effect=[meta_response, download_response])
+    sa = _sa_drive_mock(
+        metadata={"name": "invoice.pdf", "mimeType": "application/pdf"},
+        content=_DriveHttpError(404),
+    )
 
-    with (
-        patch("backend.services.integrations.google_drive_service.GoogleDriveService") as drive_cls,
-        patch("httpx.AsyncClient") as client_cls,
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
     ):
-        drive_cls.SYSTEM_USER_ID = "SYSTEM"
-        drive_cls.return_value.get_valid_token = AsyncMock(return_value="access-token")
-        client_cls.return_value.__aenter__ = AsyncMock(return_value=async_http)
-        client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         result = await service.download_invoice_pdf(
             client_id=1,
@@ -621,20 +633,15 @@ async def test_download_invoice_pdf_raises_when_download_fails() -> None:
             "drive_file_id": "invoice_drive_123",
         }
     )
-    meta_response = MagicMock(status_code=200)
-    meta_response.json.return_value = {"name": "invoice.pdf", "mimeType": "application/pdf"}
-    download_response = MagicMock(status_code=500)
-    async_http = MagicMock()
-    async_http.get = AsyncMock(side_effect=[meta_response, download_response])
+    sa = _sa_drive_mock(
+        metadata={"name": "invoice.pdf", "mimeType": "application/pdf"},
+        content=_DriveHttpError(500),
+    )
 
-    with (
-        patch("backend.services.integrations.google_drive_service.GoogleDriveService") as drive_cls,
-        patch("httpx.AsyncClient") as client_cls,
+    with patch(
+        "backend.services.integrations.service_account_drive_service.ServiceAccountDriveService",
+        return_value=sa,
     ):
-        drive_cls.SYSTEM_USER_ID = "SYSTEM"
-        drive_cls.return_value.get_valid_token = AsyncMock(return_value="access-token")
-        client_cls.return_value.__aenter__ = AsyncMock(return_value=async_http)
-        client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with pytest.raises(RuntimeError, match="Failed to download invoice"):
             await service.download_invoice_pdf(

--- a/evidence/2026-09/agent-air-m5-backend-rag-portal-download-service-ff6c3ac3/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-portal-download-service-ff6c3ac3/brief.yml
@@ -1,0 +1,54 @@
+task: >-
+  Fix the portal download proxies: a client pressing DOWNLOAD on their own vault document got
+  HTTP 500 and no toast (measured live 2026-09-11 on document 19454 — portal audit finding
+  F-01). All three proxies (vault document, invoice PDF, LKPM receipt) asked
+  GoogleDriveService.get_valid_token("SYSTEM"), which returns None BY DESIGN since 2026-05-10
+  ("OAuth SYSTEM disabled — Drive operations use ServiceAccountDriveService"); the stored
+  SYSTEM row expired 2026-06-15. Uploads had already moved to the Service Account, which also
+  OWNS the files, so the reads must use the same credential. Adds
+  ServiceAccountDriveService.download_file_content and one shared read path
+  (services/portal/_drive_fetch.py) used by all three call sites.
+lane: backend-rag/portal-download-service-account
+machine: M5
+date: 2026-09-11
+
+gear: 2
+gear_reason: >-
+  Deterministic floor 2, source `size`: CI run 34544192384 measured the diff above the SIZE
+  term's threshold (378+/305- across 9 files, brief excluded). No hot-zone path: services and
+  tests only, no app/routers, no migration, no ingestion. The work itself is one root cause at
+  three call sites, not three problems.
+
+appetite:
+  wall_clock_hours: 1
+  adversarial_rounds: 1
+
+acceptance:
+  A1: >-
+    The vault download proxy fetches bytes through the Service Account and never consults the
+    SYSTEM OAuth token; a Drive 404/410 surfaces as a client-visible 404 while any other Drive
+    failure stays a 5xx, so an outage is never reported as "your document does not exist".
+    probe: >-
+      apps/backend-rag/.venv/bin/python -m pytest
+      backend/tests/unit/app/services/portal/test_documents_mixin.py -v
+  A2: >-
+    The invoice-PDF and LKPM-receipt proxies use the same shared read path, with a guilt-proof
+    per surface asserting get_valid_token is never called.
+    probe: >-
+      apps/backend-rag/.venv/bin/python -m pytest
+      backend/tests/unit/routers/test_portal_billing.py
+      backend/tests/unit/app/routers/test_lkpm_receipt_client_safe.py -v
+  A3: >-
+    No regression on the portal service suite, whose previous tests passed only by mocking
+    get_valid_token to return "access-token" — a value production cannot obtain (superscar #2,
+    esiste != armato, inside the test suite). They now mock only the Drive API boundary.
+    probe: >-
+      apps/backend-rag/.venv/bin/python -m pytest
+      backend/tests/unit/app/services/portal/test_portal_service.py -v
+
+out_of_scope: >-
+  Migrating the remaining non-portal Drive read paths off GoogleDriveService (this lane touches
+  only the three client-facing download proxies named above). Streaming the download to disk
+  instead of buffering the response body (portal documents observed are sub-10MB, the upload
+  cap). Surfacing a richer error body to the vault UI — the client-visible detail is handled in
+  the separate vault-upload-detail lane (PR #6192).


### PR DESCRIPTION
## What

Measured live 2026-09-11 on a client's OWN document:

```
GET /api/portal/documents/19454/download
→ 500 {"detail":"Failed to download document","correlation_id":"4c5e27aa-…"}
```

reproduced twice. In the vault the DOWNLOAD button opens a popup and nothing arrives — silent failure, no toast (portal audit **F-01, P1**).

## Root cause — code-proven, not inferred

All three portal download proxies asked `GoogleDriveService.get_valid_token("SYSTEM")` and refused when it came back empty. **It always comes back empty:** `GoogleDriveService._refresh_token` returns `None` for `SYSTEM` *by design* since 2026-05-10 — its own docstring says "OAuth SYSTEM disabled — Drive operations use ServiceAccountDriveService … callers that still request it receive None". The stored SYSTEM row expired 2026-06-15 and is deliberately never refreshed.

So this is not an expired token, it is a dead branch: **every portal download has 500'd since 2026-05-10**, for every document, not only client-uploaded ones. The routers turned the RuntimeError into a generic 500, which is why the real reason never reached anyone.

Uploads had already moved to the Service Account — which is also the identity that **owns** the files it wrote. So the reads have to use the same credential, not merely a working one.

## How

- `ServiceAccountDriveService.download_file_content` — `alt=media` through the SA, the same `service.files().get_media(...)` + `asyncio.to_thread` idiom `drive_poll_service.py` and `intake/drive_adapter.py` already use.
- `services/portal/_drive_fetch.py` — one read path for all three proxies. A Drive 404/410 stays a client-visible 404; anything else stays a failure, so an outage is never reported to a client as "your document does not exist".
- Rewired: portal vault download, portal invoice-PDF download, portal LKPM receipt download. Same bug, same line, three call sites.

## Adversarial review

- *Why one shared helper instead of three local fixes?* The three copies are how one dead credential became three broken features. A fourth download proxy is likelier than not.
- *Does the SA have read access to files the CRM uploaded?* Yes — the CRM upload path (`crm_enhanced_documents.py`) already writes through `ServiceAccountDriveService` with domain-wide delegation, so it is reading files it created. This is verified by code path, and by the live proof below, not by assumption.
- *The tests were green.* They passed by mocking `get_valid_token` to return `"access-token"` — a value production cannot obtain. That is superscar #2 (esiste≠armato) **inside the suite**: green, and guarding nothing. They are replaced by tests that mock only the Drive API boundary, plus a guilt-proof per surface asserting the OAuth token is never consulted.
- *Not fixed here:* the routers' blanket `except Exception → 500 "Failed to download document"` is what hid the cause for four months. Worth narrowing, separate concern.

## Bites

**Consumers:** `PortalService.download_document` (vault), `PortalService.download_invoice_pdf` (billing), `LKPMService.download_receipt_for_portal_client` (LKPM receipts) — the three routes the live probe hit.

**Observation (run now, on this branch):**
`pytest backend/tests/unit/app/services/portal backend/tests/unit/routers/test_portal_billing.py backend/tests/unit/routers/test_portal.py backend/tests/unit/app/routers/test_lkpm_receipt_client_safe.py backend/tests/unit/app/routers/test_portal_notfound_404.py backend/tests/unit/services/portal` → **341 passed**. Before the fix the same set was **14 failed** — every one of those failures was a test that had been asserting against the dead credential.

Live proof after deploy: `GET /api/portal/documents/19454/download` as the synthetic audit client returns 200 with the file bytes and `Content-Disposition: attachment` — recorded as a comment on this PR before the audit client is cleaned up. This is the observation that matters: the unit tests can only prove the credential changed, not that the SA can actually read the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
