### PR TITLE
fix(prompts): give the citation rule a licit exit (RC3, RULED 2026-09-11)

### DIFF
--- a/apps/backend-rag/backend/prompts/zantara_core.py
+++ b/apps/backend-rag/backend/prompts/zantara_core.py
@@ -311,13 +311,27 @@ CITATION_RULES: str = """\
 <citation_rules>
   - **LEGAL/MONEY:** Use formal markers with exact values from KB, e.g., "The price is [AMOUNT FROM KB] [1]."
   - **CHAT:** Use natural attribution, e.g., "As your founder mentions..."
-  - **MANDATORY LAW CITATION:** At the END of every response about regulations, visas, taxes, or legal matters,
-    you MUST cite the source law. Format: "📜 Sumber: [Nama Peraturan], Pasal [X]" or "📜 Source: [Law Name], Article [X]"
+  - **LAW CITATION — required when a law is the basis, forbidden when it is not.**
+    Cite a source law at the END of a response ONLY when the answer's substance rests on a
+    statute, regulation or official tariff that is present in the KB context you were given.
+    Format: "📜 Sumber: [Nama Peraturan], Pasal [X]" or "📜 Source: [Law Name], Article [X]".
     Examples:
     - "📜 Sumber: PP 48/2021 tentang Keimigrasian, Pasal 123"
     - "📜 Sumber: UU PPh No. 36/2008, Pasal 26"
-    - "📜 Source: Government Regulation 48/2021 on Immigration, Article 123"
-    If the exact pasal is not in the KB, cite the regulation name only: "📜 Sumber: PP 48/2021 tentang Keimigrasian"
+    If the regulation is in the KB but the exact pasal is not, cite the regulation name alone:
+    "📜 Sumber: PP 48/2021 tentang Keimigrasian".
+    **Cite NOTHING — and add no source line at all — when:**
+    (a) the question is operational or commercial rather than legal: our prices, our payment
+        methods and bank details, our timelines, which documents WE need, how to
+        send them, appointment or office logistics, the status of a file;
+    (b) the answer is a courtesy, a greeting, a clarifying question, or a hand-off to a
+        colleague;
+    (c) the KB context you were given contains no regulation that actually governs the answer.
+    In case (c) you may still answer from the context you have — you simply do not attach a
+    citation, and you never name a law you were not given.
+    **A citation is a claim about the source of the answer. Naming a statute that does not govern
+    the question is a fabrication, and it is worse than no citation** — an operational answer with
+    no source line is correct and complete.
 </citation_rules>"""
 
 # ---------------------------------------------------------------------------

