### PR TITLE
fix(portal): notification consent has one home, and it is notification_prefs

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -66,10 +66,19 @@ class SendMessageRequest(BaseModel):
 
 
 class UpdatePreferencesRequest(BaseModel):
-    """Request to update preferences"""
+    """Request to update LOCALE preferences.
 
-    email_notifications: bool | None = None
-    whatsapp_notifications: bool | None = None
+    Notification consent is not settable here: `notification_prefs`
+    (`PUT /api/portal/notifications/prefs`) is the single source of truth,
+    because it is the only store `alert_dispatcher` reads. Declaring
+    `email_notifications` / `whatsapp_notifications` on this endpoint is how
+    the two came to disagree live (portal audit F-04): it answered
+    `whatsapp_notifications: true` for an account whose enforced setting was
+    false. Pydantic ignores unknown keys by default, so an older client build
+    that still sends them keeps working — its values are simply no longer
+    written anywhere.
+    """
+
     language: Literal["it", "en", "id"] | None = None
     timezone: str | None = None
 

--- a/apps/backend-rag/backend/services/portal/_mixins/messaging.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/messaging.py
@@ -184,12 +184,35 @@ class PortalMessagingMixin:
         *,
         current_user: ClientContext,
     ) -> dict[str, Any]:
-        """Get client preferences."""
+        """Get client locale preferences.
+
+        NOTIFICATION CONSENT IS NOT HERE. `notification_prefs` (keyed by the
+        portal `user_id`, served by `portal_notification_prefs.py`) is the
+        single source of truth, because it is the only one anything reads:
+        `services/compliance/alert_dispatcher.py` consults it to decide
+        whether a client gets a compliance email or WhatsApp message. The
+        `client_preferences.email_notifications` /
+        `whatsapp_notifications` columns had NO reader anywhere — not a cron,
+        not a dispatcher, not a CRM surface — yet this endpoint kept
+        reporting them, defaulting to true/true.
+
+        Measured live 2026-09-11 on the same account at the same moment
+        (portal audit F-04 + bridge F3):
+            GET /api/portal/notifications/prefs -> {"wa_enabled": false, ...}
+            GET /api/portal/settings            -> {"whatsapp_notifications": true, ...}
+        Two answers to one question, and the one a client could reach through
+        the UI was the one nobody enforces. Under UU PDP that is a consent
+        mismatch, not a display bug — so the field is gone from this
+        endpoint rather than left as the obvious place for the next
+        developer to wire a new UI or cron.
+
+        The columns themselves are left in place: dropping them is a
+        migration and a data decision, not a bug fix.
+        """
         async with self.pool.acquire() as conn:
             prefs = await conn.fetchrow(
                 """
-                SELECT email_notifications, whatsapp_notifications,
-                       language, timezone
+                SELECT language, timezone
                 FROM client_preferences
                 WHERE client_id = $1
                 """,
@@ -199,15 +222,11 @@ class PortalMessagingMixin:
             if not prefs:
                 # Return defaults
                 return {
-                    "email_notifications": True,
-                    "whatsapp_notifications": True,
                     "language": "en",
                     "timezone": "Asia/Jakarta",
                 }
 
             return {
-                "email_notifications": prefs["email_notifications"],
-                "whatsapp_notifications": prefs["whatsapp_notifications"],
                 "language": prefs["language"],
                 "timezone": prefs["timezone"],
             }
@@ -225,7 +244,14 @@ class PortalMessagingMixin:
         *,
         current_user: ClientContext,
     ) -> dict[str, Any]:
-        """Update client preferences."""
+        """Update client locale preferences.
+
+        `email_notifications` / `whatsapp_notifications` are deliberately NOT
+        accepted here — see `get_preferences` for why. A payload carrying
+        them is ignored rather than rejected, so an older client build cannot
+        start failing; what it can no longer do is write a consent value that
+        nothing enforces.
+        """
         async with self.pool.acquire() as conn:
             # Build dynamic update
             updates = []
@@ -233,8 +259,6 @@ class PortalMessagingMixin:
             param_idx = 2
 
             allowed_fields = {
-                "email_notifications": bool,
-                "whatsapp_notifications": bool,
                 "language": str,
                 "timezone": str,
             }
@@ -252,10 +276,15 @@ class PortalMessagingMixin:
                 )
 
             # Upsert preferences
