### PR TITLE
fix(portal): re-light passageGlow for the day theme

### DIFF
--- a/apps/mouth/src/app/portal/login-upgraded/page.tsx
+++ b/apps/mouth/src/app/portal/login-upgraded/page.tsx
@@ -329,6 +329,14 @@ function UpgradedLoginPageInner() {
         [data-theme="operative-light"] .gate-scene [stroke="#8a6030"] { stroke: #9c7c4e; } /* token-lint-ok: decorative illustration dim gold stroke */
         [data-theme="operative-light"] .gate-scene [fill="#000000"] { fill: #d8cdb6; } /* token-lint-ok: decorative illustration sand silhouette (moon cover, ground, foliage) */
         [data-theme="operative-light"] .gate-scene [fill="#0a0a0a"] { fill: #d9a441; } /* token-lint-ok: decorative illustration sun disc */
+        /* #passageGlow was still the night-only ember (#1a1008 → #000000,
+           opaque both stops), so in daylight the central passage rendered
+           as a near-black slab instead of a glimpse of sky through the
+           gate. Re-lit with the same two skyGrad tones so the passage
+           reads as daylight, not a void — both stops clear WCAG 3:1
+           against the copper title text that overlaps this rect. */
+        [data-theme="operative-light"] .gate-scene #passageGlow stop[stop-color="#1a1008"] { stop-color: #f7f3ea; } /* token-lint-ok: decorative illustration daylight passage glow (reuses day sky) */
+        [data-theme="operative-light"] .gate-scene #passageGlow stop[stop-color="#000000"] { stop-color: #e6dcc8; } /* token-lint-ok: decorative illustration daylight passage glow depth (reuses day sky depth) */
       `}</style>
 
       {/* ═══════════════════════════════════════


### PR DESCRIPTION
## Summary
- `#passageGlow` (the central-passage radial gradient in the login-upgraded gate SVG) still carried its night-only stops (`#1a1008` → `#000000`, both opaque), so on `operative-light` it rendered as a near-black slab overlapping the "TURN ON / YOUR BALI LIFE." title instead of a luminous passage.
- Re-lit it via the same `[data-theme="operative-light"] .gate-scene #<id> stop[stop-color="..."]` mechanism already used for `skyGrad`/`goldEdge`/stone fills, reusing the existing `skyGrad` day tones (`#f7f3ea` / `#e6dcc8`) rather than inventing a new hex — no new token/hardcoded color introduced.
- Dark theme (`operative-dark`) is untouched: the selector only matches `operative-light`, so the night scene renders pixel-identically.

## Evidence (Playwright, 1440x900, 3.5s post-fade-in settle)
Repro'd locally via `next dev --webpack` on the worktree (Turbopack hit an unrelated pre-existing "symlink points out of filesystem root" error in this worktree layout, unrelated to this change).

**Before:** solid near-black rect `[x=640,y=365,w=160,h=415]` sits between the two temple towers; title overlaps it.
**After:** same rect now reads as a soft warm-cream glow (matches the day sky palette), title fully legible over it, no visual "black slab" left.

Gradient stops read from the DOM via `getComputedStyle` on the `<stop>` elements (not from source):
- offset 0%: `rgb(26, 16, 8)` → `rgb(247, 243, 234)`
- offset 100%: `rgb(0, 0, 0)` → `rgb(230, 220, 200)`

WCAG contrast of the title text (`rgb(157, 82, 48)`) against each new stop color, computed with the standard relative-luminance formula:
- vs `#f7f3ea` (247,243,234): **5.15:1**
- vs `#e6dcc8` (230,220,200): **4.19:1**

Both clear the 3:1 large-text threshold and both *improve* on the pre-fix numbers (title vs the old stop colors: 3.28:1 / 3.68:1). This was never an accessibility bug (both old and new pass 3:1) — it was a gradient left tuned for the dark theme; the contrast math above is reported only as the falsifiable acceptance check requested, not as a claim that this fixes an a11y issue.

Console errors and failed requests: 0 and 0, both before and after (unchanged).

**Mobile (390x844):** the passage rect sits well above the card — no overlap with the email field or the "Pass the portal" button, before or after.

## Bites:
Consumer: `my.balizero.com` / `/portal/login-upgraded` after the Vercel deploy of this branch. Observation that proves it's in force: `getComputedStyle` on `#passageGlow`'s two `<stop>` elements under `[data-theme="operative-light"]` reads `rgb(247, 243, 234)` and `rgb(230, 220, 200)` instead of the source's `#1a1008`/`#000000`.

## Test plan
- [x] `tsc --noEmit` clean on `apps/mouth`
- [x] Pre-commit typecheck hook passed
- [x] Visual diff verified via Playwright screenshots (desktop before/after, mobile after)
- [x] Console/network check: 0 errors, 0 failed requests
- [ ] Post-deploy: screenshot `my.balizero.com/portal/login-upgraded` in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1nYQpv7ehFa44rZBNMMzx