--- a/apps/backend-rag/backend/tests/unit/prompts/test_citation_rule_exit.py
+++ b/apps/backend-rag/backend/tests/unit/prompts/test_citation_rule_exit.py
@@ -1,0 +1,139 @@
+"""The citation rule gets an exit (RULED Zero 2026-09-11: ZERO-DECISIONS §Item 3 ratified).
+
+`CITATION_RULES` in `backend/prompts/zantara_core.py` used to say the model MUST cite the
+source law at the end of every regulatory answer, with no licit way to cite nothing.
+Measured on WhatsApp thread 30 (cycle 359, 2026-09-01): a bank-transfer question closed
+with PP 36/2021 (a wages regulation) and a passport-photo refusal cited immigration law.
+The ratified bullet cites a law only when a law is the basis of the answer and names the
+cases where no source line is the correct answer.
+
+Text-level only: no LLM is called. Whether a live model obeys the new bullet is measured
+by the cycle-360 battery, not by this file.
+
+Guilt: the old mandatory bullet is gone from the SSOT and from every built prompt.
+Innocence: every consumer that interpolates CITATION_RULES (the v1-v4 master templates,
+the three v5 audience builds and the WhatsApp codex-leg persona digest) carries the new
+bullet AND the untouched LEGAL/MONEY and CHAT bullets, and the citation format is still
+there for answers that do rest on a law: the cure is a replacement, not a silent removal
+of citations.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from backend.prompts import zantara_core as v1
+from backend.prompts import zantara_core_v2 as v2
+from backend.prompts import zantara_core_v3 as v3
+from backend.prompts import zantara_core_v4 as v4
+from backend.prompts import zantara_core_v5 as v5
+from backend.services.rag.agentic.prompt_builder import _safe_template_fill
+from backend.services.rag.agentic.wa_package_builder import _build_persona_digest
+
+NEW_BULLET_HEAD = (
+    "  - **LAW CITATION — required when a law is the basis, forbidden when it is not.**"
+)
+KEY_SENTENCE = "required when a law is the basis, forbidden when it is not"
+NO_CITATION_CLAUSE = "**Cite NOTHING — and add no source line at all — when:**"
+NO_CITATION_CASES = (
+    "(a) the question is operational or commercial rather than legal: our prices, our payment",
+    "(b) the answer is a courtesy, a greeting, a clarifying question, or a hand-off to a",
+    "(c) the KB context you were given contains no regulation that actually governs the answer.",
+)
+FORMAT_LINE = (
+    'Format: "📜 Sumber: [Nama Peraturan], Pasal [X]" or "📜 Source: [Law Name], Article [X]".'
+)
+LEGAL_MONEY_BULLET = (
+    "  - **LEGAL/MONEY:** Use formal markers with exact values from KB, "
+    'e.g., "The price is [AMOUNT FROM KB] [1]."'
+)
+CHAT_BULLET = '  - **CHAT:** Use natural attribution, e.g., "As your founder mentions..."'
+OLD_LABEL = "MANDATORY LAW CITATION"
+OLD_OBLIGATION = "you MUST cite the source law"
+
+
+def _new_bullet() -> str:
+    """The ratified bullet as it sits in CITATION_RULES, from its head to the closing tag."""
+    rules = v1.CITATION_RULES
+    start = rules.index(NEW_BULLET_HEAD)
+    end = rules.index("</citation_rules>", start)
+    return rules[start:end]
+
+
+def _v5_build(audience: str) -> Callable[[], str]:
+    return lambda: v5.build_master_template(audience)
+
+
+_BUILT_PROMPTS: dict[str, Callable[[], str]] = {
+    "v1_master_template": lambda: v1.ZANTARA_MASTER_TEMPLATE,
+    "v2_master_template": lambda: v2.ZANTARA_MASTER_TEMPLATE,
+    "v3_master_template": lambda: v3.ZANTARA_MASTER_TEMPLATE,
+    "v4_master_template": lambda: v4.ZANTARA_MASTER_TEMPLATE,
+    **{f"v5_build_{audience}": _v5_build(audience) for audience in v5.VALID_AUDIENCES},
+    "wa_codex_persona_digest": _build_persona_digest,
+}
+
+
+class TestGuilt:
+    def test_ssot_no_longer_carries_the_mandatory_bullet(self) -> None:
+        assert OLD_LABEL not in v1.CITATION_RULES
+        assert OLD_OBLIGATION not in v1.CITATION_RULES
+
+    @pytest.mark.parametrize("name", sorted(_BUILT_PROMPTS))
+    def test_no_built_prompt_carries_the_mandatory_bullet(self, name: str) -> None:
+        built = _BUILT_PROMPTS[name]()
+        assert OLD_LABEL not in built
+        assert OLD_OBLIGATION not in built
+
+
+class TestInnocence:
+    def test_ssot_carries_the_ratified_bullet(self) -> None:
+        bullet = _new_bullet()
+        assert KEY_SENTENCE in bullet
+        assert NO_CITATION_CLAUSE in bullet
+        for case in NO_CITATION_CASES:
+            assert case in bullet
+        assert FORMAT_LINE in bullet
+
+    def test_legal_money_and_chat_bullets_are_untouched_and_first(self) -> None:
+        assert v1.CITATION_RULES.splitlines()[:3] == [
+            "<citation_rules>",
+            LEGAL_MONEY_BULLET,
+            CHAT_BULLET,
+        ]
+
+    def test_every_v5_audience_is_covered(self) -> None:
+        assert set(v5.VALID_AUDIENCES) == {"client", "team", "creator"}
+
+    @pytest.mark.parametrize("name", sorted(_BUILT_PROMPTS))
+    def test_every_consumer_carries_the_new_bullet_and_the_untouched_ones(self, name: str) -> None:
+        built = _BUILT_PROMPTS[name]()
+        assert _new_bullet() in built
+        assert LEGAL_MONEY_BULLET in built
+        assert CHAT_BULLET in built
+
+
+class TestTemplateFillSafety:
+    """The prompt goes through `.format()` (v1) and `_safe_template_fill()` (v2-v5)."""
+
+    def test_new_bullet_has_no_braces(self) -> None:
+        bullet = _new_bullet()
+        assert "{" not in bullet
+        assert "}" not in bullet
+
+    def test_citation_rules_survive_str_format_unchanged(self) -> None:
+        assert v1.CITATION_RULES.format() == v1.CITATION_RULES
+
+    def test_safe_template_fill_leaves_the_bullet_intact(self) -> None:
+        filled = _safe_template_fill(
+            v4.ZANTARA_MASTER_TEMPLATE,
+            today_wita="Friday, 11 September 2026",
+            user_memory="",
+            rag_results="",
+            query="posso pagare con bonifico?",
+        )
+        assert _new_bullet() in filled
+        assert LEGAL_MONEY_BULLET in filled
+        assert OLD_LABEL not in filled

--- a/apps/backend-rag/backend/tests/unit/prompts/test_citation_rule_exit.py
+++ b/apps/backend-rag/backend/tests/unit/prompts/test_citation_rule_exit.py
@@ -10,12 +10,17 @@ cases where no source line is the correct answer.
 Text-level only: no LLM is called. Whether a live model obeys the new bullet is measured
 by the cycle-360 battery, not by this file.
 
+`RATIFIED_BULLET` below is an independent copy of the fenced paragraph under "Item 3" in
+docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md, not derived from the constant
+under test: any drift of the bullet's wording, in either place, fails here.
+
 Guilt: the old mandatory bullet is gone from the SSOT and from every built prompt.
-Innocence: every consumer that interpolates CITATION_RULES (the v1-v4 master templates,
-the three v5 audience builds and the WhatsApp codex-leg persona digest) carries the new
-bullet AND the untouched LEGAL/MONEY and CHAT bullets, and the citation format is still
-there for answers that do rest on a law: the cure is a replacement, not a silent removal
-of citations.
+Innocence: every consumer that carries CITATION_RULES (the v1-v4 master templates, the
+versioned door in prompt_manager, the three v5 audience builds, the WhatsApp persona, the
+Zantara persona and the WhatsApp codex-leg persona digest) carries the ratified bullet
+AND the untouched LEGAL/MONEY and CHAT bullets, and the citation format is still there
+for answers that do rest on a law: the cure is a replacement, not a silent removal of
+citations.
 """
 
 from __future__ import annotations
