### PR TITLE
fix(portal): a soft-deleted client is cut off at the front door, not halfway

### DIFF
--- a/apps/backend-rag/backend/app/routers/auth.py
+++ b/apps/backend-rag/backend/app/routers/auth.py
@@ -345,14 +345,35 @@ async def login(
         async with db_pool.acquire() as conn:
             # Real database authentication using team_members
             # Use case-insensitive query to handle email case variations
+            # A soft-deleted CRM client must not be able to sign in.
+            #
+            # Until 2026-09-11 this query hit `team_members` alone, with no
+            # join to `clients` — so a client whose CRM record carried
+            # `deleted_at` but whose `team_members` row was still
+            # `active`/`portal_access` with a real PIN logged in
+            # successfully. Most portal endpoints then 404'd on first use
+            # (the "BUG C" fixes: `portal_dashboard.py`, `portal.py:262`,
+            # `send_message`), but not all of them, so the result was a
+            # partially-open door rather than the clean cutoff the repo's
+            # own comments state as the intent (portal audit bridge F4).
+            #
+            # Gating HERE closes the whole class, including endpoints added
+            # later that forget the filter. `linked_client_id IS NULL` keeps
+            # every staff login — which has no client row — untouched; the
+            # no-row branch below is the existing generic failure, so this
+            # adds no enumeration signal.
             query = """
-                SELECT id, email,
-                       COALESCE(full_name, name) as name,
-                       pin_hash as password_hash, role,
-                       'active' as status, NULL::jsonb as metadata, language as language_preference,
-                       active, avatar, linked_client_id, portal_access
-                FROM team_members
-                WHERE LOWER(email) = LOWER($1)
+                SELECT tm.id, tm.email,
+                       COALESCE(tm.full_name, tm.name) as name,
+                       tm.pin_hash as password_hash, tm.role,
+                       'active' as status, NULL::jsonb as metadata,
+                       tm.language as language_preference,
+                       tm.active, tm.avatar, tm.linked_client_id,
+                       tm.portal_access
+                FROM team_members tm
+                LEFT JOIN clients c ON c.id = tm.linked_client_id
+                WHERE LOWER(tm.email) = LOWER($1)
+                  AND (tm.linked_client_id IS NULL OR c.deleted_at IS NULL)
             """
             user = await conn.fetchrow(query, request.email)
 

--- a/apps/backend-rag/backend/services/portal/_mixins/messaging.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/messaging.py
@@ -32,8 +32,23 @@ class PortalMessagingMixin:
         *,
         current_user: ClientContext,
     ) -> dict[str, Any]:
-        """Get message threads for client."""
+        """Get message threads for client.
+
+        `send_message` has always refused a soft-deleted client; READING the
+        thread did not, so a deleted client's session could still pull their
+        entire message history (portal audit bridge F4). The router's
+        `ValueError` catch was written for exactly this and documented as
+        unreachable — it is now reachable, and answers 404 like
+        `get_dashboard` does.
+        """
         async with self.pool.acquire() as conn:
