### PR TITLE
docs(ops): name the company director as PSE responsible officer for every system

### DIFF
--- a/docs/ops/pse-registration-balizero.md
+++ b/docs/ops/pse-registration-balizero.md
@@ -42,18 +42,18 @@ legal name before concluding.
 
 ## 2. Company-level fields (shared by every system)
 
-| Field                   | Value                                                                 | Source                                         |
-| ----------------------- | --------------------------------------------------------------------- | ---------------------------------------------- |
-| Legal entity            | PT PMA, legal name as on the akta (to confirm)                        | `apps/mouth/src/app/terms/page.tsx` ("PT PMA") |
-| NIB                     | Active NIB number (to confirm)                                        | owner / accounting                             |
-| KBLI                    | KBLI on the NIB that covers the electronic systems below (to confirm) | owner / accounting                             |
-| NPWP                    | Company NPWP (to confirm)                                             | owner / accounting                             |
-| Akta and SK Kemenkumham | Deed of establishment and ministry decree (to confirm)                | owner / accounting                             |
-| Responsible officer     | `<to be named by the owner>`                                          | owner decision                                 |
-| Data-protection contact | privacy@balizero.com (role address published in the privacy policy)   | `apps/mouth/src/app/privacy/page.tsx`          |
-| Privacy policy          | https://balizero.com/privacy                                          | `apps/mouth/src/app/privacy/page.tsx`          |
-| Terms of service        | https://balizero.com/terms                                            | `apps/mouth/src/app/terms/page.tsx`            |
-| Registration fee        | None (no PNBP fee)                                                    | prep-check §3                                  |
+| Field                   | Value                                                                                     | Source                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Legal entity            | PT PMA, legal name as on the akta (to confirm)                                            | `apps/mouth/src/app/terms/page.tsx` ("PT PMA") |
+| NIB                     | Active NIB number (to confirm)                                                            | owner / accounting                             |
+| KBLI                    | KBLI on the NIB that covers the electronic systems below (to confirm)                     | owner / accounting                             |
+| NPWP                    | Company NPWP (to confirm)                                                                 | owner / accounting                             |
+| Akta and SK Kemenkumham | Deed of establishment and ministry decree (to confirm)                                    | owner / accounting                             |
+| Responsible officer     | `Company director per the akta (the owner), position Direktur, contact zero@balizero.com` | owner ruling 2026-09-11                        |
+| Data-protection contact | privacy@balizero.com (role address published in the privacy policy)                       | `apps/mouth/src/app/privacy/page.tsx`          |
+| Privacy policy          | https://balizero.com/privacy                                                              | `apps/mouth/src/app/privacy/page.tsx`          |
+| Terms of service        | https://balizero.com/terms                                                                | `apps/mouth/src/app/terms/page.tsx`            |
+| Registration fee        | None (no PNBP fee)                                                                        | prep-check §3                                  |
 
 The privacy policy states it follows UU PDP No. 27/2022 and lists the data categories,
 legal bases, storage locations and retention periods reused in section 3.
@@ -88,7 +88,7 @@ policy:
 | Repo source         | `apps/mouth` route groups `(marketing)`, `(blog)`; `PUBLIC_DOMAIN` in `apps/mouth/src/proxy.ts`                                                                                                                                                 |
 | Data categories     | Newsletter email address; inquiry contact details (name, email, phone, message); Visa Oracle answers held in the browser session (`evaluation-identity-store.ts`); web analytics (Google Analytics, per the CSP in `apps/mouth/next.config.ts`) |
 | Privacy policy      | https://balizero.com/privacy; Visa Oracle has its own notice at https://balizero.com/visa-oracle/privacy                                                                                                                                        |
-| Responsible officer | `<to be named by the owner>`                                                                                                                                                                                                                    |
+| Responsible officer | `Company director per the akta (the owner), position Direktur, contact zero@balizero.com`                                                                                                                                                       |
 | KBLI                | To confirm                                                                                                                                                                                                                                      |
 
 ### 3.2 kita.balizero.com