@@ -24,6 +29,8 @@ from collections.abc import Callable
 
 import pytest
 
+from backend.llm import prompt_manager
+from backend.prompts import whatsapp_persona, zantara_persona
 from backend.prompts import zantara_core as v1
 from backend.prompts import zantara_core_v2 as v2
 from backend.prompts import zantara_core_v3 as v3
@@ -32,19 +39,33 @@ from backend.prompts import zantara_core_v5 as v5
 from backend.services.rag.agentic.prompt_builder import _safe_template_fill
 from backend.services.rag.agentic.wa_package_builder import _build_persona_digest
 
+RATIFIED_BULLET = (
+    "  - **LAW CITATION — required when a law is the basis, forbidden when it is not.**\n"
+    "    Cite a source law at the END of a response ONLY when the answer's substance rests on a\n"
+    "    statute, regulation or official tariff that is present in the KB context you were given.\n"
+    '    Format: "📜 Sumber: [Nama Peraturan], Pasal [X]" or "📜 Source: [Law Name], Article [X]".\n'
+    "    Examples:\n"
+    '    - "📜 Sumber: PP 48/2021 tentang Keimigrasian, Pasal 123"\n'
+    '    - "📜 Sumber: UU PPh No. 36/2008, Pasal 26"\n'
+    "    If the regulation is in the KB but the exact pasal is not, cite the regulation name alone:\n"
+    '    "📜 Sumber: PP 48/2021 tentang Keimigrasian".\n'
+    "    **Cite NOTHING — and add no source line at all — when:**\n"
+    "    (a) the question is operational or commercial rather than legal: our prices, our payment\n"
+    "        methods and bank details, our timelines, which documents WE need from a client, how to\n"
+    "        send them, appointment or office logistics, the status of a file;\n"
+    "    (b) the answer is a courtesy, a greeting, a clarifying question, or a hand-off to a\n"
+    "        colleague;\n"
+    "    (c) the KB context you were given contains no regulation that actually governs the answer.\n"
+    "    In case (c) you may still answer from the context you have — you simply do not attach a\n"
+    "    citation, and you never name a law you were not given.\n"
+    "    **A citation is a claim about the source of the answer. Naming a statute that does not govern\n"
+    "    the question is a fabrication, and it is worse than no citation** — an operational answer with\n"
+    "    no source line is correct and complete.\n"
+)
 NEW_BULLET_HEAD = (
     "  - **LAW CITATION — required when a law is the basis, forbidden when it is not.**"
 )
 KEY_SENTENCE = "required when a law is the basis, forbidden when it is not"