+            client = await conn.fetchrow(
+                "SELECT id FROM clients WHERE id = $1 AND deleted_at IS NULL",
+                client_id,
+            )
+            if not client:
+                raise ValueError(f"Client {client_id} not found")
+
             messages = await conn.fetch(
                 """
                 SELECT m.id, m.subject, m.content, m.direction, m.sent_by,

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_deleted_client_cutoff.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_deleted_client_cutoff.py
@@ -1,0 +1,120 @@
+"""A soft-deleted CRM client must not reach the portal — front door included.
+
+Portal↔CRM bridge audit F4 (2026-09-11). Before this, the cutoff was
+partial: `auth.py`'s login hit `team_members` alone with no join to
+`clients`, so a client whose CRM record carried `deleted_at` — but whose
+`team_members` row was still active with a real PIN — signed in
+successfully. Most portal endpoints then 404'd on first use (the "BUG C"
+fixes), but `get_messages` filtered nothing, so the archived client's whole
+message history stayed readable.
+
+Narrowing portal access for archived clients is a business decision reserved
+to the owner (see `test_deleted_at_guard_registry.py`'s docstring). It was
+taken deliberately, as item 8 of the owner's ordered remediation list, and
+`DELETED_AT_GUARD_REGISTRY` records it in the same PR.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.app.routers import auth
+from backend.services.portal.portal_service import PortalService
+
+
+def _login_sql() -> str:
+    """The login query, with comment lines stripped.
+
+    The cure's own comment quotes what it replaced, and a substring test over
+    raw source would convict the explanation (superscar #3, guard-over-match).
+    """
+    return "\n".join(
+        line
+        for line in inspect.getsource(auth.login).splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+def test_login_joins_clients_and_excludes_soft_deleted_ones() -> None:
+    """Guilt-proof: drop the join or the predicate and this fails."""
+    sql = _login_sql()
+
+    assert "LEFT JOIN clients c ON c.id = tm.linked_client_id" in sql
+    assert "c.deleted_at IS NULL" in sql
+
+
+def test_login_still_admits_staff_who_have_no_client_row() -> None:
+    """The gate must not lock out staff.
+
+    Staff `team_members` rows carry `linked_client_id IS NULL`, so a plain
+    `c.deleted_at IS NULL` on a LEFT JOIN would evaluate NULL and exclude
+    every one of them. The `linked_client_id IS NULL OR` arm is what keeps
+    them in — remove it and this fails.
+    """
+    sql = _login_sql()
+
+    assert "tm.linked_client_id IS NULL OR c.deleted_at IS NULL" in sql
+
+
+class _Ctx:
+    async def __aenter__(self) -> object:
+        return None
+
+    async def __aexit__(self, *_a: object) -> None:
+        return None
+
+
+def _service(client_row: object) -> tuple[PortalService, AsyncMock]:
+    conn = AsyncMock()
+    conn.fetchrow.return_value = client_row
+    conn.transaction = MagicMock(return_value=_Ctx())
+    pool = MagicMock()
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+    return PortalService(pool), conn
+
+
+@pytest.mark.asyncio
+async def test_get_messages_refuses_a_soft_deleted_client() -> None:
+    """The one read that never filtered.
+
+    The router's `ValueError` catch was written for exactly this and carried
+    a comment saying it was unreachable. It is reachable now, and answers 404
+    like `get_dashboard` does.
+    """
+    service, conn = _service(client_row=None)
+
+    with pytest.raises(ValueError, match="not found"):
+        await service.get_messages(
+            7,
+            current_user={"client_id": 7, "email": "client@example.test"},
+        )
+
+    # The guard ran BEFORE any message was read.
+    conn.fetch.assert_not_awaited()
+    guard_sql = conn.fetchrow.call_args.args[0]
+    assert "FROM clients" in guard_sql
+    assert "deleted_at IS NULL" in guard_sql
+
+
+@pytest.mark.asyncio
+async def test_get_messages_still_serves_a_live_client() -> None:
+    """INNOCENCE half: the guard must not refuse everyone.
+
+    Without this, `raise ValueError` unconditionally would pass the test
+    above — the guilt proof alone is not a discriminator.
+    """
+    service, conn = _service(client_row={"id": 7})
+    conn.fetch.return_value = []
+    conn.fetchval.return_value = 0
+
+    result = await service.get_messages(
+        7,
+        current_user={"client_id": 7, "email": "client@example.test"},
+    )
+
+    conn.fetch.assert_awaited()
+    assert result["messages"] == []

--- a/apps/backend-rag/backend/tests/unit/services/portal/test_deleted_at_guard_registry.py
+++ b/apps/backend-rag/backend/tests/unit/services/portal/test_deleted_at_guard_registry.py
@@ -103,6 +103,24 @@ VISIBILITY_HELPER_NAME = "document_visibility_clause"
 # `download_document` and `get_documents` stay in the registry — same PR
 # moved their guard from an inline literal to the shared helper call, the
 # runtime SQL is unchanged.
+#
+# One name was ADDED 2026-09-11, ON THE OWNER'S INSTRUCTION, as item 8 of
+# the ordered remediation list for the 2026-09-11 portal audit:
+#   - `get_messages`: the last gap. `send_message` has refused a
+#     soft-deleted client since the BUG C fixes, but READING the thread
+#     filtered nothing — so an archived client's session could still pull
+#     their entire message history while the dashboard and the send path
+#     404'd around them. That is not a policy, it is an inconsistency: the
+#     repo's own BUG C comments state a clean cutoff as the intent, and this
+#     was the one method left out of it. The owner named both this and the
+#     login gate explicitly, so the narrowing is deliberate and visible, as
+#     this module's docstring requires — not absorbed by a routine change.
+#
+# The same PR gates `auth.py`'s login itself on `clients.deleted_at IS NULL`
+# (staff rows, which have no `linked_client_id`, are untouched). That is the
+# structural half of the decision and it is NOT expressible in this
+# registry, which only scans PortalService mixins — recorded here so the
+# next reader of this file knows the front door moved too.
 DELETED_AT_GUARD_REGISTRY = frozenset(
     {
         "_get_profile_data",
@@ -110,6 +128,7 @@ DELETED_AT_GUARD_REGISTRY = frozenset(
         "get_company_detail",
         "get_dashboard",
         "get_documents",
+        "get_messages",
         "get_timeline",
         "get_visa_status",
         "restore_document",


### PR DESCRIPTION
## What

The cutoff for a soft-deleted client was partial.

`auth.py`'s login hit `team_members` alone with no join to `clients`, so a client whose CRM record carried `deleted_at` — but whose `team_members` row was still `active`/`portal_access` with a real PIN — **signed in successfully**. Most portal endpoints then 404'd on first use (the "BUG C" fixes in `portal_dashboard.py`, `portal.py:262`, `send_message`), but `get_messages` filtered nothing at all: the archived client's entire message history stayed readable while everything around it refused.

A partially-open door, not the clean cutoff the repo's own BUG C comments state as the intent. Portal audit **bridge F4 (P2)**.

## How

- **Login** gates on `clients.deleted_at IS NULL`, which closes the whole class — including endpoints added later that forget the filter.
- **`get_messages`** acquires the same guard `send_message` already had, before reading anything. The router's `ValueError` catch was written for exactly this and carried a comment saying it was unreachable; it is reachable now and answers 404 like `get_dashboard`.

## Adversarial review

- *Does the login gate lock out staff?* No, and this is the subtle part. Staff rows carry `linked_client_id IS NULL`, so a bare `c.deleted_at IS NULL` on a LEFT JOIN would evaluate NULL and exclude **every staff login**. The `tm.linked_client_id IS NULL OR` arm is load-bearing, and there is a test whose only job is to fail if it is removed.
- *Does this add an enumeration signal?* No. The no-row branch is the pre-existing generic "User not found" path, with the same audit log and the same brute-force accounting.
- *Is this mine to decide?* Not unilaterally, and the repo enforces that: `test_deleted_at_guard_registry.py`'s docstring reserves "should archived clients be locked out of more of the portal" to the owner, and its registry test **went red** on this change, exactly as designed. The owner named both gaps — login and `get_messages` — as item 8 of the ordered remediation list for this audit, so the narrowing is deliberate and visible. `DELETED_AT_GUARD_REGISTRY` is updated in this same PR with that reasoning, which is what the test asks for. The login half is also recorded there even though the registry cannot express it (it only scans PortalService mixins), so the next reader knows the front door moved too.
- *Does a live session survive deletion?* Its JWT stays valid until expiry, and `get_current_user` reads `team_members` only. Every portal read it can reach is now guarded, so it gets 404s rather than data — but revoking the session on soft-delete would be the stronger move, and it is not in this PR.

## Bites

**Consumers:** `POST /api/auth/login` (which was admitting archived clients) and `GET /api/portal/messages` (which was serving them their history).

**Observation (run now, on this branch):**
- `pytest backend/tests/unit/app/routers/test_deleted_client_cutoff.py` → **4 passed**: two structural guilt-proofs on the login SQL (join present, predicate present, and the staff arm present) and a guilt/innocence pair on `get_messages` — refuses a deleted client *before* reading (`conn.fetch.assert_not_awaited()`), still serves a live one.
- `pytest backend/tests/unit/services/portal backend/tests/unit/app/services/portal backend/tests/unit/routers/test_portal.py` → **273 passed**, with the guard registry green again against the updated pin.

The innocence half is not decoration: without it, `raise ValueError` unconditionally would satisfy the guilt proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
