### PR TITLE
fix(portal): registration moves the login email to the invited address

### DIFF
--- a/apps/backend-rag/backend/services/portal/invite_service.py
+++ b/apps/backend-rag/backend/services/portal/invite_service.py
@@ -251,15 +251,50 @@ class InviteService:
                     if already_registered and existing_user["active"]:
                         raise ValueError("This client already has an active portal account")
 
+                    # The login identity must be the address the invitation
+                    # was SENT to, or registration succeeds and login fails.
+                    #
+                    # Measured 2026-09-11 (portal audit F1): `update_client`
+                    # lets a consultant change `clients.email` freely, the
+                    # re-invite correctly goes to the NEW address, the client
+                    # sets a PIN through it — and then cannot sign in, because
+                    # `auth.py`'s login matches `team_members.email` only and
+                    # this UPDATE never touched it. `ensure_portal_profile`
+                    # cannot repair it either: `email` IS its ON CONFLICT key.
+                    # Nothing surfaced the failure to either side; the CRM
+                    # panel kept reporting "Portal active — <dead address>".
+                    invite_email = invitation["email"]
+                    if invite_email:
+                        # team_members.email is unique. A different row already
+                        # holding it is a real identity collision, not something
+                        # to overwrite silently — refuse and say so.
+                        conflict = await conn.fetchval(
+                            """
+                            SELECT id FROM team_members
+                            WHERE LOWER(email) = LOWER($1) AND id <> $2
+                            LIMIT 1
+                            """,
+                            invite_email,
+                            existing_user["id"],
+                        )
+                        if conflict:
+                            raise ValueError(
+                                "Another account already uses this email address"
+                            )
+
                     # Update existing (never-registered or deactivated) user
                     await conn.execute(
                         """
                         UPDATE team_members
-                        SET pin_hash = $1, active = true, portal_access = true
+                        SET pin_hash = $1,
+                            active = true,
+                            portal_access = true,
+                            email = COALESCE($3, email)
                         WHERE id = $2
                         """,
                         pin_hash,
                         existing_user["id"],
+                        invite_email,
                     )
                     user_id = existing_user["id"]
                 else:

--- a/apps/backend-rag/backend/tests/services/portal/test_invite_service.py
+++ b/apps/backend-rag/backend/tests/services/portal/test_invite_service.py
@@ -36,16 +36,24 @@ class FakeConnection:
         self,
         fetchrow_results: list[dict | None] | None = None,
         fetch_results: list[dict] | None = None,
+        fetchval_results: list[object] | None = None,
     ) -> None:
         self.fetchrow_results = list(fetchrow_results or [])
         self.fetch_results = fetch_results or []
+        self.fetchval_results = list(fetchval_results or [])
         self.fetchrow_calls: list[tuple[str, tuple]] = []
         self.execute_calls: list[tuple[str, tuple]] = []
         self.fetch_calls: list[tuple[str, tuple]] = []
+        self.fetchval_calls: list[tuple[str, tuple]] = []
 
     async def fetchrow(self, query: str, *args) -> dict | None:
         self.fetchrow_calls.append((query, args))
         return self.fetchrow_results.pop(0)
+
+    async def fetchval(self, query: str, *args) -> object:
+        self.fetchval_calls.append((query, args))
+        # Default: no row found. Only the email-collision test seeds a value.
+        return self.fetchval_results.pop(0) if self.fetchval_results else None
 
     async def execute(self, query: str, *args) -> str:
         self.execute_calls.append((query, args))
@@ -374,7 +382,9 @@ async def test_complete_registration_reactivates_inactive_existing_account() -> 
     # seed default client_preferences.
     assert len(conn.execute_calls) == 3
     update_query, update_args = conn.execute_calls[0]
-    assert "SET pin_hash = $1, active = true, portal_access = true" in update_query
+    assert "SET pin_hash = $1," in update_query
+    assert "active = true" in update_query
+    assert "portal_access = true" in update_query
     assert update_args[1] == 55
 
 
@@ -419,8 +429,89 @@ async def test_complete_registration_allows_placeholder_active_account() -> None
     assert result["user_id"] == 55
     # The real PIN is written over the placeholder — this IS onboarding.
     update_query, update_args = conn.execute_calls[0]
-    assert "SET pin_hash = $1, active = true, portal_access = true" in update_query
+    assert "SET pin_hash = $1," in update_query
+    assert "active = true" in update_query
+    assert "portal_access = true" in update_query
     assert update_args[1] == 55