+            # The INSERT arm seeds the row's defaults; the DO UPDATE arm
+            # applies the caller's values. The seed list is written out, not
+            # derived from `allowed_fields`, because the two used to be
+            # coupled by position — a field added to or removed from that
+            # dict silently shifted the VALUES tuple.
             await conn.execute(
                 f"""
-                INSERT INTO client_preferences (client_id, {", ".join(allowed_fields.keys())})
-                VALUES ($1, true, true, 'en', 'Asia/Jakarta')
+                INSERT INTO client_preferences (client_id, language, timezone)
+                VALUES ($1, 'en', 'Asia/Jakarta')
                 ON CONFLICT (client_id) DO UPDATE
                 SET {", ".join(updates)}
                 """,

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_portal_service.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_portal_service.py
@@ -652,9 +652,7 @@ class TestPortalServicePreferences:
             client_id=1,
             current_user=ctx_client_1,
         )
-        assert result["email_notifications"] is True
-        assert result["language"] == "en"
-        assert result["timezone"] == "Asia/Jakarta"
+        assert result == {"language": "en", "timezone": "Asia/Jakarta"}
 
     @pytest.mark.asyncio
     async def test_get_preferences_stored(
@@ -663,10 +661,15 @@ class TestPortalServicePreferences:
         mock_conn,
         ctx_client_1,
     ):
-        """Returns stored preferences."""
+        """Returns stored LOCALE preferences — and no notification consent.
+
+        Portal audit F-04 (2026-09-11): this endpoint used to answer
+        `whatsapp_notifications: true` for an account whose enforced setting
+        — in `notification_prefs`, the only store `alert_dispatcher` reads —
+        was false. Two answers to one consent question. Guilt-proof: put
+        either field back into `get_preferences` and this fails.
+        """
         mock_conn.fetchrow.return_value = {
-            "email_notifications": False,
-            "whatsapp_notifications": True,
             "language": "it",
             "timezone": "Europe/Rome",
         }
@@ -674,8 +677,38 @@ class TestPortalServicePreferences:
             client_id=1,
             current_user=ctx_client_1,
         )
-        assert result["language"] == "it"
-        assert result["email_notifications"] is False
+        assert result == {"language": "it", "timezone": "Europe/Rome"}
+
+    @pytest.mark.asyncio
+    async def test_update_preferences_refuses_to_write_notification_consent(
+        self,
+        portal_service,
+        mock_conn,
+        ctx_client_1,
+    ):
+        """A payload carrying notification fields is ignored, not written.
+
+        An older client build must keep working; what it can no longer do is
+        write a consent value that nothing enforces.
+        """
+        mock_conn.fetchrow.return_value = {
+            "language": "en",
+            "timezone": "Asia/Jakarta",
+        }
+        await portal_service.update_preferences(
+            client_id=1,
+            preferences={
+                "whatsapp_notifications": False,
+                "email_notifications": False,
+                "language": "id",
+            },
+            current_user=ctx_client_1,
+        )
+
+        written = "".join(str(call) for call in mock_conn.execute.call_args_list)
+        assert "language" in written
+        assert "whatsapp_notifications" not in written
+        assert "email_notifications" not in written
 
 
 # ============================================================================