@@ -102,7 +102,7 @@ policy:
 | Repo source         | `APP_DOMAIN` and `INTERNAL_ROUTES` in `apps/mouth/src/proxy.ts`                                                                                                                                                                                                                                                   |
 | Data categories     | Staff accounts and roles; client records: identity (name, nationality, date of birth, gender, address), passport data, contact details, family members, company data; case and permit status; client documents (passport, KTP, NPWP scans); message history across channels; financial data for visa applications |
 | Privacy policy      | https://balizero.com/privacy                                                                                                                                                                                                                                                                                      |
-| Responsible officer | `<to be named by the owner>`                                                                                                                                                                                                                                                                                      |
+| Responsible officer | `Company director per the akta (the owner), position Direktur, contact zero@balizero.com`                                                                                                                                                                                                                         |
 | KBLI                | To confirm                                                                                                                                                                                                                                                                                                        |
 
 ### 3.3 my.balizero.com
@@ -116,7 +116,7 @@ policy:
 | Repo source         | `PORTAL_DOMAIN` in `apps/mouth/src/proxy.ts`; pages in `apps/mouth/src/app/portal/(authenticated)/`                                                                                                                   |
 | Data categories     | Client account and session cookie; profile; family members; company data; visa and permit status; tax and LKPM data; document vault (passport, KTP, NPWP scans); messages and chat; billing records; privacy settings |
 | Privacy policy      | https://balizero.com/privacy                                                                                                                                                                                          |
-| Responsible officer | `<to be named by the owner>`                                                                                                                                                                                          |
+| Responsible officer | `Company director per the akta (the owner), position Direktur, contact zero@balizero.com`                                                                                                                             |
 | KBLI                | To confirm                                                                                                                                                                                                            |
 
 ### 3.4 zantara.balizero.com
@@ -130,7 +130,7 @@ policy:
 | Repo source         | `ZANTARA_DOMAIN` in `apps/mouth/src/proxy.ts`. `apps/web/README.md` also names this host; the live response carries the `x-pathname` header set by the mouth proxy, so mouth serves it today. Confirm in Vercel which project owns the domain. |
 | Data categories     | Chat messages and conversation history; account and session                                                                                                                                                                                    |
 | Privacy policy      | https://balizero.com/privacy                                                                                                                                                                                                                   |
-| Responsible officer | `<to be named by the owner>`                                                                                                                                                                                                                   |
+| Responsible officer | `Company director per the akta (the owner), position Direktur, contact zero@balizero.com`                                                                                                                                                      |
 | KBLI                | To confirm                                                                                                                                                                                                                                     |
 
 ### 3.5 tax.balizero.com
@@ -144,7 +144,7 @@ policy:
 | Repo source         | `TAX_DOMAIN` in `apps/mouth/src/proxy.ts`; route group `apps/mouth/src/app/(tax-calendar)/`   |
 | Data categories     | No input form found in the route group on 2026-09-11: public content only, plus web analytics |
 | Privacy policy      | https://balizero.com/privacy                                                                  |
-| Responsible officer | `<to be named by the owner>`                                                                  |
+| Responsible officer | `Company director per the akta (the owner), position Direktur, contact zero@balizero.com`     |
 | KBLI                | To confirm                                                                                    |
 
 DNS setup for this host: [tax-balizero-dns-setup.md](tax-balizero-dns-setup.md).
@@ -160,7 +160,7 @@ DNS setup for this host: [tax-balizero-dns-setup.md](tax-balizero-dns-setup.md).
 | Repo source         | `prime` rewrite in `apps/mouth/src/proxy.ts`; `apps/mouth/src/app/prime/`; chat route `apps/mouth/src/app/api/prime/chat/route.ts` |
 | Data categories     | Chat questions forwarded to the backend API; property proposal pages reached by token link                                         |
 | Privacy policy      | https://balizero.com/privacy                                                                                                       |
-| Responsible officer | `<to be named by the owner>`                                                                                                       |
+| Responsible officer | `Company director per the akta (the owner), position Direktur, contact zero@balizero.com`                                          |
 | KBLI                | To confirm                                                                                                                         |
 
 ### 3.7 Backend API: Fly app nuzantara-rag
