### PR TITLE
fix(crm): a document the client removed is no longer shown as live

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_enhanced.py
+++ b/apps/backend-rag/backend/app/routers/crm_enhanced.py
@@ -1084,6 +1084,7 @@ async def get_client_profile(
                 d.file_name, d.file_id, d.file_url, d.google_drive_file_url,
                 d.status, d.expiry_date, d.notes, d.family_member_id,
                 d.practice_id, d.created_at, d.updated_at,
+                d.deleted_at, d.uploaded_source,
                 fm.full_name as family_member_name,
                 CASE
                     WHEN d.expiry_date <= CURRENT_DATE THEN 'expired'

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_enhanced.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_enhanced.py
@@ -98,6 +98,37 @@ class TestGetClientProfile:
         assert result["stats"]["family_count"] == 0
 
     @pytest.mark.asyncio
+    async def test_profile_documents_query_projects_deleted_at(
+        self, mock_db_pool: MagicMock, mock_db_conn: AsyncMock, admin_user: dict, client_row: dict
+    ) -> None:
+        """The documents SELECT must name d.deleted_at and d.uploaded_source.
+
+        Guilt-proof for portal audit finding F-02: a document the CLIENT removed
+        from their vault is soft-deleted (deleted_at set, file kept in Drive,
+        restorable for 30 days) but is NOT archived, so it stays in this list —
+        and until 2026-09-11 the projection did not carry deleted_at, so the
+        team's CRM rendered it exactly like a live document. The assertion is on
+        the SQL text because the handler returns the rows unchanged
+        (``[dict(d) for d in documents]``): a row-level mock would only prove the
+        mock. Drop either column from the SELECT and this test goes red.
+        """
+        from backend.app.routers.crm_enhanced import get_client_profile
+
+        with patch("backend.app.routers.crm_enhanced.verify_client_access", new=AsyncMock()):
+            mock_db_conn.fetchrow = AsyncMock(return_value=client_row)
+            mock_db_conn.fetch = AsyncMock(return_value=[])
+            await get_client_profile(client_id=42, pool=mock_db_pool, current_user=admin_user)
+
+        doc_queries = [
+            call.args[0]
+            for call in mock_db_conn.fetch.await_args_list
+            if "FROM documents d" in call.args[0]
+        ]
+        assert len(doc_queries) == 1, "expected exactly one SELECT ... FROM documents d"
+        assert "d.deleted_at" in doc_queries[0]
+        assert "d.uploaded_source" in doc_queries[0]
+
+    @pytest.mark.asyncio
     async def test_profile_not_found(
         self, mock_db_pool: MagicMock, mock_db_conn: AsyncMock, admin_user: dict
     ) -> None:

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/DocumentsTab.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/DocumentsTab.tsx
@@ -251,10 +251,29 @@ export function DocumentsTab({
                                 {badge.label}
                               </span>
                             )}
-                            {doc.status === "verified" && (
-                              <span className="text-xs text-green-500">
-                                ✓ Verified
+                            {doc.deleted_at ? (
+                              /* The client removed this from their vault.
+                                 It used to render identically to a live
+                                 document — status "received", alert_color
+                                 "green" — so the team could chase a file the
+                                 client had deliberately taken down, or count
+                                 it as still on file (portal audit F-02).
+                                 Flagged rather than hidden: it is restorable
+                                 for 30 days and the file is still in Drive,
+                                 so the team removing it from view would lose
+                                 information they may need. */
+                              <span
+                                className="text-xs px-1.5 py-0.5 rounded bg-[var(--state-danger)]/10 text-[var(--state-danger)]"
+                                title={`Removed by the client on ${formatDate(doc.deleted_at)} — restorable by them for 30 days`}
+                              >
+                                Removed by client
                               </span>
+                            ) : (
+                              doc.status === "verified" && (
+                                <span className="text-xs text-green-500">
+                                  ✓ Verified
+                                </span>
+                              )
                             )}
                           </div>
                         </div>

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -397,6 +397,19 @@ export interface ClientDocument {
   alert_color?: "green" | "yellow" | "red" | "expired";
   created_at?: string;
   updated_at?: string;
+  /**
+   * Set when the CLIENT removed the document from their portal vault
+   * (soft delete, restorable by them for 30 days; the file stays in Drive).
+   *
+   * Distinct from `is_archived`, which is the team-side archive and is
+   * already excluded from this list server-side. Until 2026-09-11 this field
+   * was not returned at all, so a removed document appeared in the team's
+   * list with `status: "received"` and `alert_color: "green"` — identical to
+   * a live one, with no field distinguishing them (portal audit F-02).
+   */
+  deleted_at?: string | null;
+  /** 'client' for a portal upload, 'team' for a CRM one. */
+  uploaded_source?: "client" | "team" | string;
 }
 
 export interface DocumentCreate {


### PR DESCRIPTION
## What

Portal audit finding F-02, measured live 2026-09-11: a client removed a document from their vault — a soft delete (`deleted_at` set, the file stays in Drive, restorable by the client for 30 days) — and the team's CRM kept listing it with `status: "received"` and `alert_color: "green"`, indistinguishable from a live document.

`GET /api/crm/clients/{id}/profile` excludes `is_archived` (the TEAM-side archive) but never projected `deleted_at`, so **no field in the payload could tell the two apart**. A consultant could chase a file the client had deliberately taken down, or count it as still on file.

- the documents SELECT now projects `d.deleted_at` and `d.uploaded_source`
- `ClientDocument` carries both, documented against the team-side archive
- `DocumentsTab` renders a "Removed by client" chip — with the removal date, and the 30-day restore window in the tooltip — in place of the verified tick

Flagged, not hidden: the removal is reversible and the file is still in Drive, so dropping the row from the team's view would lose information the team may need.

## Test

`test_profile_documents_query_projects_deleted_at` asserts on the **SQL text**, not on a mocked row: the handler returns rows unchanged (`[dict(d) for d in documents]`), so a row-level fixture would prove only the fixture. Verified red with the projection removed, green with it.

```
apps/backend-rag/.venv/bin/python -m pytest backend/tests/unit/routers/test_crm_enhanced.py -k profile
13 passed
```

## Bites

CONSUMER: the Documents tab of the CRM client page (`/clients/{id}`), which reads this endpoint's `documents[]`.
OBSERVATION: on client 12402 — whose vault holds one live document (19454) and one the client removed (19453) — the Documents tab shows the removed one with the "Removed by client" chip and the live one unchanged. To be made after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)