### PR TITLE
fix(portal): no tax obligations for a client the system knows nothing about

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/dashboard.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/dashboard.py
@@ -103,9 +103,14 @@ class PortalDashboardMixin:
                 companies[0] if companies else None,
             )
 
-            # Get upcoming tax deadlines (next 30 days)
+            # Get upcoming tax deadlines (next 30 days) — only for a client
+            # the system knows has tax obligations at all (F-05).
             today = datetime.now(timezone.utc)
-            tax_deadlines = self._get_standard_tax_deadlines(today)
+            tax_deadlines = (
+                self._get_standard_tax_deadlines(today)
+                if await self._has_tax_footprint(conn, client_id)
+                else []
+            )
             next_deadline = tax_deadlines[0] if tax_deadlines else None
 
             # Get action items (practices with required documents)
@@ -808,9 +813,16 @@ class PortalDashboardMixin:
             except Exception as e:
                 logger.warning("Could not fetch tax practices: %s", e)
 
-            # Generate standard tax deadlines
+            # Generate standard tax deadlines — only for a client the system
+            # knows has tax obligations at all (F-05). Without this gate a
+            # client with no company, no tax practice and no NPWP was shown
+            # three dated "Pending" obligations that are not theirs.
             today = datetime.now(timezone.utc)
-            deadlines = self._get_standard_tax_deadlines(today)
+            deadlines = (
+                self._get_standard_tax_deadlines(today)
+                if await self._has_tax_footprint(conn, client_id)
+                else []
+            )
 
             # Build obligations from deadlines (upcoming tax filings)
             obligations = []
