### PR TITLE
fix(seat-widget): a hung refresh must not freeze the widget, and a 429 is not a dead seat

### DIFF
--- a/infra/seat-widget/main.swift
+++ b/infra/seat-widget/main.swift
@@ -125,6 +125,13 @@ enum Labels {
     }()
 }
 
+/// Quanto si concede a una misura prima di considerarla persa. Il refresh sano dura ~30s.
+enum Budget {
+    static let measure: TimeInterval = 120
+    static let stuck: TimeInterval = 180
+    static let retry: TimeInterval = 180
+}
+
 enum Quota {
     struct Outcome {
         var seats: [Seat] = []
@@ -164,15 +171,30 @@ enum Quota {
         do { try proc.run() } catch {
             return Outcome(failure: "avvio fallito: \(error.localizedDescription)", source: source)
         }
-        let watchdog = DispatchWorkItem { if proc.isRunning { proc.terminate() } }
-        DispatchQueue.global().asyncAfter(deadline: .now() + 300, execute: watchdog)
-        var errData = Data()
-        let errThread = Thread { errData = err.fileHandleForReading.readDataToEndOfFile() }
-        errThread.start()
-        let outData = out.fileHandleForReading.readDataToEndOfFile()
+        // Due stadi: un figlio che ignora SIGTERM non deve poter tenere fermo il widget.
+        let pid = proc.processIdentifier
+        let term = DispatchWorkItem { if proc.isRunning { kill(pid, SIGTERM) } }
+        let hard = DispatchWorkItem { if proc.isRunning { kill(pid, SIGKILL) } }
+        DispatchQueue.global().asyncAfter(deadline: .now() + Budget.measure, execute: term)
+        DispatchQueue.global().asyncAfter(deadline: .now() + Budget.measure + 15, execute: hard)
+
+        // Entrambi i pipe su thread propri con una scadenza: readDataToEndOfFile() sul thread
+        // chiamante era il punto in cui una misura poteva non tornare mai.
+        final class Box: @unchecked Sendable { var data = Data() }
+        let outBox = Box(), errBox = Box()
+        let readers = DispatchGroup()
+        for (pipe, box) in [(out, outBox), (err, errBox)] {
+            readers.enter()
+            DispatchQueue.global().async {
+                box.data = pipe.fileHandleForReading.readDataToEndOfFile()
+                readers.leave()
+            }
+        }
+        let readOK = readers.wait(timeout: .now() + Budget.measure + 30) == .success
         proc.waitUntilExit()
-        while errThread.isExecuting { usleep(10_000) }
-        watchdog.cancel()
+        term.cancel(); hard.cancel()
+        let outData = outBox.data, errData = errBox.data
+        if !readOK { return Outcome(failure: "misura scaduta dopo \(Int(Budget.measure))s", source: source) }
 
         let stderr = String(decoding: errData, as: UTF8.self)
             .split(separator: "\n").last.map(String.init) ?? ""
@@ -214,34 +236,104 @@ final class Model: ObservableObject {
     }
     var onChange: (() -> Void)?
     private var timer: Timer?
+    private var supervisor: Timer?
+    private(set) var interval: TimeInterval = 30 * 60
+    private var inflight: UUID?
+    private var inflightSince: Date?
+    private var attempt = 0
+
+    /// Vero quando i numeri a schermo hanno passato due intervalli: vanno dichiarati vecchi,
+    /// non mostrati come se fossero di adesso.
+    var isStale: Bool {
+        guard let t = updatedAt else { return true }
+        return Date().timeIntervalSince(t) > interval * 2
+    }
+
+    var age: String? {
+        guard let t = updatedAt else { return nil }
+        let m = Int(Date().timeIntervalSince(t) / 60)
+        return m < 60 ? "\(m)m fa" : "\(m / 60)h\(m % 60 > 0 ? "\(m % 60)" : "") fa"
+    }
 
     func start(every seconds: TimeInterval) {
+        interval = seconds
         refresh()
         timer = Timer.scheduledTimer(withTimeInterval: seconds, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.refresh() }
         }
+        // Un Timer non recupera i tick persi mentre il Mac dorme, e un tick perso è mezz'ora
+        // di numeri fermi: il supervisore al minuto li ripesca e scade i refresh appesi.
+        supervisor = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+        for t in [timer, supervisor] { t.map { RunLoop.main.add($0, forMode: .common) } }
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in Task { @MainActor in self?.refresh(force: true) } }
     }
 
-    func refresh() {
-        guard !loading else { return }
+    private func tick() {
+        if let since = inflightSince, Date().timeIntervalSince(since) > Budget.stuck {
+            log("stuck \(Int(Date().timeIntervalSince(since)))s: refresh abbandonato")
+            inflight = nil
+            inflightSince = nil
+            loading = false
+            note = "misura bloccata, riprovo"
+        }
+        let waited = updatedAt.map { Date().timeIntervalSince($0) } ?? .greatestFiniteMagnitude
+        if !loading, waited >= nextDelay { refresh() } else { onChange?() }
+    }
+
+    /// Dopo un errore si riprova presto e si allarga, invece di aspettare l'intervallo pieno.
+    private var nextDelay: TimeInterval {
+        attempt == 0 ? interval
+                     : min(interval, Budget.retry * pow(2, Double(min(attempt, 4) - 1)))
+    }
+
+    func refresh(force: Bool = false) {
+        if loading {
+            let expired = inflightSince.map { Date().timeIntervalSince($0) > Budget.stuck } ?? true
+            guard force || expired else { return }
+            inflight = nil          // se l'esito abbandonato arriva tardi, va scartato
+        }
+        let token = UUID()
+        inflight = token
+        inflightSince = Date()
         loading = true
         let started = Date()
         DispatchQueue.global(qos: .userInitiated).async {
             let outcome = Quota.measure()
-            DispatchQueue.main.async { self.apply(outcome, started: started) }
+            DispatchQueue.main.async { self.apply(outcome, started: started, token: token) }
         }
+        onChange?()
     }
 
-    private func apply(_ o: Quota.Outcome, started: Date) {
+    private func apply(_ o: Quota.Outcome, started: Date, token: UUID) {
+        guard token == inflight else {
+            log("scartato: esito di un refresh gia abbandonato")
+            return
+        }
+        inflight = nil
+        inflightSince = nil
         loading = false
         source = o.source
         defer { onChange?() }
         let secs = Int(Date().timeIntervalSince(started))
         if let f = o.failure {
+            attempt += 1
             note = f
-            log("err \(secs)s \(o.source): \(f)")
+            log("err \(secs)s \(o.source): \(f) [tentativo \(attempt), riprovo fra \(Int(nextDelay / 60))m]")
             return
         }
+        // Nessun seat leggibile (tipicamente 429 su tutti i profili): l'ultima misura buona
+        // vale piu del vuoto, la si tiene e la si dichiara vecchia.
+        if o.seats.isEmpty, !seats.isEmpty {
+            attempt += 1
+            note = o.note ?? "nessun seat leggibile, mostro l'ultima misura buona"
+            log("vuoto \(secs)s \(o.source) hidden=\(o.hidden) [tengo \(age ?? "?"), tentativo \(attempt)]")
+            return
+        }
+        attempt = 0
         seats = o.seats
         hidden = o.hidden
         note = o.note
@@ -399,20 +491,22 @@ struct RootView: View {
 
     var header: some View {
         HStack(spacing: 6) {
-            Circle().fill(Palette.text).frame(width: 8, height: 8)
+            Circle().fill(model.isStale ? Palette.ink : Palette.text).frame(width: 8, height: 8)
             Text(model.expanded ? "Claude seats" : "Claude")
                 .font(.system(size: model.expanded ? 15 : 13, weight: .medium, design: .serif))
                 .foregroundStyle(Palette.text)
                 .onTapGesture { model.expanded.toggle() }
             Spacer(minLength: 4)
             if model.expanded, let t = model.updatedAt {
-                Text("agg. " + Fmt.hm.string(from: t) + (model.source == "local" ? "" : " · " + model.source))
-                    .font(.system(size: 10)).foregroundStyle(Palette.muted)
+                Text((model.isStale ? "fermo da " + (model.age ?? "?") + " · " : "agg. ")
+                     + Fmt.hm.string(from: t) + (model.source == "local" ? "" : " · " + model.source))
+                    .font(.system(size: 10))
+                    .foregroundStyle(model.isStale ? Palette.ink : Palette.muted)
             }
             if model.loading {
                 ProgressView().controlSize(.mini).tint(.white)
             } else {
-                Button { model.refresh() } label: {
+                Button { model.refresh(force: true) } label: {
                     Image(systemName: "arrow.clockwise")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(Palette.text)
@@ -473,7 +567,7 @@ struct RootView: View {
         .environment(\.colorScheme, .dark)
         .modifier(DragAnywhere())
         .contextMenu {
-            Button("Aggiorna adesso") { model.refresh() }
+            Button("Aggiorna adesso") { model.refresh(force: true) }
             Button(model.expanded ? "Riduci" : "Espandi") { model.expanded.toggle() }
             Divider()
             Button("Esci") { NSApp.terminate(nil) }

--- a/infra/seat-widget/main.swift
+++ b/infra/seat-widget/main.swift
@@ -125,7 +125,7 @@ enum Labels {
     }()
 }
 
-/// Quanto si concede a una misura prima di considerarla persa. Il refresh sano dura ~30s.
+/// What a measurement is given before it counts as lost. A healthy refresh takes ~30s.
 enum Budget {
     static let measure: TimeInterval = 120
     static let stuck: TimeInterval = 180
@@ -171,15 +171,15 @@ enum Quota {
         do { try proc.run() } catch {
             return Outcome(failure: "avvio fallito: \(error.localizedDescription)", source: source)
         }
-        // Due stadi: un figlio che ignora SIGTERM non deve poter tenere fermo il widget.
+        // Two stages: a child that ignores SIGTERM must not be able to hold the widget still.
         let pid = proc.processIdentifier
         let term = DispatchWorkItem { if proc.isRunning { kill(pid, SIGTERM) } }
         let hard = DispatchWorkItem { if proc.isRunning { kill(pid, SIGKILL) } }
         DispatchQueue.global().asyncAfter(deadline: .now() + Budget.measure, execute: term)
         DispatchQueue.global().asyncAfter(deadline: .now() + Budget.measure + 15, execute: hard)
 
-        // Entrambi i pipe su thread propri con una scadenza: readDataToEndOfFile() sul thread
-        // chiamante era il punto in cui una misura poteva non tornare mai.
+        // Both pipes on their own threads with a deadline: readDataToEndOfFile() on the
+        // calling thread was the point where a measurement could never return.
         final class Box: @unchecked Sendable { var data = Data() }
         let outBox = Box(), errBox = Box()
         let readers = DispatchGroup()
@@ -242,8 +242,8 @@ final class Model: ObservableObject {
     private var inflightSince: Date?
     private var attempt = 0
 
-    /// Vero quando i numeri a schermo hanno passato due intervalli: vanno dichiarati vecchi,
-    /// non mostrati come se fossero di adesso.
+    /// True once the numbers on screen are two intervals old: they must be declared stale,
+    /// not shown as if they were current.
     var isStale: Bool {
         guard let t = updatedAt else { return true }
         return Date().timeIntervalSince(t) > interval * 2
@@ -261,8 +261,9 @@ final class Model: ObservableObject {
         timer = Timer.scheduledTimer(withTimeInterval: seconds, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.refresh() }
         }
-        // Un Timer non recupera i tick persi mentre il Mac dorme, e un tick perso è mezz'ora
-        // di numeri fermi: il supervisore al minuto li ripesca e scade i refresh appesi.
+        // A Timer does not make up ticks missed while the Mac sleeps, and one missed tick is
+        // half an hour of frozen numbers: the per-minute supervisor picks them up and expires
+        // a hung refresh.
         supervisor = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
         }
@@ -274,7 +275,7 @@ final class Model: ObservableObject {
 
     private func tick() {
         if let since = inflightSince, Date().timeIntervalSince(since) > Budget.stuck {
-            log("stuck \(Int(Date().timeIntervalSince(since)))s: refresh abbandonato")
+            log("stuck \(Int(Date().timeIntervalSince(since)))s: refresh abandoned")
             inflight = nil
             inflightSince = nil
             loading = false
@@ -284,7 +285,7 @@ final class Model: ObservableObject {
         if !loading, waited >= nextDelay { refresh() } else { onChange?() }
     }
 
-    /// Dopo un errore si riprova presto e si allarga, invece di aspettare l'intervallo pieno.
+    /// After a failure it retries soon and widens, instead of waiting the full interval.
     private var nextDelay: TimeInterval {
         attempt == 0 ? interval
                      : min(interval, Budget.retry * pow(2, Double(min(attempt, 4) - 1)))
@@ -294,7 +295,7 @@ final class Model: ObservableObject {
         if loading {
             let expired = inflightSince.map { Date().timeIntervalSince($0) > Budget.stuck } ?? true
             guard force || expired else { return }
-            inflight = nil          // se l'esito abbandonato arriva tardi, va scartato
+            inflight = nil          // a late outcome from the abandoned run must be dropped
         }
         let token = UUID()
         inflight = token
@@ -310,7 +311,7 @@ final class Model: ObservableObject {
 
     private func apply(_ o: Quota.Outcome, started: Date, token: UUID) {
         guard token == inflight else {
-            log("scartato: esito di un refresh gia abbandonato")
+            log("dropped: outcome of an already abandoned refresh")
             return
         }
         inflight = nil
@@ -322,15 +323,15 @@ final class Model: ObservableObject {
         if let f = o.failure {
             attempt += 1
             note = f
-            log("err \(secs)s \(o.source): \(f) [tentativo \(attempt), riprovo fra \(Int(nextDelay / 60))m]")
+            log("err \(secs)s \(o.source): \(f) [attempt \(attempt), retry in \(Int(nextDelay / 60))m]")
             return
         }
-        // Nessun seat leggibile (tipicamente 429 su tutti i profili): l'ultima misura buona
-        // vale piu del vuoto, la si tiene e la si dichiara vecchia.
+        // No readable seat (typically a 429 on every profile): the last good measurement is
+        // worth more than the void, so it is kept and declared stale.
         if o.seats.isEmpty, !seats.isEmpty {
             attempt += 1
             note = o.note ?? "nessun seat leggibile, mostro l'ultima misura buona"
-            log("vuoto \(secs)s \(o.source) hidden=\(o.hidden) [tengo \(age ?? "?"), tentativo \(attempt)]")
+            log("empty \(secs)s \(o.source) hidden=\(o.hidden) [keeping \(age ?? "?"), attempt \(attempt)]")
             return
         }
         attempt = 0

--- a/scripts/claude_seat_quota.py
+++ b/scripts/claude_seat_quota.py
@@ -162,6 +162,9 @@ def access_token(service: str) -> str | None:
     return tok or None
 
 
+RETRYABLE = {429, 500, 502, 503, 529}
+
+
 def api_get(path: str, token: str, attempts: int = 3) -> tuple[int, Any]:
     """GET with backoff on 429.
 
@@ -190,7 +193,7 @@ def api_get(path: str, token: str, attempts: int = 3) -> tuple[int, Any]:
             except json.JSONDecodeError:
                 payload = {"raw": body[:200]}
             last = (exc.code, payload)
-            if exc.code not in (429, 500, 502, 503, 529):
+            if exc.code not in RETRYABLE:
                 return last
         except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
             last = (0, {"error": {"message": str(exc)[:160]}})
@@ -257,7 +260,7 @@ def collect(pace: float = 1.2) -> list[dict]:
             rows.append({"account": None, "stale": True,
                          "error": "no access token in keychain entry"})
             continue
-        _, prof = api_get(PROFILE_PATH, tok)
+        pcode, prof = api_get(PROFILE_PATH, tok)
         email = None
         if isinstance(prof, dict):
             acct = prof.get("account") or {}
@@ -267,8 +270,13 @@ def collect(pace: float = 1.2) -> list[dict]:
             msg = "unreadable"
             if isinstance(usage, dict):
                 msg = (usage.get("error") or {}).get("message", msg)
+            # A 429 outlives api_get's retries and leaves the account unnamed: that is a
+            # REFUSED PROBE, not an old login. Calling it stale is how ten logged-in seats
+            # read as ten dead credentials on 2026-09-11.
+            throttled = RETRYABLE & {code, pcode}
             rows.append({"account": email, "error": msg[:80], "http": code,
-                         "stale": email is None})
+                         "throttled": bool(throttled),
+                         "stale": email is None and not throttled})
             continue
         rows.append({
             "account": email,
@@ -444,7 +452,9 @@ def main() -> int:
         for r in rows:
             seat = r.get("seat") or "?"
             if r.get("error"):
-                label = r.get("account") or "(stale keychain entry)"
+                label = (r.get("account")
+                         or ("(probe refused)" if r.get("throttled")
+                             else "(stale keychain entry)"))
                 print(f"{seat:6s} | {label:30s} | {'-':>4} | {'-':26s} | {'-':>4} | "
                       f"{r['error']}")
                 continue
@@ -453,6 +463,11 @@ def main() -> int:
                   f"{when(r.get('session_resets_at'), now):26s} | "
                   f"{fmt(r.get('weekly_pct')):>4} | "
                   f"{when(r.get('weekly_resets_at'), now)}{flag}")
+        throttled = [r for r in rows if r.get("throttled")]
+        if throttled:
+            print(f"\n{len(throttled)} profile{'' if len(throttled) == 1 else 's'} "
+                  f"rate-limited by the endpoint: credential is LIVE, quota unreadable now. "
+                  f"Not a dead seat — retry later or measure from another egress.")
         if stale:
             print(f"\n{len(stale)} stale keychain entr{'y' if len(stale) == 1 else 'ies'} "
                   f"(old logins, no live credential) — informational, not a seat failure")

--- a/scripts/tests/test_claude_seat_quota.py
+++ b/scripts/tests/test_claude_seat_quota.py
@@ -199,6 +199,31 @@ def test_stale_entry_does_not_flip_the_exit_code(mod, monkeypatch):
         assert mod.main() == 0, "a stale leftover must not be reported as a seat failure"
 
 
+def test_persistent_429_is_throttled_not_a_stale_leftover(mod, monkeypatch):
+    """The 429 that OUTLIVES api_get's retries. The retry test above covers a 429 that
+    clears; this covers the one that does not, which is what a saturated endpoint
+    actually returns. It leaves the account unnamed, and naming it `stale` is what made
+    ten logged-in seats read as ten old logins on 2026-09-11."""
+    monkeypatch.setattr(mod, "keychain_services",
+                        lambda: ["Claude Code-credentials", "Claude Code-credentials-dead"])
+    monkeypatch.setattr(mod, "access_token",
+                        lambda svc: None if svc.endswith("dead") else "tok")
+    monkeypatch.setattr(mod, "warm_profiles", lambda deep: None)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(mod, "api_get", lambda path, token, attempts=3: (
+        429, {"error": {"message": "Rate limited. Please try again later."}}
+    ))
+    rows = mod.collect(pace=0)
+
+    throttled = [r for r in rows if r.get("throttled")]
+    stale = [r for r in rows if r.get("stale")]
+    assert len(throttled) == 1, "the rate-limited entry must be reported as throttled"
+    assert throttled[0].get("stale") is False, \
+        "a live credential behind a 429 is not a stale leftover"
+    assert len(stale) == 1 and stale[0]["error"] == "no access token in keychain entry", \
+        "only the entry with no token at all is a genuine leftover"
+
+
 def test_named_seat_that_cannot_be_read_does_flip_the_exit_code(mod, monkeypatch):
     """Guilt side of the pair above: a seat we CAN name but cannot read is a real
     failure and must be loud."""


### PR DESCRIPTION
Two concerns, one chain: the widget on the desk showed nothing, and the tool behind it said the seats were dead. Neither was true.

## 1 — The widget froze, and did not say so

Measured on Pro: process alive (`ClaudeSeats`, started `01:27:23Z`), no hung child, and **zero log lines in 7h42m** — the last line, `01:25:40Z`, belonged to the previous process. On screen, numbers 8 hours old presented as current.

`refresh()` opened with `guard !loading else { return }`, and `loading` returned to `false` **only** inside `apply()`. A measurement that never returns leaves the latch shut forever: every 30-minute tick re-enters and exits, **and the ↻ button and menu item go mute too**. That is the defect behind "it is no longer refreshable on demand".

| # | Defect | Cure |
|---|---|---|
| 1 | `guard !loading` with no way out | in-flight token + `Budget.stuck` deadline; late outcome dropped; button calls `refresh(force: true)` |
| 2 | `readDataToEndOfFile()` on the calling thread; watchdog SIGTERM-only at 300s | both pipes on their own threads with a deadline; two-stage watchdog (SIGTERM at `Budget.measure`, SIGKILL +15s) |
| 3 | `Timer` does not make up ticks missed while the Mac sleeps | per-minute supervisor + refresh on `NSWorkspace.didWakeNotification` |
| 4 | 0 readable seats (429) wiped the good numbers | keeps them, declares them stale, retries with backoff instead of waiting the full interval |
| 5 | success-only log: silence was indistinguishable from "off" | logs `stuck`, `empty`, `dropped`, and the attempt on the `err` branch |

Staleness is now visible even when collapsed: the dot turns `Palette.ink` and the header reads `fermo da Xh` instead of passing an old timestamp off as fresh.

**Proven live**: after `build.sh`, `09:29:27Z ok 52s local` — the first log line after 8 hours of silence.

## 2 — And then the numbers were still empty, for a different reason

`collect()` closed with `"stale": email is None`. A 429 outlives `api_get`'s retries and leaves the `PROFILE` call unable to name the account, so every rate-limited entry was reported as `(stale keychain entry)` and counted as an "old login, no live credential".

The facts: **ten `~/.claude*` profiles report `loggedIn: true`**, and the tool reported eleven stale leftovers and zero seats. `--pace 9` (90s of spacing) gives the same result as `--pace 1.2`, so the limiter is saturated upstream — pacing is not the cure. `api_get`'s own docstring defends this exact distinction; `collect()` undid it one function later.

Rows now carry `throttled`; `stale` requires a non-retryable answer; the footer separates *"credential is LIVE, quota unreadable now"* from a genuine leftover. Against the live 429 it now prints **10 rate-limited, 1 genuine leftover** (the entry with no access token).

## Verification

- `scripts/tests/test_claude_seat_quota.py`: **12 passed** (11 pre-existing + 1 new).
- `test_persistent_429_is_throttled_not_a_stale_leftover` covers the 429 that does NOT clear; the existing test covered only the one that does. **Proven load-bearing**: restoring `"stale": email is None` turns it red — 1 failed / 11 passed.
- `swiftc -O -target arm64-apple-macos13.0` on `main.swift`: builds.

## Not in this PR

- **No LaunchAgent.** Nothing brings the widget back after a crash, logout or reboot; the `com.nuzantara.seat-usage` plist present on Pro is an unarmed template for a different collector. Writing it was denied in-session as Unauthorized Persistence — owner's call.
- **The last good measurement does not survive an app restart.** Defect 4 keeps it in memory only, so a rebuild while the 429 is active still shows `seats=0`. Persisting it to disk is the follow-up.
- **Who saturates the limiter** is not diagnosed here. No LaunchAgent on Pro calls `claude_seat_quota.py`.
- The first commit's subject line is in Italian, against the repo convention; it is already pushed, so it stands. Its comments and log lines were put back into English in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)