### PR TITLE
feat(mouth): obligations register reviewer screen in the workspace

### DIFF
--- a/apps/mouth/src/app/(workspace)/obligations/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/page.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/lib/api/error-handler";
+
+import ObligationsPage from "./page";
+
+const pushMock = vi.hoisted(() => vi.fn());
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const PROPOSED_ROW = {
+  id: 101,
+  client_id: 42,
+  rule_id: "PPH21_MONTHLY",
+  period_key: "2026-09",
+  due_date: "2026-10-10",
+  status: "proposed",
+  needs_review_reason: "New rule matched",
+  reviewer_email: null,
+  reviewed_at: null,
+  review_note: null,
+  alert_id: null,
+  created_at: "2026-09-01T00:00:00Z",
+  updated_at: "2026-09-01T00:00:00Z",
+};
+
+const LIST_RESPONSE = {
+  total: 1,
+  limit: 50,
+  offset: 0,
+  items: [PROPOSED_ROW],
+};
+
+describe("ObligationsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.get.mockResolvedValue(LIST_RESPONSE);
+    apiMock.post.mockResolvedValue({});
+  });
+
+  it("renders proposed rows from the list response", async () => {
+    render(<ObligationsPage />);
+
+    expect(await screen.findByText("PPH21_MONTHLY")).toBeVisible();
+    expect(screen.getByText("2026-09")).toBeVisible();
+    expect(screen.getByText("2026-10-10")).toBeVisible();
+    expect(screen.getByText("New rule matched")).toBeVisible();
+    // "proposed" also appears as the status-filter default option, so assert
+    // presence (>=1) rather than uniqueness.
+    expect(screen.getAllByText("proposed").length).toBeGreaterThan(0);
+    // client_id and id are rendered as bare numbers, ids-only (no PII join).
+    expect(screen.getByText("42")).toBeVisible();
+    expect(screen.getByText("101")).toBeVisible();
+
+    expect(apiMock.get).toHaveBeenCalledWith(
+      expect.stringContaining("/api/compliance/obligations?"),
+    );
+    expect(apiMock.get).toHaveBeenCalledWith(
+      expect.stringContaining("status=proposed"),
+    );
+  });
+
+  it("approve sends the note and refetches the list", async () => {
+    apiMock.post.mockResolvedValueOnce({
+      obligation: { ...PROPOSED_ROW, status: "alerted" },
+      alert_id: "alert_obligation_42_abcd1234",
+    });
+
+    render(<ObligationsPage />);
+    await screen.findByText("PPH21_MONTHLY");
+
+    const noteInput = screen.getByLabelText("Note for obligation 101");
+    fireEvent.change(noteInput, { target: { value: "looks correct" } });
+
+    const approveBtn = screen.getByRole("button", { name: "Approve" });
+    fireEvent.click(approveBtn);
+
+    await waitFor(() => {
+      expect(apiMock.post).toHaveBeenCalledWith(
+        "/api/compliance/obligations/101/approve",
+        { note: "looks correct" },
+      );
+    });
+
+    // Refetch: the initial load + the post-approve reload.
+    await waitFor(() => expect(apiMock.get).toHaveBeenCalledTimes(2));
+
+    expect(
+      await screen.findByText(
+        "✓ Obligation #101 approved → alert alert_obligation_42_abcd1234.",
+      ),
+    ).toBeVisible();
+  });
+
+  it("reject requires a reason and is disabled without one", async () => {
+    render(<ObligationsPage />);
+    await screen.findByText("PPH21_MONTHLY");
+
+    const rejectBtn = screen.getByRole("button", { name: "Reject" });
+    fireEvent.click(rejectBtn);
+
+    expect(
+      await screen.findByText("A reason is required to reject."),
+    ).toBeVisible();
+    expect(apiMock.post).not.toHaveBeenCalled();
+
+    const noteInput = screen.getByLabelText("Note for obligation 101");
+    fireEvent.change(noteInput, { target: { value: "duplicate rule" } });
+    fireEvent.click(rejectBtn);
+
+    await waitFor(() => {
+      expect(apiMock.post).toHaveBeenCalledWith(
+        "/api/compliance/obligations/101/reject",
+        { reason: "duplicate rule" },
+      );
+    });
+  });
+
+  it("generate with needs_manual_classification=true shows the warning banner", async () => {
+    apiMock.post.mockResolvedValueOnce({
+      client_id: 42,
+      inserted_count: 3,
+      company_type: "OTHER",
+      needs_manual_classification: true,
+      warning:
+        "profile_from_rows could not map this client's company_type to a known type",
+      rows: [],
+    });
+
+    render(<ObligationsPage />);
+    await screen.findByText("PPH21_MONTHLY");
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. 42"), {
+      target: { value: "42" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate proposals" }));
+
+    await waitFor(() => {
+      expect(apiMock.post).toHaveBeenCalledWith(
+        "/api/compliance/obligations/generate",
+        { client_id: 42, horizon_days: 90 },
+      );
+    });
+
+    expect(
+      await screen.findByText(/Inserted 3 new proposals for client 42/),
+    ).toBeVisible();
+    expect(screen.getByText(/company_type to a known type/)).toBeVisible();
+  });
+
+  it("shows the admin-only message on a 403", async () => {
+    apiMock.get.mockReset();
+    apiMock.get.mockRejectedValue(
+      new ApiError("CRM admin required", 403, { detail: "CRM admin required" }),
+    );
+
+    render(<ObligationsPage />);
+
+    expect(await screen.findByText("Admin only.")).toBeVisible();
+  });
+});