@@ -863,7 +875,12 @@ class PortalDashboardMixin:
             return {
                 "summary": {
                     "status": status,
-                    "totalDue": 0,  # No payment tracking yet
+                    # No payment tracking exists in this system: there is no
+                    # amount to sum. It used to emit 0, which the portal
+                    # rendered as a confident "Rp 0" — a figure the backend
+                    # had not measured (portal audit finding, ux F2). None
+                    # means "not tracked" and the UI says so.
+                    "totalDue": None,
                     "nextDeadline": next_deadline,
                     "daysToDeadline": days_to_deadline,
                 },
@@ -1052,9 +1069,14 @@ class PortalDashboardMixin:
             except Exception as e:
                 logger.warning("Could not fetch practices for timeline: %s", e)
 
-            # Add upcoming deadlines (future events)
+            # Add upcoming deadlines (future events) — same gate as the
+            # dashboard and the Taxes page (F-05).
             today = datetime.now(timezone.utc)
-            deadlines = self._get_standard_tax_deadlines(today)
+            deadlines = (
+                self._get_standard_tax_deadlines(today)
+                if await self._has_tax_footprint(conn, client_id)
+                else []
+            )
             for deadline in deadlines[:3]:  # Max 3 deadlines
                 entries.append(
                     {
@@ -1081,6 +1103,46 @@ class PortalDashboardMixin:
     # ================================================
     # HELPER METHODS
     # ================================================
+
+    async def _has_tax_footprint(self, conn, client_id: int) -> bool:
+        """Does this client have anything that makes a tax calendar theirs?
+
+        ``_get_standard_tax_deadlines`` is a pure calendar: it generates PPh
+        21/23/4(2), PPN and the Annual SPT from today's date and nothing else.
+        Shown unconditionally, a brand-new client with no company, no tax
+        practice and no NPWP saw three dated obligations marked "Pending" on
+        their Taxes page and a live countdown on their dashboard — statutory
+        dates that are not, as far as this system knows, theirs to file
+        (portal audit finding F-05). A footprint is one company link, one
+        tax-category practice, or an NPWP on the client record.
+
+        FAILS OPEN on a query error (returns True, i.e. keep showing the
+        calendar): hiding a real deadline from a real taxpayer is the worse
+        of the two errors, and every other query in this mixin degrades the
+        same way rather than blanking the page.
+        """
+        try:
+            return bool(
+                await conn.fetchval(
+                    """
+                    SELECT
+                        EXISTS (SELECT 1 FROM client_company_links WHERE client_id = $1)
+                        OR EXISTS (
+                            SELECT 1 FROM practices p
+                            JOIN practice_types pt ON pt.id = p.practice_type_id
+                            WHERE p.client_id = $1 AND pt.category = 'tax'
+                        )
+                        OR EXISTS (
+                            SELECT 1 FROM clients
+                            WHERE id = $1 AND npwp IS NOT NULL AND btrim(npwp) <> ''
+                        )
+                    """,
+                    client_id,
+                ),
+            )
+        except Exception as e:
+            logger.warning("Could not determine tax footprint for client %s: %s", client_id, e)
+            return True
 
     def _get_standard_tax_deadlines(self, today: datetime) -> list[dict[str, Any]]:
         """Generate standard Indonesian tax deadlines."""

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_dashboard_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_dashboard_mixin.py
@@ -474,7 +474,9 @@ async def test_get_tax_overview_shapes_obligations_and_history() -> None:
 
     assert result["summary"]["status"] in {"none", "upcoming", "attention", "overdue"}
     assert result["summary"]["status"] != "compliant"
-    assert result["summary"]["totalDue"] == 0
+    # None, not 0: no payment tracking exists, so there is no figure to
+    # assert — the portal prints "Not tracked" rather than "Rp 0" (ux F2).
+    assert result["summary"]["totalDue"] is None
     assert len(result["obligations"]) == 3
     assert result["history"] == [
         {
@@ -485,6 +487,58 @@ async def test_get_tax_overview_shapes_obligations_and_history() -> None:
             "amount": 0,
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_tax_overview_is_empty_for_a_client_with_no_tax_footprint() -> None:
+    """No company, no tax practice, no NPWP -> no obligations at all.
+
+    Portal audit finding F-05: the deadlines are a pure calendar generated
+    from today's date, and a brand-new client with nothing registered was
+    shown three dated obligations marked "Pending" plus a live countdown,
+    reading as real per-client data.
+    """
+    service, conn = _service_with_conn()
+    conn.fetch.return_value = []
+    conn.fetchval.return_value = False  # _has_tax_footprint
+
+    result = await service.get_tax_overview(1, current_user=_ctx())
+
+    assert result["obligations"] == []
+    assert result["summary"]["status"] == "none"
+    assert result["summary"]["nextDeadline"] is None
+    assert result["summary"]["daysToDeadline"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_tax_overview_keeps_the_calendar_when_the_footprint_query_fails() -> None:
+    """The gate fails OPEN: hiding a real deadline is the worse error."""
+    service, conn = _service_with_conn()
+    conn.fetch.return_value = []
+    conn.fetchval.side_effect = RuntimeError("clients table unavailable")
+
+    result = await service.get_tax_overview(1, current_user=_ctx())
+
+    assert len(result["obligations"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_shows_no_tax_countdown_without_a_tax_footprint() -> None:
+    """Same gate on the dashboard widget (F-05): no footprint, no countdown."""
+    service, conn = _service_with_conn()
+    conn.fetchrow.side_effect = [
+        {"id": 1, "full_name": "Client One", "email": "client@example.com"},
+        None,
+        None,
+    ]
+    conn.fetch.return_value = []
+    conn.fetchval.return_value = False
+
+    result = await service.get_dashboard(1, current_user=_ctx())
+
+    assert result["taxes"]["status"] == "none"
+    assert result["taxes"]["nextDeadline"] is None
+    assert result["taxes"]["daysToDeadline"] is None
 
 
 @pytest.mark.asyncio

--- a/apps/mouth/src/app/portal/(authenticated)/taxes/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/taxes/page.test.tsx
@@ -95,6 +95,41 @@ describe("TaxesPage", () => {
     expect(container.innerHTML).not.toContain("rgba(255,255,255,0.05)");
   });
 
+  it("says Total Due is not tracked instead of printing Rp 0", async () => {
+    // The backend has no payment tracking, so it now sends totalDue: null
+    // rather than a hardcoded 0 that this tile rendered as a confident
+    // "Rp 0" (portal audit, ux F2). A measured zero still prints Rp 0.
+    mockGetTaxOverview.mockResolvedValue({
+      summary: { ...TAX_DATA.summary, totalDue: null },
+      obligations: [],
+    });
+    render(<TaxesPage />);
+
+    expect(await screen.findByText("Not tracked")).toBeInTheDocument();
+    expect(screen.queryByText("Rp 0")).toBeNull();
+  });
+
+  it("renders no obligations section when the client has none", async () => {
+    // A client with no company, no tax practice and no NPWP gets an empty
+    // obligations list from the backend (portal audit, live F-05).
+    mockGetTaxOverview.mockResolvedValue({
+      summary: {
+        status: "none",
+        totalDue: null,
+        nextDeadline: null,
+        daysToDeadline: null,
+        pendingCount: 0,
+        overdueCount: 0,
+      },
+      obligations: [],
+    });
+    render(<TaxesPage />);
+
+    await screen.findByText("Not tracked");
+    expect(screen.queryByText("Current Obligations")).toBeNull();
+    expect(screen.queryByText("Pending")).toBeNull();
+  });
+
   it("maps obligation statuses to the semantic --state-* tokens", async () => {
     await renderLoaded();
 

--- a/apps/mouth/src/app/portal/(authenticated)/taxes/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/taxes/page.tsx
@@ -211,11 +211,21 @@ export default function TaxesPage() {
             <p className="text-xs mb-1" style={{ color: "var(--bz-text-2)" }}>
               Total Due
             </p>
-            <p className="text-lg font-bold">
-              {taxData.summary.totalDue > 0
-                ? formatIDR(taxData.summary.totalDue)
-                : "Rp 0"}
-            </p>
+            {/* null means the backend tracks no payment amounts at all —
+                it used to send 0 and this tile rendered a confident
+                "Rp 0" (ux F2). A measured zero still prints Rp 0. */}
+            {taxData.summary.totalDue === null ? (
+              <p
+                className="text-lg font-bold"
+                style={{ color: "var(--bz-text-2)" }}
+              >
+                Not tracked
+              </p>
+            ) : (
+              <p className="text-lg font-bold">
+                {formatIDR(taxData.summary.totalDue)}
+              </p>
+            )}
           </div>
 
           <div className="p-4 rounded-lg" style={TILE_STYLE}>

--- a/apps/mouth/src/lib/api/portal/portal.api.ts
+++ b/apps/mouth/src/lib/api/portal/portal.api.ts
@@ -307,7 +307,7 @@ export class PortalApi {
         status:
           pick<TaxOverview["summary"]["status"]>(summary, ["status"]) ??
           "none",
-        totalDue: pick<number>(summary, ["totalDue", "total_due"]) ?? 0,
+        totalDue: pick<number>(summary, ["totalDue", "total_due"]) ?? null,
         nextDeadline:
           pick<string>(summary, ["nextDeadline", "next_deadline"]) ?? null,
         daysToDeadline:

--- a/apps/mouth/src/lib/api/portal/portal.types.ts
+++ b/apps/mouth/src/lib/api/portal/portal.types.ts
@@ -131,7 +131,9 @@ export interface ComplianceItem {
 export interface TaxOverview {
   summary: {
     status: "none" | "upcoming" | "attention" | "overdue";
-    totalDue: number;
+    /** null = the backend tracks no payment amounts, so there is no figure
+     *  to show. Distinct from 0, which would be a measured "nothing due". */
+    totalDue: number | null;
     nextDeadline: string | null;
     daysToDeadline: number | null;
     pendingCount: number;


### PR DESCRIPTION
## What

Portal audit finding **F-05**, measured live 2026-09-11 on a fresh client with 0 companies and no visa: the Taxes page listed three "Current Obligations" — PPh 21/23/4(2), PPN, Annual SPT — all **"Pending"**, each with a specific due date and countdown, and the dashboard ran a live `TAX: Oct 10 · 30 DAYS` widget.

None of that is per-client data. `_get_standard_tax_deadlines` is a pure calendar built from today's date, and it was called **unconditionally** at all three call sites (dashboard widget, Taxes page, timeline). A client with no company, no tax-category practice and no NPWP was shown statutory dates as if they were theirs to file.

`_has_tax_footprint(conn, client_id)` now gates all three: one company link, one tax-category practice, or an NPWP on the client record. It **fails open** on a query error — hiding a real deadline from a real taxpayer is the worse of the two errors, and every other query in this mixin degrades the same way.

Also **ux F2**, same page: the summary emitted `totalDue: 0` under the comment "No payment tracking yet", and the tile rendered it as a confident **"Rp 0"**. There is no payment tracking, so there is no figure: the backend sends `null` and the tile says "Not tracked". A measured zero still prints Rp 0.

The frontend already hides the obligations section on an empty list, so nothing was needed there.

## Test

Three new backend tests, verified red with the gate removed (obligations came back as 3, dashboard status `upcoming` instead of `none`) and green with it:

```
apps/backend-rag/.venv/bin/python -m pytest backend/tests/unit/app/services/portal/test_dashboard_mixin.py
27 passed
npx vitest run "src/app/portal/(authenticated)/taxes/page.test.tsx" src/lib/api/portal/portal.api.test.ts
49 passed
```

- `test_get_tax_overview_is_empty_for_a_client_with_no_tax_footprint`
- `test_get_tax_overview_keeps_the_calendar_when_the_footprint_query_fails` (fail-open guard)
- `test_get_dashboard_shows_no_tax_countdown_without_a_tax_footprint`

## Bites

CONSUMER: the portal's Taxes page and dashboard tax widget (`GET /api/portal/taxes`, `GET /api/portal/dashboard`).
OBSERVATION: on client 12402 — no company, no tax practice, no NPWP — the Taxes page shows no Current Obligations section and "Total Due: Not tracked", and the dashboard shows no tax countdown. To be made after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)