### PR TITLE
feat(website): compliance corner as the fifth service pillar

### DIFF
--- a/apps/website/src/app/services/services.test.tsx
+++ b/apps/website/src/app/services/services.test.tsx
@@ -30,7 +30,7 @@ describe("service journeys", () => {
       }
     }
   });
-  it("publishes an overview and four resolvable local journeys", () => {
+  it("publishes an overview and five resolvable local journeys", () => {
     render(<ServicesOverview />);
     const main = screen.getByRole("main");
     const localRoutes = new Set([
@@ -39,7 +39,7 @@ describe("service journeys", () => {
       ...servicePages.map(({ slug }) => `/services/${slug}`),
     ]);
     const links = [...main.querySelectorAll('a[href^="/"]')];
-    expect(servicePages).toHaveLength(4);
+    expect(servicePages).toHaveLength(5);
     expect(generateStaticParams()).toEqual(
       servicePages.map(({ slug }) => ({ slug })),
     );
@@ -92,10 +92,16 @@ describe("service journeys", () => {
     expect(
       screen.getByRole("link", { name: "Back to all services" }),
     ).toHaveAttribute("href", "/services");
-    const tool = getDestination(service.toolDestinationId);
-    expect(
-      screen.getByRole("link", { name: `Open ${tool.label}` }),
-    ).toHaveAttribute("href", tool.href);
+    if (service.toolDestinationId) {
+      const tool = getDestination(service.toolDestinationId);
+      expect(
+        screen.getByRole("link", { name: `Open ${tool.label}` }),
+      ).toHaveAttribute("href", tool.href);
+    } else {
+      expect(
+        screen.queryByText("Optional independent starting point"),
+      ).not.toBeInTheDocument();
+    }
     expect(container.querySelector("form")).toBeNull();
     const content = serviceSectionContent[service.slug];
     const expectedServices = content.catalog.flatMap((group) => group.services);

--- a/apps/website/src/components/Company.test.tsx
+++ b/apps/website/src/components/Company.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import AboutPage, { metadata } from "../app/about/page";
-import LegacyAboutPage, { metadata as legacyMetadata } from "../app/v2/company/about/page";
+import LegacyAboutPage, {
+  metadata as legacyMetadata,
+} from "../app/v2/company/about/page";
 import TeamPage from "../app/team/page";
 import { responsibilityGroups } from "../content/team";
 
@@ -14,17 +16,41 @@ describe("company content and responsibility journeys", () => {
   it("restores factual company context and practical steps without unsupported historical claims", () => {
     render(<AboutPage />);
     const main = screen.getByRole("main");
-    expect(main).toHaveTextContent("Bali Zero was founded by Zainal Abidin and Pak Heru.");
+    expect(main).toHaveTextContent(
+      "Bali Zero was founded by Zainal Abidin and Pak Heru.",
+    );
     expect(main).toHaveTextContent("Kerobokan, Bali");
-    expect(main).not.toHaveTextContent(/2006|2019|2020|5,000|licensed|friends for|trained on every/i);
-    const method = screen.getByRole("region", { name: "From a question to a practical next step." });
+    expect(main).not.toHaveTextContent(
+      /2006|2019|2020|5,000|licensed|friends for|trained on every/i,
+    );
+    const method = screen.getByRole("region", {
+      name: "From a question to a practical next step.",
+    });
     expect(within(method).getAllByRole("listitem")).toHaveLength(3);
-    expect(within(method).getByRole("link", { name: "Find your starting point" })).toHaveAttribute("href", "/#tools");
-    expect(within(method).getByRole("link", { name: "Explore service details" })).toHaveAttribute("href", "/services");
-    expect(within(method).getByRole("link", { name: "Plan a conversation" })).toHaveAttribute("href", "/contact?from=about");
-    const expertise = screen.getByRole("region", { name: "The work behind your next chapter." });
-    const expectedRoutes = ["/services/immigration", "/services/company-setup", "/services/tax", "/services/property"];
-    expect(within(expertise).getAllByRole("link").map((link) => link.getAttribute("href"))).toEqual(expectedRoutes);
+    expect(
+      within(method).getByRole("link", { name: "Find your starting point" }),
+    ).toHaveAttribute("href", "/#tools");
+    expect(
+      within(method).getByRole("link", { name: "Explore service details" }),
+    ).toHaveAttribute("href", "/services");
+    expect(
+      within(method).getByRole("link", { name: "Plan a conversation" }),
+    ).toHaveAttribute("href", "/contact?from=about");
+    const expertise = screen.getByRole("region", {
+      name: "The work behind your next chapter.",
+    });
+    const expectedRoutes = [
+      "/services/immigration",
+      "/services/company-setup",
+      "/services/tax",
+      "/services/property",
+      "/services/compliance",
+    ];
+    expect(
+      within(expertise)
+        .getAllByRole("link")
+        .map((link) => link.getAttribute("href")),
+    ).toEqual(expectedRoutes);
   });
 
   it("groups the exact approved roster once and preserves project responsibilities", () => {
@@ -37,18 +63,33 @@ describe("company content and responsibility journeys", () => {
     };
     for (const [name, people] of Object.entries(expected)) {
       const group = screen.getByRole("region", { name });
-      expect(within(group).getAllByRole("heading", { level: 3 }).map((heading) => heading.textContent)).toEqual(people);
+      expect(
+        within(group)
+          .getAllByRole("heading", { level: 3 })
+          .map((heading) => heading.textContent),
+      ).toEqual(people);
     }
-    expect(responsibilityGroups.flatMap((group) => [...group.people]).sort()).toEqual(Object.values(expected).flat().sort());
+    expect(
+      responsibilityGroups.flatMap((group) => [...group.people]).sort(),
+    ).toEqual(Object.values(expected).flat().sort());
     expect(screen.getAllByRole("article")).toHaveLength(16);
-    expect(screen.getByRole("link", { name: "Explore Second Home Studio" })).toHaveAttribute("href", "/#second-home-studio");
-    expect(screen.getByRole("link", { name: "Explore E-VOA" })).toHaveAttribute("href", "/#evoa");
-    expect(screen.getByRole("link", { name: "Discuss accounting support" })).toHaveAttribute("href", "/contact?from=team&topic=tax");
+    expect(
+      screen.getByRole("link", { name: "Explore Second Home Studio" }),
+    ).toHaveAttribute("href", "/#second-home-studio");
+    expect(screen.getByRole("link", { name: "Explore E-VOA" })).toHaveAttribute(
+      "href",
+      "/#evoa",
+    );
+    expect(
+      screen.getByRole("link", { name: "Discuss accounting support" }),
+    ).toHaveAttribute("href", "/contact?from=team&topic=tax");
   });
 
   it("gives every responsibility jump link a visible destination", () => {
     const { container } = render(<TeamPage />);
-    const navigation = screen.getByRole("navigation", { name: "Team responsibilities" });
+    const navigation = screen.getByRole("navigation", {
+      name: "Team responsibilities",
+    });
     for (const link of within(navigation).getAllByRole("link")) {
       const target = container.querySelector(link.getAttribute("href")!);
       expect(target).toBeInTheDocument();
@@ -56,13 +97,24 @@ describe("company content and responsibility journeys", () => {
     }
   });
 
-  it.each([AboutPage, TeamPage])("uses the shared public shell and keeps account functions separate", (Page) => {
-    render(<Page />);
-    const navigation = screen.getByRole("navigation", { name: "Main navigation" });
-    expect(within(navigation).getByRole("link", { name: "My account" })).toHaveAttribute("href", "https://my.balizero.com/");
-    expect(screen.getByRole("contentinfo")).toBeInTheDocument();
-    expect(within(screen.getByRole("contentinfo")).getByRole("link", { name: "Our story" })).toHaveAttribute("href", "/about");
-    expect(screen.getAllByRole("main")).toHaveLength(1);
-    expect(screen.getAllByRole("banner")).toHaveLength(1);
-  });
+  it.each([AboutPage, TeamPage])(
+    "uses the shared public shell and keeps account functions separate",
+    (Page) => {
+      render(<Page />);
+      const navigation = screen.getByRole("navigation", {
+        name: "Main navigation",
+      });
+      expect(
+        within(navigation).getByRole("link", { name: "My account" }),
+      ).toHaveAttribute("href", "https://my.balizero.com/");
+      expect(screen.getByRole("contentinfo")).toBeInTheDocument();
+      expect(
+        within(screen.getByRole("contentinfo")).getByRole("link", {
+          name: "Our story",
+        }),
+      ).toHaveAttribute("href", "/about");
+      expect(screen.getAllByRole("main")).toHaveLength(1);
+      expect(screen.getAllByRole("banner")).toHaveLength(1);
+    },
+  );
 });

--- a/apps/website/src/components/ContactOptions.tsx
+++ b/apps/website/src/components/ContactOptions.tsx
@@ -18,6 +18,7 @@ const labels: Record<ContactTopic, string> = {
   company: "Company setup & licensing",
   tax: "Tax & accounting",
   property: "Property due diligence",
+  compliance: "Compliance & obligations",
   evoa: "E-VOA arrival planning",
   "second-home": "Second Home planning",
   portal: "Client portal access",

--- a/apps/website/src/components/Entry.test.tsx
+++ b/apps/website/src/components/Entry.test.tsx
@@ -112,6 +112,7 @@ describe("Hero", () => {
       ["Business & company", "/services/company-setup"],
       ["Tax", "/services/tax"],
       ["Property", "/services/property"],
+      ["Compliance", "/services/compliance"],
     ];
     expect(within(startingPoints).getAllByRole("link")).toHaveLength(
       destinations.length,

--- a/apps/website/src/components/Entry.tsx
+++ b/apps/website/src/components/Entry.tsx
@@ -92,6 +92,7 @@ const categories = [
   { label: "Business & company", href: "/services/company-setup" },
   { label: "Tax", href: "/services/tax" },
   { label: "Property", href: "/services/property" },
+  { label: "Compliance", href: "/services/compliance" },
 ];
 
 export function Hero() {

--- a/apps/website/src/components/Home.test.tsx
+++ b/apps/website/src/components/Home.test.tsx
@@ -82,17 +82,24 @@ describe("editorial carousel", () => {
   });
 });
 describe("service routes", () => {
-  it("provides four direct product links and four contextual conversations", () => {
+  it("provides five direct product links and five contextual conversations", () => {
     render(<Services />);
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /Find a business code/ }),
     ).toHaveAttribute("href", "/kbli");
     const contacts = screen.getAllByRole("link", { name: /Talk to our team/ });
-    expect(contacts).toHaveLength(4);
-    expect(new Set(contacts.map((x) => x.getAttribute("href"))).size).toBe(4);
-    for (const id of ["visa", "business", "tax", "property"])
+    expect(contacts).toHaveLength(5);
+    expect(new Set(contacts.map((x) => x.getAttribute("href"))).size).toBe(5);
+    for (const id of ["visa", "business", "tax", "property", "compliance"])
       expect(document.getElementById(id + "-tool")).toBeInTheDocument();
+    const complianceCard = document.getElementById("compliance-tool")!;
+    expect(
+      within(complianceCard).getByRole("link", {
+        name: "Explore Compliance and obligations",
+      }),
+    ).toHaveAttribute("href", "/services/compliance");
+    expect(within(complianceCard).getAllByRole("link")).toHaveLength(2);
   });
   it("encodes user-facing topics as a single message parameter", () => {
     const url = new URL(contactHref("Tax & accounting"));

--- a/apps/website/src/components/Services.tsx
+++ b/apps/website/src/components/Services.tsx
@@ -1,4 +1,9 @@
-import { services, contactHref } from "../content/services";
+import {
+  services,
+  contactHref,
+  type HomeServiceEntry,
+} from "../content/services";
+const entries: readonly HomeServiceEntry[] = services;
 export function Services() {
   return (
     <div className="wrap services-area">
@@ -15,43 +20,52 @@ export function Services() {
         </a>
       </section>
       <section className="tools" id="tools" aria-label="Services and tools">
-        {services.map((service, index) => (
-          <article key={service.id} id={service.id + "-tool"} className="tool">
-            <span className="tool-index" aria-hidden="true">
-              {String(index + 1).padStart(2, "0")}
-              <span>↗</span>
-            </span>
-            <span className="eyebrow">{service.title}</span>
-            <h3
-              id={service.id === "business" ? "kbli" : service.id}
-              tabIndex={-1}
+        {entries.map((service, index) => {
+          const headingId = service.id === "business" ? "kbli" : service.id;
+          const heading: string = service.tool ?? service.title;
+          return (
+            <article
+              key={service.id}
+              id={service.id + "-tool"}
+              className="tool"
             >
-              {service.tool}
-            </h3>
-            <div className="tool-art" aria-hidden="true">
-              <img
-                src={"/assets/" + service.image}
-                alt=""
-                width="1448"
-                height="1086"
-                loading="lazy"
-              />
-            </div>
-            <p className="service-description">{service.description}</p>
-            <div className="tool-ui">
-              <p>{service.detail}</p>
-            </div>
-            <a className="textlink service-main-link" href={service.route}>
-              Explore {service.title} <span aria-hidden="true">→</span>
-            </a>
-            <a className="textlink service-tool-link" href={service.href}>
-              {service.action} <span aria-hidden="true">↗</span>
-            </a>
-            <a className="service-contact" href={contactHref(service.title)}>
-              Talk to our team <span aria-hidden="true">↗</span>
-            </a>
-          </article>
-        ))}
+              <span className="tool-index" aria-hidden="true">
+                {String(index + 1).padStart(2, "0")}
+                <span>↗</span>
+              </span>
+              <span className="eyebrow">{service.title}</span>
+              <h3 id={headingId} tabIndex={-1}>
+                {heading}
+              </h3>
+              <div className="tool-art" aria-hidden="true">
+                <img
+                  src={"/assets/" + service.image}
+                  alt=""
+                  width="1448"
+                  height="1086"
+                  loading="lazy"
+                />
+              </div>
+              <p className="service-description">{service.description}</p>
+              {service.detail && (
+                <div className="tool-ui">
+                  <p>{service.detail}</p>
+                </div>
+              )}
+              <a className="textlink service-main-link" href={service.route}>
+                Explore {service.title} <span aria-hidden="true">→</span>
+              </a>
+              {service.href && service.action && (
+                <a className="textlink service-tool-link" href={service.href}>
+                  {service.action} <span aria-hidden="true">↗</span>
+                </a>
+              )}
+              <a className="service-contact" href={contactHref(service.title)}>
+                Talk to our team <span aria-hidden="true">↗</span>
+              </a>
+            </article>
+          );
+        })}
       </section>
     </div>
   );

--- a/apps/website/src/components/services/ServiceDossiers.test.tsx
+++ b/apps/website/src/components/services/ServiceDossiers.test.tsx
@@ -19,8 +19,8 @@ afterEach(() => {
 
 describe("editorial service restoration", () => {
   it("preserves the independently pinned legacy identities and exact pricing keys", () => {
-    expect(inventory).toHaveLength(103);
-    expect(inventory.flatMap((item) => item.features)).toHaveLength(132);
+    expect(inventory).toHaveLength(108);
+    expect(inventory.flatMap((item) => item.features)).toHaveLength(142);
     expect(
       serviceDossiers.map(({ id, name, domain }) => ({ id, name, domain })),
     ).toEqual(
@@ -35,7 +35,7 @@ describe("editorial service restoration", () => {
         pricing.map(({ name, key, category }) => [name, { key, category }]),
       ),
     );
-    expect(pricing).toHaveLength(86);
+    expect(pricing).toHaveLength(91);
     const visaGroups = serviceSectionContent.immigration.catalog;
     expect(visaGroups.map(({ title }) => title)).toEqual([
       "Single-entry visits",
@@ -45,8 +45,11 @@ describe("editorial service restoration", () => {
       "Documents & permit administration",
       "Urgent processing enquiries",
     ]);
+    const visaPricing = pricing.filter(
+      ({ category }) => category !== "compliance_retainers",
+    );
     expect(visaGroups.flatMap(({ services }) => services)).toEqual(
-      pricing.map(({ name }) => name),
+      visaPricing.map(({ name }) => name),
     );
     expect(
       visaGroups.map(
@@ -99,7 +102,7 @@ describe("editorial service restoration", () => {
     }
     expect(
       new Set(serviceDossiers.map(({ explanation }) => explanation)).size,
-    ).toBe(103);
+    ).toBe(108);
   });
 
   it("keeps consequential neighboring choices and corrected legacy assumptions explicit", () => {
@@ -188,7 +191,7 @@ describe("editorial service restoration", () => {
         );
         expect(text).toContain(expected.id);
         expect(text).toContain(expected.currentName);
-        if (service.slug !== "immigration") {
+        if (!["immigration", "compliance"].includes(service.slug)) {
           expect(
             within(row as HTMLElement).queryByRole("button", {
               name: /price/i,
@@ -197,6 +200,12 @@ describe("editorial service restoration", () => {
           expect(
             within(row as HTMLElement).getByText("Scope-based quotation"),
           ).toBeVisible();
+        } else {
+          expect(
+            within(row as HTMLElement).getByRole("button", {
+              name: /Check current price/,
+            }),
+          ).toBeInTheDocument();
         }
       }
     },

--- a/apps/website/src/components/services/ServiceJourneys.tsx
+++ b/apps/website/src/components/services/ServiceJourneys.tsx
@@ -58,7 +58,7 @@ export function ServicesOverview() {
             className={styles.familyIndex}
             aria-label="Choose a service family"
           >
-            <span className={styles.eyebrow}>Four areas of practice</span>
+            <span className={styles.eyebrow}>Five areas of practice</span>
             {servicePages.map((service, index) => (
               <Link key={service.slug} href={`/services/${service.slug}`}>
                 <span className={styles.index}>0{index + 1}</span>
@@ -139,7 +139,9 @@ export function ServicesOverview() {
 
 export function ServiceDetail({ service }: { service: ServicePage }) {
   const contact = destinationIntents.whatsapp({ topic: service.contactTopic });
-  const tool = getDestination(service.toolDestinationId);
+  const tool = service.toolDestinationId
+    ? getDestination(service.toolDestinationId)
+    : undefined;
   return (
     <ServiceFrame>
       <Container
@@ -198,19 +200,21 @@ export function ServiceDetail({ service }: { service: ServicePage }) {
             </nav>
           </aside>
         </header>
-        <ServiceSectionNav />
+        <ServiceSectionNav service={service} />
         <ServiceSections service={service} />
-        <aside className={styles.toolAction}>
-          <div>
-            <span className={styles.eyebrow}>
-              Optional independent starting point
-            </span>
-            <h2>{tool.label}</h2>
-          </div>
-          <TextLink href={tool.href}>
-            Open {tool.label} <span aria-hidden="true">↗</span>
-          </TextLink>
-        </aside>
+        {tool && (
+          <aside className={styles.toolAction}>
+            <div>
+              <span className={styles.eyebrow}>
+                Optional independent starting point
+              </span>
+              <h2>{tool.label}</h2>
+            </div>
+            <TextLink href={tool.href}>
+              Open {tool.label} <span aria-hidden="true">↗</span>
+            </TextLink>
+          </aside>
+        )}
         <section id="next-steps" className={styles.nextSteps}>
           <span className={styles.eyebrow}>How the next step works</span>
           <h2>A conversation before a commitment.</h2>

--- a/apps/website/src/components/services/ServiceSections.tsx
+++ b/apps/website/src/components/services/ServiceSections.tsx
@@ -108,7 +108,7 @@ export function ServiceSections({ service }: { service: ServicePage }) {
         >
           <div className={styles.sectionHeading}>
             <span className={styles.eyebrow}>04 / Why it matters now</span>
-            <h2 id="why-now-heading">The obligations landscape is moving.</h2>
+            <h2 id="why-now-heading">The obligations keep moving.</h2>
           </div>
           <ul className={styles.scopeList}>
             {content.whyNow.map((fact) => (

--- a/apps/website/src/components/services/ServiceSections.tsx
+++ b/apps/website/src/components/services/ServiceSections.tsx
@@ -4,12 +4,14 @@ import { getServiceDossier } from "../../content/service-dossiers";
 import { ServiceCatalog } from "./ServiceCatalog";
 import styles from "./service-sections.module.css";
 
-export function ServiceSectionNav() {
+export function ServiceSectionNav({ service }: { service: ServicePage }) {
+  const hasWhyNow = Boolean(serviceSectionContent[service.slug].whyNow);
   return (
     <nav aria-label="On this service page" className={styles.jumpLinks}>
       <a href="#available-services">Available services</a>
       <a href="#service-scope">What’s included</a>
       <a href="#preparation">Documents & eligibility</a>
+      {hasWhyNow && <a href="#why-now">Why it matters now</a>}
       <a href="#service-faqs">Common questions</a>
       <a href="#next-steps">Next steps</a>
     </nav>
@@ -98,13 +100,32 @@ export function ServiceSections({ service }: { service: ServicePage }) {
           </div>
         </div>
       </section>
+      {content.whyNow && (
+        <section
+          id="why-now"
+          aria-labelledby="why-now-heading"
+          className={styles.section}
+        >
+          <div className={styles.sectionHeading}>
+            <span className={styles.eyebrow}>04 / Why it matters now</span>
+            <h2 id="why-now-heading">The obligations landscape is moving.</h2>
+          </div>
+          <ul className={styles.scopeList}>
+            {content.whyNow.map((fact) => (
+              <li key={fact}>{fact}</li>
+            ))}
+          </ul>
+        </section>
+      )}
       <section
         id="service-faqs"
         aria-labelledby="faq-heading"
         className={`${styles.section} ${styles.faqs}`}
       >
         <div className={styles.sectionHeading}>
-          <span className={styles.eyebrow}>04 / Common questions</span>
+          <span className={styles.eyebrow}>
+            {content.whyNow ? "05" : "04"} / Common questions
+          </span>
           <h2 id="faq-heading">Before you take the next step.</h2>
         </div>
         <div>

--- a/apps/website/src/components/services/__fixtures__/legacy-pricing-identities.json
+++ b/apps/website/src/components/services/__fixtures__/legacy-pricing-identities.json
@@ -428,5 +428,30 @@
     "name": "Urgent 3 Hari",
     "key": "Urgent 3 Hari",
     "category": "urgent_processing"
+  },
+  {
+    "name": "Compliance Takeover",
+    "key": "compliance_takeover",
+    "category": "compliance_retainers"
+  },
+  {
+    "name": "Core Compliance Retainer (Monthly)",
+    "key": "compliance_core_retainer_monthly",
+    "category": "compliance_retainers"
+  },
+  {
+    "name": "Employer Compliance Retainer (Monthly)",
+    "key": "compliance_employer_retainer_monthly",
+    "category": "compliance_retainers"
+  },
+  {
+    "name": "PSE Registration",
+    "key": "pse_registration_fixed",
+    "category": "compliance_retainers"
+  },
+  {
+    "name": "PMSE VAT Assessment",
+    "key": "pmse_vat_assessment",
+    "category": "compliance_retainers"
   }
 ]

--- a/apps/website/src/components/services/__fixtures__/legacy-service-inventory.json
+++ b/apps/website/src/components/services/__fixtures__/legacy-service-inventory.json
@@ -1407,5 +1407,90 @@
         "sha256": "fe3e8f634e20b964d6e493f288a5e0739a24d22699c95b972e4d6c0714f28c14"
       }
     ]
+  },
+  {
+    "id": "svc-compliance-001",
+    "legacyName": "Compliance Takeover",
+    "currentName": "Compliance Takeover",
+    "domain": "compliance",
+    "descriptionSha256": "448a854876c50e240b5c7b1ac09233eb01eb6fbd546dfcdf2df34a0cc230d226",
+    "features": [
+      {
+        "id": "svc-compliance-001.feature.01",
+        "sha256": "fc15e8365d3c1636314604172170c906019eedbc8feed04054d752a653308e7f"
+      },
+      {
+        "id": "svc-compliance-001.feature.02",
+        "sha256": "4dcd014b15f7c0816b2401f44f09aa5a25125e4a2c20d3d745bddcdb14f9143f"
+      }
+    ]
+  },
+  {
+    "id": "svc-compliance-002",
+    "legacyName": "Core Compliance Retainer (Monthly)",
+    "currentName": "Core Compliance Retainer (Monthly)",
+    "domain": "compliance",
+    "descriptionSha256": "8b2f541c59cbd0e7e91da51d4403c723cd0fc0c5163980ab59f968ef86c80764",
+    "features": [
+      {
+        "id": "svc-compliance-002.feature.01",
+        "sha256": "76450eafe0775a32b5f206d665c5fd0cf9d6b7f9cc5593217b9a024a0cf89187"
+      },
+      {
+        "id": "svc-compliance-002.feature.02",
+        "sha256": "e64006e06a2439d2aeea06acd3654ae56c3c4a7904a2779fce8a9607332d48da"
+      }
+    ]
+  },
+  {
+    "id": "svc-compliance-003",
+    "legacyName": "Employer Compliance Retainer (Monthly)",
+    "currentName": "Employer Compliance Retainer (Monthly)",
+    "domain": "compliance",
+    "descriptionSha256": "dbe33649c659425278843c4301541df25edae657d5358f116b925b5a26579ccf",
+    "features": [
+      {
+        "id": "svc-compliance-003.feature.01",
+        "sha256": "95b8e4d4f197204887af8f6cbb215037816c016eda20269674de51133e2f5181"
+      },
+      {
+        "id": "svc-compliance-003.feature.02",
+        "sha256": "da5f8e976e7488155834fe5d52995bc4a4899ffe5817934d67a022258466b3ab"
+      }
+    ]
+  },
+  {
+    "id": "svc-compliance-004",
+    "legacyName": "PSE Registration",
+    "currentName": "PSE Registration",
+    "domain": "compliance",
+    "descriptionSha256": "8a9da80ed03f229b69eb5a423867cf542d31620b7d4333bf160352a82670bbbb",
+    "features": [
+      {
+        "id": "svc-compliance-004.feature.01",
+        "sha256": "272e241034ef9918a7c331c2aaf0a8b44af156e97b2a5f08705ad5a6273c2afa"
+      },
+      {
+        "id": "svc-compliance-004.feature.02",
+        "sha256": "12dcd0f98e85879dd053392dc13d12e3f70dcb84f9d6038b5b7e54982d41e4b4"
+      }
+    ]
+  },
+  {
+    "id": "svc-compliance-005",
+    "legacyName": "PMSE VAT Assessment",
+    "currentName": "PMSE VAT Assessment",
+    "domain": "compliance",
+    "descriptionSha256": "b088dbd171c6f842cb1260b3486bc68a9a1b25d02316f66567da7ca6bfd60d38",
+    "features": [
+      {
+        "id": "svc-compliance-005.feature.01",
+        "sha256": "6306d15825c7ada1d965642ecd924a2c5586f922ad394b9f960f7a11d146c558"
+      },
+      {
+        "id": "svc-compliance-005.feature.02",
+        "sha256": "0c791d288623e1a124f1815547cb6b19746dbb000f88364bd01a3354f3abfe9e"
+      }
+    ]
   }
 ]

--- a/apps/website/src/content/company.ts
+++ b/apps/website/src/content/company.ts
@@ -6,19 +6,65 @@
  */
 export const company = {
   location: "Kerobokan, Bali",
-  beginning: "Bali Zero was founded by Zainal Abidin and Pak Heru. Based in Kerobokan, Bali, the company works with people moving to Indonesia and founders setting up businesses here. Its services span immigration, company setup, tax compliance and property due diligence.",
-  approach: "A move rarely involves just one decision. A residence plan can lead to questions about a business, its reporting obligations or a property. Our team brings together setup, tax, accounting and advisory roles. Exploring those areas together helps you identify the questions to raise before proceeding.",
+  beginning:
+    "Bali Zero was founded by Zainal Abidin and Pak Heru. Based in Kerobokan, Bali, the company works with people moving to Indonesia and founders setting up businesses here. Its services span immigration, company setup, tax compliance and property due diligence.",
+  approach:
+    "A move rarely involves just one decision. A residence plan can lead to questions about a business, its reporting obligations or a property. Our team brings together setup, tax, accounting and advisory roles. Exploring those areas together helps you identify the questions to raise before proceeding.",
 } as const;
 
 export const workingSteps = [
-  { title: "Start with your situation", description: "Planning a move, already in Indonesia, opening a company or reviewing a property? Start with the relevant service or tool and the question you need to resolve.", label: "Find your starting point", href: "/#tools" },
-  { title: "Understand the work involved", description: "Read the service scope, preparation notes and common questions. Use them to distinguish the work you need and prepare a focused conversation with the team.", label: "Explore service details", href: "/services" },
-  { title: "Discuss the next step", description: "Tell us your goal and where you are in the process. Ask about scope, required documents and the next action for your case, or arrange an office appointment.", label: "Plan a conversation", href: "/contact?from=about" },
+  {
+    title: "Start with your situation",
+    description:
+      "Planning a move, already in Indonesia, opening a company or reviewing a property? Start with the relevant service or tool and the question you need to resolve.",
+    label: "Find your starting point",
+    href: "/#tools",
+  },
+  {
+    title: "Understand the work involved",
+    description:
+      "Read the service scope, preparation notes and common questions. Use them to distinguish the work you need and prepare a focused conversation with the team.",
+    label: "Explore service details",
+    href: "/services",
+  },
+  {
+    title: "Discuss the next step",
+    description:
+      "Tell us your goal and where you are in the process. Ask about scope, required documents and the next action for your case, or arrange an office appointment.",
+    label: "Plan a conversation",
+    href: "/contact?from=about",
+  },
 ] as const;
 
 export const companyExpertise = [
-  { title: "Immigration", description: "Visits, residence plans and visa renewals. Start with the purpose of your stay and whether you are already in Indonesia.", href: "/services/immigration" },
-  { title: "Company setup", description: "Incorporation, business activities and licensing. Bring your business idea so the company structure and setup questions can be considered together.", href: "/services/company-setup" },
-  { title: "Tax & accounting", description: "Personal and company reporting, registration and bookkeeping questions. Identify the obligations and records that need attention.", href: "/services/tax" },
-  { title: "Property", description: "Due diligence, ownership structures and questions about a property's permitted use. Understand what to investigate before making a commitment.", href: "/services/property" },
+  {
+    title: "Immigration",
+    description:
+      "Visits, residence plans and visa renewals. Start with the purpose of your stay and whether you are already in Indonesia.",
+    href: "/services/immigration",
+  },
+  {
+    title: "Company setup",
+    description:
+      "Incorporation, business activities and licensing. Bring your business idea so the company structure and setup questions can be considered together.",
+    href: "/services/company-setup",
+  },
+  {
+    title: "Tax & accounting",
+    description:
+      "Personal and company reporting, registration and bookkeeping questions. Identify the obligations and records that need attention.",
+    href: "/services/tax",
+  },
+  {
+    title: "Property",
+    description:
+      "Due diligence, ownership structures and questions about a property's permitted use. Understand what to investigate before making a commitment.",
+    href: "/services/property",
+  },
+  {
+    title: "Compliance",
+    description:
+      "Recurring obligations across tax, registration and reporting. Keep track of what is due and stay ahead of the deadlines.",
+    href: "/services/compliance",
+  },
 ] as const;

--- a/apps/website/src/content/service-dossier-data.ts
+++ b/apps/website/src/content/service-dossier-data.ts
@@ -1305,9 +1305,9 @@ export const dossierFamilies = {
     purpose:
       "For an operator assessing whether it is likely to be appointed a PMSE VAT collector by DJP.",
     distinction:
-      "No one applies to become a collector; DJP appoints under PMK 60/2022. This service assesses the threshold and prepares readiness, it does not request or confirm appointment.",
+      "No one applies to become a collector; DJP appoints under PMK 81/2024. This service assesses the threshold and prepares readiness, it does not request or confirm appointment.",
     scope: [
-      "Threshold assessment under PMK 60/2022",
+      "Threshold assessment under PMK 81/2024",
       "A readiness pack for systems and invoicing",
       "Support during a DJP appointment, if one follows",
     ],

--- a/apps/website/src/content/service-dossier-data.ts
+++ b/apps/website/src/content/service-dossier-data.ts
@@ -1225,6 +1225,100 @@ export const dossierFamilies = {
       "A PT PMA does not confer unrestricted land ownership. “Asset protection” and “tax efficiency” are objectives to assess, not guaranteed outcomes.",
     next: "Review the title and activity alongside the structure before incorporating or transferring assets.",
   },
+  "compliance-takeover": {
+    purpose:
+      "For a foreign-owned company that wants a full picture of its Indonesian filing obligations before choosing a retainer.",
+    distinction:
+      "A one-off review, not a subscription: it produces the register and gap list, not an ongoing filing service. The Core or Employer retainer is the follow-on for regular months.",
+    scope: [
+      "Review of current tax, LKPM, payroll and BPJS records",
+      "An obligations register naming each filing, its legal basis, deadline, owner and status",
+      "A written gap list and remediation quote",
+    ],
+    preparation: [
+      "Company deed, NIB and current tax registrations",
+      "Existing filing history, payroll and BPJS records available",
+    ],
+    limit:
+      "Historical clean-up of missed filings is quoted separately once the gap list is confirmed. This review does not submit any filing itself.",
+    next: "Share the entity's current records so the register and gap list can be prepared.",
+  },
+  "compliance-core-retainer": {
+    purpose:
+      "Recurring compliance support for a PT PMA that needs its monthly and quarterly filings owned end to end.",
+    distinction:
+      "Core retainer covers the entity's tax and LKPM cadence. Payroll and BPJS administration for staff sit in the Employer retainer, on top of this scope.",
+    scope: [
+      "Monthly tax filings prepared and submitted on Coretax",
+      "Quarterly LKPM prepared and submitted on OSS-RBA",
+      "An obligations calendar with deadlines and owners",
+      "A monthly compliance report with submission receipts",
+    ],
+    preparation: [
+      "Monthly cutoff records: invoices, payroll summary and bank movements",
+      "Current NIB, OSS project record and prior filings",
+    ],
+    limit:
+      "Bookkeeping, audit, disputes and transfer pricing are separate services. Your director reviews and signs; we prepare and submit under that authorisation.",
+    next: "Set the monthly document cutoff date so filings are prepared with time for your review before each deadline.",
+  },
+  "compliance-employer-retainer": {
+    purpose:
+      "For an employer that also needs payroll compliance and BPJS administration alongside its tax and LKPM filings.",
+    distinction:
+      "This extends the Core retainer to cover up to fifteen employees, including expat residency reviews and permit-expiry tracking; a larger headcount is scoped separately.",
+    scope: [
+      "Everything in the Core retainer",
+      "Payroll compliance checks for local and foreign staff",
+      "BPJS enrolment for expats employed six months or more",
+      "PPh 21 versus PPh 26 residency review",
+      "RPTKA and KITAS expiry tracking",
+    ],
+    preparation: [
+      "Payroll roster with local and foreign staff, start dates and contract terms",
+      "Existing BPJS registrations and current RPTKA/KITAS records",
+    ],
+    limit:
+      "Payroll processing itself is excluded if you use your own provider; this retainer checks compliance, it does not run payroll.",
+    next: "Share the current staff roster and permit expiry dates before the next filing cycle.",
+  },
+  "pse-registration": {
+    purpose:
+      "For an operator whose website, app or platform is used by people in Indonesia and needs PSE registration.",
+    distinction:
+      "This is a one-off registration to the TD-PSE certificate, not a retainer. Applicability reaches a foreign operator with no Indonesian office when Indonesian users can access its systems.",
+    scope: [
+      "Applicability assessment under PP 71/2019 and Permenkominfo 5/2020",
+      "Entity and system mapping across each domain and app",
+      "Document pack preparation and submission",
+      "Follow-up with Komdigi until the TD-PSE is issued",
+    ],
+    preparation: [
+      "List of systems, domains and apps reachable from Indonesia",
+      "Responsible officer, company registration and privacy policy documents",
+    ],
+    limit:
+      "Ongoing liaison after issuance, including keeping registered details current, is a separate monthly service.",
+    next: "List every system, domain and app your users in Indonesia can reach before the assessment.",
+  },
+  "pmse-vat-assessment": {
+    purpose:
+      "For an operator assessing whether it is likely to be appointed a PMSE VAT collector by DJP.",
+    distinction:
+      "No one applies to become a collector; DJP appoints under PMK 60/2022. This service assesses the threshold and prepares readiness, it does not request or confirm appointment.",
+    scope: [
+      "Threshold assessment under PMK 60/2022",
+      "A readiness pack for systems and invoicing",
+      "Support during a DJP appointment, if one follows",
+    ],
+    preparation: [
+      "Revenue and transaction volume reaching Indonesian consumers",
+      "Current invoicing and systems documentation",
+    ],
+    limit:
+      "Monthly VAT reporting after any appointment is quoted separately, like bookkeeping.",
+    next: "Share the transaction volumes reaching Indonesian consumers so the threshold can be assessed.",
+  },
 } satisfies Record<string, DossierFamily>;
 
 export const dossierRecords = [
@@ -2049,6 +2143,46 @@ export const dossierRecords = [
     name: "Ownership Structures (PT PMA)",
     domain: "property",
     family: "ownership",
+    route: "",
+    variant: "",
+  },
+  {
+    id: "svc-compliance-001",
+    name: "Compliance Takeover",
+    domain: "compliance",
+    family: "compliance-takeover",
+    route: "",
+    variant: "",
+  },
+  {
+    id: "svc-compliance-002",
+    name: "Core Compliance Retainer (Monthly)",
+    domain: "compliance",
+    family: "compliance-core-retainer",
+    route: "",
+    variant: "",
+  },
+  {
+    id: "svc-compliance-003",
+    name: "Employer Compliance Retainer (Monthly)",
+    domain: "compliance",
+    family: "compliance-employer-retainer",
+    route: "",
+    variant: "",
+  },
+  {
+    id: "svc-compliance-004",
+    name: "PSE Registration",
+    domain: "compliance",
+    family: "pse-registration",
+    route: "",
+    variant: "",
+  },
+  {
+    id: "svc-compliance-005",
+    name: "PMSE VAT Assessment",
+    domain: "compliance",
+    family: "pmse-vat-assessment",
     route: "",
     variant: "",
   },

--- a/apps/website/src/content/service-pages.test.ts
+++ b/apps/website/src/content/service-pages.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  getServicePage,
+  servicePages,
+  type ServicePage,
+} from "./service-pages";
+import { serviceSectionContent } from "./service-section-content";
+import { servicePriceIdentities } from "./service-price-identities";
+
+const COMPLIANCE_KEYS = [
+  "compliance_takeover",
+  "compliance_core_retainer_monthly",
+  "compliance_employer_retainer_monthly",
+  "pse_registration_fixed",
+  "pmse_vat_assessment",
+] as const;
+
+describe("service pages content contract", () => {
+  it("publishes exactly five pillars with unique slugs", () => {
+    expect(servicePages).toHaveLength(5);
+    expect(new Set(servicePages.map(({ slug }) => slug)).size).toBe(5);
+    expect(servicePages.map(({ slug }) => slug)).toEqual([
+      "immigration",
+      "company-setup",
+      "tax",
+      "property",
+      "compliance",
+    ]);
+  });
+
+  it("gives every pillar substantive, non-empty required fields", () => {
+    for (const service of servicePages) {
+      for (const field of [
+        service.title,
+        service.cardTitle,
+        service.eyebrow,
+        service.summary,
+        service.metaDescription,
+        service.whoItHelps,
+        service.contactTopic,
+      ] as const) {
+        expect(field.trim(), service.slug).not.toBe("");
+      }
+      expect(service.questions.length, service.slug).toBeGreaterThanOrEqual(2);
+      expect(service.image.src, service.slug).toMatch(/^\/assets\//);
+      expect(service.image.alt.trim(), service.slug).not.toBe("");
+    }
+  });
+
+  it("resolves the compliance entry by slug with the expected shape", () => {
+    const compliance = getServicePage("compliance") as ServicePage;
+    expect(compliance).toBeDefined();
+    expect(compliance.title).toBe("Compliance and obligations");
+    expect(compliance.cardTitle).toBe("Compliance");
+    // No independent public tool exists yet for this pillar; the field stays absent
+    // rather than pointing at an invented destination.
+    expect(compliance.toolDestinationId).toBeUndefined();
+    expect(getServicePage("not-a-real-slug")).toBeUndefined();
+  });
+
+  it("wires the compliance catalog to the five live pricing identities", () => {
+    const content = serviceSectionContent.compliance;
+    const names = content.catalog.flatMap((group) => group.services);
+    expect(names.toSorted()).toEqual(
+      [
+        "Compliance Takeover",
+        "Core Compliance Retainer (Monthly)",
+        "Employer Compliance Retainer (Monthly)",
+        "PMSE VAT Assessment",
+        "PSE Registration",
+      ].toSorted(),
+    );
+    for (const name of names) {
+      expect(servicePriceIdentities[name], name).toBeDefined();
+      expect(servicePriceIdentities[name].category).toBe(
+        "compliance_retainers",
+      );
+    }
+    expect(
+      names.map((name) => servicePriceIdentities[name].key).toSorted(),
+    ).toEqual([...COMPLIANCE_KEYS].toSorted());
+  });
+
+  it("keeps the compliance FAQ and why-now facts sourced and specific", () => {
+    const content = serviceSectionContent.compliance;
+    expect(content.whyNow).toBeDefined();
+    expect(content.whyNow).toHaveLength(3);
+    expect(content.whyNow!.join(" ")).toContain("28 June 2025");
+    expect(content.whyNow!.join(" ")).toContain("26 June 2026");
+    expect(content.whyNow!.join(" ")).toContain("9446");
+    expect(content.whyNow!.join(" ")).toContain("10354");
+    expect(content.whyNow!.join(" ")).toContain("31 May");
+    expect(content.whyNow!.join(" ")).toContain("BKPM Regulation 5/2025");
+    expect(content.whyNow!.join(" ")).not.toMatch(/PP 28\/2025/);
+    const questions = content.faqs.map((faq) => faq.question);
+    expect(questions).toEqual([
+      "Do you sign filings for us?",
+      "Do foreign operators without an Indonesian office need to register as a PSE?",
+      "Can you get us appointed as a PMSE VAT collector?",
+    ]);
+    expect(content.faqs[0]!.answer).toContain(
+      "Your director approves and signs",
+    );
+    expect(content.faqs[1]!.answer).toMatch(/Permenkominfo 5\/2020/);
+    expect(content.faqs[2]!.answer).toContain("DJP appoints");
+    // Never a numeric price literal in editorial content.
+    for (const service of servicePages) {
+      expect(JSON.stringify(service)).not.toMatch(
+        /[0-9]{3},[0-9]{3}|USD [0-9]|[0-9]{1,3}\.[0-9]{3}\.[0-9]{3}/,
+      );
+    }
+    expect(JSON.stringify(serviceSectionContent.compliance)).not.toMatch(
+      /[0-9]{3},[0-9]{3}|USD [0-9]|[0-9]{1,3}\.[0-9]{3}\.[0-9]{3}/,
+    );
+  });
+});

--- a/apps/website/src/content/service-pages.ts
+++ b/apps/website/src/content/service-pages.ts
@@ -1,7 +1,7 @@
 import type { DestinationId } from "./destinations";
 
 export type ServicePage = {
-  slug: "immigration" | "company-setup" | "tax" | "property";
+  slug: "immigration" | "company-setup" | "tax" | "property" | "compliance";
   title: string;
   cardTitle: string;
   eyebrow: string;
@@ -11,7 +11,8 @@ export type ServicePage = {
   whoItHelps: string;
   questions: readonly string[];
   contactTopic: string;
-  toolDestinationId: Extract<
+  // Absent when the pillar has no independent public tool of its own (e.g. compliance).
+  toolDestinationId?: Extract<
     DestinationId,
     "visaOracle" | "kbliNavigator" | "taxIntelligence" | "propertyEligibility"
   >;
@@ -109,6 +110,30 @@ export const servicePages = [
     ],
     contactTopic: "property and due diligence questions in Indonesia",
     toolDestinationId: "propertyEligibility",
+  },
+  {
+    slug: "compliance",
+    title: "Compliance and obligations",
+    cardTitle: "Compliance",
+    eyebrow: "Ongoing regulatory obligations",
+    summary:
+      "Coretax filings, quarterly LKPM, payroll and BPJS, PSE registration. One accountable team, an obligations register for your entity, and a receipt for every submission.",
+    metaDescription:
+      "Discuss Indonesia compliance retainers, PSE registration and PMSE VAT obligations with the Bali Zero team.",
+    image: {
+      src: "/assets/tool-tax-illustration.png",
+      alt: "Illustration representing recurring compliance filings and reporting",
+    },
+    whoItHelps:
+      "Foreign-owned companies (PT PMA) with 5 to 50 staff and no in-house Indonesian finance lead, foreign platforms and apps reaching Indonesian users, and hotel or villa operators with booking systems and foreign staff.",
+    questions: [
+      "How many local and foreign staff does the company employ, and are expats past six months enrolled in BPJS?",
+      "Which websites, apps or platforms does the company operate that people in Indonesia can access?",
+      "What is the entity's current filing record: monthly tax, quarterly LKPM, annual return?",
+    ],
+    contactTopic:
+      "Indonesia compliance retainers, PSE registration and PMSE VAT obligations",
+    toolDestinationId: undefined,
   },
 ] as const satisfies readonly ServicePage[];
 

--- a/apps/website/src/content/service-price-identities.ts
+++ b/apps/website/src/content/service-price-identities.ts
@@ -346,4 +346,24 @@ export const servicePriceIdentities: Readonly<
     key: "Urgent 3 Hari",
     category: "urgent_processing",
   },
+  "Compliance Takeover": {
+    key: "compliance_takeover",
+    category: "compliance_retainers",
+  },
+  "Core Compliance Retainer (Monthly)": {
+    key: "compliance_core_retainer_monthly",
+    category: "compliance_retainers",
+  },
+  "Employer Compliance Retainer (Monthly)": {
+    key: "compliance_employer_retainer_monthly",
+    category: "compliance_retainers",
+  },
+  "PSE Registration": {
+    key: "pse_registration_fixed",
+    category: "compliance_retainers",
+  },
+  "PMSE VAT Assessment": {
+    key: "pmse_vat_assessment",
+    category: "compliance_retainers",
+  },
 };

--- a/apps/website/src/content/service-section-content.ts
+++ b/apps/website/src/content/service-section-content.ts
@@ -13,6 +13,9 @@ type ServiceSectionsContent = {
   documents: readonly string[];
   review: readonly string[];
   faqs: readonly { question: string; answer: string }[];
+  // Present only where a pillar has a small set of dated, sourced facts worth
+  // surfacing as their own section (currently compliance only).
+  whyNow?: readonly string[];
 };
 
 // Migrated from apps/mouth/src/data/services_data.ts. These are service scopes
@@ -258,6 +261,65 @@ export const serviceSectionContent: Record<
         answer:
           "No. The company’s activities and ownership structure must be considered alongside the exact land right, intended use, building approvals and transaction. Formation is one component. The review should also cover governance, tax implications and the intended exit or succession arrangements.",
       },
+    ],
+  },
+  compliance: {
+    catalog: [
+      {
+        title: "Retainers",
+        description: "Ongoing filing and payroll compliance for your entity.",
+        services: [
+          "Compliance Takeover",
+          "Core Compliance Retainer (Monthly)",
+          "Employer Compliance Retainer (Monthly)",
+        ],
+      },
+      {
+        title: "Registrations & assessments",
+        description:
+          "One-off reviews for platform and VAT-collector obligations.",
+        services: ["PSE Registration", "PMSE VAT Assessment"],
+      },
+    ],
+    included: [
+      "An obligations register for your entity: every filing, its legal basis, deadline, owner and status",
+      "Filings prepared by our team, approved by your director, submitted, receipt archived",
+      "Payroll compliance checks for local and foreign staff, including BPJS enrolment for expats employed six months or more",
+      "Quarterly LKPM prepared from your figures and submitted on OSS-RBA",
+      "A compliance report: what was due, what was filed, evidence attached",
+    ],
+    documents: [
+      "Company deed, NIB and current tax registrations",
+      "Existing filing history, payroll and BPJS records",
+      "List of systems, domains and apps reachable from Indonesia, if registering as a PSE",
+    ],
+    review: [
+      "How many local and foreign staff the company employs",
+      "Which systems, apps or platforms the company operates and who can reach them",
+      "The entity's current filing cadence and any missed deadlines",
+    ],
+    faqs: [
+      {
+        question: "Do you sign filings for us?",
+        answer:
+          "No. Your director approves and signs with the company's own digital certificate; we prepare, check and submit under your authorisation.",
+      },
+      {
+        question:
+          "Do foreign operators without an Indonesian office need to register as a PSE?",
+        answer:
+          "Yes, if the website, app or platform is used by people in Indonesia. Permenkominfo 5/2020 reaches a foreign operator on that basis alone; having no local entity does not place it outside scope.",
+      },
+      {
+        question: "Can you get us appointed as a PMSE VAT collector?",
+        answer:
+          "No one can. DJP appoints collectors under PMK 60/2022. We assess the threshold and prepare readiness; appointment itself is DJP's decision.",
+      },
+    ],
+    whyNow: [
+      "Komdigi blocked eBay and KLM on 28 June 2025 and sent notification letters to 25 operators on 26 June 2026 (Komdigi press releases 9446 and 10354).",
+      "Coretax: the 2026 corporate filing deadline was extended to 31 May after around 4,000 complaints.",
+      "Quarterly LKPM deadlines moved to the 15th under BKPM Regulation 5/2025.",
     ],
   },
 };

--- a/apps/website/src/content/service-section-content.ts
+++ b/apps/website/src/content/service-section-content.ts
@@ -313,7 +313,7 @@ export const serviceSectionContent: Record<
       {
         question: "Can you get us appointed as a PMSE VAT collector?",
         answer:
-          "No one can. DJP appoints collectors under PMK 60/2022. We assess the threshold and prepare readiness; appointment itself is DJP's decision.",
+          "No one can. DJP appoints collectors under PMK 81/2024. We assess the threshold and prepare readiness; appointment itself is DJP's decision.",
       },
     ],
     whyNow: [

--- a/apps/website/src/content/service-section-content.ts
+++ b/apps/website/src/content/service-section-content.ts
@@ -318,7 +318,7 @@ export const serviceSectionContent: Record<
     ],
     whyNow: [
       "Komdigi blocked eBay and KLM on 28 June 2025 and sent notification letters to 25 operators on 26 June 2026 (Komdigi press releases 9446 and 10354).",
-      "Coretax: the 2026 corporate filing deadline was extended to 31 May after around 4,000 complaints.",
+      "KEP-71/PJ/2026 (reinforced by PENG-31/PJ.09/2026) extended the 2025 corporate income tax return filing window through 31 May 2026, waiving administrative sanctions for corporate taxpayers who file and settle any Article 29 underpayment within that period.",
       "Quarterly LKPM deadlines moved to the 15th under BKPM Regulation 5/2025.",
     ],
   },

--- a/apps/website/src/content/service-section-content.ts
+++ b/apps/website/src/content/service-section-content.ts
@@ -318,7 +318,7 @@ export const serviceSectionContent: Record<
     ],
     whyNow: [
       "Komdigi blocked eBay and KLM on 28 June 2025 and sent notification letters to 25 operators on 26 June 2026 (Komdigi press releases 9446 and 10354).",
-      "KEP-71/PJ/2026 (reinforced by PENG-31/PJ.09/2026) extended the 2025 corporate income tax return filing window through 31 May 2026, waiving administrative sanctions for corporate taxpayers who file and settle any Article 29 underpayment within that period.",
+      "Coretax's first corporate filing season needed a rescue: DJP's KEP-71/PJ/2026 (issued 30 April 2026) waived late-filing penalties on 2025 corporate income tax returns (SPT Tahunan Badan) through 31 May 2026.",
       "Quarterly LKPM deadlines moved to the 15th under BKPM Regulation 5/2025.",
     ],
   },

--- a/apps/website/src/content/services.ts
+++ b/apps/website/src/content/services.ts
@@ -1,5 +1,18 @@
 import { destinations, destinationIntents } from "./destinations";
 
+export type HomeServiceEntry = {
+  id: string;
+  route: string;
+  title: string;
+  description: string;
+  image: string;
+  // A pillar without an independent public tool (e.g. compliance) omits these.
+  tool?: string;
+  detail?: string;
+  href?: string;
+  action?: string;
+};
+
 export const services = [
   {
     id: "visa",
@@ -49,7 +62,20 @@ export const services = [
     href: destinations.propertyEligibility.href,
     action: "Explore Property Check",
   },
-] as const;
+  {
+    id: "compliance",
+    route: "/services/compliance",
+    title: "Compliance and obligations",
+    description:
+      "Talk through Coretax filings, quarterly LKPM, payroll, BPJS and PSE registration with our team.",
+    tool: "Compliance corner",
+    detail:
+      "Explore the obligations register, retainer options and PSE/PMSE registration support.",
+    image: "tool-tax-illustration.png",
+    href: undefined,
+    action: undefined,
+  },
+] as const satisfies readonly HomeServiceEntry[];
 export function contactHref(topic: string) {
   return destinationIntents.whatsapp({ topic });
 }

--- a/apps/website/src/lib/destinations/contact-context.ts
+++ b/apps/website/src/lib/destinations/contact-context.ts
@@ -14,6 +14,7 @@ const sources: Record<string, string> = {
   company: "/services/company-setup",
   tax: "/services/tax",
   property: "/services/property",
+  compliance: "/services/compliance",
 };
 
 export function resolveContactSource(value: unknown): string {

--- a/apps/website/src/lib/destinations/lead-handoff.ts
+++ b/apps/website/src/lib/destinations/lead-handoff.ts
@@ -6,6 +6,7 @@ export const contactTopics = {
   company: "company setup and business licensing",
   tax: "tax and accounting",
   property: "property due diligence",
+  compliance: "compliance retainers and regulatory obligations",
   evoa: "an E-VOA arrival plan",
   "second-home": "a Second Home plan",
   portal: "access to my client portal",
@@ -25,6 +26,7 @@ export const contactSourcePages = [
   "/services/company-setup",
   "/services/tax",
   "/services/property",
+  "/services/compliance",
   "/visa/voa",
   "/visa/clock",
   "/visa/match",
@@ -123,6 +125,7 @@ export function inferContactTopic(pathname: string): ContactTopic {
     source === "/zoning"
   )
     return "property";
+  if (source === "/services/compliance") return "compliance";
   const category = articleCategory(pathname);
   if (category === "visas") return "immigration";
   if (category === "business") return "company";

--- a/apps/website/tests/qa/site-smoke.mjs
+++ b/apps/website/tests/qa/site-smoke.mjs
@@ -8,6 +8,7 @@ const REQUIRED_ROUTES = [
   "/services/company-setup",
   "/services/tax",
   "/services/property",
+  "/services/compliance",
   "/journal",
 ];
 

--- a/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
@@ -1,18 +1,24 @@
 task_id: compliance-corner
-gear: 1
+gear: 2
 l_level: L2
 gate_class: opus
 gear_note: >-
-  Floor the CI way: git diff --name-only codex/website-r19-integrated... (19 files) piped to
-  scripts/evidence_pack_lint.py --print-floor --changed-files-file <that list> --net-lines 2135
-  (net-lines = git diff --numstat codex/website-r19-integrated... | awk '{a+=$1-$2}') -> floor 1,
-  source none (no hot-zone path hit). Declared 1. The raw git diff --stat is much larger than the
-  content this PR adds because the repo's pre-commit hook runs `prettier --check` on the FULL
-  content of every staged file, not just the diff, and several touched files (service-dossier-
-  data.ts especially) were not prettier-clean before this change (confirmed against an untouched
-  sibling file, which also fails `prettier --check` with no config override anywhere in the repo).
-  Committing without --no-verify required a whole-file `prettier --write`, which is reformatting
-  churn, not new content -- recorded here so the size term is read correctly.
+  RECOMPUTED after the PR was rebased onto agent/nuzantara/website/prettier-content-files (PR
+  #6211, which prettier-normalizes the pre-existing content of every file this PR also touches,
+  merged in as this PR's new base) -- the earlier gear:1 declaration above was measured against
+  the OLD base (codex/website-r19-integrated) where those files were not yet prettier-clean, so
+  this PR's own diff against that old base was inflated by reformatting churn belonging to
+  #6211, not to this PR's content. Recipe: `git diff --name-only
+  agent/nuzantara/website/prettier-content-files...HEAD > /tmp/cfb.txt; git diff --numstat
+  agent/nuzantara/website/prettier-content-files...HEAD > /tmp/nsb.txt; python3
+  scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/cfb.txt --numstat-file
+  /tmp/nsb.txt` -> floor 2, source size (`--print-floor-source` confirms `size`). 20 files
+  changed against the new base (19 content/test files + this brief.yml), churn (added+deleted
+  per file, per _size_term_net_lines(), `awk -F'\t' '{s+=$1+$2} END{print s}' /tmp/nsb.txt`)
+  totals 811 (12+6 + 1+0 + 1+0 + 1+0 + 11+4 + 51+37 + 15+6 + 18+14 + 23+2 + 25+0 + 85+0 + 134+0
+  + 116+0 + 27+2 + 20+0 + 62+0 + 27+1 + 1+0 + 3+0 + 106+0), between SIZE_GEAR2_THRESHOLD (400)
+  and SIZE_GEAR3_THRESHOLD (1828), no hot-zone path hit ->
+  floor 2. Declared 2 to match the measurement, superseding the stale gear:1 above.
 objective: >-
   Add "compliance" as the fifth first-class service pillar on the NEW apps/website R19 site
   (branch codex/website-r19-integrated, not yet on main): a full ServicePage entry rendered by

--- a/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
@@ -31,6 +31,16 @@ gear_note: >-
   brief.yml), churn `awk -F'\t' '{s+=$1+$2} END{print s}' /tmp/nsb3.txt` = 984, still between
   SIZE_GEAR2_THRESHOLD (400) and SIZE_GEAR3_THRESHOLD (1828), no hot-zone path hit. Gear stays
   2.
+
+  FINAL RECOMPUTE after #6211 merged (909e257d97) and this branch was rebased --onto
+  origin/codex/website-r19-integrated (the PR's own base as GitHub now reads it, once
+  agent/nuzantara/website/prettier-content-files merged into it), plus the #6211 pack brief_ref
+  fix and the Coretax re-cure landed inside this branch: `git diff --name-only
+  origin/codex/website-r19-integrated...HEAD > /tmp/cfb5.txt; git diff --numstat
+  origin/codex/website-r19-integrated...HEAD > /tmp/nsb5.txt; python3
+  scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/cfb5.txt --numstat-file
+  /tmp/nsb5.txt` -> still floor 2, source size. 24 files, churn `awk -F'\t' '{s+=$1+$2}
+  END{print s}' /tmp/nsb5.txt` = 1021, still between 400 and 1828. Gear stays 2.
 objective: >-
   Add "compliance" as the fifth first-class service pillar on the NEW apps/website R19 site
   (branch codex/website-r19-integrated, not yet on main): a full ServicePage entry rendered by
@@ -64,17 +74,27 @@ constraints:
     Why-now facts are the three the task specified, sourced, and NOT the draft's unverified
     "PP 28/2025 fines" line: (a) Komdigi blocked eBay and KLM on 28 June 2025 and sent
     notification letters to 25 operators on 26 June 2026 (Komdigi press releases 9446 and
-    10354); (b) CURED at gate r1 (REWORK-BUILD, comment 5630621483) -- the original "extended to
-    31 May after around 4,000 complaints" had no repo provenance for the causal "~4,000
-    complaints" claim. Resourced to
+    10354); (b) CURED at gate r1 (REWORK-BUILD, comment 5630621483), then RE-CURED with more
+    precise sourcing -- the original "extended to 31 May after around 4,000 complaints" had no
+    repo provenance for the causal "~4,000 complaints" claim. First resourced to
     docs/superpowers/specs/2026-05-08-domain-mesh-research/r3-djp-coretax-tax-tech-2026-05-08.md
-    sec. 1.4 (LMI Consultancy, quoted): KEP-71/PJ/2026 (reinforced by PENG-31/PJ.09/2026)
-    extended the 2025 corporate income tax return filing window through 31 May 2026 and waived
-    administrative sanctions for corporate taxpayers who file and settle any Article 29
-    underpayment within that window. The same doc's "~4,000" figure (HeyGoTrade) attaches to a
-    different claim ("formal petitions... for the deadline relief"), not "complaints" -- dropped
-    rather than restated imprecisely; (c) quarterly LKPM deadlines moved to the 15th under BKPM
-    Regulation 5/2025.
+    sec. 1.4 (LMI Consultancy paraphrase) as an "extended... filing window" framing; corrected
+    again on the team-lead's finding of more precise, DDTC-backed sourcing:
+    research/regulatory/2026-05-28-delta.json ("DJP decision (KEP) issued 30 April 2026 setting
+    tax policy for corporate taxpayers filing annual SPT... under the Coretax... system for tax
+    year 2025", citation KEP-71/PJ/2026) and
+    research/regulatory/2026-05-31-delta.json (verbatim_excerpt: "KEP-71/PJ/2026 grants
+    corporate taxpayers a relaxation window to file their 2025 annual income tax returns (SPT
+    Tahunan Badan) without administrative penalties, with the deadline expiring on May 31,
+    2026"). Both files verified directly (grep) before writing. This DDTC-sourced framing is a
+    penalty-free relaxation window layered on KEP-71's issuance, not a moved statutory deadline
+    -- "extended" dropped per instruction. Final bullet: "Coretax's first corporate filing
+    season needed a rescue: DJP's KEP-71/PJ/2026 (issued 30 April 2026) waived late-filing
+    penalties on 2025 corporate income tax returns (SPT Tahunan Badan) through 31 May 2026." The
+    same delta files' "~4,000" figure (HeyGoTrade, in the earlier doc) attaches to a different
+    claim ("formal petitions... for the deadline relief"), not "complaints" against Coretax --
+    dropped rather than restated imprecisely; (c) quarterly LKPM deadlines moved to the 15th
+    under BKPM Regulation 5/2025.
   - >-
     A parallel, unrelated lane (roster name dux-w1-pr2-compliance-page) is adding an UNLISTED,
     noindex /services/compliance page to a DIFFERENT app (apps/mouth, reading a committed price
@@ -111,7 +131,11 @@ acceptance:
       both still listed only four pillars; both cured (commit bb76bbecef), plus
       Company.test.tsx's hardcoded expected-routes assertion, which the sweep also missed
       (commit 96dd25fe33). grep -rn "companyExpertise\|REQUIRED_ROUTES" apps/website/src
-      apps/website/tests now shows both including /services/compliance.
+      apps/website/tests now shows both including /services/compliance. Live-server check:
+      `npm run build && npx next start --hostname 127.0.0.1 --port 3105` then `node
+      tests/qa/site-smoke.mjs` against it -> requiredRoutes 8/8 passing (incl.
+      /services/compliance), fragmentTargets 1/1, homeAssets 14/14, failures 0. Server killed
+      after.
   - text: Typecheck, full test suite and production build SHALL be clean.
     probe: >-
       npx tsc --noEmit (exit 0); npm test -- --maxWorkers=1 --no-file-parallelism (100 files /

--- a/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
@@ -1,0 +1,106 @@
+task_id: compliance-corner
+gear: 1
+l_level: L2
+gate_class: opus
+gear_note: >-
+  Floor the CI way: git diff --name-only codex/website-r19-integrated... (19 files) piped to
+  scripts/evidence_pack_lint.py --print-floor --changed-files-file <that list> --net-lines 2135
+  (net-lines = git diff --numstat codex/website-r19-integrated... | awk '{a+=$1-$2}') -> floor 1,
+  source none (no hot-zone path hit). Declared 1. The raw git diff --stat is much larger than the
+  content this PR adds because the repo's pre-commit hook runs `prettier --check` on the FULL
+  content of every staged file, not just the diff, and several touched files (service-dossier-
+  data.ts especially) were not prettier-clean before this change (confirmed against an untouched
+  sibling file, which also fails `prettier --check` with no config override anywhere in the repo).
+  Committing without --no-verify required a whole-file `prettier --write`, which is reformatting
+  churn, not new content -- recorded here so the size term is read correctly.
+objective: >-
+  Add "compliance" as the fifth first-class service pillar on the NEW apps/website R19 site
+  (branch codex/website-r19-integrated, not yet on main): a full ServicePage entry rendered by
+  the existing ServiceJourneys/ServiceSections/ServiceCatalog machinery exactly like immigration,
+  company-setup, tax and property -- hero, who-it-helps, catalog with live prices, documents/
+  review, a "why it matters now" section carrying three sourced facts, and FAQ. Wires the five
+  live compliance_retainers catalogue keys (compliance_takeover,
+  compliance_core_retainer_monthly, compliance_employer_retainer_monthly,
+  pse_registration_fixed, pmse_vat_assessment) through service-price-identities.ts /
+  service-dossier-data.ts so prices render from GET https://nuzantara-rag.fly.dev/api/pricing/
+  service, never as a literal. Public and indexable (owner-confirmed prices, 2026-09-10) -- no
+  noindex.
+constraints:
+  - No price literal anywhere in changed source; the five catalogue keys are exact strings, not
+    inferred or guessed near-matches.
+  - >-
+    Every surface enumerating the four existing pillars gets a fifth compliance entry: /services
+    overview + [slug] detail route (slug-driven, automatic once servicePages has 5 entries),
+    the homepage hero "Choose where to start" nav (Entry.tsx), the homepage "Services and tools"
+    block (content/services.ts + Services.tsx), and the contact-topic system (lead-handoff.ts,
+    contact-context.ts, ContactOptions.tsx). Footer.tsx was checked and deliberately left
+    untouched -- it links to /services generically and does not enumerate individual pillars.
+  - >-
+    Compliance has no independent public tool (no equivalent of Visa Oracle / KBLI Navigator /
+    Tax Compliance Calendar / Property Check exists or was invented for it). ServicePage.
+    toolDestinationId became optional; the "Optional independent starting point" aside is
+    omitted for compliance rather than pointed at a fabricated destination. The homepage tools
+    card for compliance likewise omits the tool-specific CTA link, keeping only "Explore ..." and
+    "Talk to our team".
+  - >-
+    Why-now facts are the three the task specified, sourced, and NOT the draft's unverified
+    "PP 28/2025 fines" line: (a) Komdigi blocked eBay and KLM on 28 June 2025 and sent
+    notification letters to 25 operators on 26 June 2026 (Komdigi press releases 9446 and
+    10354); (b) the 2026 Coretax corporate filing deadline was extended to 31 May after around
+    4,000 complaints; (c) quarterly LKPM deadlines moved to the 15th under BKPM Regulation
+    5/2025.
+  - >-
+    A parallel, unrelated lane (roster name dux-w1-pr2-compliance-page) is adding an UNLISTED,
+    noindex /services/compliance page to a DIFFERENT app (apps/mouth, reading a committed price
+    snapshot) per evidence/2026-09/agent-nuzantara-mouth-compliance-retainer-page-0bf73876/
+    brief.yml on origin/main. No file overlap with this PR (different app, different branch,
+    different pricing mechanism) -- flagged for the reviewer's awareness, not coordinated with.
+acceptance:
+  - text: >-
+      WHEN /services and /services/compliance render THEY SHALL list/show the fifth pillar with
+      the same section shape as the other four (hero, catalog with live prices, documents/
+      review, FAQ) plus the compliance-only "why it matters now" section.
+    probe: >-
+      npx vitest run src/app/services/services.test.tsx src/components/services/
+      ServiceDossiers.test.tsx src/content/service-pages.test.ts (all green); `npm run build`
+      route table prints "/services/[slug]" with 5 SSG paths ("● /services/immigration,
+      company-setup, tax, [+2 more paths]" = property, compliance).
+  - text: The five compliance_retainers catalogue keys SHALL be wired exactly, never a literal price.
+    probe: >-
+      grep -nE "[0-9]{3},[0-9]{3}|USD [0-9]|[0-9]{1,3}\.[0-9]{3}\.[0-9]{3}" against every changed
+      file (19 files) -> 0 hits (exit 1, no match); service-pages.test.ts asserts the five
+      catalog names map onto servicePriceIdentities with category compliance_retainers and the
+      exact five key literals.
+  - text: A mutation to the new price-identity wiring SHALL be caught by the new test.
+    probe: >-
+      Renamed the "Compliance Takeover" key in service-price-identities.ts -> service-pages.
+      test.ts "wires the compliance catalog..." went RED (AssertionError: Compliance Takeover:
+      expected undefined to be defined); reverted -> GREEN again (5 passed).
+  - text: Every surface listing the four pillars SHALL list five, or be shown not to enumerate them.
+    probe: >-
+      Entry.test.tsx / Home.test.tsx updated and green for the fifth nav category and homepage
+      card; Footer.tsx read in full -- contains no per-pillar links to update.
+  - text: Typecheck, full test suite and production build SHALL be clean.
+    probe: >-
+      npx tsc --noEmit (exit 0); npm test -- --maxWorkers=1 --no-file-parallelism (100 files /
+      1345 tests passed, 1 pre-existing skip, unchanged before/after this PR); npm run build
+      (next build --webpack) completed, full route table printed, no errors.
+consumer_map:
+  - "Public visitors on the new R19 site (once codex/website-r19-integrated ships) looking for compliance/PSE/PMSE VAT support."
+  - "The other four ServicePage consumers (ServiceJourneys, ServiceSections, ServiceCatalog) -- unmodified in shape, just fed a fifth entry."
+risks:
+  - >-
+    The homepage "Compliance corner" card heading (content/services.ts) and the compliance
+    dossier's FAQ/why-now text are original copy written for this PR, adapted from the sourced
+    draft at ~/Desktop/ricerca-nicchie-online-indonesia-2026-09-11/build/page-content.draft.md;
+    they were not independently re-verified against primary regulatory sources beyond what the
+    task instructions already specified as checked.
+  - >-
+    No dedicated compliance illustration exists in public/assets; both the ServicePage hero image
+    and the homepage card reuse tool-tax-illustration.png as a placeholder (thematically adjacent
+    -- Coretax/LKPM filings) rather than fabricate a new asset. Flagged for a follow-up asset.
+grader: >-
+  The final on-disk gate is a fresh Opus 5 session commissioned by the imperator; this agent does
+  not arm auto-merge, does not merge, and posts no harness/fable-gate verdict.
+budget: Existing subscription only; no paid API calls; no subagents used (direct work throughout).
+pii: none

--- a/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
@@ -19,6 +19,18 @@ gear_note: >-
   + 116+0 + 27+2 + 20+0 + 62+0 + 27+1 + 1+0 + 3+0 + 106+0), between SIZE_GEAR2_THRESHOLD (400)
   and SIZE_GEAR3_THRESHOLD (1828), no hot-zone path hit ->
   floor 2. Declared 2 to match the measurement, superseding the stale gear:1 above.
+
+  RE-RECOMPUTED after the gate r1 REWORK-BUILD cures (5 more commits: PMK 81/2024 citation,
+  drop the forbidden "landscape" metaphor, four-pillar parity in company.ts/site-smoke.mjs +
+  Company.test.tsx, Coretax bullet resourced to the repo's KEP-71/PENG-31 record). Same recipe,
+  same base: `git diff --name-only agent/nuzantara/website/prettier-content-files...HEAD >
+  /tmp/cfb3.txt; git diff --numstat agent/nuzantara/website/prettier-content-files...HEAD >
+  /tmp/nsb3.txt; python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file
+  /tmp/cfb3.txt --numstat-file /tmp/nsb3.txt` -> still floor 2, source size
+  (`--print-floor-source` confirms `size`). 23 files now (22 content/test files + this
+  brief.yml), churn `awk -F'\t' '{s+=$1+$2} END{print s}' /tmp/nsb3.txt` = 984, still between
+  SIZE_GEAR2_THRESHOLD (400) and SIZE_GEAR3_THRESHOLD (1828), no hot-zone path hit. Gear stays
+  2.
 objective: >-
   Add "compliance" as the fifth first-class service pillar on the NEW apps/website R19 site
   (branch codex/website-r19-integrated, not yet on main): a full ServicePage entry rendered by
@@ -52,9 +64,17 @@ constraints:
     Why-now facts are the three the task specified, sourced, and NOT the draft's unverified
     "PP 28/2025 fines" line: (a) Komdigi blocked eBay and KLM on 28 June 2025 and sent
     notification letters to 25 operators on 26 June 2026 (Komdigi press releases 9446 and
-    10354); (b) the 2026 Coretax corporate filing deadline was extended to 31 May after around
-    4,000 complaints; (c) quarterly LKPM deadlines moved to the 15th under BKPM Regulation
-    5/2025.
+    10354); (b) CURED at gate r1 (REWORK-BUILD, comment 5630621483) -- the original "extended to
+    31 May after around 4,000 complaints" had no repo provenance for the causal "~4,000
+    complaints" claim. Resourced to
+    docs/superpowers/specs/2026-05-08-domain-mesh-research/r3-djp-coretax-tax-tech-2026-05-08.md
+    sec. 1.4 (LMI Consultancy, quoted): KEP-71/PJ/2026 (reinforced by PENG-31/PJ.09/2026)
+    extended the 2025 corporate income tax return filing window through 31 May 2026 and waived
+    administrative sanctions for corporate taxpayers who file and settle any Article 29
+    underpayment within that window. The same doc's "~4,000" figure (HeyGoTrade) attaches to a
+    different claim ("formal petitions... for the deadline relief"), not "complaints" -- dropped
+    rather than restated imprecisely; (c) quarterly LKPM deadlines moved to the 15th under BKPM
+    Regulation 5/2025.
   - >-
     A parallel, unrelated lane (roster name dux-w1-pr2-compliance-page) is adding an UNLISTED,
     noindex /services/compliance page to a DIFFERENT app (apps/mouth, reading a committed price
@@ -85,7 +105,13 @@ acceptance:
   - text: Every surface listing the four pillars SHALL list five, or be shown not to enumerate them.
     probe: >-
       Entry.test.tsx / Home.test.tsx updated and green for the fifth nav category and homepage
-      card; Footer.tsx read in full -- contains no per-pillar links to update.
+      card; Footer.tsx read in full -- contains no per-pillar links to update. CORRECTED at gate
+      r1 (REWORK-BUILD): this sweep missed two surfaces. src/content/company.ts's
+      companyExpertise array (rendered on /about) and tests/qa/site-smoke.mjs's REQUIRED_ROUTES
+      both still listed only four pillars; both cured (commit bb76bbecef), plus
+      Company.test.tsx's hardcoded expected-routes assertion, which the sweep also missed
+      (commit 96dd25fe33). grep -rn "companyExpertise\|REQUIRED_ROUTES" apps/website/src
+      apps/website/tests now shows both including /services/compliance.
   - text: Typecheck, full test suite and production build SHALL be clean.
     probe: >-
       npx tsc --noEmit (exit 0); npm test -- --maxWorkers=1 --no-file-parallelism (100 files /

--- a/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml
@@ -41,6 +41,16 @@ gear_note: >-
   scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/cfb5.txt --numstat-file
   /tmp/nsb5.txt` -> still floor 2, source size. 24 files, churn `awk -F'\t' '{s+=$1+$2}
   END{print s}' /tmp/nsb5.txt` = 1021, still between 400 and 1828. Gear stays 2.
+
+  RE-RECOMPUTED a fourth time after the Detect Secrets cure (8cb6a5a6f4: one
+  CONTENT_KEYED_RULES entry in scripts/detect_secrets_auto_triage.py + its guilt/innocence
+  tests, because the legacy-service-inventory.json parity fixture's 250 sha256 content
+  digests arrived as 222 unaudited Hex High Entropy findings on db5e7cac60). Same recipe
+  against origin/codex/website-r19-integrated (909e257d97): 26 files, churn 1168
+  (+1059/-109), `--print-floor` -> 2, `--print-floor-source` -> size. Still gear 2; the
+  two scripts/ files do not trip a path floor (measured before committing, option B --
+  hand-marking the baseline -- would have read 3 and was not taken).
+
 objective: >-
   Add "compliance" as the fifth first-class service pillar on the NEW apps/website R19 site
   (branch codex/website-r19-integrated, not yet on main): a full ServicePage entry rendered by

--- a/evidence/2026-09/agent-nuzantara-website-prettier-content-files-adc9ad7f/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-website-prettier-content-files-adc9ad7f/pack.yml
@@ -1,4 +1,13 @@
-brief_ref: evidence/2026-09/agent-nuzantara-website-prettier-content-files-adc9ad7f/brief.yml
+# brief_ref is deliberately the bare "evidence/brief.yml", not this pack's own nested path:
+# the CI "Harness floor recompute" workflow copies both discovered per-PR files
+# (brief.yml/pack.yml) into a flat evidence/{brief,pack}.yml under a temp repo-root before
+# validating (check_brief_ref_exists resolves brief_ref against THAT staged repo_root, not the
+# real tree) -- every other merged Gear-3 pack on origin/main uses this exact form (grep -rn
+# "^brief_ref" evidence/2026-09/*/pack.yml). Side effect for LOCAL runs of
+# `evidence_pack_lint.py --repo-root=<worktree>`: a stray root-level evidence/brief.yml
+# (belonging to an unrelated PR, task_id oracle-decisiveness-spec) shadows this reference and
+# gets validated instead -- known, not a defect in this pack; CI's staged copy is authoritative.
+brief_ref: evidence/brief.yml
 plan_ref: PR #6211 — agent/nuzantara/website/prettier-content-files
 diff:
   files: 14

--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -657,6 +657,30 @@ CONTENT_KEYED_RULES: list[tuple[re.Pattern[str], re.Pattern[str], str]] = [
         "Evidence Pack diff.measured_at: a git commit SHA (merge-base "
         "the diff was measured against), not a credential",
     ),
+    # apps/website/src/components/services/__fixtures__/legacy-service-inventory.json
+    # (2026-09-11, PR #6210): the compliance-corner parity fixture carries the
+    # 108 legacy service records with `descriptionSha256` (digest of the
+    # legacy service description) and one `sha256` per feature (digest of
+    # the feature prose) — 250 sha256 content digests of PUBLIC marketing
+    # copy, kept as provenance pins so the migrated catalog can be checked
+    # against the legacy copy without carrying the prose. Detect Secrets
+    # flags every one as a Hex High Entropy String (222 residue on PR
+    # #6210's head). Path-keyed to that one fixture, content-keyed to a line
+    # that is exactly one of the two digest keys holding 64 lowercase hex
+    # (optional trailing comma), so a real secret added to the same file
+    # under any other key — or any other value shape — stays unaudited.
+    (
+        re.compile(
+            r"(^|/)apps/website/src/components/services/__fixtures__/"
+            r"legacy-service-inventory\.json$"
+        ),
+        re.compile(
+            r'^\s*"(?:descriptionSha256|sha256)"\s*:\s*"[0-9a-f]{64}"\s*,?\s*$'
+        ),
+        "website legacy-service-inventory fixture: descriptionSha256/sha256 are "
+        "sha256 content digests of legacy public service prose (provenance pins "
+        "for the compliance-corner parity tests), never a credential",
+    ),
 ]
 
 # Each rule is (pattern, reason). The pattern matches the file path

--- a/scripts/tests/test_detect_secrets_auto_triage.py
+++ b/scripts/tests/test_detect_secrets_auto_triage.py
@@ -322,8 +322,8 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     # trail are derived from the live registry post-merge, not summed by
     # hand (team-lead's call: a rule appears once in the trail regardless of
     # how many PRs tried to add it).
-    assert len(CONTENT_KEYED_RULES) == 24, (
-        f"CONTENT_KEYED_RULES now has {len(CONTENT_KEYED_RULES)} entries, not 24. "
+    assert len(CONTENT_KEYED_RULES) == 25, (
+        f"CONTENT_KEYED_RULES now has {len(CONTENT_KEYED_RULES)} entries, not 25. "
         "If you just ADDED a rule: bump this number AND append a `# +1: <what> "
         "(<date>, PR #NNNN)` line below, matching the existing trail's format — "
         "that comment IS the audit record this assert exists to force. "
@@ -349,6 +349,7 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     # +1: fold_pack_seq18.py seq-17 chain anchor exact-value pin (2026-08-31, #5333)
     # +1: fold_pack_seq19.py seq-18/seq-13/seq-15 chain-of-custody exact-value pins (2026-09-05, #5784)
     # +1: test_seq19_signed_bundle.py signed-bundle trust anchors (public key, seq-18 chain anchor, seq-19 payload_sha256) (2026-09-06)
+    # +1: apps/website legacy-service-inventory.json descriptionSha256/sha256 content digests (2026-09-11, #6210)
     #
     # Note (2026-08-23): "appended last" is no longer a constraint. It was
     # true only because this test and the two Google-OAuth tests below
@@ -1690,3 +1691,97 @@ def test_innocence_evidence_pack_other_key_not_approved() -> None:
         EVIDENCE_PACK_MEASURED_AT_REASON
     )
     assert content_pat.match("  api_key: 63bfa19ec") is None
+
+
+# ---------------------------------------------------------------------------
+# apps/website legacy-service-inventory fixture (2026-09-11, PR #6210)
+# ---------------------------------------------------------------------------
+
+LEGACY_SERVICE_INVENTORY = (
+    "apps/website/src/components/services/__fixtures__/legacy-service-inventory.json"
+)
+LEGACY_SERVICE_INVENTORY_REASON = "legacy-service-inventory fixture"
+LEGACY_SERVICE_INVENTORY_DIGEST = (
+    "a1919cffc3a9cba0a135fc01ebab975b3fa5c05cd6202f7d2ac9d22559cc58ab"
+)
+# Lines 7 and 11 of the fixture on PR #6210's head db5e7cac60, verbatim:
+# descriptionSha256 is never last in its object (trailing comma), a
+# feature's sha256 always is (no trailing comma).
+LEGACY_SERVICE_INVENTORY_REAL_LINES = [
+    '    "descriptionSha256": "a1919cffc3a9cba0a135fc01ebab975b3fa5c05cd6202f7d2ac9d22559cc58ab",',
+    '        "sha256": "ffd7280513ce285e6d9dc8d0b7078c4f39c8fe0e69b0d0a87d8af2965e445d7a"',
+]
+
+
+def test_legacy_service_inventory_rule_registered_and_scoped_to_one_file() -> None:
+    """Path-scoped to the one parity fixture — not its sibling fixture, not
+    the content files it pins, not another app's fixture of the same name."""
+    path_pat, _content_pat, reason = _find_content_keyed_rule(
+        LEGACY_SERVICE_INVENTORY_REASON
+    )
+    assert path_pat.search(LEGACY_SERVICE_INVENTORY)
+    assert not path_pat.search(
+        "apps/website/src/components/services/__fixtures__/legacy-pricing-identities.json"
+    )
+    assert not path_pat.search("apps/website/src/content/service-dossier-data.ts")
+    assert not path_pat.search(
+        "apps/website/src/components/services/legacy-service-inventory.json"
+    )
+    assert not path_pat.search(
+        "apps/mouth/src/components/services/__fixtures__/legacy-service-inventory.json"
+    )
+    assert "credential" in reason
+
+
+def test_guilt_legacy_service_inventory_real_lines_approved() -> None:
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        LEGACY_SERVICE_INVENTORY_REASON
+    )
+    for line in LEGACY_SERVICE_INVENTORY_REAL_LINES:
+        assert content_pat.match(line), f"should be approved: {line!r}"
+
+
+def test_guilt_legacy_service_inventory_both_comma_variants_approved() -> None:
+    """Either key, with or without the trailing comma — a future edit that
+    reorders fields must not silently stop matching."""
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        LEGACY_SERVICE_INVENTORY_REASON
+    )
+    d = LEGACY_SERVICE_INVENTORY_DIGEST
+    assert content_pat.match(f'  "sha256": "{d}",')
+    assert content_pat.match(f'  "descriptionSha256": "{d}"')
+
+
+def test_innocence_legacy_service_inventory_other_key_not_approved() -> None:
+    """A real secret under any OTHER key in the same file — even one with the
+    exact 64-hex shape — must stay unaudited. Keyed on the field NAME."""
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        LEGACY_SERVICE_INVENTORY_REASON
+    )
+    d = LEGACY_SERVICE_INVENTORY_DIGEST
+    assert content_pat.match(f'    "apiKey": "{d}",') is None
+    assert content_pat.match(f'    "id": "{d}",') is None
+    assert content_pat.match(f'    "legacyName": "{d}",') is None
+
+
+def test_innocence_legacy_service_inventory_wrong_value_shape_not_approved() -> None:
+    """The value must be exactly 64 lowercase hex — not a token prefix, not
+    63/65 chars, not uppercase."""
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        LEGACY_SERVICE_INVENTORY_REASON
+    )
+    assert content_pat.match('    "sha256": "ghp_realtoken1234567890abcdef"') is None
+    assert content_pat.match('    "sha256": "' + "a" * 63 + '"') is None
+    assert content_pat.match('    "sha256": "' + "a" * 65 + '"') is None
+    assert content_pat.match('    "sha256": "' + "A" * 64 + '"') is None
+
+
+def test_innocence_legacy_service_inventory_ride_along_not_approved() -> None:
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        LEGACY_SERVICE_INVENTORY_REASON
+    )
+    d = LEGACY_SERVICE_INVENTORY_DIGEST
+    assert (
+        content_pat.match(f'    "sha256": "{d}", "api_key": "realsecret123456"')
+        is None
+    )


### PR DESCRIPTION
## What
Adds **Compliance** as a fifth first-class service pillar on the new `apps/website` R19 site, alongside immigration, company-setup, tax and property — same architecture, same components, no special-casing.

## Why
Owner-confirmed public pricing (2026-09-10) for five `compliance_retainers` catalogue keys now live on the pricing route; this makes the corner discoverable and quotable through the site's existing service-journey machinery.

## Surfaces touched (grep for "property"/"company-setup" across apps/website/src, every hit reviewed)
- `src/content/service-pages.ts` — 5th slug `"compliance"`, full `ServicePage` entry. `toolDestinationId` made **optional** (compliance has no independent public tool; none invented — the "Optional independent starting point" aside is omitted for it instead of pointing at a fabricated destination).
- `src/content/service-price-identities.ts` — 5 identities, category `compliance_retainers`, exact catalogue keys: `compliance_takeover`, `compliance_core_retainer_monthly`, `compliance_employer_retainer_monthly`, `pse_registration_fixed`, `pmse_vat_assessment`.
- `src/content/service-dossier-data.ts` — 5 dossier families + 5 dossier records (domain `"compliance"`), same shape as the other 103 pinned records.
- `src/content/service-section-content.ts` — catalog (2 groups), included, documents, review, FAQs (signing, PSE for foreign operators without an Indonesian office, PMSE VAT collector appointment), and a new optional `whyNow` field carrying the 3 sourced facts (Komdigi press releases 9446/10354, Coretax deadline extension to 31 May, BKPM Regulation 5/2025 LKPM date) — **not** the draft's unverified "PP 28/2025 fines" line.
- `src/components/services/ServiceSections.tsx` + `ServiceJourneys.tsx` — conditional "Why it matters now" section (04, before FAQ which renumbers to 05 only when present), `ServiceSectionNav` now takes `service` for the conditional jump link, tool aside conditional on `toolDestinationId`, "Four areas of practice" → "Five".
- `src/components/Entry.tsx` — 5th homepage hero category (`Compliance` → `/services/compliance`).
- `src/content/services.ts` + `src/components/Services.tsx` — 5th homepage "Services and tools" card. No fake tool link: only "Explore Compliance and obligations" + "Talk to our team" (no `href`/`action`, both fields made optional on `HomeServiceEntry`).
- Contact-topic parity: `src/lib/destinations/lead-handoff.ts`, `src/lib/destinations/contact-context.ts`, `src/components/ContactOptions.tsx` gain a `compliance` topic/source.
- **`Footer.tsx` checked and left untouched** — it links to `/services` generically and does not enumerate individual pillars.
- No sitemap/robots files exist in this app (grep confirmed) — nothing to update there.
- PSE guide article: grepped `pse-registration` across `apps/website` — no such article exists yet; the compliance dossier's PSE FAQ answer stands on its own (Permenkominfo 5/2020 scope) with no dangling link to a guide that doesn't exist.

**Not touched, and why:** `src/features/supporting/CompanyPage.tsx` (careers/press sidebar) already uses a curated 3-item subset (combines tax+property into one link) rather than an exhaustive 4-pillar list — adding a 5th there would be a scope change beyond parity, left alone.

**Known lane overlap (no file conflict):** a separate, unrelated lane (`dux-w1-pr2-compliance-page` on the team roster) is adding an **unlisted, noindex** `/services/compliance` page to **`apps/mouth`** (a different app, different branch, reading a committed price snapshot instead of the live API) — see `evidence/2026-09/agent-nuzantara-mouth-compliance-retainer-page-0bf73876/brief.yml` on `origin/main`. This PR's corner is the opposite: fully public and indexed, on the new `apps/website` R19 site, live-priced via `GET /api/pricing/service`.

## Tests
- New `src/content/service-pages.test.ts`: exact 5-slug order, non-empty required fields per pillar, compliance entry shape (no invented `toolDestinationId`), the 5 catalogue keys wired to `compliance_retainers`, why-now/FAQ content asserted against the sourced facts and the absence of the "PP 28/2025" line.
- `ServiceDossiers.test.tsx`, `src/app/services/services.test.tsx`, `Entry.test.tsx`, `Home.test.tsx`: counts/fixtures updated 4→5 (`legacy-pricing-identities.json` 86→91, `legacy-service-inventory.json` 103→108 items / 132→142 features), and the shared "no live price for non-immigration" / "tool destination always present" assertions made conditional so compliance (which now has both a live price and no tool) takes the opposite branch from the other three non-immigration pillars.
- **Mutation-proof**: renamed `"Compliance Takeover"` in `service-price-identities.ts` → `service-pages.test.ts`'s new wiring test went RED (`AssertionError: Compliance Takeover: expected undefined to be defined`); reverted → GREEN (5 passed). Full tail quoted in the evidence brief.

## Grep proof (price literals)
```
grep -nE "[0-9]{3},[0-9]{3}|USD [0-9]|[0-9]{1,3}\.[0-9]{3}\.[0-9]{3}" <19 changed files>
```
→ 0 hits (exit 1) — verified on both the pre- and post-prettier commit states.

## Build/lint/typecheck
- `npx tsc --noEmit` — exit 0.
- `npm test -- --maxWorkers=1 --no-file-parallelism` — **100 files / 1345 tests passed**, 1 pre-existing skip (unchanged before/after).
- `npm run build` (`next build --webpack`) — clean; route table shows `/services/[slug]` with 5 SSG paths (`immigration, company-setup, tax, [+2 more]` = property, compliance).
- No `lint` script or ESLint config exists in `apps/website` (checked `package.json` + repo); README's documented validation trio is test/typecheck/build, all green above.
- **Prettier note**: this repo's pre-commit hook runs `prettier --check` on the *full content* of every staged file, not just the diff. Several files I had to touch (`service-dossier-data.ts` especially) were not prettier-clean before this change — confirmed by running the same check against an untouched sibling file (`service-visa-catalog.ts`), which also fails, with no `.prettierrc`/prettier config anywhere in the repo. Without `--no-verify`, committing required a whole-file `prettier --write`, which is why `git diff --stat` on some files (e.g. `service-dossier-data.ts`: +1900/-840) is far larger than the actual content added (~120 semantic lines there). Content correctness is asserted by the tests, not by line count.

## Floor/gear
Measured the CI way exactly as specified: `git diff --name-only codex/website-r19-integrated...` (19 files) → `evidence_pack_lint.py --print-floor --changed-files-file <list> --net-lines 2135` (net-lines = `git diff --numstat ... | awk '{a+=$1-$2}'`) → **floor 1, source none**. Declaring gear **1**. No gate status asserted by me.

Evidence: `evidence/2026-09/agent-nuzantara-website-compliance-corner-38497b36/brief.yml`.

## Adversarial review
What I checked myself before opening this PR:
- **Five-pillar parity on every surface**: walked every consumer of `servicePages`/the 4-pillar pattern found via grep (`ServiceJourneys.tsx`, `Entry.tsx`, `Services.tsx`/`content/services.ts`, contact-topic system, `Footer.tsx`, sitemap/robots) and either extended it to 5 or documented why it doesn't apply.
- **No price literal**: grep run twice (pre- and post-formatting) on the actual changed-file list, 0 hits both times.
- **Sourced claims only**: the three why-now facts are exactly the ones specified in the task (Komdigi 9446/10354, Coretax 31 May, BKPM 5/2025), not the draft's flagged-for-verification "PP 28/2025 fines" line; FAQ answers match the task's exact framing (director signs, PSE reaches foreign operators used by people in Indonesia, DJP appoints VAT collectors).
- **No invented capability**: compliance has no interactive tool; rather than fabricate one, `toolDestinationId` became optional end to end (type, `ServiceJourneys.tsx`, `services.test.tsx`) and the homepage card drops the tool-specific CTA.
- **Asset honesty**: no dedicated compliance illustration exists; reused `tool-tax-illustration.png` as a labelled placeholder (flagged as a risk in the evidence brief) rather than invent a new asset.

Not armed, not merged. No subagents were used — all work done directly per instructions.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)