@@ -173,7 +173,7 @@ DNS setup for this host: [tax-balizero-dns-setup.md](tax-balizero-dns-setup.md).
 | Hosting and region  | Fly.io app `nuzantara-rag`, `primary_region = 'sin'` (Singapore), processes `api` and `rag` (`apps/backend-rag/fly.toml`) |
 | Data categories     | All categories in 3.1 to 3.6; stores listed in the table at the start of section 3                                        |
 | Privacy policy      | https://balizero.com/privacy                                                                                              |
-| Responsible officer | `<to be named by the owner>`                                                                                              |
+| Responsible officer | `Company director per the akta (the owner), position Direktur, contact zero@balizero.com`                                 |
 | KBLI                | To confirm                                                                                                                |
 
 The API answers `GET` only: `curl -I` (HEAD) returns 404 on `/health` while `GET /health`
@@ -187,7 +187,7 @@ Channel: OSS-RBA (https://oss.go.id), integrated with the Komdigi PSE portal
 - [ ] Active NIB with a KBLI coherent with the systems in section 3 (KBLI to confirm)
 - [ ] Akta pendirian and SK Kemenkumham
 - [ ] Company NPWP
-- [ ] Responsible officer: `<to be named by the owner>`, with position and a reachable contact
+- [ ] Responsible officer: `Company director per the akta (the owner), position Direktur, contact zero@balizero.com`, with position and a reachable contact
 - [ ] System description and technology, one per system (section 3)
 - [ ] Domain or URL for every system, web and app filed separately (section 3)
 - [ ] Server and data location (section 3 storage table and each system's hosting row)

--- a/evidence/2026-09/agent-nuzantara-docs-pse-responsible-officer-b6adc6a2/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-docs-pse-responsible-officer-b6adc6a2/brief.yml
@@ -1,0 +1,33 @@
+task_id: pse-responsible-officer
+gear: 1
+l_level: L2
+gate_class: opus
+grader: Fresh Opus 5 on-disk gate commissioned by the imperator; no verdict asserted here.
+pii: none
+objective: >
+  In docs/ops/pse-registration-balizero.md, replace the literal placeholder
+  `<to be named by the owner>` (8 table-row occurrences across the per-system
+  tables plus 1 checklist line) with the owner's 2026-09-11 ruling ("fai tu")
+  naming the company director as the responsible officer for every system:
+  `Company director per the akta (the owner), position Direktur, contact
+  zero@balizero.com`. In the company-level table row where the source column
+  read "owner decision", change it to "owner ruling 2026-09-11" to reflect
+  that the field is now settled rather than pending.
+constraints:
+  - Docs only. Text substitution, no new claims, no regulatory interpretation added.
+  - No personal names beyond the literal role text the owner dictated; no PII introduced.
+  - Do not touch anything else in the file (URLs, hosting facts, other placeholders).
+acceptance:
+  - text: The old placeholder SHALL no longer appear anywhere in the file.
+    probe: "grep -c 'to be named by the owner' docs/ops/pse-registration-balizero.md"
+    expect: "0"
+  - text: The new responsible-officer text SHALL appear exactly 9 times.
+    probe: "grep -c 'Company director per the akta' docs/ops/pse-registration-balizero.md"
+    expect: "9"
+  - text: The file SHALL remain valid Prettier-formatted markdown.
+    probe: "npx prettier --check docs/ops/pse-registration-balizero.md"
+consumer_map:
+  - The staff member filing the PSE self-registration on OSS-RBA, reading the
+    responsible-officer field per system.
+deviations:
+  - none

--- a/evidence/2026-09/agent-nuzantara-docs-pse-responsible-officer-b6adc6a2/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-docs-pse-responsible-officer-b6adc6a2/pack.yml
@@ -1,0 +1,57 @@
+brief_ref: evidence/2026-09/agent-nuzantara-docs-pse-responsible-officer-b6adc6a2/brief.yml
+task_id: pse-responsible-officer
+gear: 1
+date: 2026-09-11
+machine: Pro
+machine_note: worktree /Users/nuzantara/nuzantara/.worktrees/docs-pse-responsible-officer, branch agent/nuzantara/docs/pse-responsible-officer
+floor: >-
+  compute_floor = 1, floor source "none" (python3 scripts/evidence_pack_lint.py
+  --changed-files-file <git diff --name-only origin/main -- list> --numstat-file
+  <git diff --numstat origin/main --> --print-floor); measured 1 file +20/-20,
+  well below SIZE_GEAR2_THRESHOLD 400; no hot-zone path.
+lanes:
+  - lane: pse-responsible-officer
+    role: build
+    seat: claude-sonnet-5 (subagent dispatched by the Pro imperator session, docs lane)
+pii_scan: clean
+dissent: []
+receipts:
+  - claim: The old placeholder no longer appears anywhere in the file.
+    cmd: grep -c "to be named by the owner" docs/ops/pse-registration-balizero.md
+    result: "0"
+    exit: 0
+    ts: "2026-09-11T01:13:06Z"
+    seat: claude-sonnet-5
+  - claim: The new responsible-officer text appears exactly 9 times (8 table rows + 1 checklist line).
+    cmd: grep -c "Company director per the akta" docs/ops/pse-registration-balizero.md
+    result: "9"
+    exit: 0
+    ts: "2026-09-11T01:13:06Z"
+    seat: claude-sonnet-5
+  - claim: The company-level table's "owner decision" source column now reads the 2026-09-11 ruling.
+    cmd: grep -n "owner ruling 2026-09-11" docs/ops/pse-registration-balizero.md
+    result: "52:| Responsible officer     | `Company director per the akta (the owner), position Direktur, contact zero@balizero.com` | owner ruling 2026-09-11                        |"
+    exit: 0
+    ts: "2026-09-11T01:13:06Z"
+    seat: claude-sonnet-5
+  - claim: Prettier accepts the file as correctly formatted after --write.
+    cmd: npx prettier --check docs/ops/pse-registration-balizero.md
+    result: "All matched files use Prettier code style!"
+    exit: 0
+    ts: "2026-09-11T01:13:06Z"
+    seat: claude-sonnet-5
+  - claim: Evidence pack floor for this change is 1 (docs-only, small diff, no hot-zone path).
+    cmd: git diff --numstat origin/main -- ; python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/x.txt --numstat-file /tmp/numstat.txt
+    result: "1 file +20/-20; floor=1, floor-source=none"
+    exit: 0
+    ts: "2026-09-11T01:13:06Z"
+    seat: claude-sonnet-5
+outcome: >-
+  docs/ops/pse-registration-balizero.md: every occurrence (9) of the literal
+  placeholder `<to be named by the owner>` replaced with the owner's
+  2026-09-11 ruling naming the company director (per the akta, position
+  Direktur, contact zero@balizero.com) as responsible officer for every
+  system. The company-level table's source column changed from "owner
+  decision" to "owner ruling 2026-09-11" to reflect the field is now settled.
+  Pure text substitution, no regulatory claim added, no other content touched.
+  Prettier re-ran clean after edits.


### PR DESCRIPTION
## Summary
- Replaced all 9 occurrences of the literal placeholder `<to be named by the owner>` in `docs/ops/pse-registration-balizero.md` (8 per-system table rows + 1 checklist line) with the owner's 2026-09-11 ruling ("fai tu"): the company director per the akta is the responsible officer for every system, position Direktur, contact zero@balizero.com.
- The company-level table's source column changed from `owner decision` to `owner ruling 2026-09-11` to reflect the field is now settled rather than pending.
- Pure text substitution — nothing else in the doc touched.

## Proofs
```
$ grep -c "to be named by the owner" docs/ops/pse-registration-balizero.md
0
$ grep -c "Company director per the akta" docs/ops/pse-registration-balizero.md
9
$ npx prettier --check docs/ops/pse-registration-balizero.md
All matched files use Prettier code style!
```
Evidence floor: `python3 scripts/evidence_pack_lint.py --print-floor` = 1 (docs-only, 1 file, +20/-20, no hot-zone). Gear 1 brief.yml + pack.yml included in this commit; `evidence_pack_lint.py` reports the pack clean.

## Adversarial review
docs-only text substitution, reviewed by the imperator by diff; no regulatory claim added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)