### PR TITLE
fix(crm): the last sign-in says when it happened, and in which zone

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_portal_integration.py
+++ b/apps/backend-rag/backend/app/routers/crm_portal_integration.py
@@ -13,6 +13,7 @@ This creates the "intradinamici" connection between Team and Portal.
 Created: 2025-12-30
 """
 
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 import asyncpg
@@ -32,6 +33,24 @@ if TYPE_CHECKING:
 else:
     InviteService = Any
     PortalService = Any
+
+
+def _utc_iso(value: datetime | None) -> str | None:
+    """ISO-8601 with an explicit UTC offset, even for a naive datetime.
+
+    `team_members.last_login` is `timestamp WITHOUT time zone` and is written
+    by `NOW()` on a database whose session timezone is UTC — so the value IS
+    UTC, but `.isoformat()` emitted it bare ("2026-09-10T21:54:37"), and
+    `new Date(...)` in the browser reads a bare timestamp as LOCAL time. On a
+    WITA screen that shifted a login made at 05:54 today to "Sep 10" —
+    yesterday (portal audit finding F-07). Attaching the offset the value
+    already has costs nothing and lets every reader localise it correctly.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
 
 
 def _team_impersonation_ctx(client_id: int, current_user: dict) -> ClientContext:
@@ -219,9 +238,7 @@ async def get_portal_status(
                     "has_portal_access": True,
                     "portal_user_id": portal_user["id"],
                     "portal_email": portal_user["email"],
-                    "last_login": portal_user["last_login"].isoformat()
-                    if portal_user["last_login"]
-                    else None,
+                    "last_login": _utc_iso(portal_user["last_login"]),
                     "pending_invite": False,
                     "invite_expires_at": None,
                 },

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_crm_portal_status_placeholder.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_crm_portal_status_placeholder.py
@@ -172,3 +172,29 @@ async def test_access_check_still_runs_before_any_read(
         db_pool=_Pool(conn),  # type: ignore[arg-type]
     )
     assert calls == [7]
+
+
+@pytest.mark.asyncio
+async def test_last_login_carries_an_explicit_utc_offset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GUILT: a bare timestamp is read as LOCAL time by the browser.
+
+    `team_members.last_login` is `timestamp WITHOUT time zone`, written by
+    `NOW()` on a UTC database — the value is UTC but carries no offset.
+    Emitted bare, `new Date("2026-09-10T21:54:37")` in a WITA browser is
+    2026-09-10 21:54 *local*, so the CRM showed "Sep 10" for a sign-in made
+    at 05:54 on Sep 11 (portal audit finding F-07).
+    """
+    from datetime import datetime, timezone
+
+    from backend.app.routers.crm_portal_integration import _utc_iso
+
+    naive = datetime(2026, 9, 10, 21, 54, 37)
+    assert _utc_iso(naive) == "2026-09-10T21:54:37+00:00"
+
+    # An already-aware value is passed through untouched, not double-shifted.
+    aware = datetime(2026, 9, 10, 21, 54, 37, tzinfo=timezone.utc)
+    assert _utc_iso(aware) == "2026-09-10T21:54:37+00:00"
+
+    assert _utc_iso(None) is None

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalAccess.tsx
@@ -109,6 +109,22 @@ export function PortalAccess({
         })
       : null;
 
+  /* A sign-in is a moment, not a day: the date alone read "Sep 10" in Bali
+     for a login made at 05:54 on Sep 11 (portal audit F-07 — the backend
+     sent a bare UTC timestamp, now offset-carrying). Showing the time and
+     naming the zone is what makes the answer checkable. */
+  const formatMoment = (value: string | null) =>
+    value
+      ? new Date(value).toLocaleString(undefined, {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+          timeZoneName: "short",
+        })
+      : null;
+
   return (
     <div className="bz-product-panel overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--bz-border)]">
@@ -160,7 +176,7 @@ export function PortalAccess({
               </p>
               <p className="text-xs text-[var(--bz-text-2)] mt-1">
                 {status.last_login
-                  ? `Last signed in ${formatDate(status.last_login)}`
+                  ? `Last signed in ${formatMoment(status.last_login)}`
                   : "Registered, but has never signed in yet"}
               </p>
               {/* The login identity is team_members.email, which a CRM email


### PR DESCRIPTION
## What

Portal audit finding **F-07**: the Portal Access panel showed "Last signed in Sep 10, 2026" for a sign-in made on **Sep 11 at 05:54 WITA**. Two causes, both on this path.

1. `team_members.last_login` is `timestamp WITHOUT time zone`, written by `NOW()` on a database whose session timezone is UTC (verified on prod: `SHOW timezone` → `UTC`). The value **is** UTC, but `.isoformat()` shipped it bare — and `new Date("2026-09-10T21:54:37")` in a browser reads a bare timestamp as **local** time, which on a WITA screen is 21:54 the previous evening. `_utc_iso` attaches the offset the value already has; an already-aware value passes through untouched (no double shift).
2. The panel rendered only the date. A sign-in is a moment, not a day: it now shows date + time + zone name, so a Bali reader can check it against the clock.

A column-type migration to `TIMESTAMPTZ` is deliberately **not** attempted here — that is a schema change on a hot table for a display bug, and the boundary fix makes the wire format correct for every reader today. `client_invitations.expires_at` is already `timestamptz` and needed nothing.

## Test

```
apps/backend-rag/.venv/bin/python -m pytest backend/tests/unit/app/routers/test_crm_portal_status_placeholder.py
5 passed
```

`test_last_login_carries_an_explicit_utc_offset` pins all three cases: naive → `+00:00` appended, aware → unchanged, None → None.

## Bites

CONSUMER: the Portal Access panel on the CRM client page (`GET /api/crm/clients/{id}/portal-status`).
OBSERVATION: for client 12402, whose last sign-in was 2026-09-10T21:54:37 UTC, the panel reads "Last signed in Sep 11, 2026, 05:54 GMT+8" on a WITA screen instead of "Sep 10, 2026". To be made after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)