### PR TITLE
fix(portal): dates follow the client's language instead of hardcoded en-US

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/_components/TimelineItem.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/_components/TimelineItem.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { TimelineEntry } from "@/lib/api/types/timeline.types";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 export function TimelineItem({
   entry,
@@ -28,6 +29,7 @@ export function TimelineItem({
   entry: TimelineEntry;
   isLast: boolean;
 }) {
+  const { formatDate } = usePortalDateFormat();
   const isFuture =
     "isFuture" in entry
       ? Boolean((entry as unknown as { isFuture?: boolean }).isFuture)
@@ -128,14 +130,14 @@ export function TimelineItem({
           </div>
           <span
             className="text-[10px] font-bold uppercase tracking-widest text-[var(--tx-secondary)]"
-            title={new Date(entry.occurredAt).toLocaleDateString("en-US", {
+            title={formatDate(entry.occurredAt, {
               weekday: "long",
               month: "long",
               day: "numeric",
               year: "numeric",
             })}
           >
-            {new Date(entry.occurredAt).toLocaleDateString("en-US", {
+            {formatDate(entry.occurredAt, {
               month: "short",
               day: "numeric",
               year: "numeric",

--- a/apps/mouth/src/app/portal/(authenticated)/billing/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/billing/page.tsx
@@ -28,6 +28,7 @@ import { useToast } from "@/components/ui/toast";
 import { logger } from "@/lib/logger";
 import type { PortalInvoice } from "@/lib/api/portal/portal.types";
 import { Money } from "@balizero/core";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 // Day masthead (GARUDA Day Edition): copper rule + Cormorant serif headline
 // per concept (--font-serif, wired on <html>); Inter everywhere else.
@@ -54,6 +55,7 @@ function BillingMasthead() {
 export default function BillingPage() {
   const { data, isLoading, isError, refetch } = usePortalBilling();
   const { error: toastError } = useToast();
+  const { formatDate } = usePortalDateFormat();
 
   const handleDownloadPdf = async (invoice: PortalInvoice) => {
     try {
@@ -258,14 +260,11 @@ export default function BillingPage() {
                       style={{ color: "var(--bz-text-2)" }}
                     >
                       Issued:{" "}
-                      {new Date(invoice.generated_at).toLocaleDateString(
-                        "en-US",
-                        {
-                          month: "short",
-                          day: "numeric",
-                          year: "numeric",
-                        },
-                      )}
+                      {formatDate(invoice.generated_at, {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
                     </p>
                   )}
                 </div>

--- a/apps/mouth/src/app/portal/(authenticated)/chat/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/chat/page.tsx
@@ -37,6 +37,7 @@ import type {
   MessagesResponse,
 } from "@/lib/api/portal/portal.types";
 import { Button } from "@/components/ui/button";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 const POLL_INTERVAL = 30000; // 30 seconds
 
@@ -45,6 +46,8 @@ const PAGE_SIZE = 100;
 export default function ChatPage() {
   const router = useRouter();
   const { error } = useToast();
+  const { formatDateTime: formatDateTimeLocale, formatDate: formatDateLocale } =
+    usePortalDateFormat();
   const [messages, setMessages] = useState<PortalMessage[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
@@ -250,8 +253,7 @@ export default function ChatPage() {
   };
 
   const formatTime = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleTimeString("en-US", {
+    return formatDateTimeLocale(dateString, {
       hour: "numeric",
       minute: "2-digit",
       hour12: true,
@@ -269,7 +271,7 @@ export default function ChatPage() {
     } else if (date.toDateString() === yesterday.toDateString()) {
       return "Yesterday";
     } else {
-      return date.toLocaleDateString("en-US", {
+      return formatDateLocale(dateString, {
         month: "short",
         day: "numeric",
         year:

--- a/apps/mouth/src/app/portal/(authenticated)/lkpm/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/lkpm/page.tsx
@@ -35,6 +35,7 @@ import type {
 } from "@/lib/api/portal/portal.types";
 import { formatIDR } from "@balizero/core/utils";
 import { Button } from "@/components/ui/button";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 // Day card surface (GARUDA Day concept .panel): white card on warm paper,
 // hairline warm border, soft navy shadow (near-invisible on dark).
@@ -85,6 +86,7 @@ function LkpmMasthead() {
 
 export default function LKPMPage() {
   const { error } = useToast();
+  const { formatDate } = usePortalDateFormat();
   const [history, setHistory] = useState<LKPMDraftSummary[]>([]);
   const [deadlines, setDeadlines] = useState<LKPMDeadline[]>([]);
   const [receipts, setReceipts] = useState<LKPMReceipt[]>([]);
@@ -341,7 +343,7 @@ export default function LKPMPage() {
               </p>
               <p className="text-xs" style={{ color: "var(--bz-text-2)" }}>
                 Deadline:{" "}
-                {new Date(nextDeadline.deadline).toLocaleDateString("en-US", {
+                {formatDate(nextDeadline.deadline, {
                   month: "long",
                   day: "numeric",
                   year: "numeric",

--- a/apps/mouth/src/app/portal/(authenticated)/matters/[id]/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/matters/[id]/page.tsx
@@ -25,6 +25,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import type { PortalApprovedIntelligence } from "@/lib/api/portal/portal.types";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 function parseMatterId(value: string | string[] | undefined): number | null {
   const raw = Array.isArray(value) ? value[0] : value;
@@ -32,15 +33,21 @@ function parseMatterId(value: string | string[] | undefined): number | null {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
-function formatReviewedAt(value: string | null): string | null {
+function formatReviewedAt(
+  value: string | null,
+  formatDate: (
+    value: string | Date | null | undefined,
+    options?: Intl.DateTimeFormatOptions,
+  ) => string,
+): string | null {
   if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  return (
+    formatDate(value, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }) || null
+  );
 }
 
 function LoadingState() {
@@ -79,7 +86,11 @@ function ApprovedIntelligencePanel({
 }: {
   intelligence: PortalApprovedIntelligence;
 }) {
-  const reviewedAt = formatReviewedAt(intelligence.last_reviewed_at);
+  const { formatDate } = usePortalDateFormat();
+  const reviewedAt = formatReviewedAt(
+    intelligence.last_reviewed_at,
+    formatDate,
+  );
 
   if (!intelligence.available) {
     return (
@@ -172,6 +183,7 @@ export default function PortalMatterDetailPage() {
   const params = useParams<{ id?: string | string[] }>();
   const matterId = parseMatterId(params?.id);
   const { data, isLoading, isError, refetch } = usePortalMatter(matterId);
+  const { formatDate } = usePortalDateFormat();
 
   if (!matterId) {
     return (
@@ -276,7 +288,8 @@ export default function PortalMatterDetailPage() {
                 Next deadline
               </p>
               <p className="mt-1 text-sm font-medium text-[var(--bz-text-1)]">
-                {formatReviewedAt(data.next_deadline) ?? data.next_deadline}
+                {formatReviewedAt(data.next_deadline, formatDate) ??
+                  data.next_deadline}
               </p>
             </div>
           )}

--- a/apps/mouth/src/app/portal/(authenticated)/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/page.tsx
@@ -47,6 +47,7 @@ import { Button } from "@/components/ui/button";
 import type { TimelineEntry } from "@/lib/api/types/timeline.types";
 import type { DashboardSummary } from "@/lib/api/portal/portal.types";
 import { DeadlineBadge } from "@balizero/core";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 function getStatusCode(error: unknown): number | undefined {
   if (!error || typeof error !== "object") return undefined;
@@ -63,6 +64,7 @@ function isClientConnectionError(error: unknown): boolean {
 
 export default function PortalHomePage() {
   const router = useRouter();
+  const { formatDate } = usePortalDateFormat();
   const dashboardQuery = usePortalDashboard();
   const summaryQuery = usePortalDashboardSummary();
   const timelineQuery = usePortalTimeline(20);
@@ -267,9 +269,7 @@ export default function PortalHomePage() {
           status={defaultDashboard.taxes.status}
           label={
             defaultDashboard.taxes.nextDeadline
-              ? new Date(
-                  defaultDashboard.taxes.nextDeadline,
-                ).toLocaleDateString("en-US", {
+              ? formatDate(defaultDashboard.taxes.nextDeadline, {
                   month: "short",
                   day: "numeric",
                 })
@@ -447,6 +447,7 @@ function StatusCard({
   // fix): forward it to the button so the card has an accessible name.
   "aria-label"?: string;
 }) {
+  const { formatDate } = usePortalDateFormat();
   // Semantic state tokens: WS2 light overrides keep these ≥4.5:1 on paper
   // (success 4.80, warning 4.78, danger 5.74, info 5.94 — see semantic.css).
   const getStatusStyle = (s: string) => {
@@ -483,8 +484,7 @@ function StatusCard({
   // shares the warning step with the ≤30d tier.
   const getExpiryInfo = () => {
     if (!expiry) return { text: subLabel || "", color: "" };
-    const date = new Date(expiry);
-    const formatted = date.toLocaleDateString("en-US", {
+    const formatted = formatDate(expiry, {
       month: "short",
       day: "numeric",
       year: "numeric",
@@ -536,7 +536,7 @@ function StatusCard({
         )}
         title={
           expiry
-            ? new Date(expiry).toLocaleDateString("en-US", {
+            ? formatDate(expiry, {
                 month: "long",
                 day: "numeric",
                 year: "numeric",

--- a/apps/mouth/src/app/portal/(authenticated)/profile/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/profile/page.tsx
@@ -106,6 +106,7 @@ const isBirthdayToday = (dateOfBirth: string | undefined): boolean => {
 };
 
 import { formatDate } from "@/lib/utils/format-date";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 // ============================================================================
 // DAY THEME PRIMITIVES (GARUDA Day Edition, WS3)
@@ -182,6 +183,7 @@ function ProfileMasthead() {
 export default function ProfilePage() {
   const router = useRouter();
   const { error } = useToast();
+  const { formatDate: formatDateLocale } = usePortalDateFormat();
   const [profile, setProfile] = useState<PortalProfile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
@@ -398,7 +400,7 @@ export default function ProfilePage() {
             <h2 className="text-xl font-bold">{profile.fullName}</h2>
             <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
               Member since{" "}
-              {new Date(profile.memberSince).toLocaleDateString("en-US", {
+              {formatDateLocale(profile.memberSince, {
                 month: "long",
                 year: "numeric",
               })}

--- a/apps/mouth/src/app/portal/(authenticated)/taxes/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/taxes/page.tsx
@@ -30,6 +30,7 @@ import {
 import { trackTaxDashboardViewed } from "@/lib/analytics";
 import { formatIDR } from "@balizero/core/utils";
 import { Button } from "@/components/ui/button";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 // Day card surface (GARUDA Day concept .panel): white card on warm paper,
 // hairline warm border, soft navy shadow (near-invisible on dark).
@@ -83,6 +84,7 @@ function TaxesMasthead() {
 
 export default function TaxesPage() {
   const { error } = useToast();
+  const { formatDate } = usePortalDateFormat();
   const [taxData, setTaxData] = useState<TaxOverview | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [initialLoadFailed, setInitialLoadFailed] = useState(false);
@@ -235,14 +237,11 @@ export default function TaxesPage() {
             {taxData.summary.nextDeadline ? (
               <div className="flex items-baseline gap-2 flex-wrap">
                 <p className="text-lg font-bold">
-                  {new Date(taxData.summary.nextDeadline).toLocaleDateString(
-                    "en-US",
-                    {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    },
-                  )}
+                  {formatDate(taxData.summary.nextDeadline, {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
                 </p>
                 <CountdownChip date={taxData.summary.nextDeadline} />
               </div>
@@ -351,6 +350,7 @@ function ObligationCard({
   obligation: TaxObligation;
   formatCurrency: (amount: number) => string;
 }) {
+  const { formatDate } = usePortalDateFormat();
   return (
     <div
       className="rounded-lg border p-4 transition-colors"
@@ -379,7 +379,7 @@ function ObligationCard({
         >
           <Calendar className="w-3.5 h-3.5" />
           Due:{" "}
-          {new Date(obligation.dueDate).toLocaleDateString("en-US", {
+          {formatDate(obligation.dueDate, {
             month: "short",
             day: "numeric",
             year: "numeric",

--- a/apps/mouth/src/app/portal/(authenticated)/visa/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/visa/page.tsx
@@ -34,6 +34,7 @@ import type {
   VisaHistoryItem,
   PortalDocument,
 } from "@/lib/api/portal/portal.types";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 // Day surface (concept .panel): warm-paper card, hairline warm border, soft
 // navy shadow (near-invisible on dark). Shared by every card on this page.
@@ -112,6 +113,7 @@ function getStatusCode(error: unknown): number | undefined {
 export default function VisaPage() {
   const router = useRouter();
   const { error: showErrorToast } = useToast();
+  const { formatDate } = usePortalDateFormat();
   const [visaInfo, setVisaInfo] = useState<VisaInfo | null>(null);
   const [needsClientSelection, setNeedsClientSelection] = useState(false);
   const [needsClientConnection, setNeedsClientConnection] = useState(false);
@@ -313,25 +315,19 @@ export default function VisaPage() {
             >
               <InfoRow
                 label="Issue Date"
-                value={new Date(visaInfo.current.issueDate).toLocaleDateString(
-                  "en-US",
-                  {
-                    month: "long",
-                    day: "numeric",
-                    year: "numeric",
-                  },
-                )}
+                value={formatDate(visaInfo.current.issueDate, {
+                  month: "long",
+                  day: "numeric",
+                  year: "numeric",
+                })}
               />
               <InfoRow
                 label="Expiry Date"
-                value={new Date(visaInfo.current.expiryDate).toLocaleDateString(
-                  "en-US",
-                  {
-                    month: "long",
-                    day: "numeric",
-                    year: "numeric",
-                  },
-                )}
+                value={formatDate(visaInfo.current.expiryDate, {
+                  month: "long",
+                  day: "numeric",
+                  year: "numeric",
+                })}
                 chip={
                   visaInfo.current.daysRemaining !== null
                     ? {

--- a/apps/mouth/src/components/portal/CountdownChip.tsx
+++ b/apps/mouth/src/components/portal/CountdownChip.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import React from "react";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 /**
  * CountdownChip — shared portal deadline / age pill.
@@ -31,6 +34,7 @@ export function CountdownChip({
   mode = "countdown",
   className,
 }: CountdownChipProps) {
+  const { formatDate } = usePortalDateFormat();
   const now = Date.now();
   const target = new Date(date).getTime();
   const diffDays = Math.round((target - now) / 86400000);
@@ -87,7 +91,7 @@ export function CountdownChip({
       suppressHydrationWarning
       className={`text-[10px] px-1.5 py-0.5 rounded-full font-semibold ${className ?? ""}`}
       style={chipStyle}
-      title={new Date(date).toLocaleDateString("en-US", {
+      title={formatDate(date, {
         month: "long",
         day: "numeric",
         year: "numeric",

--- a/apps/mouth/src/components/portal/PortalHeader.tsx
+++ b/apps/mouth/src/components/portal/PortalHeader.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { routeTitles } from "@/types/navigation";
 import { cn } from "@/lib/utils";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 // Lazy: notifications + impersonation are not first-paint critical.
 // Reduces parallel chunks on /portal/* — ERR_INSUFFICIENT_RESOURCES mitigation.
@@ -54,6 +55,7 @@ export function PortalHeader({
   mobileMenuToggleRef,
 }: PortalHeaderProps) {
   const pathname = usePathname();
+  const { formatDate: formatDateLocale } = usePortalDateFormat();
 
   // Get page title from pathname
   const getPageTitle = () => {
@@ -86,7 +88,7 @@ export function PortalHeader({
       day: "numeric",
       month: "long",
     };
-    return new Date().toLocaleDateString("en-US", options);
+    return formatDateLocale(new Date(), options);
   };
 
   return (

--- a/apps/mouth/src/components/portal/PortalNotifications.tsx
+++ b/apps/mouth/src/components/portal/PortalNotifications.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { usePortalNotifications } from "@/hooks/usePortalNotifications";
 import type { PortalNotification } from "@/lib/api/portal/portal.types";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 function getNotificationIcon(type: string) {
   switch (type) {
@@ -29,7 +30,13 @@ function getNotificationIcon(type: string) {
   }
 }
 
-function timeAgo(dateStr: string | null): string {
+function timeAgo(
+  dateStr: string | null,
+  formatDate: (
+    value: string | Date | null | undefined,
+    options?: Intl.DateTimeFormatOptions,
+  ) => string,
+): string {
   if (!dateStr) return "";
   const diff = Date.now() - new Date(dateStr).getTime();
   const minutes = Math.floor(diff / 60000);
@@ -39,7 +46,7 @@ function timeAgo(dateStr: string | null): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d ago`;
-  return new Date(dateStr).toLocaleDateString("en-US", {
+  return formatDate(dateStr, {
     month: "short",
     day: "numeric",
   });
@@ -78,6 +85,7 @@ export function PortalNotificationsList({
   onRetryMarkRead?: () => void;
   onRetryMarkAllRead?: () => void;
 }) {
+  const { formatDate } = usePortalDateFormat();
   const unread = notifications.filter((n) => !n.read);
 
   return (
@@ -203,7 +211,7 @@ export function PortalNotificationsList({
                   style={{ color: "var(--bz-text-3)" }}
                   suppressHydrationWarning
                 >
-                  {timeAgo(notif.created_at)}
+                  {timeAgo(notif.created_at, formatDate)}
                 </p>
               </div>
               {!notif.read && (

--- a/apps/mouth/src/components/portal/ProcessStepper.tsx
+++ b/apps/mouth/src/components/portal/ProcessStepper.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { CheckCircle, Circle, Loader } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ProcessTimelineStep } from "@/lib/api/portal/portal.types";
+import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
 
 interface ProcessStepperProps {
   steps: ProcessTimelineStep[];
@@ -11,6 +12,7 @@ interface ProcessStepperProps {
 }
 
 export function ProcessStepper({ steps, className }: ProcessStepperProps) {
+  const { formatDate } = usePortalDateFormat();
   if (steps.length === 0) return null;
 
   return (
@@ -93,7 +95,7 @@ export function ProcessStepper({ steps, className }: ProcessStepperProps) {
                   className="text-xs mt-0.5"
                   style={{ color: "var(--text-tertiary, var(--bz-text-3))" }}
                 >
-                  {new Date(step.changed_at).toLocaleDateString("en-US", {
+                  {formatDate(step.changed_at, {
                     month: "short",
                     day: "numeric",
                     year: "numeric",

--- a/apps/mouth/src/lib/format/date.test.ts
+++ b/apps/mouth/src/lib/format/date.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { formatDate, formatDateTime, localeTagFor } from "./date";
+
+describe("localeTagFor", () => {
+  it("maps it to it-IT", () => {
+    expect(localeTagFor("it")).toBe("it-IT");
+  });
+
+  it("maps en to en-US", () => {
+    expect(localeTagFor("en")).toBe("en-US");
+  });
+
+  it("maps id to id-ID", () => {
+    expect(localeTagFor("id")).toBe("id-ID");
+  });
+
+  it("maps null/undefined to undefined (browser default)", () => {
+    expect(localeTagFor(null)).toBeUndefined();
+    expect(localeTagFor(undefined)).toBeUndefined();
+  });
+});
+
+describe("formatDate", () => {
+  const sample = "2026-03-25T00:00:00.000Z";
+
+  it("returns empty string for null/undefined", () => {
+    expect(formatDate(null, "en")).toBe("");
+    expect(formatDate(undefined, "en")).toBe("");
+  });
+
+  it("returns empty string for an unparseable value", () => {
+    expect(formatDate("not-a-date", "en")).toBe("");
+  });
+
+  it("matches Intl.DateTimeFormat for the mapped locale, with no options", () => {
+    const date = new Date(sample);
+    expect(formatDate(sample, "it")).toBe(
+      new Intl.DateTimeFormat("it-IT").format(date),
+    );
+    expect(formatDate(sample, "id")).toBe(
+      new Intl.DateTimeFormat("id-ID").format(date),
+    );
+  });
+
+  it("passes an explicit options object through unchanged", () => {
+    const date = new Date(sample);
+    const options: Intl.DateTimeFormatOptions = {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    };
+    expect(formatDate(sample, "en", options)).toBe(
+      new Intl.DateTimeFormat("en-US", options).format(date),
+    );
+  });
+
+  it("accepts a Date instance directly", () => {
+    const date = new Date(sample);
+    expect(formatDate(date, "en")).toBe(
+      new Intl.DateTimeFormat("en-US").format(date),
+    );
+  });
+});
+
+describe("formatDateTime", () => {
+  const sample = "2026-03-25T14:30:00.000Z";
+
+  it("returns empty string for null/undefined/unparseable input", () => {
+    expect(formatDateTime(null, "en")).toBe("");
+    expect(formatDateTime(undefined, "en")).toBe("");
+    expect(formatDateTime("not-a-date", "en")).toBe("");
+  });
+
+  it("matches Date#toLocaleString for a null language (browser default)", () => {
+    const date = new Date(sample);
+    expect(formatDateTime(sample, null)).toBe(date.toLocaleString(undefined));
+  });
+
+  it("passes an explicit options object through unchanged", () => {
+    const date = new Date(sample);
+    const options: Intl.DateTimeFormatOptions = {
+      hour: "2-digit",
+      minute: "2-digit",
+    };
+    expect(formatDateTime(sample, "id", options)).toBe(
+      new Intl.DateTimeFormat("id-ID", options).format(date),
+    );
+  });
+});

--- a/apps/mouth/src/lib/format/date.ts
+++ b/apps/mouth/src/lib/format/date.ts
@@ -1,0 +1,69 @@
+/**
+ * Locale-aware date formatting for the portal.
+ *
+ * Portal surfaces used to hardcode `toLocaleDateString("en-US", ...)` in
+ * ~20 call sites regardless of the client's saved language preference
+ * (`useLanguage`, cookie `bz_lang`). This module is the single place that
+ * maps a saved language to an IETF locale tag, so the choice a client
+ * makes is actually honoured.
+ */
+import type { Language } from "@/lib/schemas/settings";
+
+/**
+ * Map a saved portal language to an IETF locale tag for `Intl`/
+ * `toLocaleDateString`/`toLocaleString`.
+ *
+ * `null`/`undefined` (no saved preference yet) returns `undefined`,
+ * which tells the `Intl` APIs to fall back to the browser's own locale
+ * rather than guessing.
+ */
+export function localeTagFor(
+  language: Language | null | undefined,
+): string | undefined {
+  switch (language) {
+    case "it":
+      return "it-IT";
+    case "en":
+      return "en-US";
+    case "id":
+      return "id-ID";
+    default:
+      return undefined;
+  }
+}
+
+function toValidDate(value: string | Date | null | undefined): Date | null {
+  if (value == null) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Locale-aware wrapper over `Date#toLocaleDateString`.
+ * Returns `""` for `null`/`undefined`/unparseable input instead of the
+ * native `"Invalid Date"` string.
+ */
+export function formatDate(
+  value: string | Date | null | undefined,
+  language: Language | null | undefined,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  const date = toValidDate(value);
+  if (!date) return "";
+  return date.toLocaleDateString(localeTagFor(language), options);
+}
+
+/**
+ * Locale-aware wrapper over `Date#toLocaleString`.
+ * Returns `""` for `null`/`undefined`/unparseable input instead of the
+ * native `"Invalid Date"` string.
+ */
+export function formatDateTime(
+  value: string | Date | null | undefined,
+  language: Language | null | undefined,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  const date = toValidDate(value);
+  if (!date) return "";
+  return date.toLocaleString(localeTagFor(language), options);
+}

--- a/apps/mouth/src/lib/format/usePortalDateFormat.ts
+++ b/apps/mouth/src/lib/format/usePortalDateFormat.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useMemo } from "react";
+import { useLanguage } from "@/hooks/useLanguage";
+import { formatDate, formatDateTime } from "./date";
+
+/**
+ * Binds `formatDate`/`formatDateTime` to the client's current portal
+ * language (`useLanguage`, cookie `bz_lang`), so a portal component never
+ * has to pass the language through by hand.
+ */
+export function usePortalDateFormat() {
+  const { language } = useLanguage();
+
+  return useMemo(
+    () => ({
+      formatDate: (
+        value: string | Date | null | undefined,
+        options?: Intl.DateTimeFormatOptions,
+      ) => formatDate(value, language, options),
+      formatDateTime: (
+        value: string | Date | null | undefined,
+        options?: Intl.DateTimeFormatOptions,
+      ) => formatDateTime(value, language, options),
+    }),
+    [language],
+  );
+}


### PR DESCRIPTION
## What

Portal audit finding **ux F4**. `toLocaleDateString("en-US", …)` was hardcoded in ~20 portal call sites, while partner surfaces used `"id-ID"`, one company page `"en-GB"`, and three sites passed `undefined` — the same product formatting dates four different ways, and none of them reading the language the client actually saved (`useLanguage`, cookie `bz_lang`, offered in Settings → Language).

`src/lib/format/date.ts` is now the single mapping: `it`→`it-IT`, `en`→`en-US`, `id`→`id-ID`, and no saved preference → `undefined`, which lets `Intl` fall back to the browser rather than guessing. **`en` stays `en-US` on purpose**: this change is about honouring a choice, not restyling English dates, so an English reader sees exactly what they saw yesterday. `usePortalDateFormat()` binds both helpers to the current language so no component threads it by hand.

Every converted call site keeps its own options object unchanged. Two module-level helpers that cannot call a hook (`formatReviewedAt` in `matters/[id]`, `timeAgo` in `PortalNotifications`) take the formatter as a parameter. `CountdownChip` gained the `"use client"` directive it now needs. Unparseable or null input returns `""` rather than the native `"Invalid Date"`.

Out of scope, deliberately: the team-facing workspace (`app/(workspace)/`), partner and company surfaces, and the three portal sites already passing `undefined` (`VaultFileGrid`, `StepDetailDrawer`, `TimelineStep`).

## Test

New `src/lib/format/date.test.ts` (12 cases): the three language mappings, null/undefined → browser default, `""` on invalid input, and options pass-through — each asserted against the native `Intl`/`toLocaleString` output for the same tag rather than a hardcoded string, so it does not break on a different ICU build.

Verified in this worktree, not taken on trust:

```
npm run typecheck -w apps/mouth        # tsc --noEmit, clean
npx vitest run --root apps/mouth src/lib/format "src/app/portal/(authenticated)" src/components/portal
Test Files  58 passed (58)
     Tests  349 passed (349)
```

## Bites

CONSUMER: every portal surface that prints a date — dashboard, chat, visa, profile, LKPM, taxes, matters, billing, notifications, header, stepper.
OBSERVATION: with `bz_lang=it`, the portal dashboard's next-deadline date renders in Italian month order (`11 set 2026`) instead of `Sep 11, 2026`; with `bz_lang=en` it is unchanged. To be made after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)