### PR TITLE
fix(crm): an unlinked client's page stops naming two other clients' companies

### DIFF
--- a/apps/mouth/src/hooks/useClientDetail.test.tsx
+++ b/apps/mouth/src/hooks/useClientDetail.test.tsx
@@ -77,11 +77,13 @@ describe("buildBusinessStorySearchTerms", () => {
     ]);
   });
 
-  it("keeps Ocean and Bimala fallback search terms for unlinked people", () => {
+  it("names only the client when no company is linked", () => {
+    /* GUILT for portal audit F-06: the term list used to fall back to the
+       two tax-pilot keys, which are REAL client companies — so viewing an
+       unlinked client emitted two unrelated clients' company names into
+       the evidence-dossiers query string. */
     expect(buildBusinessStorySearchTerms("Natan Kleimonov", [])).toEqual([
       "Natan Kleimonov",
-      "ocean",
-      "bimala",
     ]);
   });
 });

--- a/apps/mouth/src/hooks/useClientDetail.ts
+++ b/apps/mouth/src/hooks/useClientDetail.ts
@@ -11,8 +11,6 @@ import type {
   TaxCompanyPilotMap,
 } from "@/lib/api/crm/crm.types";
 
-const PILOT_FALLBACK_TERMS = ["ocean", "bimala"] as const;
-
 export const clientDetailQueryKey = (clientId: string | number) =>
   ["client", String(clientId)] as const;
 
@@ -25,11 +23,22 @@ export function buildBusinessStorySearchTerms(
     companyLinks
       ?.map((link) => link.company_name.trim())
       .filter((companyName) => companyName.length > 0) ?? [];
-  const rawTerms = [
-    normalizedClientName,
-    ...companyNames,
-    ...(companyNames.length === 0 ? PILOT_FALLBACK_TERMS : []),
-  ].filter((term) => term.length > 0);
+  /* A client with no linked company searches for THEMSELVES and nothing
+     else. This used to append ["ocean", "bimala"] — the two curated pilot
+     keys of the standalone /clients/tax-pilot demo, which are real client
+     companies, not placeholders. So opening any unlinked client's page
+     fired
+       GET /api/crm/intelligence/evidence-dossiers?company=<this client>
+           &company=<real company A>&company=<real company B>
+     naming two unrelated clients' companies in a URL, an access log and
+     whatever analytics observes them (portal audit finding F-06). Nothing
+     was ever displayed from it: BusinessStoryPanel filters the response
+     down to maps matching THIS client's own name or companies, which for
+     an unlinked client is always empty. The fallback bought no UI and
+     leaked two names on every such page view. */
+  const rawTerms = [normalizedClientName, ...companyNames].filter(
+    (term) => term.length > 0,
+  );
 
   const seen = new Set<string>();
   return rawTerms.filter((term) => {


### PR DESCRIPTION
## What

Portal audit finding **F-06**, observed live 2026-09-11. Opening a brand-new client with no linked company fired, in the background:

```
GET /api/crm/intelligence/evidence-dossiers?company=<this client>
    &company=<real company A>&company=<real company B>
```

— putting two **unrelated clients'** company names into a URL, the access log, and whatever analytics observes requests, while a consultant was viewing someone else's record.

The source was `PILOT_FALLBACK_TERMS = ["ocean", "bimala"]` in `useClientDetail.ts`: the two curated keys of the standalone `/clients/tax-pilot` demo page. They are not placeholders — they are real client companies — and the generic client page appended them whenever the client had no linked company.

Nothing was ever displayed from those extra results: `BusinessStoryPanel` filters the response down to maps matching **this** client's own name or companies, which for an unlinked client is always empty. The fallback bought no UI at all and leaked two names on every such page view.

## Not addressed here

`GET /api/crm/intelligence/evidence-dossiers` takes any `company=` string from any authenticated team member (`require_team_member`) and runs a global `LOWER(company_name) LIKE '%term%'` across every row in `client_company_links`/`clients`/`companies`, returning full dossiers — Drive folder ids, NIB, NPWP, KBLI, assigned consultant. There is no per-client scoping and no CRM user filter, unlike the rest of the CRM routers. That is a separate authorization decision, reported to the owner rather than changed unilaterally here.

## Test

`buildBusinessStorySearchTerms("Natan Kleimonov", [])` now returns `["Natan Kleimonov"]`; the test that pinned the old fallback is rewritten as a guilt-proof for F-06.

```
npx vitest run --root apps/mouth src/hooks/useClientDetail.test.tsx
5 passed
```

## Bites

CONSUMER: the CRM client page (`/clients/{id}`) Business Story panel.
OBSERVATION: on client 12402 (no linked company), the network log shows a single `company=` parameter — the client's own name — where it previously carried three. To be made after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)