-NO_CITATION_CLAUSE = "**Cite NOTHING — and add no source line at all — when:**"
-NO_CITATION_CASES = (
-    "(a) the question is operational or commercial rather than legal: our prices, our payment",
-    "(b) the answer is a courtesy, a greeting, a clarifying question, or a hand-off to a",
-    "(c) the KB context you were given contains no regulation that actually governs the answer.",
-)
-FORMAT_LINE = (
-    'Format: "📜 Sumber: [Nama Peraturan], Pasal [X]" or "📜 Source: [Law Name], Article [X]".'
-)
 LEGAL_MONEY_BULLET = (
     "  - **LEGAL/MONEY:** Use formal markers with exact values from KB, "
     'e.g., "The price is [AMOUNT FROM KB] [1]."'
@@ -54,8 +75,8 @@ OLD_LABEL = "MANDATORY LAW CITATION"
 OLD_OBLIGATION = "you MUST cite the source law"
 
 
-def _new_bullet() -> str:
-    """The ratified bullet as it sits in CITATION_RULES, from its head to the closing tag."""
+def _ssot_bullet() -> str:
+    """The bullet as it sits in CITATION_RULES, from its head to the closing tag."""
     rules = v1.CITATION_RULES
     start = rules.index(NEW_BULLET_HEAD)
     end = rules.index("</citation_rules>", start)
@@ -71,7 +92,10 @@ _BUILT_PROMPTS: dict[str, Callable[[], str]] = {
     "v2_master_template": lambda: v2.ZANTARA_MASTER_TEMPLATE,
     "v3_master_template": lambda: v3.ZANTARA_MASTER_TEMPLATE,
     "v4_master_template": lambda: v4.ZANTARA_MASTER_TEMPLATE,
+    "prompt_manager_versioned_door": lambda: prompt_manager.ZANTARA_MASTER_TEMPLATE,
     **{f"v5_build_{audience}": _v5_build(audience) for audience in v5.VALID_AUDIENCES},
+    "whatsapp_persona_system_prompt": whatsapp_persona.build_system_prompt,
+    "zantara_persona_system_instruction": lambda: zantara_persona.SYSTEM_INSTRUCTION,
     "wa_codex_persona_digest": _build_persona_digest,
 }
 
@@ -89,13 +113,8 @@ class TestGuilt:
 
 
 class TestInnocence:
-    def test_ssot_carries_the_ratified_bullet(self) -> None:
-        bullet = _new_bullet()
-        assert KEY_SENTENCE in bullet
-        assert NO_CITATION_CLAUSE in bullet
-        for case in NO_CITATION_CASES:
-            assert case in bullet
-        assert FORMAT_LINE in bullet
+    def test_ssot_bullet_is_exactly_the_ratified_text(self) -> None:
+        assert _ssot_bullet() == RATIFIED_BULLET
 
     def test_legal_money_and_chat_bullets_are_untouched_and_first(self) -> None:
         assert v1.CITATION_RULES.splitlines()[:3] == [
@@ -108,9 +127,12 @@ class TestInnocence:
         assert set(v5.VALID_AUDIENCES) == {"client", "team", "creator"}
 
     @pytest.mark.parametrize("name", sorted(_BUILT_PROMPTS))
-    def test_every_consumer_carries_the_new_bullet_and_the_untouched_ones(self, name: str) -> None:
+    def test_every_consumer_carries_the_ratified_bullet_and_the_untouched_ones(
+        self, name: str
+    ) -> None:
         built = _BUILT_PROMPTS[name]()
-        assert _new_bullet() in built
+        assert KEY_SENTENCE in built
+        assert RATIFIED_BULLET in built
         assert LEGAL_MONEY_BULLET in built
         assert CHAT_BULLET in built
 
@@ -118,10 +140,9 @@ class TestInnocence:
 class TestTemplateFillSafety:
     """The prompt goes through `.format()` (v1) and `_safe_template_fill()` (v2-v5)."""
 
-    def test_new_bullet_has_no_braces(self) -> None:
-        bullet = _new_bullet()
-        assert "{" not in bullet
-        assert "}" not in bullet
+    def test_ratified_bullet_has_no_braces(self) -> None:
+        assert "{" not in RATIFIED_BULLET
+        assert "}" not in RATIFIED_BULLET
 
     def test_citation_rules_survive_str_format_unchanged(self) -> None:
         assert v1.CITATION_RULES.format() == v1.CITATION_RULES
@@ -134,6 +155,6 @@ class TestTemplateFillSafety:
             rag_results="",
             query="posso pagare con bonifico?",
         )
-        assert _new_bullet() in filled
+        assert RATIFIED_BULLET in filled
         assert LEGAL_MONEY_BULLET in filled
         assert OLD_LABEL not in filled

--- a/apps/backend-rag/backend/tests/unit/prompts/test_citation_rule_exit.py
+++ b/apps/backend-rag/backend/tests/unit/prompts/test_citation_rule_exit.py
@@ -1,4 +1,5 @@
-"""The citation rule gets an exit (RULED Zero 2026-09-11: ZERO-DECISIONS §Item 3 ratified).
+"""The citation rule gets an exit (RULED Zero 2026-09-11: ZERO-DECISIONS §Item 3 ratified,
+amended per README §0 ruling 4 to drop " from a client" from case (a)).
 
 `CITATION_RULES` in `backend/prompts/zantara_core.py` used to say the model MUST cite the
 source law at the end of every regulatory answer, with no licit way to cite nothing.
@@ -11,8 +12,12 @@ Text-level only: no LLM is called. Whether a live model obeys the new bullet is 
 by the cycle-360 battery, not by this file.
 
 `RATIFIED_BULLET` below is an independent copy of the fenced paragraph under "Item 3" in
-docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md, not derived from the constant
+docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md, AS AMENDED (README §0 ruling 4 drops
+" from a client" from case (a) for v5 client-audience purity), not derived from the constant
 under test: any drift of the bullet's wording, in either place, fails here.
+`TestFenceParity` below re-derives the fence from the doc file at runtime and asserts it
+matches this constant byte-for-byte, so the two copies can never silently drift again; it
+skips if the doc file is not present in the checkout (e.g. a sparse CI clone).
 
 Guilt: the old mandatory bullet is gone from the SSOT and from every built prompt.
 Innocence: every consumer that carries CITATION_RULES (the v1-v4 master templates, the
@@ -25,7 +30,9 @@ citations.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
@@ -51,7 +58,7 @@ RATIFIED_BULLET = (
     '    "📜 Sumber: PP 48/2021 tentang Keimigrasian".\n'
     "    **Cite NOTHING — and add no source line at all — when:**\n"
     "    (a) the question is operational or commercial rather than legal: our prices, our payment\n"
-    "        methods and bank details, our timelines, which documents WE need from a client, how to\n"
+    "        methods and bank details, our timelines, which documents WE need, how to\n"
     "        send them, appointment or office logistics, the status of a file;\n"
     "    (b) the answer is a courtesy, a greeting, a clarifying question, or a hand-off to a\n"
     "        colleague;\n"
@@ -73,6 +80,28 @@ LEGAL_MONEY_BULLET = (
 CHAT_BULLET = '  - **CHAT:** Use natural attribution, e.g., "As your founder mentions..."'
 OLD_LABEL = "MANDATORY LAW CITATION"
 OLD_OBLIGATION = "you MUST cite the source law"
+
+# Repo root: .../apps/backend-rag/backend/tests/unit/prompts/<this file> -> 6 parents up.
+ZERO_DECISIONS_PATH = (
+    Path(__file__).resolve().parents[6]
+    / "docs"
+    / "plans"
+    / "2026-09-03-relaunch-lanes"
+    / "ZERO-DECISIONS.md"
+)
+_FENCE_PATTERN = re.compile(r"```\n(  - \*\*LAW CITATION.*?)\n```", re.DOTALL)
+
+
+def _fence_from_zero_decisions() -> str | None:
+    """The ratified paragraph as it sits in the ZERO-DECISIONS.md fence, or None if the
+    doc is not present in this checkout (e.g. a sparse CI clone that ships apps/ only)."""
+    if not ZERO_DECISIONS_PATH.is_file():
+        return None
+    text = ZERO_DECISIONS_PATH.read_text(encoding="utf-8")
+    match = _FENCE_PATTERN.search(text)
+    if match is None:
+        return None
+    return match.group(1) + "\n"
 
 
 def _ssot_bullet() -> str:
@@ -158,3 +187,16 @@ class TestTemplateFillSafety:
         assert RATIFIED_BULLET in filled
         assert LEGAL_MONEY_BULLET in filled
         assert OLD_LABEL not in filled
+
+
+class TestFenceParity:
+    """`RATIFIED_BULLET` is a hand-typed copy of ZERO-DECISIONS.md's fence; this class
+    re-derives the fence at test time so the two can never silently drift again."""
+
+    def test_ratified_bullet_matches_zero_decisions_fence(self) -> None:
+        fence = _fence_from_zero_decisions()
+        if fence is None:
+            pytest.skip(
+                f"{ZERO_DECISIONS_PATH} not present in this checkout (sparse clone?)"
+            )
+        assert RATIFIED_BULLET == fence

--- a/docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md
+++ b/docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md
@@ -118,7 +118,7 @@ bullets above it are unchanged):
     "📜 Sumber: PP 48/2021 tentang Keimigrasian".
     **Cite NOTHING — and add no source line at all — when:**
     (a) the question is operational or commercial rather than legal: our prices, our payment
-        methods and bank details, our timelines, which documents WE need from a client, how to
+        methods and bank details, our timelines, which documents WE need, how to
         send them, appointment or office logistics, the status of a file;
     (b) the answer is a courtesy, a greeting, a clarifying question, or a hand-off to a
         colleague;
@@ -129,6 +129,8 @@ bullets above it are unchanged):
     the question is a fabrication, and it is worse than no citation** — an operational answer with
     no source line is correct and complete.
 ```
+
+Amended 2026-09-11 per research/operations/2026-09-11-bot-staff-room/README.md §0 ruling 4: " from a client" dropped from case (a) for v5 client-audience purity (test_zantara_core_v5.py::TestClientAudiencePurity).
 
 **What changes, in one line:** `MUST cite` becomes `cite when a law is the basis, and never
 otherwise`; the "cite the regulation name only" fallback narrows to regulations actually present in

--- a/evidence/2026-09/agent-nuzantara-backend-rag-rc3-citation-rule-ex-4b393e9e/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-rc3-citation-rule-ex-4b393e9e/brief.yml
@@ -10,7 +10,7 @@ gear: 2
 # imperator: Gear-2 machinery, not a Gear-3 council.
 l_level: L2
 gate_class: opus
-base_sha: 19d47e938674b856039e53c541a03660673b3ef0 # pragma: allowlist secret - verified public Git commit
+base_sha: 42d41f86e2be91306e263d5c2f7a182b50042451 # pragma: allowlist secret - verified public Git commit
 objective: >-
   Replace the `MANDATORY LAW CITATION` bullet of `CITATION_RULES` in
   apps/backend-rag/backend/prompts/zantara_core.py with the paragraph Zero

--- a/evidence/2026-09/agent-nuzantara-backend-rag-rc3-citation-rule-ex-4b393e9e/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-rc3-citation-rule-ex-4b393e9e/brief.yml
@@ -1,0 +1,67 @@
+task_id: bot-rc3-citation-rule-exit
+gear: 2
+# Floor computed this run: `python3 scripts/evidence_pack_lint.py --print-floor
+# --changed-files-file ...` returns 1. Path term: no HOTZONE_PATTERNS hit
+# (backend/prompts/ is not a hot zone). Size term: the diff is far under
+# SIZE_GEAR2_THRESHOLD (400 churn). Declared ABOVE the floor on purpose: the
+# change edits the live WhatsApp bot's prompt SSOT, one of the off-limits
+# files (docs/rules/RULINGS.md), under an owner ruling. It gets a cross-family
+# adversarial spalla and a fresh Opus 5 on-disk gate commissioned by the
+# imperator: Gear-2 machinery, not a Gear-3 council.
+l_level: L2
+gate_class: opus
+base_sha: 19d47e938674b856039e53c541a03660673b3ef0 # pragma: allowlist secret - verified public Git commit
+objective: >-
+  Replace the `MANDATORY LAW CITATION` bullet of `CITATION_RULES` in
+  apps/backend-rag/backend/prompts/zantara_core.py with the paragraph Zero
+  ratified on 2026-09-11 (RULED Zero 2026-09-11: ZERO-DECISIONS §Item 3
+  ratified), byte-exact, so the bot cites a law only when a law is the basis
+  of the answer and has a licit way to cite nothing. Measured before (cycle
+  359, WhatsApp thread 30, 2026-09-01): a bank-transfer question closed with
+  PP 36/2021 (a wages regulation) and a passport-photo refusal cited
+  immigration law. Both are the old rule working as written.
+grader: >-
+  Fresh Opus 5 on-disk gate commissioned by the imperator on the head sha; no
+  verdict asserted here.
+constraints:
+  - "Only the MANDATORY LAW CITATION bullet moves; the LEGAL/MONEY and CHAT bullets stay byte-identical and nothing else in zantara_core.py changes."
+  - "The ratified wording is applied verbatim: extracted programmatically from the ZERO-DECISIONS §Item 3 fence, never retyped."
+  - "The new paragraph carries no curly braces: the templates go through str.format() (v1) and _safe_template_fill() (v2-v5)."
+acceptance:
+  - text: >-
+      WHEN any prompt version is built (v1-v4 master templates, the three v5
+      audience builds) or the WhatsApp codex-leg persona digest is assembled,
+      THEN it SHALL NOT contain "MANDATORY LAW CITATION" or "you MUST cite the
+      source law".
+    probe: PYTHONPATH=. pytest backend/tests/unit/prompts/test_citation_rule_exit.py
+  - text: >-
+      WHEN the same prompts are built, THEN each SHALL contain the ratified
+      bullet verbatim, the untouched LEGAL/MONEY and CHAT bullets, and the 📜
+      citation format for answers that do rest on a law.
+    probe: PYTHONPATH=. pytest backend/tests/unit/prompts/test_citation_rule_exit.py
+  - text: >-
+      WHEN CITATION_RULES goes through str.format() or _safe_template_fill(),
+      THEN the new bullet SHALL survive unchanged.
+    probe: PYTHONPATH=. pytest backend/tests/unit/prompts/test_citation_rule_exit.py
+  - text: >-
+      WHEN the live model answers the two cycle-359 questions, THEN no 📜 line
+      SHALL appear; WHEN it answers a substantive immigration or tax question,
+      THEN a 📜 line SHALL still appear. NOT PROVEN by this PR: it needs a live
+      model and belongs to the cycle-360 battery.
+    probe: cycle-360 battery on real WhatsApp delivery (not run here)
+consumer_map:
+  - "`backend/prompts/zantara_core.py::ZANTARA_MASTER_TEMPLATE` (v1)"
+  - "`backend/prompts/zantara_core_v2.py`, `zantara_core_v3.py`, `zantara_core_v4.py` master templates"
+  - "`backend/prompts/zantara_core_v5.py::CORE_FACTUAL` via `build_master_template` (client, team, creator)"
+  - "`backend/services/rag/agentic/wa_package_builder.py::_PERSONA_SECTIONS` via `_build_persona_digest` (the live WhatsApp codex leg)"
+risks:
+  - >-
+    The model may over-apply case (c) and drop citations on substantive
+    answers. The innocence half of the cycle-360 battery measures it.
+  - >-
+    A stale redacted copy of the old wording lives in
+    data/kb_sources/zantara_core_redacted.md (last touched 2026-03-28, no
+    runtime loader found by grep). Left out of this concern.
+pii: >-
+  none. The diff carries prompt text, test code and doc status lines only; the
+  cycle-359 questions are quoted generically with no client identifier.


### PR DESCRIPTION
## What

RULED by Zero 2026-09-11 (`research/operations/2026-09-11-bot-staff-room/README.md` §0 ruling 4, ratifying `docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md` §Item 3 with one amendment): the `MANDATORY LAW CITATION` bullet of `CITATION_RULES` is replaced by the ratified paragraph. The bot cites a law only when a statute, regulation or official tariff present in its KB context is the basis of the answer, and it has three named, licit ways to cite nothing: operational/commercial questions, courtesies/clarifications/hand-offs, and a context that holds no governing regulation.

- `apps/backend-rag/backend/prompts/zantara_core.py` — **Zero's own commit** `02a3725d64` (protected path). `.husky/pre-commit` Gate 1 blocks ANY staged `zantara_core.py`, with no agent condition, so the owner commit carries `--no-verify`, the hook's own documented path (accepted by the staff room, RC-ack 2026-09-11). Only the citation bullet moves; the LEGAL/MONEY and CHAT bullets are byte-identical and nothing else in the file changes.
- `apps/backend-rag/backend/tests/unit/prompts/test_citation_rule_exit.py` (new): guilt — the old bullet is absent from the SSOT and from every built prompt; innocence — the ratified bullet verbatim, plus the untouched LEGAL/MONEY and CHAT bullets, in every consumer (v1–v4 master templates, the `prompt_manager` versioned door, the three v5 audience builds, the WhatsApp persona, the Zantara persona, the WhatsApp codex-leg persona digest); template-fill safety (`str.format()` and `_safe_template_fill()`); fence parity — the test's copy of the bullet is re-derived from the ZERO-DECISIONS.md fence at runtime and must match byte for byte.
- `docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md`: the amendment (" from a client" dropped from case (a), for v5 client-audience purity) applied to the fence and recorded under it.
- `evidence/2026-09/agent-nuzantara-backend-rag-rc3-citation-rule-ex-4b393e9e/brief.yml`: base rebased onto `42d41f86e2` (the branch was rebased before Zero's commit; `zantara_core.py`'s blob was `c626ee6ceb` on both bases, so the patch applied byte-exact).

## Why

Cycle 359, WhatsApp thread 30 (2026-09-01): a bank-transfer question closed with PP 36/2021 (a wages regulation), and a passport-photo refusal was grounded on immigration law. Neither is a retrieval failure — the old rule forbade silence and said "cite the regulation name only" when the article was missing, so the model named the nearest-sounding statute.

## Verification (this branch's bytes, 2026-09-11, `apps/backend-rag/.venv` Python 3.11.11)

Two `git archive` throwaway copies of `861eeac77e` (the three test commits on `42d41f86e2`), one with the core patch applied — the patched blob is `3c4b934378`, the blob of Zero's commit:

| Run | Unpatched core | Patched core |
|---|---|---|
| `test_citation_rule_exit.py` | **25 failed / 5 passed** | **30 passed**, no skip |
| `test_zantara_core_v5.py::TestClientAudiencePurity` | 8 passed | 8 passed |
| `test_evidence_cross_language.py` | 122 passed, 2 xfailed | 122 passed, 2 xfailed |
| `test_evidence_scoring_abstain.py` | 26 passed | 26 passed |
| `test_wa_package_builder.py` | 29 passed | 29 passed |
| `test_wa_greeting.py` | 64 passed | 64 passed |
| `test_curated_qa_government_fee_gate.py` | 21 passed | 21 passed |
| `test_wa_finalize.py` | 79 passed | 79 passed |

On the committed tree: `grep -c "MANDATORY LAW CITATION"` = 0 and `grep -c "required when a law is the basis, forbidden when it is not"` = 1. A bare `grep -c MANDATORY` reads 1 **by design** — the pricing rule "**MANDATORY**: Call get_pricing FIRST" stays.

**Not proven here:** live model behaviour (no 📜 line on the two cycle-359 questions, a 📜 line still on a substantive immigration or tax answer). That needs a live model and belongs to the cycle-360 battery (B3).

**Residual, out of this concern:** a stale redacted copy of the old wording in `data/kb_sources/zantara_core_redacted.md` (last touched 2026-03-28; no runtime loader found by grep).

Zantara-Core-Edit: replace the MANDATORY LAW CITATION bullet with the paragraph Zero ratified on 2026-09-11 (ZERO-DECISIONS §Item 3, bot staff-room README §0 ruling 4), applied by Zero's own commit 02a3725d64.

## Bites

Bites: consumer = `wa_package_builder._build_persona_digest` (the live WhatsApp codex-leg persona; `_PERSONA_SECTIONS` imports `CITATION_RULES`) and every master template that interpolates `CITATION_RULES`. Observation, after the merge (merge on `apps/backend-rag/**` is the deploy) and after the deployed image has moved: in the running `rag` container, `fly ssh console -a nuzantara-rag --machine 1781e5eda03438 -C "grep -c MANDATORY.LAW.CITATION /app/backend/prompts/zantara_core.py"` reads **0** and `-C "grep -c forbidden.when.it.is.not /app/backend/prompts/zantara_core.py"` reads **1** — quoted here once observed.

**Observed (C1), 2026-09-11 after merge `1f63b867d3` and "Deploy Backend to Fly.io" run 34603176046 (`Fly.io rolling deploy` = success), by the RC-CLOSE Dux in the running `rag` container, machine `1781e5eda03438`:**

```text
$ fly ssh console -a nuzantara-rag --machine 1781e5eda03438 -C "grep -c MANDATORY.LAW.CITATION /app/backend/prompts/zantara_core.py"
0
$ fly ssh console -a nuzantara-rag --machine 1781e5eda03438 -C "grep -c required.when.a.law.is.the.basis,.forbidden.when.it.is.not /app/backend/prompts/zantara_core.py"
1
```

(The first command exits 1 because `grep -c` exits non-zero on zero matches; the count is the observation.) The imperator's independent read at 13:23Z on release v4421 gave the same 0 / 1.

## Gate

Gear 2, L2. Fresh Opus 5 on-disk gate outside the contribution chain, commissioned by the staff room (Fable imperator, M5) on the head sha; `harness/fable-gate` is posted by the gate session, never by this lane.

Lane: `dux-rc3` under the Fable window of the 2026-09-11 `/bot` staff room (RC-CLOSE mandate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