+
+
+# =============================================================================
+# F1 (2026-09-11 portal↔CRM bridge audit) — the login identity is
+# `team_members.email`, and this branch never wrote it. A consultant who
+# changed `clients.email` and re-invited produced a client who could complete
+# registration through the NEW address and then could not sign in with it:
+# `auth.py` matches `team_members.email` only, which still held the old one.
+# Nothing surfaced the failure to either side.
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_complete_registration_moves_the_login_email_to_the_invited_address() -> None:
+    """Guilt-proof: drop `email = COALESCE($3, email)` from the UPDATE and
+    this fails — which is exactly the state production was in."""
+    now = datetime.now(timezone.utc)
+    conn = FakeConnectionWithTransaction(
+        fetchrow_results=[
+            {
+                "id": 9,
+                "client_id": 7,
+                # the invitation went to the NEW address
+                "email": "new-address@example.com",
+                "expires_at": now + timedelta(hours=1),
+                "used_at": None,
+                "client_name": "Client Name",
+            },
+            # the provisioned row still carries the OLD login email
+            {"id": 55, "active": True, "pin_hash": PLACEHOLDER_PIN_HASH},
+        ]
+    )
+    service = InviteService(FakePool(conn))
+
+    with patch(
+        "backend.services.common.cache._invalidate_cache",
+        new=AsyncMock(return_value=1),
+    ):
+        result = await service.complete_registration(token="tok", pin="1234")
+
+    assert result["success"] is True
+    update_query, update_args = conn.execute_calls[0]
+    assert "email = COALESCE($3, email)" in update_query
+    assert update_args[2] == "new-address@example.com"
+    # and the collision check ran against that same address
+    conflict_query, conflict_args = conn.fetchval_calls[0]
+    assert "LOWER(email) = LOWER($1)" in conflict_query
+    assert conflict_args == ("new-address@example.com", 55)
+
+
+@pytest.mark.asyncio
+async def test_complete_registration_refuses_when_another_account_holds_the_email() -> None:
+    """`team_members.email` is UNIQUE. A different row already holding the
+    invited address is a real identity collision — refuse and say so, rather
+    than let the UPDATE blow up as an opaque 500 or, worse, move a login that
+    belongs to somebody else."""
+    now = datetime.now(timezone.utc)
+    conn = FakeConnectionWithTransaction(
+        fetchrow_results=[
+            {
+                "id": 9,
+                "client_id": 7,
+                "email": "taken@example.com",
+                "expires_at": now + timedelta(hours=1),
+                "used_at": None,
+                "client_name": "Client Name",
+            },
+            {"id": 55, "active": True, "pin_hash": PLACEHOLDER_PIN_HASH},
+        ],
+        # some OTHER team_members row already uses taken@example.com
+        fetchval_results=[999],
+    )
+    service = InviteService(FakePool(conn))
+
+    with pytest.raises(ValueError, match="Another account already uses this email"):
+        await service.complete_registration(token="tok", pin="1234")
+
+    # Nothing was written — not the PIN, not the invitation's used_at.
+    assert conn.execute_calls == []
 
 
 @pytest.mark.asyncio

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.test.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.test.tsx
@@ -90,6 +90,31 @@ afterEach(() => {
 });
 
 describe("PortalAccess", () => {
+  // Portal audit F1 (2026-09-11): the login identity is
+  // `team_members.email`, which a CRM email edit does not move. The panel
+  // rendered the stale address as if it were current, so a consultant who
+  // had just changed the email had no way to know the client still signs in
+  // with the old one.
+  it("names the divergence when the login email is not the CRM email", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(ACTIVE);
+    renderPanel("moved@example.com");
+
+    expect(
+      await screen.findByText(/signs in as client@example\.com/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/the CRM now has moved@example\.com/i),
+    ).toBeInTheDocument();
+  });
+
+  it("stays quiet when the two emails agree", async () => {
+    vi.mocked(api.crm.getPortalStatus).mockResolvedValue(ACTIVE);
+    renderPanel("client@example.com");
+
+    await screen.findByText(/portal active/i);
+    expect(screen.queryByText(/signs in as/i)).not.toBeInTheDocument();
+  });
+
   it("offers the invite button when the client has no portal access", async () => {
     vi.mocked(api.crm.getPortalStatus).mockResolvedValue(NO_ACCESS);
     renderPanel();

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.tsx
@@ -92,6 +92,14 @@ export function PortalAccess({
     }
   };
 
+  // team_members.email (the login) vs clients.email (what the CRM shows).
+  // Only meaningful once a portal account exists.
+  const loginEmailDiverged = Boolean(
+    status?.portal_email &&
+    clientEmail &&
+    status.portal_email.toLowerCase() !== clientEmail.toLowerCase(),
+  );
+
   const formatDate = (value: string | null) =>
     value
       ? new Date(value).toLocaleDateString(undefined, {
@@ -155,6 +163,20 @@ export function PortalAccess({
                   ? `Last signed in ${formatDate(status.last_login)}`
                   : "Registered, but has never signed in yet"}
               </p>
+              {/* The login identity is team_members.email, which a CRM email
+                  edit does not move (portal audit F1). Saying so is the whole
+                  point: the panel used to render the stale address as if it
+                  were current, so a consultant who had just changed the email
+                  had no way to know the client still signs in with the old
+                  one. */}
+              {loginEmailDiverged ? (
+                <p className="text-xs text-[var(--bz-warning,#d97706)] mt-1">
+                  Signs in as {status.portal_email} — the CRM now has{" "}
+                  {clientEmail}. Changing the email here does not move the
+                  portal login; the client must keep using {status.portal_email}
+                  .
+                </p>
+              ) : null}
             </div>
           </div>
         ) : status?.pending_invite ? (


### PR DESCRIPTION
## What

The portal login identity is `team_members.email`, and `complete_registration`'s existing-user branch never wrote it — it set `pin_hash`, `active` and `portal_access` only.

Traced end to end (portal↔CRM bridge audit **F1, P1**):

1. `update_client` (`crm_clients.py:1597`) lets a consultant change `clients.email` freely — `field_mapping` includes it, with no portal side effect.
2. The re-invite correctly goes to the NEW address (`crm_portal_integration.py:284-295`).
3. The client sets a PIN through it and `complete_registration` reports success.
4. They cannot sign in: `auth.py`'s login matches `WHERE LOWER(email) = LOWER($1)` against `team_members.email` only, which still holds the OLD, possibly dead address.

`ensure_portal_profile` cannot repair it either — `email` **is** its `ON CONFLICT` key, so its `DO UPDATE` can never change it. And nothing surfaced the failure to either side: the kita panel kept reporting "Portal active — \<old email\>" as if all were well.

## How

- `complete_registration` sets `email` from the invitation. `team_members.email` is UNIQUE, so a DIFFERENT row already holding that address is a real identity collision: refuse with a stated reason rather than blow up on the constraint as an opaque 500 — and write **nothing** in that case, not the PIN, not the invitation's `used_at`.
- The kita panel names the divergence when it exists, instead of rendering the stale login email as current.

## Adversarial review

- *Why also the panel?* Because one case stays reachable **by design**: an already-registered ACTIVE account correctly refuses a re-invite (an invitation is not a password reset — the 2026-08-23 P0). Its login email therefore cannot follow a CRM edit, and the honest move is to tell the consultant which address the client actually uses. Silently syncing the login on a CRM edit would move who can sign in, without a consent step; that is a decision, not a bug fix, so it is not in this PR.
- *Why not lowercase-normalise on write?* Login already compares case-insensitively (`LOWER(email) = LOWER($1)`) and the collision check here does the same, so a case-only difference cannot create a second identity. Normalising the stored column is a data migration, separate.
- *Is `COALESCE($3, email)` needed?* Yes — an invitation with a null email must not blank the login. It cannot happen through `create_invitation` today; the COALESCE means it cannot happen at all.

## Bites

**Consumers:** `InviteService.complete_registration` (the registration that produced the unusable login) and `PortalAccess` in kita (the panel that hid it).

**Observation (run now, on this branch):**
- `pytest backend/tests/services/portal/test_invite_service.py` → **16 passed**, including a case where the invitation carries a new address, a row carries the old one, and the UPDATE is asserted to move it — plus a collision case asserting `conn.execute_calls == []` (nothing written when refused).
- `npx vitest run "src/app/(workspace)/clients/[id]/components/PortalAccess.test.tsx"` → **12 passed**, two of them new: the divergence is named, and stays silent when the two emails agree.

Guilt-proofs: dropping `email = COALESCE($3, email)` from the UPDATE turns `test_complete_registration_moves_the_login_email_to_the_invited_address` red; forcing the panel's condition to `false` turns `names the divergence when the login email is not the CRM email` red. `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
