### PR TITLE
fix(portal): the vault upload error shows the reason, not just the status code

### DIFF
--- a/apps/mouth/src/hooks/useVaultUpload.test.tsx
+++ b/apps/mouth/src/hooks/useVaultUpload.test.tsx
@@ -231,6 +231,67 @@ describe("useVaultUpload", () => {
     expect(result.current.canRetry).toBe(false);
   });
 
+  // Portal audit ux F1 (2026-09-11): the failure branch rendered
+  // `Upload failed (${status})` and threw the response body away, even
+  // though the success branch parses it two lines above. A client hitting
+  // the hour-long duplicate guard saw "Upload failed (409)" instead of the
+  // sentence the backend had already written for them.
+  it("shows the reason the server gave, not just its status code", async () => {
+    const { result } = renderHook(() => useVaultUpload());
+    const file = makeFile("ok.pdf", 4096, "application/pdf");
+
+    act(() => result.current.upload(file));
+    const xhr = MockXHR.last!;
+
+    // The live 409 from the duplicate guard, verbatim.
+    const detail =
+      "A file with this name was uploaded less than an hour ago. " +
+      "Please rename it or wait.";
+    act(() => xhr.resolve(409, JSON.stringify({ detail })));
+
+    await waitFor(() => expect(result.current.state.status).toBe("error"));
+    if (result.current.state.status === "error") {
+      expect(result.current.state.message).toBe(detail);
+      expect(result.current.state.httpStatus).toBe(409);
+    }
+  });
+
+  it("prefers `message` when the envelope uses it instead of `detail`", async () => {
+    const { result } = renderHook(() => useVaultUpload());
+    const file = makeFile("ok.pdf", 4096, "application/pdf");
+
+    act(() => result.current.upload(file));
+    const xhr = MockXHR.last!;
+    act(() => xhr.resolve(422, JSON.stringify({ message: "Wrong doc type" })));
+
+    await waitFor(() => expect(result.current.state.status).toBe("error"));
+    if (result.current.state.status === "error") {
+      expect(result.current.state.message).toBe("Wrong doc type");
+    }
+  });
+
+  it.each([
+    ["an empty body", ""],
+    ["HTML from a proxy", "<html><body>502</body></html>"],
+    [
+      "a non-string detail (FastAPI validation errors are a LIST)",
+      JSON.stringify({ detail: [{ loc: ["body"], msg: "x", type: "y" }] }),
+    ],
+    ["a blank detail", JSON.stringify({ detail: "   " })],
+  ])("falls back to the status code for %s", async (_label, body) => {
+    const { result } = renderHook(() => useVaultUpload());
+    const file = makeFile("ok.pdf", 4096, "application/pdf");
+
+    act(() => result.current.upload(file));
+    const xhr = MockXHR.last!;
+    act(() => xhr.resolve(500, body));
+
+    await waitFor(() => expect(result.current.state.status).toBe("error"));
+    if (result.current.state.status === "error") {
+      expect(result.current.state.message).toBe("Upload failed (500)");
+    }
+  });
+
   it("surfaces network error", async () => {
     const { result } = renderHook(() => useVaultUpload());
     const file = makeFile("ok.pdf", 4096, "application/pdf");

--- a/apps/mouth/src/hooks/useVaultUpload.ts
+++ b/apps/mouth/src/hooks/useVaultUpload.ts
@@ -53,6 +53,42 @@ function isRetryableHttpStatus(status: number): boolean {
  * the backend's client-safe document projection; scan, OCR, and storage
  * internals are intentionally unavailable to the UI.
  */
+/**
+ * The reason the server gave, not just the number it gave it with.
+ *
+ * The failure branch used to render `Upload failed (${status})` and throw
+ * `xhr.responseText` away — even though the success branch two lines above
+ * already parses it. A client hitting the hour-long duplicate guard saw
+ * "Upload failed (409)" instead of "A file with this name was uploaded less
+ * than an hour ago", and a client hitting a document-type rule saw
+ * "Upload failed (422)" instead of the rule (portal audit ux F1).
+ *
+ * FastAPI puts the reason in `detail`; this app's own envelopes use
+ * `message`. Anything else — HTML from a proxy, an empty body, a non-string
+ * `detail` (FastAPI's validation errors are a LIST of objects, which is
+ * exactly the shape that must not be stringified at a client) — falls back
+ * to the status code, which is still more honest than a wrong sentence.
+ */
+function serverRejectionMessage(responseText: string, status: number): string {
+  const fallback = `Upload failed (${status})`;
+  try {
+    const body: unknown = JSON.parse(responseText);
+    if (typeof body !== "object" || body === null) return fallback;
+    const { detail, message } = body as {
+      detail?: unknown;
+      message?: unknown;
+    };
+    for (const candidate of [detail, message]) {
+      if (typeof candidate === "string" && candidate.trim().length > 0) {
+        return candidate.trim();
+      }
+    }
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 export function useVaultUpload() {
   const [state, setState] = useState<UploadState>({ status: "idle" });
   const retryableUploadRef = useRef<RetryableUpload | null>(null);
@@ -143,7 +179,7 @@ export function useVaultUpload() {
         }
         setState({
           status: "error",
-          message: `Upload failed (${xhr.status})`,
+          message: serverRejectionMessage(xhr.responseText, xhr.status),
           httpStatus: xhr.status,
         });
       }


### PR DESCRIPTION
## What

`useVaultUpload`'s failure branch rendered `` `Upload failed (${xhr.status})` `` and threw `xhr.responseText` away — even though the success branch two lines above already parses it.

So a client hitting the hour-long duplicate guard saw "Upload failed (409)" instead of *"A file with this name was uploaded less than an hour ago"*, and a client hitting a document-type rule saw "Upload failed (422)" instead of the rule. The backend had already written the sentence; the client just never showed it.

Portal audit finding **ux F1 (P2)**.

## How

Prefer `detail` (FastAPI's shape) then `message` (this app's own envelope shape), and fall back to the status code for everything else.

## Adversarial review

- *Can this surface something a client should not see?* The fallback exists for exactly that. `detail` is what FastAPI already returns in the HTTP body to this caller, so it is not new exposure — but the fallback catches an empty body, HTML from a proxy, a blank string, and a **non-string `detail`**. That last case is the one worth naming: FastAPI's own validation errors put a LIST of objects (`loc`/`msg`/`type`) in `detail`, and stringifying that at a client surface would leak internal field paths and read like a stack trace. It is refused by type, not by inspection.
- *Why not a message map keyed on status?* Because the backend's reasons are more specific than its status codes — 409 alone cannot say whether the name collided or the content hash did. A map would have to be kept in sync with the backend forever; this reads what the backend actually said.

## Bites

**Consumer:** the `/portal/vault` upload error toast — the surface the audit found showing a bare number.

**Observation (run now, on this branch):** `npx vitest run src/hooks/useVaultUpload.test.tsx` → **16 passed**, with four new cases: the live 409 duplicate-guard sentence verbatim, a `message`-shaped envelope, and a parameterised fallback over empty body / proxy HTML / list-shaped `detail` / blank `detail`.

Guilt-proof: restoring `` message: `Upload failed (${xhr.status})` `` turns exactly the two positive cases red and leaves the four fallback cases green —
```
FAIL src/hooks/useVaultUpload.test.tsx > shows the reason the server gave, not just its status code
FAIL src/hooks/useVaultUpload.test.tsx > prefers `message` when the envelope uses it instead of `detail`
```
That split is the point: the guard discriminates, it does not just pass. `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
