### PR TITLE
fix(mouth): the diverged-login warning uses the semantic warning token, not a hex fallback

### DIFF
--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.tsx
@@ -170,7 +170,7 @@ export function PortalAccess({
                   had no way to know the client still signs in with the old
                   one. */}
               {loginEmailDiverged ? (
-                <p className="text-xs text-[var(--bz-warning,#d97706)] mt-1">
+                <p className="text-xs text-[var(--state-warning)] mt-1">
                   Signs in as {status.portal_email} — the CRM now has{" "}
                   {clientEmail}. Changing the email here does not move the
                   portal login; the client must keep using {status.portal_email}


### PR DESCRIPTION
## What

`PortalAccess.tsx:173` shipped `var(--bz-warning,#d97706)` in #6190. token-lint flagged the hex fallback as a hardcoded brand colour in a redesigned surface (run 34544307961) — the check failed on that PR and the PR merged anyway, so the violation is on `main`. This replaces it with `--state-warning`, the token the rest of this tree already uses for the same state (`AiSummaryCard.tsx:70`, `GateScreen.tsx:190`).

No behaviour change — same warning, same place, themed instead of hardcoded.

## Bites

CONSUMER: the CRM client page's Portal Access panel, and the token-lint required check.
OBSERVATION: token-lint goes green on this PR's own diff (it is the only added line touching that surface), and the rendered warning keeps its amber colour from `--state-warning` — verified after deploy on the client page of a client whose CRM email diverges from the portal login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)