### PR TITLE
fix(mouth): route title for /obligations so the workspace header names the page

### DIFF
--- a/apps/mouth/src/types/navigation.test.ts
+++ b/apps/mouth/src/types/navigation.test.ts
@@ -1,0 +1,29 @@
+import { navigation, routeTitles } from "./navigation";
+
+/**
+ * `/obligations` shipped in the "Work" nav group (#6209) without a
+ * routeTitles entry, so getRouteTitle() in (workspace)/layout.tsx and
+ * PortalHeader/workspace Header fell through to the generic "Workspace"
+ * fallback instead of naming the page. Pin every "Work" nav href against
+ * routeTitles so the next new route can't ship the same gap silently.
+ */
+describe("routeTitles vs the Work nav group", () => {
+  const workItems =
+    navigation.find((section) => section.title === "Work")?.items ?? [];
+
+  it("finds the Work group to check (the probe can produce a positive)", () => {
+    expect(workItems.length).toBeGreaterThan(0);
+  });
+
+  it("every internal Work nav href has a routeTitles entry", () => {
+    const missing = workItems
+      .filter((item) => !item.external)
+      .map((item) => item.href)
+      .filter((href) => !routeTitles[href]);
+    expect(missing).toEqual([]);
+  });
+
+  it("/obligations names the page instead of falling back to Workspace", () => {
+    expect(routeTitles["/obligations"]).toBe("Obligations");
+  });
+});

--- a/apps/mouth/src/types/navigation.ts
+++ b/apps/mouth/src/types/navigation.ts
@@ -157,6 +157,7 @@ export const routeTitles: Record<string, string> = {
   "/second-home": "Second Home",
   "/second-home/new": "New Second Home Case",
   "/review": "Document Review",
+  "/obligations": "Obligations",
   "/knowledge": "Knowledge Base",
   "/team": "Team",
   "/team/timesheet": "Timesheet",

--- a/evidence/2026-09/agent-nuzantara-mouth-obligations-route-title-ddda78c3/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-mouth-obligations-route-title-ddda78c3/brief.yml
@@ -1,0 +1,45 @@
+task_id: obligations-route-title
+gear: 1
+gear_reason: >-
+  Computed, not chosen. scripts/evidence_pack_lint.py --print-floor over this branch's diff
+  vs origin/main (git diff --numstat/--name-only origin/main...) returns 1: no HOTZONE_PATTERNS
+  hit (apps/mouth/src/types/navigation.ts and its new test are not hot-zone paths) and 30 net
+  lines over 2 files stay far under the size thresholds.
+l_level: L1
+gate_class: opus
+objective: >-
+  Residual R1 of PR #6209 (obligations reviewer UI, kita workspace /obligations page): that PR
+  added the nav item and the page but left routeTitles without an "/obligations" entry, so
+  (workspace)/layout.tsx's getRouteTitle() and the workspace/portal Header components fell
+  through to the generic "Workspace" fallback instead of naming the page in the header. Add
+  "/obligations": "Obligations" to apps/mouth/src/types/navigation.ts's routeTitles map, right
+  after the existing "/review" entry (matching style: PR #6209 itself placed the nav item
+  immediately after "Review" in the "Work" section for the same reason).
+constraints:
+  - >-
+    One map entry only — no change to navigation.ts's navigation/portalNavigation arrays, no
+    change to any component. Value "Obligations" matches the existing nav item's `title` field
+    exactly (src/types/navigation.ts:52), same convention every other routeTitles value follows
+    (e.g. "/review": "Document Review" mirrors the "Review" nav item's own title-ish wording).
+  - >-
+    No prior test enumerated routeTitles against nav items (grepped `routeTitles` across
+    *.test.*/*.spec.* — zero hits before this change), so a new file
+    src/types/navigation.test.ts was added rather than extending an existing suite. It asserts
+    every non-external href in the "Work" nav group has a routeTitles key, so the next new
+    "Work" route can't ship the same gap silently — not just re-pinning "/obligations" alone.
+acceptance:
+  - text: >-
+      WHEN the "Work" nav group is checked against routeTitles THEN every internal
+      (non-external) href SHALL have a routeTitles entry, including "/obligations".
+    probe: >-
+      cd apps/mouth && npx vitest run src/types/navigation.test.ts — 3 passed (807ms rerun:
+      637ms). Bite proven by mutation: temporarily removed the "/obligations" line from
+      routeTitles -> RED, 2 failed / 1 passed — `expect(missing).toEqual([])` got
+      `["/obligations"]`, and `expect(routeTitles["/obligations"]).toBe("Obligations")` got
+      `undefined`; restored the line -> GREEN, 3 passed / 0 failed. Tails quoted in the PR body.
+  - text: Typecheck and formatting SHALL be clean on the changed files.
+    probe: >-
+      npx tsc --noEmit (exit 0, no output); npx prettier --check
+      src/types/navigation.ts src/types/navigation.test.ts -> "All matched files use Prettier
+      code style!".
+pii_scan: clean


### PR DESCRIPTION
## Why

Gate residual R1 of PR #6209 (obligations reviewer UI, kita workspace `/obligations` page): that PR added the nav item and the page but left `routeTitles` (`apps/mouth/src/types/navigation.ts`) without an `"/obligations"` entry, so `(workspace)/layout.tsx`'s `getRouteTitle()` and the workspace/portal `Header` components fell through to the generic `"Workspace"` fallback instead of naming the page. `/obligations` was the only nav route (of 29) missing a title.

## Change

One map entry, right after the existing `"/review"` entry, matching the existing style:

```ts
"/review": "Document Review",
"/obligations": "Obligations",
```

No prior test enumerated `routeTitles` against nav items, so added `src/types/navigation.test.ts`: it asserts every internal (non-external) href in the "Work" nav group has a `routeTitles` key — proving `/obligations` and guarding the next new "Work" route from shipping the same gap silently.

## Test tails

```
$ npx vitest run src/types/navigation.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Bite proven by mutation — temporarily removed the `"/obligations"` line:

```
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)

- Expected: []
+ Received: ["/obligations"]

AssertionError: expected undefined to be 'Obligations'
```

Restored the line → back to 3 passed / 0 failed.

`npx tsc --noEmit`: exit 0, no output. `npx prettier --check`: "All matched files use Prettier code style!".

## Floor

`evidence_pack_lint.py --print-floor` over `git diff --numstat/--name-only origin/main...` → **1**. 2 files, +30/-0, no hot-zone hit. Brief at `evidence/2026-09/agent-nuzantara-mouth-obligations-route-title-ddda78c3/brief.yml`.

## Adversarial review

One map entry, covered by a test; reviewed by the imperator by diff.