--- a/apps/mouth/src/app/(workspace)/obligations/page.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/page.tsx
@@ -1,0 +1,680 @@
+"use client";
+
+/**
+ * Compliance obligations register — reviewer screen (kita workspace).
+ *
+ * Backend: apps/backend-rag/backend/app/routers/compliance_obligations.py,
+ * prefix `/api/compliance/obligations`, EVERY route (reads included) gated
+ * by `is_crm_admin` — a non-admin gets a plain 403, surfaced below as
+ * "Admin only." rather than a generic failure.
+ *
+ * Flow (see the router's module docstring): `propose()` (PR A1) fills
+ * `client_obligations` with `status='proposed'` rows. This page lets the tax
+ * team list them, ask for more (`POST /generate`, idempotent), and decide
+ * each one. Approve is the ONLY place a row becomes client-visible: the
+ * backend bridges it into `compliance_alerts` in the SAME transaction as the
+ * `proposed -> approved -> alerted` status flip, so a successful approve
+ * always returns an `alert_id`. Reject is terminal and never touches
+ * `compliance_alerts`.
+ *
+ * Both decisions are compare-and-swap on `status='proposed'` server-side — a
+ * stale row (already decided by someone else, or re-clicked) comes back 409
+ * with the current status in the message; that message is shown verbatim.
+ *
+ * Auth + transport reuse the shared `api` client (httpOnly cookie + bearer),
+ * same as `(workspace)/review/page.tsx`. No client join / no PII beyond what
+ * the API already returns (ids only — this page never fetches client names).
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { api } from "@/lib/api";
+import { ApiError } from "@/lib/api/error-handler";
+import { logger } from "@/lib/logger";
+
+// ── API contract (local types — review/page.tsx also calls `api.get`/`api.post`
+//    with plain interfaces rather than the generated `schema.d.ts` typed paths,
+//    so this page follows the same convention; see PR notes for why no
+//    `npm run generate:openapi` regen was needed). ─────────────────────────
+type ObligationStatus =
+  "proposed" | "approved" | "rejected" | "alerted" | "done";
+
+const STATUS_FILTER_OPTIONS = [
+  "proposed",
+  "approved",
+  "rejected",
+  "alerted",
+  "done",
+  "all",
+] as const;
+type StatusFilter = (typeof STATUS_FILTER_OPTIONS)[number];
+
+interface ObligationOut {
+  id: number;
+  client_id: number;
+  rule_id: string;
+  period_key: string;
+  due_date: string;
+  status: ObligationStatus;
+  needs_review_reason: string | null;
+  reviewer_email: string | null;
+  reviewed_at: string | null;
+  review_note: string | null;
+  alert_id: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+interface ObligationListOut {
+  total: number;
+  limit: number;
+  offset: number;
+  items: ObligationOut[];
+}
+
+interface GenerateOut {
+  client_id: number;
+  inserted_count: number;
+  company_type: string;
+  needs_manual_classification: boolean;
+  warning: string | null;
+  rows: ObligationOut[];
+}
+
+interface ApproveOut {
+  obligation: ObligationOut;
+  alert_id: string;
+}
+
+const LIMIT = 50;
+
+const CARD = {
+  borderColor: "var(--bz-border)",
+  background: "var(--bz-card, var(--bz-surface))",
+} as const;
+
+const INPUT_STYLE = {
+  borderColor: "var(--bz-border)",
+  background: "var(--bz-surface)",
+  color: "var(--bz-text-1)",
+} as const;
+
+/** Turn a thrown api error into the exact text a reviewer should see. */
+function describeError(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) {
+    if (e.statusCode === 401 || e.statusCode === 403) return "Admin only.";
+    if (e.statusCode === 404) return e.message || "Not found.";
+    if (e.statusCode === 409)
+      return e.message || "Conflict — this row was already decided.";
+    return e.message || fallback;
+  }
+  if (e instanceof Error) return e.message || fallback;
+  return fallback;
+}
+
+export default function ObligationsPage() {
+  const router = useRouter();
+
+  // ── register list ──────────────────────────────────────────────────────
+  const [items, setItems] = useState<ObligationOut[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [listError, setListError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  // ── filters ─────────────────────────────────────────────────────────────
+  const [filterClientId, setFilterClientId] = useState("");
+  const [filterStatus, setFilterStatus] = useState<StatusFilter>("proposed");
+
+  // ── generate proposals ─────────────────────────────────────────────────
+  const [genClientId, setGenClientId] = useState("");
+  const [genHorizonDays, setGenHorizonDays] = useState("90");
+  const [generating, setGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState<string | null>(null);
+  const [generateResult, setGenerateResult] = useState<GenerateOut | null>(
+    null,
+  );
+
+  // ── per-row decision state ─────────────────────────────────────────────
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [notes, setNotes] = useState<Record<number, string>>({});
+  const [rowError, setRowError] = useState<Record<number, string>>({});
+
+  const loadList = useCallback(async () => {
+    setLoading(true);
+    setListError(null);
+    try {
+      const params = new URLSearchParams();
+      const cid = filterClientId.trim();
+      if (cid) params.set("client_id", cid);
+      params.set("status", filterStatus);
+      params.set("limit", String(LIMIT));
+      params.set("offset", String(offset));
+      const res = await api.get<ObligationListOut>(
+        `/api/compliance/obligations?${params.toString()}`,
+      );
+      setItems(res.items ?? []);
+      setTotal(res.total ?? 0);
+    } catch (e) {
+      logger.error(
+        "obligations list load failed",
+        { component: "ObligationsPage", action: "loadList" },
+        e instanceof Error ? e : new Error(String(e)),
+      );
+      setListError(
+        describeError(e, "Could not load the obligations register."),
+      );
+      setItems([]);
+      setTotal(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [filterClientId, filterStatus, offset]);
+
+  useEffect(() => {
+    void loadList();
+  }, [loadList]);
+
+  // A filter change starts back at the first page.
+  useEffect(() => {
+    setOffset(0);
+  }, [filterClientId, filterStatus]);
+
+  const handleGenerate = useCallback(async () => {
+    setGenerateError(null);
+    const cid = Number(genClientId);
+    if (!genClientId.trim() || !Number.isInteger(cid) || cid <= 0) {
+      setGenerateError("Enter a valid client id.");
+      return;
+    }
+    const horizon = Number(genHorizonDays);
+    if (!Number.isInteger(horizon) || horizon < 1 || horizon > 730) {
+      setGenerateError("Horizon days must be an integer between 1 and 730.");
+      return;
+    }
+    setGenerating(true);
+    setGenerateResult(null);
+    setNotice(null);
+    try {
+      const res = await api.post<GenerateOut>(
+        "/api/compliance/obligations/generate",
+        { client_id: cid, horizon_days: horizon },
+      );
+      setGenerateResult(res);
+      await loadList();
+    } catch (e) {
+      logger.error(
+        "obligations generate failed",
+        { component: "ObligationsPage", action: "generate" },
+        e instanceof Error ? e : new Error(String(e)),
+      );
+      setGenerateError(describeError(e, "Could not generate proposals."));
+    } finally {
+      setGenerating(false);
+    }
+  }, [genClientId, genHorizonDays, loadList]);
+
+  const handleApprove = useCallback(
+    async (row: ObligationOut) => {
+      setBusyId(row.id);
+      setRowError((prev) => ({ ...prev, [row.id]: "" }));
+      setNotice(null);
+      try {
+        const note = (notes[row.id] ?? "").trim();
+        const body: { note?: string } = {};
+        if (note) body.note = note;
+        const res = await api.post<ApproveOut>(
+          `/api/compliance/obligations/${row.id}/approve`,
+          body,
+        );
+        setNotice(`✓ Obligation #${row.id} approved → alert ${res.alert_id}.`);
+        await loadList();
+      } catch (e) {
+        logger.error(
+          "obligation approve failed",
+          {
+            component: "ObligationsPage",
+            action: "approve",
+            metadata: { id: row.id },
+          },
+          e instanceof Error ? e : new Error(String(e)),
+        );
+        setRowError((prev) => ({
+          ...prev,
+          [row.id]: describeError(e, "Could not approve this obligation."),
+        }));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [notes, loadList],
+  );
+
+  const handleReject = useCallback(
+    async (row: ObligationOut) => {
+      // RejectBody.reason is REQUIRED (min_length=1) server-side — unlike
+      // approve's optional note — so we enforce it client-side too rather
+      // than round-trip a guaranteed 422.
+      const reason = (notes[row.id] ?? "").trim();
+      if (!reason) {
+        setRowError((prev) => ({
+          ...prev,
+          [row.id]: "A reason is required to reject.",
+        }));
+        return;
+      }
+      setBusyId(row.id);
+      setRowError((prev) => ({ ...prev, [row.id]: "" }));
+      setNotice(null);
+      try {
+        await api.post(`/api/compliance/obligations/${row.id}/reject`, {
+          reason,
+        });
+        setNotice(`Obligation #${row.id} rejected.`);
+        await loadList();
+      } catch (e) {
+        logger.error(
+          "obligation reject failed",
+          {
+            component: "ObligationsPage",
+            action: "reject",
+            metadata: { id: row.id },
+          },
+          e instanceof Error ? e : new Error(String(e)),
+        );
+        setRowError((prev) => ({
+          ...prev,
+          [row.id]: describeError(e, "Could not reject this obligation."),
+        }));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [notes, loadList],
+  );
+
+  const pageStart = total === 0 ? 0 : offset + 1;
+  const pageEnd = Math.min(offset + LIMIT, total);
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1
+            className="text-2xl font-semibold"
+            style={{ color: "var(--bz-text-1)" }}
+          >
+            Obligations register
+          </h1>
+          <p className="mt-1 text-sm" style={{ color: "var(--bz-text-3)" }}>
+            Generate, review and decide compliance obligation proposals before
+            they become client-visible deadline alerts.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => router.push("/dashboard")}
+          className="rounded-md border px-3 py-1.5 text-sm"
+          style={{ borderColor: "var(--bz-border)", color: "var(--bz-text-2)" }}
+        >
+          ← Back
+        </button>
+      </div>
+
+      {notice && (
+        <div
+          className="mb-4 rounded-md border px-4 py-2 text-sm"
+          role="status"
+          style={{
+            borderColor: "var(--state-success)",
+            color: "var(--bz-text-1)",
+          }}
+        >
+          {notice}
+        </div>
+      )}
+
+      {/* ── Generate proposals ───────────────────────────────────────── */}
+      <section className="mb-6 rounded-xl border p-4" style={CARD}>
+        <h2
+          className="mb-2 text-lg font-medium"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          Generate proposals
+        </h2>
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="text-xs" style={{ color: "var(--bz-text-3)" }}>
+            Client id
+            <input
+              type="number"
+              min={1}
+              className="mt-1 block w-32 rounded border px-2 py-1.5 text-sm"
+              style={INPUT_STYLE}
+              value={genClientId}
+              onChange={(e) => setGenClientId(e.target.value)}
+              placeholder="e.g. 42"
+            />
+          </label>
+          <label className="text-xs" style={{ color: "var(--bz-text-3)" }}>
+            Horizon days
+            <input
+              type="number"
+              min={1}
+              max={730}
+              className="mt-1 block w-32 rounded border px-2 py-1.5 text-sm"
+              style={INPUT_STYLE}
+              value={genHorizonDays}
+              onChange={(e) => setGenHorizonDays(e.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            disabled={generating}
+            onClick={() => void handleGenerate()}
+            className="rounded-md px-4 py-2 text-sm font-medium text-white"
+            style={{
+              background: "var(--bz-accent)",
+              opacity: generating ? 0.6 : 1,
+            }}
+          >
+            {generating ? "Generating…" : "Generate proposals"}
+          </button>
+        </div>
+
+        {generateError && (
+          <p
+            className="mt-2 text-sm"
+            role="alert"
+            style={{ color: "var(--state-danger)" }}
+          >
+            {generateError}
+          </p>
+        )}
+
+        {generateResult && (
+          <div className="mt-3 space-y-1">
+            <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
+              Inserted {generateResult.inserted_count} new proposal
+              {generateResult.inserted_count === 1 ? "" : "s"} for client{" "}
+              {generateResult.client_id} — company type{" "}
+              <strong>{generateResult.company_type}</strong>.
+            </p>
+            {generateResult.needs_manual_classification && (
+              <div
+                className="rounded-md border px-3 py-2 text-sm"
+                role="alert"
+                style={{
+                  borderColor: "var(--state-warning)",
+                  color: "var(--bz-text-1)",
+                }}
+              >
+                ⚠ {generateResult.warning}
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+
+      {/* ── Filters ──────────────────────────────────────────────────── */}
+      <section className="mb-4 flex flex-wrap items-end gap-3">
+        <label className="text-xs" style={{ color: "var(--bz-text-3)" }}>
+          Client id
+          <input
+            type="number"
+            min={1}
+            className="mt-1 block w-32 rounded border px-2 py-1.5 text-sm"
+            style={INPUT_STYLE}
+            value={filterClientId}
+            onChange={(e) => setFilterClientId(e.target.value)}
+            placeholder="all clients"
+          />
+        </label>
+        <label className="text-xs" style={{ color: "var(--bz-text-3)" }}>
+          Status
+          <select
+            className="mt-1 block w-40 rounded border px-2 py-1.5 text-sm"
+            style={INPUT_STYLE}
+            value={filterStatus}
+            onChange={(e) => setFilterStatus(e.target.value as StatusFilter)}
+          >
+            {STATUS_FILTER_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={() => void loadList()}
+          disabled={loading}
+          className="rounded-md border px-3 py-1.5 text-sm"
+          style={{ borderColor: "var(--bz-border)", color: "var(--bz-text-2)" }}
+        >
+          {loading ? "Refreshing…" : "Refresh"}
+        </button>
+      </section>
+
+      {listError && (
+        <div
+          className="mb-4 rounded-md border px-4 py-2 text-sm"
+          role="alert"
+          style={{
+            borderColor: "var(--state-danger)",
+            color: "var(--bz-text-1)",
+          }}
+        >
+          {listError}
+        </div>
+      )}
+
+      {/* ── Table ────────────────────────────────────────────────────── */}
+      {loading ? (
+        <p style={{ color: "var(--bz-text-3)" }}>Loading…</p>
+      ) : !listError && items.length === 0 ? (
+        <p style={{ color: "var(--bz-text-3)" }}>No obligations found.</p>
+      ) : (
+        !listError && (
+          <div className="overflow-auto rounded-xl border" style={CARD}>
+            <table className="w-full text-sm">
+              <thead>
+                <tr
+                  className="border-b text-left"
+                  style={{ borderColor: "var(--bz-border)" }}
+                >
+                  {[
+                    "ID",
+                    "Client",
+                    "Rule",
+                    "Period",
+                    "Due date",
+                    "Needs review",
+                    "Status",
+                    "Reviewer",
+                    "Actions",
+                  ].map((h) => (
+                    <th
+                      key={h}
+                      className="px-3 py-2 text-xs font-medium"
+                      style={{ color: "var(--bz-text-3)" }}
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((row) => (
+                  <tr
+                    key={row.id}
+                    className="border-b last:border-b-0"
+                    style={{ borderColor: "var(--bz-border)" }}
+                  >
+                    <td
+                      className="px-3 py-2"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      {row.id}
+                    </td>
+                    <td
+                      className="px-3 py-2"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      {row.client_id}
+                    </td>
+                    <td
+                      className="px-3 py-2"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      {row.rule_id}
+                    </td>
+                    <td
+                      className="px-3 py-2"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      {row.period_key}
+                    </td>
+                    <td
+                      className="px-3 py-2"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      {row.due_date}
+                    </td>
+                    <td
+                      className="px-3 py-2 text-xs"
+                      style={{ color: "var(--bz-text-3)" }}
+                    >
+                      {row.needs_review_reason ?? "—"}
+                    </td>
+                    <td
+                      className="px-3 py-2"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      {row.status}
+                    </td>
+                    <td
+                      className="px-3 py-2 text-xs"
+                      style={{ color: "var(--bz-text-3)" }}
+                    >
+                      {row.reviewer_email ? (
+                        <>
+                          {row.reviewer_email}
+                          {row.reviewed_at
+                            ? ` · ${new Date(row.reviewed_at).toLocaleString()}`
+                            : ""}
+                        </>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      {row.status === "proposed" ? (
+                        <div className="flex flex-col gap-1">
+                          <input
+                            aria-label={`Note for obligation ${row.id}`}
+                            className="w-40 rounded border px-2 py-1 text-xs"
+                            style={INPUT_STYLE}
+                            placeholder="note (required to reject)"
+                            value={notes[row.id] ?? ""}
+                            onChange={(e) =>
+                              setNotes((prev) => ({
+                                ...prev,
+                                [row.id]: e.target.value,
+                              }))
+                            }
+                          />
+                          <div className="flex gap-2">
+                            <button
+                              type="button"
+                              disabled={busyId === row.id}
+                              onClick={() => void handleApprove(row)}
+                              className="rounded-md px-3 py-1 text-xs font-medium text-white"
+                              style={{
+                                background: "var(--state-success)",
+                                opacity: busyId === row.id ? 0.6 : 1,
+                              }}
+                            >
+                              {busyId === row.id ? "…" : "Approve"}
+                            </button>
+                            <button
+                              type="button"
+                              disabled={busyId === row.id}
+                              onClick={() => void handleReject(row)}
+                              className="rounded-md px-3 py-1 text-xs font-medium text-white"
+                              style={{
+                                background: "var(--state-danger)",
+                                opacity: busyId === row.id ? 0.6 : 1,
+                              }}
+                            >
+                              {busyId === row.id ? "…" : "Reject"}
+                            </button>
+                          </div>
+                          {rowError[row.id] && (
+                            <p
+                              role="alert"
+                              className="text-xs"
+                              style={{ color: "var(--state-danger)" }}
+                            >
+                              {rowError[row.id]}
+                            </p>
+                          )}
+                        </div>
+                      ) : (
+                        <span
+                          className="text-xs"
+                          style={{ color: "var(--bz-text-3)" }}
+                        >
+                          {row.alert_id ? `alert ${row.alert_id}` : "—"}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )
+      )}
+
+      {/* ── Pagination ───────────────────────────────────────────────── */}
+      {!listError && total > 0 && (
+        <div
+          className="mt-3 flex items-center justify-between text-xs"
+          style={{ color: "var(--bz-text-3)" }}
+        >
+          <span>
+            Showing {pageStart}-{pageEnd} of {total}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={offset === 0 || loading}
+              onClick={() => setOffset((o) => Math.max(0, o - LIMIT))}
+              className="rounded-md border px-3 py-1"
+              style={{
+                borderColor: "var(--bz-border)",
+                color: "var(--bz-text-2)",
+              }}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              disabled={offset + LIMIT >= total || loading}
+              onClick={() => setOffset((o) => o + LIMIT)}
+              className="rounded-md border px-3 py-1"
+              style={{
+                borderColor: "var(--bz-border)",
+                color: "var(--bz-text-2)",
+              }}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mouth/src/types/navigation.ts
+++ b/apps/mouth/src/types/navigation.ts
@@ -49,6 +49,7 @@ export const navigation: NavSection[] = [
       { title: "Process", href: "/process", icon: "FolderKanban" },
       { title: "Second Home", href: "/second-home", icon: "Home" },
       { title: "Review", href: "/review", icon: "ClipboardCheck" },
+      { title: "Obligations", href: "/obligations", icon: "Receipt" },
       { title: "HR / Payroll", href: "/hr", icon: "Banknote" },
     ],
   },

--- a/evidence/2026-09/agent-nuzantara-mouth-obligations-review-ui-f5274808/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-mouth-obligations-review-ui-f5274808/brief.yml
@@ -1,0 +1,105 @@
+task_id: obligations-review-ui
+gear: 2
+l_level: L2
+gate_class: opus
+gear_note: >-
+  floor 2 by the size term (net lines 860 >= SIZE_GEAR2_THRESHOLD=400, < SIZE_GEAR3_THRESHOLD
+  1828); declared 2. Fleet finding: `evidence_pack_lint.py --print-floor` does NOT read
+  `--net-lines` (that flag is only consumed by the `--print-measured`/pack-check paths) — the
+  size term needs `--numstat-file`. The dispatch's literal command
+  (`--changed-files-file --net-lines`) prints floor 1 (path-only, no hot-zone hit, no size
+  term) because numstat is never supplied; `--changed-files-file /tmp/cf.txt --numstat-file
+  /tmp/ns.txt` on `git diff --numstat origin/main...` correctly returns 2, source "size".
+objective: >-
+  Add a reviewer screen for the compliance obligations register at
+  apps/mouth/src/app/(workspace)/obligations/page.tsx (kita workspace), so the tax team can
+  generate obligation proposals for a client (POST .../generate), filter/paginate the register
+  (GET .../obligations), and approve or reject proposed rows (POST .../{id}/approve|reject) —
+  the backend router (apps/backend-rag/backend/app/routers/compliance_obligations.py, prefix
+  /api/compliance/obligations, admin-gated via is_crm_admin on every route) was already on main
+  with no UI in front of it.
+constraints:
+  - >-
+    Reused the existing `api` client (`@/lib/api`) exactly as (workspace)/review/page.tsx does —
+    no new fetch layer; errors are classified via `ApiError.statusCode` (imported from
+    `@/lib/api/error-handler`, same source review/page.tsx's sibling
+    process/[id]/page.tsx uses for the identical 401/403/404 pattern), not string-sniffed.
+  - >-
+    Contract read from the router BEFORE coding, not assumed from the dispatch: ApproveBody.note
+    is optional but RejectBody.reason is REQUIRED (`Field(..., min_length=1)`) — the dispatch
+    said "Reject (optional note)", which is wrong for this router. The UI enforces the
+    server-side requirement client-side (Reject stays enabled but shows "A reason is required to
+    reject." and never fires the request on an empty field) rather than round-tripping a
+    guaranteed 422.
+  - >-
+    review/page.tsx calls `api.get<T>`/`api.post<T>` with local TS interfaces, not the generated
+    `src/lib/api/schema.d.ts` typed paths (only apps/mouth/src/app/sitemap.test.ts references
+    schema.d.ts in the whole app) — this page follows the same untyped-call convention, so no
+    `npm run generate:openapi && npm run generate:api` regen was run or needed.
+  - >-
+    No PII beyond what the API returns: the table shows ids only (obligation id, client_id,
+    rule_id) — never a client name/email/phone join, matching the router's own
+    ids-only response shape.
+  - >-
+    Design tokens/components match review/page.tsx and GateScreen.tsx's `--bz-*`/`--state-*`
+    CSS custom properties, not the different `var(--border)`/`var(--foreground-muted)` token
+    set used by some settings pages — review/page.tsx was named as the pattern to follow.
+  - >-
+    Nav link added to apps/mouth/src/types/navigation.ts ("Work" section, right after "Review"),
+    which apps/mouth/src/components/workspace/AppSidebar.tsx renders — the "Receipt" lucide icon
+    was already imported/mapped there (used by two portal nav entries), so no new icon import.
+acceptance:
+  - text: >-
+      WHEN the register loads THEN proposed rows from the list response SHALL render (id,
+      client_id, rule_id, period_key, due_date, needs_review_reason, status).
+    probe: >-
+      npx vitest run "src/app/(workspace)/obligations/page.test.tsx" -t "renders proposed rows"
+      — 1 passed.
+  - text: >-
+      WHEN Approve is clicked with a note THEN POST .../{id}/approve SHALL carry {note} and the
+      list SHALL refetch and show the returned alert_id.
+    probe: >-
+      npx vitest run same file -t "approve sends the note" — 1 passed. Bite proven by mutation:
+      changed `body.note = note` to `body.wrong_key = note` in page.tsx -> RED (1 failed, key
+      assertion `toHaveBeenCalledWith(".../101/approve", { note: "looks correct" })` unmet);
+      reverted -> GREEN (5 passed). Full tails below.
+  - text: WHEN Reject is clicked with an empty note THEN it SHALL refuse and never call the API.
+    probe: >-
+      npx vitest run same file -t "reject requires a reason" — 1 passed (asserts
+      apiMock.post not called until a reason is typed, then called with {reason}).
+  - text: >-
+      WHEN generate returns needs_manual_classification=true THEN the warning banner SHALL
+      render with the router's exact message.
+    probe: npx vitest run same file -t "needs_manual_classification" — 1 passed.
+  - text: WHEN the backend 403s (non-admin) THEN the page SHALL show "Admin only." not a raw error.
+    probe: npx vitest run same file -t "admin-only" — 1 passed.
+  - text: Typecheck and lint SHALL be clean; formatting SHALL match prettier.
+    probe: >-
+      npx tsc --noEmit (exit 0, no output); npx eslint page.tsx (0 errors; page.test.tsx is
+      ignored by the project's own eslint glob, verified identical on review/page.test.tsx);
+      npx prettier --check page.tsx page.test.tsx navigation.ts (all pass after one --write
+      pass).
+  - text: The full app SHALL build and /obligations SHALL resolve as its own static route.
+    probe: >-
+      npm run build (apps/mouth), exit 0; route table prints "○ /obligations" as a standalone
+      static entry; "PUBLIC_LOGIN_BUNDLE_OK: inspected 8 assets; no internal API route prefixes
+      found" printed after (chained with &&, so only runs post next-build success).
+consumer_map:
+  - "The tax team, via the kita workspace nav (Work -> Obligations), to clear the proposed-obligation backlog without a direct-DB workaround."
+  - "compliance-deadline-sentinel / obligations register backend (PR A1/A2, already on main): this page is the first UI consumer of GET/POST /api/compliance/obligations."
+risks:
+  - >-
+    The row-level action UI reuses ONE text input for both approve's optional note and reject's
+    required reason (labelled "note (required to reject)") rather than two separate fields, to
+    keep the table row compact — a reviewer who fills it in for Approve and then clicks Reject
+    on the SAME row would send that text as the rejection reason. Judged acceptable: the field
+    is per-row and cleared on refetch, and it is the same simplification review/page.tsx makes
+    for its own reject `window.prompt`.
+  - >-
+    Pagination/filter state is client-only (no URL query params) — a reviewer's page/filter
+    position is lost on reload, same as review/page.tsx's own queue view.
+grader: >-
+  The final on-disk gate is a fresh Opus 5 session commissioned by the imperator; this session
+  does not post harness/fable-gate and did not arm auto-merge.
+budget: Existing subscription only; no paid API calls.
+pii: none (ids only; no client name/email/phone rendered or fetched)


### PR DESCRIPTION
## What / why

The compliance obligations register backend (`apps/backend-rag/backend/app/routers/compliance_obligations.py`, prefix `/api/compliance/obligations`, admin-gated via `is_crm_admin` on every route) was already on `main` with no UI. This PR gives the tax team a reviewer screen in the kita workspace: generate proposals for a client, filter/paginate the register, and approve/reject proposed rows — approve is the only path that bridges a row into `compliance_alerts` (one transaction, server-side).

## Files

- `apps/mouth/src/app/(workspace)/obligations/page.tsx` (new) — the reviewer screen.
- `apps/mouth/src/app/(workspace)/obligations/page.test.tsx` (new) — 5 vitest cases.
- `apps/mouth/src/types/navigation.ts` — nav link ("Work" → "Obligations", next to "Review"), rendered by `components/workspace/AppSidebar.tsx`.
- `evidence/2026-09/agent-nuzantara-mouth-obligations-review-ui-f5274808/brief.yml` — evidence pack (gear 2).

## Contract read from the router, not assumed

`ApproveBody.note` is optional; `RejectBody.reason` is **required** (`Field(..., min_length=1)`) — the dispatch brief said "Reject (optional note)", which does not match the code. The UI enforces the server-side requirement client-side: Reject stays enabled but refuses (shows "A reason is required to reject.") until the note field is non-empty, avoiding a guaranteed 422 round-trip. Both approve/reject are CAS on `status='proposed'`; a 409's exact backend message is shown verbatim, same for 404/401/403 → "Admin only." (via `ApiError.statusCode`, same pattern as `process/[id]/page.tsx`).

## Patterns reused (per review/page.tsx)

- Same `api` client (`@/lib/api`), no new fetch layer.
- Same `--bz-*`/`--state-*` design tokens as `review/page.tsx` and `GateScreen.tsx`.
- Local TS interfaces for the API contract, not `schema.d.ts` typed paths — `review/page.tsx` also calls `api.get<T>`/`api.post<T>` untyped (only `sitemap.test.ts` references `schema.d.ts` anywhere in the app), so **no `npm run generate:openapi`/`generate:api` regen was run or needed**.
- No PII beyond ids (no client-name join).

## Tests

```
npx vitest run "src/app/(workspace)/obligations/page.test.tsx"
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Mutation proof (approve-note test): changed `body.note = note` → `body.wrong_key = note` in page.tsx:

```
✗ approve sends the note and refetches the list
  expect(apiMock.post).toHaveBeenCalledWith(
    "/api/compliance/obligations/101/approve",
    { note: "looks correct" },
  )
 Test Files  1 failed (1)
      Tests  1 failed | 4 skipped (5)
```

Reverted → green again (5 passed, shown above).

## Build / typecheck / lint / format

- `npx tsc --noEmit` — exit 0, no output.
- `npx eslint "obligations/page.tsx"` — 0 errors (page.test.tsx is ignored by the project's own eslint glob; confirmed identical on `review/page.test.tsx`).
- `npx prettier --check page.tsx page.test.tsx navigation.ts` — pass after one `--write`.
- `npm run build` (apps/mouth) — exit 0; route table prints `○ /obligations` as its own static entry; `PUBLIC_LOGIN_BUNDLE_OK: inspected 8 assets; no internal API route prefixes found` printed after (chained with `&&`, only runs post-build success).

## Floor / gear

Gear **2** — size term, net lines 860 ≥ `SIZE_GEAR2_THRESHOLD=400` (< `SIZE_GEAR3_THRESHOLD=1828`).

Fleet finding: `evidence_pack_lint.py --print-floor --changed-files-file /tmp/cf.txt --net-lines "$N"` (the dispatch's literal command) prints floor **1** — `--print-floor` does not consume `--net-lines` at all (only the `--print-measured`/pack-check code path reads it); the size term needs `--numstat-file`:

```
git diff --numstat origin/main... > /tmp/ns.txt
python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/cf.txt --numstat-file /tmp/ns.txt
# -> 2  (source: size)
```

No `pack.yml` written, matching the referenced example (`evidence/2026-09/agent-nuzantara-mouth-compliance-retainer-page-0bf73876/` also ships only `brief.yml`).

## Adversarial review (self-check)

- **CAS error surfacing**: 409 shows the backend's exact `detail` string (e.g. "Obligation must be proposed (status=approved).") via `ApiError.message`, not a generic failure — verified by reading the router's `set_status` guard and `describeError()`'s pass-through for non-401/403/404 statuses.
- **Admin gate**: every call (list/detail/generate/approve/reject) can 401/403; `describeError()` maps both to "Admin only." uniformly, tested for the list GET (403).
- **No PII**: table renders `id`/`client_id`/`rule_id`/`period_key` only — no client-search or name join was added, unlike `review/page.tsx`'s candidate-client UI (intentionally out of scope here, per the dispatch).
- **Loading states**: `loading` disables Refresh/Previous/Next; per-row `busyId === row.id` disables that row's Approve/Reject and shows "…"; `generating` disables the Generate button and shows "Generating…" — none of these block other rows/filters from being used concurrently.
- **Known simplification, flagged in brief.yml `risks`**: one shared note/reason text input per row (not two separate fields) — a reviewer who types a note then clicks Reject on the same row sends that text as the rejection reason. Judged acceptable for a compact table row; documented, not hidden.

Not armed, not merged — a fresh Opus 5 gate is commissioned separately.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>