### PR TITLE
fix(portal): LKPM shows the overdue filing instead of hiding the card

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/lkpm/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/lkpm/page.test.tsx
@@ -238,6 +238,50 @@ describe("LKPMPage (list)", () => {
     expect(panel?.style.borderColor).toContain("var(--state-success) 30%");
   });
 
+  // Portal audit ux F3 (2026-09-11): the card rendered only
+  // `deadlines.find((d) => !d.is_overdue)`, so a client whose every filing
+  // was overdue saw NO deadline card at all — the most urgent state showing
+  // as if nothing were due.
+  it("shows the most-overdue filing when every deadline is overdue", async () => {
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === "/api/v1/lkpm/history/me")
+        return Promise.resolve({ success: true, items: HISTORY });
+      if (url === "/api/v1/lkpm/deadlines")
+        return Promise.resolve({
+          success: true,
+          deadlines: [
+            {
+              quarter: "Q1",
+              year: 2026,
+              deadline: new Date(Date.now() - 12 * 86400000).toISOString(),
+              days_remaining: -12,
+              is_overdue: true,
+            },
+            {
+              quarter: "Q2",
+              year: 2026,
+              deadline: new Date(Date.now() - 95 * 86400000).toISOString(),
+              days_remaining: -95,
+              is_overdue: true,
+            },
+          ],
+        });
+      if (url === "/api/v1/lkpm/receipts/me")
+        return Promise.resolve({ success: true, items: RECEIPTS });
+      return Promise.reject(new Error(`unexpected ${url}`));
+    });
+    render(<LKPMPage />);
+
+    // The card exists, is labelled as overdue, and names the WORST one.
+    expect(await screen.findByText("Overdue Filing")).toBeInTheDocument();
+    const overdueText = screen.getByText(/overdue by 95 days/);
+    expect(overdueText).toBeInTheDocument();
+    expect(screen.queryByText(/days remaining/)).not.toBeInTheDocument();
+    // and it reads danger, not the success token 41-days-out would get
+    const panel = overdueText.closest("div")?.parentElement;
+    expect(panel?.style.background).toContain("var(--state-danger) 8%");
+  });
+
   it("renders OSS receipt statuses and copper accents with tokens", async () => {
     await renderLoaded();
 

--- a/apps/mouth/src/app/portal/(authenticated)/lkpm/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/lkpm/page.tsx
@@ -268,7 +268,22 @@ export default function LKPMPage() {
     );
   }
 
-  const nextDeadline = deadlines.find((d) => !d.is_overdue);
+  // The card used to render only `deadlines.find((d) => !d.is_overdue)`, so
+  // when EVERY deadline was overdue `find` returned undefined and the whole
+  // "Next Deadline" section was omitted — the most urgent state a client can
+  // be in rendered as if nothing were due (portal audit ux F3). An overdue
+  // filing is exactly what this page exists to surface, so show the
+  // most-overdue one instead of hiding it.
+  const upcomingDeadline = deadlines.find((d) => !d.is_overdue);
+  const mostOverdueDeadline = deadlines.reduce<LKPMDeadline | undefined>(
+    (worst, d) =>
+      d.is_overdue && (!worst || d.days_remaining < worst.days_remaining)
+        ? d
+        : worst,
+    undefined,
+  );
+  const nextDeadline = upcomingDeadline ?? mostOverdueDeadline;
+  const nextDeadlineIsOverdue = !upcomingDeadline && Boolean(nextDeadline);
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
@@ -294,23 +309,35 @@ export default function LKPMPage() {
               className="w-5 h-5"
               style={{ color: "var(--bz-copper)" }}
             />
-            <h2 className="text-lg font-semibold">Next Deadline</h2>
+            <h2 className="text-lg font-semibold">
+              {nextDeadlineIsOverdue ? "Overdue Filing" : "Next Deadline"}
+            </h2>
           </div>
 
           <div
             className="p-4 rounded-lg flex items-center gap-3 border"
-            style={tonePanelStyle(deadlineToken(nextDeadline.days_remaining))}
+            style={tonePanelStyle(
+              nextDeadlineIsOverdue
+                ? "--state-danger"
+                : deadlineToken(nextDeadline.days_remaining),
+            )}
           >
             <Calendar
               className="w-5 h-5"
               style={{
-                color: `var(${deadlineToken(nextDeadline.days_remaining)})`,
+                color: `var(${
+                  nextDeadlineIsOverdue
+                    ? "--state-danger"
+                    : deadlineToken(nextDeadline.days_remaining)
+                })`,
               }}
             />
             <div className="flex-1">
               <p className="text-sm font-semibold">
                 {nextDeadline.quarter} {nextDeadline.year} —{" "}
-                {nextDeadline.days_remaining} days remaining
+                {nextDeadlineIsOverdue
+                  ? `overdue by ${Math.abs(nextDeadline.days_remaining)} days`
+                  : `${nextDeadline.days_remaining} days remaining`}
               </p>
               <p className="text-xs" style={{ color: "var(--bz-text-2)" }}>
                 Deadline:{" "}


### PR DESCRIPTION
## What

`lkpm/page.tsx` rendered the deadline card from `deadlines.find((d) => !d.is_overdue)` alone. When **every** deadline in the list is overdue, `find` returns `undefined` and the entire "Next Deadline" section is omitted — so a client with an overdue LKPM filing saw no deadline card at all. The most urgent state a client can be in rendered as if nothing were due.

That is worse than a stale date: it is a dead end on exactly the situation the page exists to surface.

Portal audit finding **ux F3 (P1)**.

## How

When there is no upcoming deadline, show the **most** overdue one (lowest `days_remaining`), headed "Overdue Filing", read in `--state-danger`, phrased "overdue by N days". Nothing changes when an upcoming deadline exists — same card, same tokens, same copy.

## Adversarial review

- *Why the most overdue and not the least?* The oldest unfiled quarter is the one accruing exposure; showing the mildest one would understate the situation on a page whose job is to state it.
- *Why not list all overdue ones?* The card's contract is one deadline. A list is a different component and a different decision; this PR restores the card's honesty without redesigning it.
- *`--state-danger` unconditionally when overdue?* Yes — `deadlineToken(days)` branches on `<= 7` / `<= 30`, and a negative `days_remaining` already lands on danger, but relying on that coincidence would break the moment the thresholds move. It is now explicit.

## Bites

**Consumer:** the `/portal/lkpm` deadline card — the same component the audit found empty.

**Observation (run now, on this branch):** `npx vitest run "src/app/portal/(authenticated)/lkpm/page.test.tsx"` → **9 passed**, including a new case that feeds two all-overdue deadlines (−12 and −95 days) and asserts the card exists, reads "Overdue Filing", names the −95 one ("overdue by 95 days"), shows no "days remaining", and carries `var(--state-danger) 8%`.

Guilt-proof: reverting the selection to `const nextDeadline = upcomingDeadline;` turns exactly that case red —
```
FAIL src/app/portal/(authenticated)/lkpm/page.test.tsx > LKPMPage (list) >
     shows the most-overdue filing when every deadline is overdue
```
`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
