### PR TITLE
fix(observability): make api_audit_trail write failures audible without PII or log-flood risk

### DIFF
--- a/apps/backend-rag/backend/services/monitoring/activity_logger.py
+++ b/apps/backend-rag/backend/services/monitoring/activity_logger.py
@@ -37,6 +37,8 @@ Usage:
 """
 
 import json
+import re
+import time
 from typing import Any
 
 import asyncpg
@@ -45,6 +47,17 @@ from backend.app.utils.logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+# log_api_call is called on every request (1.3M+/month) — if its INSERT
+# starts failing, an uncapped warning per failure would flood the app log.
+# Emit the first failure in full, then at most once per interval or once
+# every N suppressed occurrences (whichever comes first).
+_API_LOG_FAILURE_INTERVAL_SECONDS = 60.0
+_API_LOG_FAILURE_EVERY_N = 500
+
+# Matches numeric path segments (client/resource IDs) so a masked endpoint
+# can be logged without leaking which specific client/record was involved.
+_NUMERIC_ID_RE = re.compile(r"\d+")
+
 
 class ActivityLogger:
     """Centralized activity logging service"""
@@ -52,6 +65,13 @@ class ActivityLogger:
     def __init__(self) -> None:
         self.pool: asyncpg.Pool | None = None
         self._initialized = False
+        # State for the log_api_call failure damper — see
+        # _record_api_log_failure. Instance-local, no cross-process/thread
+        # lock: an approximate count under concurrency is acceptable here,
+        # and a lock on this path would add latency to every request.
+        self._api_log_failure_count = 0
+        self._api_log_failure_suppressed = 0
+        self._api_log_failure_last_emit_at = 0.0
 
     async def initialize(self, pool: asyncpg.Pool) -> None:
         """Initialize the logger with a database pool"""
@@ -356,9 +376,59 @@ class ActivityLogger:
                 )
             return True
 
-        except Exception:
-            # Don't log API logging failures to avoid infinite loops
+        except Exception as exc:
+            # Never write to api_audit_trail (or any table) from this branch:
+            # that would put the failure back on the same DB write path that
+            # is already failing, recreating the infinite-loop risk this
+            # bare `except: return False` used to guard against by staying
+            # silent. The app logger (stderr/app-log) doesn't touch the DB,
+            # so it's a safe channel — damped so it can't flood at
+            # log_api_call's request volume.
+            self._record_api_log_failure(exc, method, endpoint, response_status)
             return False
+
+    def _record_api_log_failure(
+        self, exc: Exception, method: str, endpoint: str, response_status: int
+    ) -> None:
+        """
+        Surface an api_audit_trail INSERT failure without leaking PII and
+        without flooding the log at request volume.
+
+        PII boundary (CLAUDE.md Part A §4): only the exception TYPE, HTTP
+        method, response status and a numeric-ID-masked endpoint are
+        logged. query_params/request_body/response_body/ip_address/
+        user_agent/user_email are never referenced here. The exception
+        MESSAGE is deliberately omitted too — asyncpg sometimes embeds the
+        failing row's own values in constraint-violation text (e.g.
+        "Key (user_email)=(x@example.com) already exists"), so including
+        it would risk exactly the leak this function exists to avoid.
+        """
+        self._api_log_failure_count += 1
+        now = time.monotonic()
+        is_first_failure = self._api_log_failure_count == 1
+        due_by_time = (
+            now - self._api_log_failure_last_emit_at
+        ) >= _API_LOG_FAILURE_INTERVAL_SECONDS
+        due_by_count = self._api_log_failure_suppressed >= _API_LOG_FAILURE_EVERY_N
+
+        if not (is_first_failure or due_by_time or due_by_count):
+            self._api_log_failure_suppressed += 1
+            return
+
+        suppressed = self._api_log_failure_suppressed
+        self._api_log_failure_suppressed = 0
+        self._api_log_failure_last_emit_at = now
+
+        logger.warning(
+            "api_audit_trail insert failed: exc_type=%s method=%s status=%s "
+            "endpoint=%s total_failures=%d suppressed_since_last=%d",
+            type(exc).__name__,
+            method,
+            response_status,
+            _NUMERIC_ID_RE.sub(":id", endpoint or ""),
+            self._api_log_failure_count,
+            suppressed,
+        )
 
     async def log_session(
         self,

--- a/apps/backend-rag/backend/tests/services/monitoring/test_activity_logger.py
+++ b/apps/backend-rag/backend/tests/services/monitoring/test_activity_logger.py
@@ -1,8 +1,28 @@
 import json
+import logging
 
 import pytest
 
 from backend.services.monitoring.activity_logger import ActivityLogger
+
+ACTIVITY_LOGGER = "backend.services.monitoring.activity_logger"
+
+
+def failure_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """The WARNING+ records this module emitted, and nothing else.
+
+    ``caplog.records`` is not scoped to the ``caplog.at_level(...)`` block: it
+    holds every record captured for the whole test. ``initialize()`` runs
+    before that block and emits an INFO line, so a bare
+    ``len(caplog.records) == 1`` counts a record that has nothing to do with
+    the failure path under test — and does so only where the root level lets
+    INFO through, which is why it passed locally and failed in CI.
+    """
+    return [
+        record
+        for record in caplog.records
+        if record.name == ACTIVITY_LOGGER and record.levelno >= logging.WARNING
+    ]
 
 
 class FakeAcquire:
@@ -149,8 +169,9 @@ async def test_log_api_call_failure_returns_false_and_logs_exception_type(
         result = await logger.log_api_call("GET", "/api/clients/42", 200, 10)
 
     assert result is False
-    assert len(caplog.records) == 1
-    assert "RuntimeError" in caplog.records[0].message
+    warnings = failure_warnings(caplog)
+    assert len(warnings) == 1
+    assert "RuntimeError" in warnings[0].message
 
 
 @pytest.mark.asyncio
@@ -165,7 +186,7 @@ async def test_log_api_call_success_emits_no_failure_warning(
         result = await logger.log_api_call("GET", "/api/clients/42", 500, 10)
 
     assert result is True
-    assert caplog.records == []
+    assert failure_warnings(caplog) == []
 
 
 @pytest.mark.asyncio
@@ -182,9 +203,10 @@ async def test_log_api_call_failure_is_damped_under_repeated_failures(
     # Only the first occurrence is emitted; the rest are suppressed within
     # the damping interval (time-based reset hasn't elapsed, count-based
     # reset needs 500 occurrences).
-    assert len(caplog.records) == 1
-    assert "total_failures=1" in caplog.records[0].message
-    assert "suppressed_since_last=0" in caplog.records[0].message
+    warnings = failure_warnings(caplog)
+    assert len(warnings) == 1
+    assert "total_failures=1" in warnings[0].message
+    assert "suppressed_since_last=0" in warnings[0].message
 
     # Force a second emission via the count-based threshold and check the
     # suppressed counter is reported.
@@ -193,9 +215,10 @@ async def test_log_api_call_failure_is_damped_under_repeated_failures(
     with caplog.at_level("WARNING", logger="backend.services.monitoring.activity_logger"):
         assert await logger.log_api_call("GET", "/health", 200, 10) is False
 
-    assert len(caplog.records) == 1
-    assert "total_failures=51" in caplog.records[0].message
-    assert "suppressed_since_last=500" in caplog.records[0].message
+    warnings = failure_warnings(caplog)
+    assert len(warnings) == 1
+    assert "total_failures=51" in warnings[0].message
+    assert "suppressed_since_last=500" in warnings[0].message
 
 
 @pytest.mark.asyncio
@@ -223,7 +246,7 @@ async def test_log_api_call_failure_never_leaks_pii_into_the_log(
         )
 
     assert result is False
-    logged_text = " ".join(r.message for r in caplog.records)
+    logged_text = " ".join(r.message for r in failure_warnings(caplog))
     assert secret_ip not in logged_text
     assert secret_email not in logged_text
     assert secret_agent not in logged_text

--- a/apps/backend-rag/backend/tests/services/monitoring/test_activity_logger.py
+++ b/apps/backend-rag/backend/tests/services/monitoring/test_activity_logger.py
@@ -139,6 +139,112 @@ async def test_log_api_call_sanitizes_query_request_and_response_payloads() -> N
 
 
 @pytest.mark.asyncio
+async def test_log_api_call_failure_returns_false_and_logs_exception_type(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = ActivityLogger()
+    await logger.initialize(FakePool(FakeConn(fail=True)))
+
+    with caplog.at_level("WARNING", logger="backend.services.monitoring.activity_logger"):
+        result = await logger.log_api_call("GET", "/api/clients/42", 200, 10)
+
+    assert result is False
+    assert len(caplog.records) == 1
+    assert "RuntimeError" in caplog.records[0].message
+
+
+@pytest.mark.asyncio
+async def test_log_api_call_success_emits_no_failure_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    conn = FakeConn()
+    logger = ActivityLogger()
+    await logger.initialize(FakePool(conn))
+
+    with caplog.at_level("WARNING", logger="backend.services.monitoring.activity_logger"):
+        result = await logger.log_api_call("GET", "/api/clients/42", 500, 10)
+
+    assert result is True
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_log_api_call_failure_is_damped_under_repeated_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = ActivityLogger()
+    await logger.initialize(FakePool(FakeConn(fail=True)))
+
+    with caplog.at_level("WARNING", logger="backend.services.monitoring.activity_logger"):
+        for _ in range(50):
+            assert await logger.log_api_call("GET", "/health", 200, 10) is False
+
+    # Only the first occurrence is emitted; the rest are suppressed within
+    # the damping interval (time-based reset hasn't elapsed, count-based
+    # reset needs 500 occurrences).
+    assert len(caplog.records) == 1
+    assert "total_failures=1" in caplog.records[0].message
+    assert "suppressed_since_last=0" in caplog.records[0].message
+
+    # Force a second emission via the count-based threshold and check the
+    # suppressed counter is reported.
+    caplog.clear()
+    logger._api_log_failure_suppressed = 500
+    with caplog.at_level("WARNING", logger="backend.services.monitoring.activity_logger"):
+        assert await logger.log_api_call("GET", "/health", 200, 10) is False
+
+    assert len(caplog.records) == 1
+    assert "total_failures=51" in caplog.records[0].message
+    assert "suppressed_since_last=500" in caplog.records[0].message
+
+
+@pytest.mark.asyncio
+async def test_log_api_call_failure_never_leaks_pii_into_the_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = ActivityLogger()
+    await logger.initialize(FakePool(FakeConn(fail=True)))
+
+    secret_ip = "203.0.113.77"
+    secret_email = "client-42@example.com"
+    secret_agent = "SuperSecretBrowser/9.9"
+    secret_query = {"token": "abc123-should-never-appear"}
+
+    with caplog.at_level("WARNING", logger="backend.services.monitoring.activity_logger"):
+        result = await logger.log_api_call(
+            method="GET",
+            endpoint="/api/clients/987654",
+            response_status=200,
+            response_time_ms=10,
+            user_email=secret_email,
+            ip_address=secret_ip,
+            user_agent=secret_agent,
+            query_params=secret_query,
+        )
+
+    assert result is False
+    logged_text = " ".join(r.message for r in caplog.records)
+    assert secret_ip not in logged_text
+    assert secret_email not in logged_text
+    assert secret_agent not in logged_text
+    assert "abc123-should-never-appear" not in logged_text
+    # The numeric client ID in the endpoint must be masked, not passed through.
+    assert "987654" not in logged_text
+    assert "/api/clients/:id" in logged_text
+
+
+@pytest.mark.asyncio
+async def test_log_api_call_failure_never_propagates_to_the_caller() -> None:
+    logger = ActivityLogger()
+    await logger.initialize(FakePool(FakeConn(fail=True)))
+
+    # Must not raise — a broken audit-log write must never break the
+    # request it is trying to observe.
+    result = await logger.log_api_call("POST", "/api/clients", 201, 10)
+    assert result is False
+
+
+@pytest.mark.asyncio
 async def test_log_session_writes_login_logout_and_activity_events() -> None:
     conn = FakeConn()
     logger = ActivityLogger()


### PR DESCRIPTION
## What

`log_api_call` (services/monitoring/activity_logger.py) is the writer for
`api_audit_trail`. Its `except` branch was a bare `except Exception: return
False` with a comment "Don't log API logging failures to avoid infinite
loops" — every INSERT failure vanished with zero trace. That's why the
measured symptom (every 401 response reaches the logging middleware —
carries `x-ratelimit-remaining`/`x-correlation-id` from more-internal
middleware — but 0 rows land in `api_audit_trail` for that window while
404s in the same window are written normally) was undiagnosable: the
failure never left a mark.

This PR makes the failure audible without recreating the risk the bare
`except` was guarding against.

## Why the log channel can't recreate the infinite loop

The failure handler (`_record_api_log_failure`) writes ONLY to the module's
Python `logger` (stderr/app-log via `get_logger`). It never touches
`api_audit_trail`, or any other table, or any other DB write path. A
logging-infra failure (stderr full, log shipper down) is a different failure
class than a DB-write failure, and even if it also fails, Python's own
logging module swallows handler errors internally — it does not re-raise
into caller code, so it cannot re-enter `log_api_call`. There is no cycle.

## Damping

`log_api_call` fires on every request (~1.3M/month at current volume). The
damper is instance-local counters (`_api_log_failure_count`,
`_api_log_failure_suppressed`, `_api_log_failure_last_emit_at`), no lock,
no shared state:
- the FIRST failure is always logged in full immediately;
- after that, at most one line per 60s OR once every 500 suppressed
  occurrences (whichever comes first);
- every emitted line carries `total_failures` (cumulative) and
  `suppressed_since_last`, so the log itself reports how much was
  dropped — never silent about volume, only rate-limited.

No lock because an approximate count under concurrency is fine here, and a
lock on this path would add latency to every request that log_api_call
observes.

## Unchanged behavior

`log_api_call` still returns `False` on failure and never raises — an
audit-log failure must never fail the user's actual request. Covered by
`test_log_api_call_failure_never_propagates_to_the_caller`.

## PII (CLAUDE.md §4)

Logged: exception TYPE, HTTP method, response status, and the endpoint with
numeric path segments masked to `:id` (regex `\d+` → `:id`).

NOT logged: `query_params`, `request_body`, `response_body`, `ip_address`,
`user_agent`, `user_email`, or any client/resource ID in the endpoint.

The exception **message** is deliberately omitted entirely (not truncated).
asyncpg constraint-violation errors sometimes embed the failing row's own
values in the message text (e.g. `Key (user_email)=(x@example.com) already
exists`), so any inclusion — even truncated — risks echoing exactly the PII
this function exists to keep out of the log. Only `type(exc).__name__` is
logged; that is enough to start a diagnosis (e.g. `UniqueViolationError` vs
`ConnectionDoesNotExistError` point to very different root causes) without
any value-carrying text.

## Scope note

`log_activity` and `log_interaction` in the same file already log via
`logger.error(..., exc_info=True)` on failure — they don't have the silent
disease, so they're untouched. `log_session` also already logs via
`logger.error(...)`. Only `log_api_call` had the bare, silent
`except: return False`.

## Tests (guilt + innocence)

`apps/backend-rag/backend/tests/services/monitoring/test_activity_logger.py`,
5 new tests, run from `apps/backend-rag`:

```
$ .venv/bin/python -m pytest backend/tests/services/monitoring/test_activity_logger.py --no-header -v
============================= test session starts ==============================
collected 11 items

backend/tests/services/monitoring/test_activity_logger.py ...........   [100%]

============================= slowest 10 durations =============================
(10 durations < 0.005s hidden.  Use -vv to show these durations.)
============================== 11 passed in 0.13s ===============================
```

**Guilt** (`test_log_api_call_failure_returns_false_and_logs_exception_type`) —
real emitted line, reproduced standalone against the same code path:

```
WARNING backend.services.monitoring.activity_logger api_audit_trail insert failed: exc_type=RuntimeError method=GET status=200 endpoint=/api/clients/:id total_failures=1 suppressed_since_last=0
RETURN VALUE: False
```

**Innocence** — `test_log_api_call_success_emits_no_failure_warning`: a
successful INSERT emits zero WARNING records.

**Innocence, damping** —
`test_log_api_call_failure_is_damped_under_repeated_failures`: 50
consecutive failures inside the 60s window emit exactly 1 line
(`total_failures=1 suppressed_since_last=0`); forcing the count threshold
emits a 2nd line reporting `total_failures=51 suppressed_since_last=500`.

**Innocence, PII** — `test_log_api_call_failure_never_leaks_pii_into_the_log`:
a failing call carrying `ip_address`, `user_email`, `user_agent` and
`query_params` with a secret token, plus an endpoint with a 6-digit client
ID, asserts none of those literal values appear in the logged text, and
that the endpoint is masked to `/api/clients/:id`. Written to fail loudly
if someone later logs the whole call's `%s`.

**Propagation** — `test_log_api_call_failure_never_propagates_to_the_caller`:
a failing INSERT does not raise out of `log_api_call`.

## Root cause of the underlying INSERT failure

Not found — out of scope for this PR by design (the mandate was to make the
failure diagnosable, not to diagnose it). This PR is the instrument; the
next 401 in prod will now produce a WARNING line naming the exception type,
which is the input needed to actually find the cause.

## Bites

**Consumer:** this PR's own test suite,
`apps/backend-rag/backend/tests/services/monitoring/test_activity_logger.py`.
**Observation:** `pytest` output above — 11/11 passed, including the guilt
test whose captured WARNING record names `RuntimeError` and the innocence
test whose captured records are empty. The change is in force in the tests
that exercise it; live-prod confirmation is the next 401 after deploy,
which is out of scope for this PR (review/merge/deploy belongs to the
team-lead per this repo's ship-lifecycle rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1nYQpv7ehFa44rZBNMMzx
