### PR TITLE
fix(auth): /profile stops 500ing on the 84% of clients whose full_name is NULL

### DIFF
--- a/apps/backend-rag/backend/app/routers/auth.py
+++ b/apps/backend-rag/backend/app/routers/auth.py
@@ -213,8 +213,22 @@ async def get_current_user(
     # Get user from database using connection pool
     async with db_pool.acquire() as conn:
         logger.debug("Validating user: %s", user_id)
+        # COALESCE, not `full_name as name`: `full_name` is NULLABLE while
+        # `name` is NOT NULL, and the two portal write paths only ever fill
+        # ONE of them — `ensure_portal_profile` inserts `name` and never
+        # `full_name`, and `complete_registration`'s existing-user branch
+        # updates neither. Measured on production 2026-09-11: 455 of 540
+        # `role='client'` rows carry `full_name IS NULL`, so `name` arrived
+        # as None and `UserProfile(**current_user)` — where `name: str` is
+        # required — raised a ValidationError that GET /api/auth/profile
+        # turned into a bare HTTP 500. The portal's Settings → Account tab
+        # rendered "Unable to load profile." for 84% of clients (portal audit
+        # finding F-03).
         query = """
-            SELECT id::text, email, full_name as name, role, 'active' as status, NULL::jsonb as metadata, language as language_preference, avatar
+            SELECT id::text, email,
+                   COALESCE(full_name, name, email) as name,
+                   role, 'active' as status, NULL::jsonb as metadata,
+                   language as language_preference, avatar
             FROM team_members
             WHERE id::text = $1 AND email = $2 AND active = true
         """

--- a/apps/backend-rag/backend/services/portal/portal_profile_service.py
+++ b/apps/backend-rag/backend/services/portal/portal_profile_service.py
@@ -65,14 +65,17 @@ class PortalProfileService:
                 member_id = await conn.fetchval(
                     """
                     INSERT INTO team_members (
-                        name, email, pin_hash, role,
+                        name, full_name, email, pin_hash, role,
                         linked_client_id, portal_access, active
                     )
-                    VALUES ($1, $2, $3, 'client', $4, true, true)
+                    VALUES ($1, $1, $2, $3, 'client', $4, true, true)
                     ON CONFLICT (email) DO UPDATE
                         SET linked_client_id = EXCLUDED.linked_client_id,
                             portal_access = true,
-                            name = EXCLUDED.name
+                            name = EXCLUDED.name,
+                            full_name = COALESCE(
+                                team_members.full_name, EXCLUDED.full_name
+                            )
                         WHERE team_members.role = 'client'
                     RETURNING id
                     """,

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_auth_profile_null_full_name.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_auth_profile_null_full_name.py
@@ -1,0 +1,87 @@
+"""GET /api/auth/profile must not 500 on a client whose full_name is NULL.
+
+Portal audit finding F-03 (2026-09-11, live): the portal's Settings → Account
+tab rendered "Unable to load profile." and the backing
+`GET /api/auth/profile` answered HTTP 500.
+
+Root cause: `get_current_user` selected `full_name as name`. `full_name` is
+NULLABLE, `name` is NOT NULL, and the two portal write paths only ever fill
+ONE of them — `ensure_portal_profile` inserts `name` and never `full_name`,
+`complete_registration`'s existing-user branch updates neither. Measured on
+production the same day: **455 of 540 `role='client'` rows carry
+`full_name IS NULL`**, so `name` arrived as None and
+`UserProfile(**current_user)`, where `name: str` is required, raised a
+ValidationError that the route turned into a bare 500 — for 84% of clients.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from pydantic import ValidationError
+
+from backend.app.models import UserProfile
+from backend.app.routers import auth
+from backend.services.portal import portal_profile_service
+
+
+def _row(name: object) -> dict[str, object]:
+    """The shape `get_current_user` returns to the route."""
+    return {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "email": "client@example.test",
+        "name": name,
+        "role": "client",
+        "status": "active",
+        "metadata": None,
+        "language_preference": "en",
+        "avatar": None,
+    }
+
+
+def test_user_profile_rejects_a_null_name_which_is_why_the_route_500d() -> None:
+    """The failure mode, pinned: this is what a NULL full_name produced."""
+    with pytest.raises(ValidationError):
+        UserProfile(**_row(None))
+
+
+def test_user_profile_accepts_a_real_name() -> None:
+    profile = UserProfile(**_row("Client Name"))
+    assert profile.name == "Client Name"
+    assert profile.email == "client@example.test"
+
+
+def test_get_current_user_query_coalesces_the_nullable_column() -> None:
+    """Guilt-proof on the projection, which is where the 500 lives.
+
+    A unit test cannot reach the live query without a database, so assert the
+    SQL. Restoring `full_name as name` fails the first assertion; a COALESCE
+    that puts `email` first — losing every real name — fails the second.
+    """
+    # Comment lines are stripped first: the cure's own comment QUOTES the
+    # broken projection to explain it, and a substring test over raw source
+    # would convict the explanation (superscar #3, guard-over-match). The
+    # guard is about the CODE, so read the code.
+    code = "\n".join(
+        line
+        for line in inspect.getsource(auth.get_current_user).splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+    assert "full_name as name" not in code, (
+        "full_name is nullable: projecting it straight into UserProfile.name "
+        "(a required str) IS the 500"
+    )
+    assert "COALESCE(full_name, name, email) as name" in code
+    assert "FROM team_members" in code
+
+
+def test_ensure_portal_profile_writes_both_name_columns() -> None:
+    """The divergence stops being created: new rows carry full_name too, and
+    a re-provision never overwrites a full_name that is already set."""
+    source = inspect.getsource(portal_profile_service.PortalProfileService)
+
+    assert "name, full_name, email" in source
+    assert "full_name = COALESCE(" in source
+    assert "team_members.full_name" in source


### PR DESCRIPTION
## What

The portal's Settings → Account tab rendered "Unable to load profile." and `GET /api/auth/profile` answered HTTP 500 (portal audit **F-03**, measured live 2026-09-11).

`get_current_user` projected `full_name as name`. **`full_name` is NULLABLE while `name` is NOT NULL**, and the two portal write paths each fill only ONE of them:

- `ensure_portal_profile` inserts `name` and never `full_name`;
- `complete_registration`'s existing-user branch — the branch every provisioned client goes through — updates neither.

Measured on production the same day:

```sql
SELECT role, (full_name IS NULL) AS full_name_null, count(*)
  FROM team_members WHERE role='client' GROUP BY 1,2;
-- client | t | 455
-- client | f |  85
```

**455 of 540.** So `name` arrived as `None`, `UserProfile(**current_user)` — where `name: str` is required — raised a ValidationError, and the route had no handler for it. 84% of clients could not open the tab.

## How

- `COALESCE(full_name, name, email) as name`. `name` is the NOT NULL column, so the projection can no longer yield NULL. This closes the 500 for all 455 existing rows **without a data migration**.
- `ensure_portal_profile` writes both columns, so the divergence stops being created. On the conflict branch, an existing non-null `full_name` is filled only when empty, never overwritten.

## Adversarial review

- *Blast radius:* `get_current_user` is a dependency of nearly every authenticated route, so this line is about as hot as a line gets here. It is a projection change only, and it changes a value in exactly one direction: `None` → a real string. Nothing can start receiving `None` that was not already.
- *Could anything be relying on `name` being None?* Nothing can usefully rely on a value that makes the only model built from it raise. `UserProfile.name` is typed `str`.
- *Why `email` as the last fallback?* Defence in depth — it is unreachable today (`name` is NOT NULL) and exists so a future nullable-ing of `name` degrades to a usable label instead of a 500.
- *Why not backfill `full_name` in a migration?* A migration is a data decision and this is a read bug. The COALESCE serves every existing row; the provisioning fix stops new ones. A backfill remains available and is now cosmetic.
- *Not fixed here:* the route's bare `UserProfile(**current_user)` with no ValidationError handler is what turned a NULL into a 500 rather than a named error. Worth narrowing, separate concern.

## Bites

**Consumers:** `GET /api/auth/profile` (the 500), and `ensure_portal_profile` (the writer that created the NULLs).

**Observation (run now, on this branch):** `pytest backend/tests/unit/app/routers/test_auth_profile_null_full_name.py` → **4 passed**:
1. the failure mode pinned — `UserProfile(**row_with_name_None)` raises `ValidationError`;
2. it accepts a real name;
3. a guilt-proof on the SQL: `full_name as name` absent, `COALESCE(full_name, name, email) as name` present. **Comment lines are stripped before matching**, because the cure's own comment quotes the broken projection to explain it, and a raw substring test convicted the explanation — superscar #3, guard-over-match, caught by this test failing on its first run;
4. `ensure_portal_profile` writes both columns and coalesces on conflict.

Plus `pytest backend/tests/routers/test_crm_clients_portal_hook.py backend/tests/unit/app/routers/test_crm_portal_status_placeholder.py backend/tests/services/portal` → **68 passed** (no regression in the provisioning path).

Live proof after deploy: `GET /api/auth/profile` as the synthetic audit client — whose row is one of the 455 — returns 200, recorded as a comment on this PR before the client is cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
