### PR TITLE
fix(security): a second login counter keyed by email alone, so IP rotation stops paying

### DIFF
--- a/apps/backend-rag/backend/services/security/brute_force.py
+++ b/apps/backend-rag/backend/services/security/brute_force.py
@@ -1,8 +1,15 @@
 """
 Brute force detection for login endpoint (S03 Sprint 3).
 
-Uses IP+email pair to avoid NAT/coworking collateral blocking.
-5 failures in 5 minutes per IP+email → 429 for 5 minutes.
+TWO counters, because one was not enough:
+  - IP+email pair: 5 failures / 5 min -> 429 for 5 min. Keyed on the pair to
+    avoid NAT/coworking collateral blocking.
+  - email alone, across every source IP: 30 failures / 15 min -> 429 for
+    15 min. Added 2026-09-11 (authz audit F2) because rotating the source IP
+    reset the pair counter on every new IP, leaving only the generic
+    120 req/min-per-IP bucket between an attacker and a 4-digit PIN space.
+    See the constants below for the thresholds' reasoning and the
+    account-lockout trade-off it accepts.
 Fail-open: Redis down = no blocking.
 
 Fail-open means the login endpoint keeps serving with NO rate limiting at all,
@@ -27,6 +34,33 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_FAILURES = 5
 DEFAULT_WINDOW_SECONDS = 300
 DEFAULT_BLOCK_SECONDS = 300
+
+# A SECOND counter, keyed by email alone, across every source IP.
+#
+# WHY (portal authz audit F2, 2026-09-11): the per-(IP, email) counter is
+# NAT-friendly by design, and that is exactly what defeats it. An attacker
+# rotating source IPs — a residential proxy pool or a botnet — resets the
+# pair counter on every new IP, so against a KNOWN email the only remaining
+# backstop was the generic 120 req/min-per-IP RateLimitMiddleware bucket.
+# A PIN is 4-6 digits, minimum 4 = 10,000 combinations, so the whole space
+# was reachable in well under an hour at that rate.
+#
+# The thresholds are deliberately looser than the pair's: this key aggregates
+# every IP, and a real client on a flaky mobile connection can change IP
+# mid-attempt. 30 failures in 15 minutes for ONE account is far past any
+# human typo pattern, and it cuts a full 4-digit sweep from under an hour to
+# weeks.
+#
+# ACCEPTED TRADE-OFF, stated rather than hidden: because this key ignores the
+# source IP, an attacker who knows a client's email CAN deliberately burn 30
+# failures to lock that client out for the block window. The pair counter
+# never had that property. The block window is therefore kept SHORT (15
+# minutes, not hours) to bound the damage, and the alternative is worse — a
+# rotating-IP attacker walking a 4-digit PIN space unimpeded. Revisit if
+# targeted lockouts are ever observed.
+DEFAULT_EMAIL_MAX_FAILURES = 30
+DEFAULT_EMAIL_WINDOW_SECONDS = 900
+DEFAULT_EMAIL_BLOCK_SECONDS = 900
 
 # Process-wide last-reported state. None = nothing reported yet, so the first
 # call always logs. Logging on TRANSITION (not per request) keeps an outage to
@@ -83,11 +117,17 @@ class BruteForceDetector:
         max_failures: int = DEFAULT_MAX_FAILURES,
         window_seconds: int = DEFAULT_WINDOW_SECONDS,
         block_seconds: int = DEFAULT_BLOCK_SECONDS,
+        email_max_failures: int = DEFAULT_EMAIL_MAX_FAILURES,
+        email_window_seconds: int = DEFAULT_EMAIL_WINDOW_SECONDS,
+        email_block_seconds: int = DEFAULT_EMAIL_BLOCK_SECONDS,
     ) -> None:
         self._redis = redis_client
         self._max_failures = max_failures
         self._window_seconds = window_seconds
         self._block_seconds = block_seconds
+        self._email_max_failures = email_max_failures
+        self._email_window_seconds = email_window_seconds
+        self._email_block_seconds = email_block_seconds
 
     def _fail_key(self, ip: str, email: str) -> str:
         return f"auth_fail:{ip}:{email.lower()}"
@@ -95,11 +135,22 @@ class BruteForceDetector:
     def _block_key(self, ip: str, email: str) -> str:
         return f"auth_block:{ip}:{email.lower()}"
 
+    def _email_fail_key(self, email: str) -> str:
+        return f"auth_fail_email:{email.lower()}"
+
+    def _email_block_key(self, email: str) -> str:
+        return f"auth_block_email:{email.lower()}"
+
     async def is_blocked(self, ip: str, email: str) -> bool:
         if not self._redis:
             return False
         try:
-            return bool(await self._redis.exists(self._block_key(ip, email)))
+            # BOTH keys, and the email one is not optional: checking only the
+            # pair is what let an IP rotation walk straight past the block.
+            blocked = await self._redis.exists(self._block_key(ip, email))
+            if blocked:
+                return True
+            return bool(await self._redis.exists(self._email_block_key(email)))
         except (RedisError, OSError) as e:
             logger.warning("S03: Brute force check failed (fail-open): %s", e)
             return False
@@ -107,23 +158,59 @@ class BruteForceDetector:
             logger.exception("S03: Brute force check unexpected error (fail-open)")
             return False
 
+    async def _record_one(
+        self,
+        *,
+        fail_key: str,
+        block_key: str,
+        window_seconds: int,
+        block_seconds: int,
+        max_failures: int,
+        scope: str,
+        ip: str,
+        email: str,
+    ) -> None:
+        count = await self._redis.incr(fail_key)
+        if count == 1:
+            await self._redis.expire(fail_key, window_seconds)
+        if count > max_failures:
+            await self._redis.setex(
+                block_key,
+                block_seconds,
+                f"brute_force:{count}_attempts",
+            )
+            logger.warning(
+                "S03: Brute force block scope=%s ip=%s email=%s attempts=%s",
+                scope,
+                ip,
+                email,
+                count,
+            )
+
     async def record_failure(self, ip: str, email: str) -> None:
         if not self._redis:
             return
         try:
-            key = self._fail_key(ip, email)
-            count = await self._redis.incr(key)
-            if count == 1:
-                await self._redis.expire(key, self._window_seconds)
-            if count > self._max_failures:
-                await self._redis.setex(
-                    self._block_key(ip, email),
-                    self._block_seconds,
-                    f"brute_force:{count}_attempts",
-                )
-                logger.warning(
-                    "S03: Brute force block ip=%s email=%s attempts=%s", ip, email, count
-                )
+            await self._record_one(
+                fail_key=self._fail_key(ip, email),
+                block_key=self._block_key(ip, email),
+                window_seconds=self._window_seconds,
+                block_seconds=self._block_seconds,
+                max_failures=self._max_failures,
+                scope="ip+email",
+                ip=ip,
+                email=email,
+            )
+            await self._record_one(
+                fail_key=self._email_fail_key(email),
+                block_key=self._email_block_key(email),
+                window_seconds=self._email_window_seconds,
+                block_seconds=self._email_block_seconds,
+                max_failures=self._email_max_failures,
+                scope="email",
+                ip=ip,
+                email=email,
+            )
         except (RedisError, OSError) as e:
             logger.warning("S03: Brute force record failed: %s", e)
         except Exception:

--- a/apps/backend-rag/backend/tests/unit/services/security/test_brute_force.py
+++ b/apps/backend-rag/backend/tests/unit/services/security/test_brute_force.py
@@ -18,7 +18,13 @@ class TestBruteForceDetection:
         mock_redis.expire = AsyncMock()
         detector = BruteForceDetector(redis_client=mock_redis)
         await detector.record_failure("1.2.3.4", "user@test.com")
-        mock_redis.incr.assert_called_once()
+        # TWO counters since 2026-09-11 (authz F2): the (ip, email) pair AND
+        # email alone. Rotating the source IP used to reset the only one.
+        keys = [call.args[0] for call in mock_redis.incr.call_args_list]
+        assert keys == [
+            "auth_fail:1.2.3.4:user@test.com",
+            "auth_fail_email:user@test.com",
+        ]
 
     @pytest.mark.asyncio
     async def test_is_blocked_false_under_threshold(self):
@@ -172,3 +178,99 @@ class TestArmedStateIsAudible:
             BruteForceDetector(redis_client=redis_client)
 
         assert len(self._errors(caplog)) == 1
+
+
+# =============================================================================
+# F2 (2026-09-11 portal authz audit) — the lockout key was
+# `auth_fail:{ip}:{email}`, so an attacker rotating source IPs reset the
+# counter on every new IP. Against a KNOWN email the only remaining backstop
+# was the generic 120 req/min-per-IP bucket, and a PIN is 4-6 digits
+# (minimum 4 = 10,000 combinations). A second counter, keyed by email alone,
+# is what makes IP rotation stop paying.
+# =============================================================================
+
+
+class TestPerEmailCounter:
+    @pytest.mark.asyncio
+    async def test_ip_rotation_still_accumulates_on_the_email_key(self):
+        """The exploit, reproduced: 6 failures from 6 DIFFERENT IPs.
+
+        Each pair key stays at 1 — under the pair threshold, so the old code
+        never blocked anything — while the email key reaches 6.
+        """
+        from backend.services.security.brute_force import BruteForceDetector
+
+        counters: dict[str, int] = {}
+
+        async def incr(key: str) -> int:
+            counters[key] = counters.get(key, 0) + 1
+            return counters[key]
+
+        mock_redis = AsyncMock()
+        mock_redis.incr = incr
+        detector = BruteForceDetector(redis_client=mock_redis)
+
+        for i in range(6):
+            await detector.record_failure(f"10.0.0.{i}", "victim@test.com")
+
+        assert all(v == 1 for k, v in counters.items() if k.startswith("auth_fail:"))
+        assert counters["auth_fail_email:victim@test.com"] == 6
+
+    @pytest.mark.asyncio
+    async def test_blocks_on_the_email_key_alone(self):
+        from backend.services.security.brute_force import BruteForceDetector
+
+        mock_redis = AsyncMock()
+        mock_redis.incr = AsyncMock(return_value=31)
+        detector = BruteForceDetector(
+            redis_client=mock_redis,
+            max_failures=5,
+            email_max_failures=30,
+        )
+        await detector.record_failure("1.2.3.4", "u@t.com")
+
+        blocked = [call.args[0] for call in mock_redis.setex.call_args_list]
+        assert "auth_block_email:u@t.com" in blocked
+
+    @pytest.mark.asyncio
+    async def test_is_blocked_reads_the_email_key_when_the_pair_is_clean(self):
+        """Guilt-proof: check only the pair key and this fails.
+
+        A rotating attacker always presents a FRESH ip, so the pair block key
+        never exists for them — the email block key is the only one that can
+        stop the request.
+        """
+        from backend.services.security.brute_force import BruteForceDetector
+
+        async def exists(key: str) -> int:
+            return 1 if key == "auth_block_email:u@t.com" else 0
+
+        mock_redis = AsyncMock()
+        mock_redis.exists = exists
+        detector = BruteForceDetector(redis_client=mock_redis)
+
+        assert await detector.is_blocked("203.0.113.9", "u@t.com") is True
+
+    @pytest.mark.asyncio
+    async def test_is_blocked_false_when_neither_key_is_set(self):
+        """INNOCENCE half: without it, `return True` would satisfy the proof
+        above and lock every login out."""
+        from backend.services.security.brute_force import BruteForceDetector
+
+        async def exists(_key: str) -> int:
+            return 0
+
+        mock_redis = AsyncMock()
+        mock_redis.exists = exists
+        detector = BruteForceDetector(redis_client=mock_redis)
+
+        assert await detector.is_blocked("203.0.113.9", "u@t.com") is False
+
+    @pytest.mark.asyncio
+    async def test_email_counter_is_still_fail_open_without_redis(self):
+        """The documented degradation is unchanged — no new failure mode."""
+        from backend.services.security.brute_force import BruteForceDetector
+
+        detector = BruteForceDetector(redis_client=None)
+        await detector.record_failure("1.2.3.4", "u@t.com")
+        assert await detector.is_blocked("1.2.3.4", "u@t.com") is False


### PR DESCRIPTION
## What

The lockout key was `auth_fail:{ip}:{email}` — 5 failures per (IP, email) pair in 5 minutes. Keyed on the pair deliberately, to avoid NAT/coworking collateral blocking, and that is exactly what defeated it: **an attacker rotating source IPs resets the counter on every new IP.**

Against a KNOWN email the only remaining backstop was the generic 120 req/min-per-IP `RateLimitMiddleware` bucket, and a portal PIN is 4-6 digits (`portal_invite.py::validate_pin`) — minimum 4 = **10,000 combinations**, reachable in well under an hour at that rate. Portal authz audit finding **F2 (P2)**.

## How

A second counter keyed by email across every source IP: 30 failures / 15 min → 429 for 15 min. `is_blocked` reads **both** keys, which is the half that matters — a rotating attacker always presents a fresh IP, so the pair block key never exists for them.

Thresholds are looser than the pair's on purpose: this key aggregates every IP, and a real client on a flaky mobile connection can change IP mid-attempt. 30 failures in 15 minutes for one account is far past any human typo pattern, and it turns a full 4-digit sweep from under an hour into weeks.

## Adversarial review

**The trade-off this buys, stated rather than hidden — @Balizero1987 this is the one bit worth your eye.** Because the new key ignores the source IP, an attacker who knows a client's email **can** burn 30 failures to lock that client out of the portal for 15 minutes. The pair counter never had that property, and that was the reason it was keyed the way it was. I took it anyway, because the alternative is a rotating-IP attacker walking a 4-digit PIN space unimpeded, and the window is kept short (15 minutes, not hours) to bound the damage. It is written in the code, not just here. Say the word and I will raise the threshold or drop the email block to alert-only.

- *Why not the audit's other suggestion — a longer minimum PIN?* It has no lockout downside, but it only constrains PIN **creation**, so it does nothing for every client who already holds a 4-digit one. That is why this is the half that shipped. Raising the minimum is a separate, additive PR whenever you want it.
- *Does this touch the fail-open behaviour?* No. Redis loss still means no blocking, and `report_armed_state` still announces that transition exactly once — the W104/family-#2 cure stays intact, with a test pinning it.
- *Redis key growth?* One extra key per email with a 15-minute TTL, set only on failures.

## Bites

**Consumer:** `POST /api/auth/login` — `is_blocked` is checked before the credential comparison and `record_failure` on every miss.

**Observation (run now, on this branch):** `pytest backend/tests/unit/services/security/test_brute_force.py` → **18 passed**, five of them new:
1. **the exploit reproduced** — 6 failures from 6 different IPs, each pair key staying at 1 (under the old threshold, so the old code blocked nothing) while the email key reaches 6;
2. blocking fires on the email key alone;
3. a guilt-proof that `is_blocked` reads the email key when the pair is clean;
4. the INNOCENCE half — false when neither key is set (without it, `return True` would satisfy #3 and lock out every login);
5. fail-open with no Redis is unchanged.

Guilt-proof run: replacing the email-key read in `is_blocked` with `return False` turns exactly case 3 red, 17 others green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