--- a/apps/mouth/src/components/portal/settings/LanguageSettings.test.tsx
+++ b/apps/mouth/src/components/portal/settings/LanguageSettings.test.tsx
@@ -17,8 +17,6 @@ describe("LanguageSettings", () => {
     usePortalPreferencesMock.mockReset();
     usePortalPreferencesMock.mockReturnValue({
       data: {
-        emailNotifications: true,
-        whatsappNotifications: true,
         language: "en",
         timezone: "Asia/Jakarta",
       },
@@ -45,8 +43,6 @@ describe("LanguageSettings", () => {
   it("reads the persisted portal preference rather than the auth profile", () => {
     usePortalPreferencesMock.mockReturnValue({
       data: {
-        emailNotifications: true,
-        whatsappNotifications: true,
         language: "it",
         timezone: "Asia/Jakarta",
       },

--- a/apps/mouth/src/lib/api/portal/portal.api.test.ts
+++ b/apps/mouth/src/lib/api/portal/portal.api.test.ts
@@ -140,8 +140,8 @@ const createMockMessage = (
 const createMockPreferences = (
   overrides?: Partial<PortalPreferences>,
 ): PortalPreferences => ({
-  emailNotifications: true,
-  whatsappNotifications: false,
+  // Locale only: notification consent lives in `notification_prefs`
+  // (portal audit F-04, 2026-09-11).
   language: "en",
   timezone: "Asia/Jakarta",
   ...overrides,
@@ -608,11 +608,11 @@ describe("PortalApi", () => {
   describe("updatePreferences", () => {
     it("should update preferences successfully", async () => {
       const updates: Partial<PortalPreferences> = {
-        emailNotifications: false,
+        language: "id",
       };
 
       const mockPreferences = createMockPreferences({
-        emailNotifications: false,
+        language: "id",
       });
       mockRequest.mockResolvedValue({ data: mockPreferences });
 

--- a/apps/mouth/src/lib/api/portal/portal.types.ts
+++ b/apps/mouth/src/lib/api/portal/portal.types.ts
@@ -206,9 +206,15 @@ export interface SendMessageRequest {
 // Settings Types
 // ============================================================================
 
+/**
+ * Locale preferences only. Notification consent lives in
+ * `notification_prefs` (`/api/portal/notifications/prefs`, `useNotificationPrefs`)
+ * — the only store `alert_dispatcher` reads. The two used to disagree live
+ * (portal audit F-04): `/api/portal/settings` answered
+ * `whatsapp_notifications: true` for an account whose real setting was
+ * false. Do not add notification fields back here.
+ */
 export interface PortalPreferences {
-  emailNotifications: boolean;
-  whatsappNotifications: boolean;
   language: string;
   timezone: string;
 }

--- a/apps/mouth/src/lib/schemas/settings.test.ts
+++ b/apps/mouth/src/lib/schemas/settings.test.ts
@@ -104,26 +104,38 @@ describe("UserProfile", () => {
 describe("PortalSettings", () => {
   it("parses BE defaults (no row in client_preferences)", () => {
     const parsed = PortalSettings.parse({
-      email_notifications: true,
-      whatsapp_notifications: true,
       language: "en",
       timezone: "Asia/Jakarta",
     });
-    expect(parsed.email_notifications).toBe(true);
     expect(parsed.language).toBe("en");
+    expect(parsed.timezone).toBe("Asia/Jakarta");
   });
 
   it("rejects missing fields", () => {
-    const result = PortalSettings.safeParse({ email_notifications: true });
+    const result = PortalSettings.safeParse({ language: "en" });
     expect(result.success).toBe(false);
+  });
+
+  // Portal audit F-04 (2026-09-11): this endpoint used to carry notification
+  // consent that nothing enforced, and it disagreed live with
+  // `notification_prefs` — the store `alert_dispatcher` actually reads.
+  // Consent has ONE home; a stray field here must not become a second one.
+  it("does not carry notification consent, even if the wire still sends it", () => {
+    const parsed = PortalSettings.parse({
+      language: "en",
+      timezone: "Asia/Jakarta",
+      email_notifications: true,
+      whatsapp_notifications: true,
+    });
+    expect(parsed).toEqual({ language: "en", timezone: "Asia/Jakarta" });
+    expect("email_notifications" in parsed).toBe(false);
+    expect("whatsapp_notifications" in parsed).toBe(false);
   });
 
   it("parses the full envelope { success, data }", () => {
     const parsed = PortalSettingsResponse.parse({
       success: true,
       data: {
-        email_notifications: false,
-        whatsapp_notifications: true,
         language: "it",
         timezone: "Asia/Bali",
       },

--- a/apps/mouth/src/lib/schemas/settings.ts
+++ b/apps/mouth/src/lib/schemas/settings.ts
@@ -13,9 +13,8 @@
  *     Pydantic model has id/user_id aliases, `language` with default "en",
  *     optional tone/complexity/timezone/role_level/status/avatar/metadata.
  *   - /api/portal/settings → `apps/backend-rag/backend/app/routers/portal.py:669`
- *     Returns `{ success, data: { email_notifications, whatsapp_notifications,
- *     language, timezone } }` from
- *     `backend/services/portal/_mixins/messaging.py:160 (get_preferences)`.
+ *     Returns `{ success, data: { language, timezone } }` from
+ *     `backend/services/portal/_mixins/messaging.py (get_preferences)`.
  *   - /api/portal/notifications/prefs →
  *     `apps/backend-rag/backend/app/routers/portal_notification_prefs.py`
  *     GET returns `NotificationPrefsOut` = `{ email_enabled, wa_enabled,
@@ -106,16 +105,19 @@ export type UserProfile = z.infer<typeof UserProfile>;
 // ============================================
 
 /**
- * Inner `data` of `GET /api/portal/settings`.
+ * Inner `data` of `GET /api/portal/settings` — LOCALE only.
  *
- * Mirrors `PortalMessagingMixin.get_preferences` dict (messaging.py:187).
- * The BE defaults are `{ email_notifications: true, whatsapp_notifications:
- * true, language: "en", timezone: "Asia/Jakarta" }` when the client row is
+ * Mirrors `PortalMessagingMixin.get_preferences`. The BE defaults are
+ * `{ language: "en", timezone: "Asia/Jakarta" }` when the client row is
  * missing.
+ *
+ * `email_notifications` / `whatsapp_notifications` were removed on
+ * 2026-09-11: they had no reader anywhere, while `notification_prefs`
+ * (`NotificationPrefs` below) is what `alert_dispatcher` actually enforces —
+ * and the two disagreed live on the same account at the same moment (portal
+ * audit F-04). Do not add them back here.
  */
 export const PortalSettings = z.object({
-  email_notifications: z.boolean(),
-  whatsapp_notifications: z.boolean(),
   language: z.string(),
   timezone: z.string(),
 });


### PR DESCRIPTION
## What

Two stores answered the same consent question, and they disagreed live. Measured 2026-09-11 on the same account at the same moment (portal audit **F-04** live + **bridge F3**):

```
GET /api/portal/notifications/prefs -> {"wa_enabled": false,  ...}
GET /api/portal/settings            -> {"whatsapp_notifications": true, ...}
```

`notification_prefs` is the real one: `services/compliance/alert_dispatcher.py` reads it to decide whether a client gets a compliance email or WhatsApp message. `client_preferences.email_notifications` / `whatsapp_notifications` had **no reader anywhere** — not a cron, not a dispatcher, not a CRM surface — yet `/api/portal/settings` kept reporting them, defaulting to `true`/`true`, and its PATCH kept accepting writes to them.

Under UU PDP that is a consent mismatch, not a display bug: the value a client could reach through the UI was the one nobody enforces. And it was a standing invitation — the obvious-looking place for the next developer to wire a new UI or cron, which would then silently ignore a real opt-out.

## How

- `/api/portal/settings` GET/PATCH are locale-only (`language`, `timezone`) — the only fields any live caller uses.
- `UpdatePreferencesRequest` drops the two fields. Pydantic ignores unknown keys, so an older client build that still sends them keeps working; what it can no longer do is write a consent value nothing enforces.
- `PortalPreferences` (TS) and the `PortalSettings` zod schema follow.
- The DB columns are left alone — dropping them is a migration and a data decision, not a bug fix.

## Adversarial review

- *The audit claimed these had "zero frontend callers" — is that right?* **No, and I checked rather than repeating it.** `usePortalPreferences` (`usePortal.ts:288`) is live and `LanguageSettings.tsx:54` calls its mutation — but only ever with `{ language }`, and it only reads `preferences.language`. `useLanguage.ts:78` PATCHes `{ language }`. So the endpoint is in use; the two notification fields are not. Removing them is safe for a different reason than the audit gave.
- *A second confirmation they were dead:* the TS type declared `emailNotifications`/`whatsappNotifications` in **camelCase** while `getPreferences` returns the wire body unmapped, i.e. snake_case. Those properties were never present at runtime at all.
- *Why not make `/settings` a read-through alias instead of removing?* An alias keeps two names for one value and needs the `user_id` key inside a `client_id`-keyed mixin. Removal leaves exactly one place to read and write consent, which is the property worth having.
- *Why not also drop the columns?* A migration that deletes stored consent values is a data decision, and `invite_service` still seeds the row. Flagged, not done.

## Bites

**Consumers:** `GET/PATCH /api/portal/settings` (the endpoint that gave the wrong answer) and `alert_dispatcher` (which keeps reading the one remaining store, untouched).

**Observation (run now, on this branch):**
- `pytest backend/tests/unit/app/services/portal/test_portal_service.py` → **53 passed**, including a rewritten `test_get_preferences_stored` that asserts the response `== {"language", "timezone"}` exactly — put either notification field back and it fails — plus a new `test_update_preferences_refuses_to_write_notification_consent` that sends both fields and asserts neither reaches the SQL.
- `npx vitest run src/lib/api/portal/portal.api.test.ts src/lib/schemas/settings.test.ts src/components/portal/settings/` → **68 passed**, including a case that feeds the zod schema a wire body still carrying both fields and asserts the parsed object drops them.
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
