### PR TITLE
feat(crm): open an inquiry without a service; service required before waiting_documents

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_practices.py
+++ b/apps/backend-rag/backend/app/routers/crm_practices.py
@@ -26,8 +26,11 @@ from backend.app.utils.logging_utils import get_logger, log_database_operation, 
 from backend.core.cache import cached, invalidate_cache
 from backend.services.common.background import spawn
 from backend.services.crm.practice_state_machine import (
+    OPEN_INQUIRY_TYPE_CODE,
+    STATES_WITHOUT_SERVICE,
     InvalidTransitionError,
     normalize_state,
+    validate_service_selected,
     validate_transition,
 )
 from backend.services.invoicing import InvoiceAutomationService
@@ -298,7 +301,10 @@ PAYMENT_STATUS_VALUES = {"unpaid", "partial", "paid"}
 
 class PracticeCreate(BaseModel):
     client_id: int
-    practice_type_code: str  # Practice type code retrieved from database
+    # Optional since 2026-09-11 (Ari): an inquiry may be opened without a
+    # service; it is stored against the `open_inquiry` placeholder type and
+    # the real service must be picked before leaving the inquiry stage.
+    practice_type_code: str | None = None
     status: str = "inquiry"
     priority: str = "normal"  # 'low', 'normal', 'high', 'urgent'
     quoted_price: Decimal | None = None
@@ -357,6 +363,9 @@ class PracticeCreate(BaseModel):
 
 class PracticeUpdate(BaseModel):
     status: str | None = None
+    # Pick (or change) the service after creation — resolved to
+    # practice_type_id in update_practice. Required before leaving inquiry.
+    practice_type_code: str | None = None
     priority: str | None = None
     quoted_price: Decimal | None = None
     discount_amount: Decimal | None = None
@@ -455,18 +464,31 @@ async def create_practice(
     # Extract created_by from current user
     created_by = current_user.get("email", "").lower()
 
+    # No service picked → open inquiry against the placeholder type. Only an
+    # inquiry-stage practice may start without a service.
+    practice_type_code = practice.practice_type_code or OPEN_INQUIRY_TYPE_CODE
+    if (
+        practice_type_code == OPEN_INQUIRY_TYPE_CODE
+        and practice.status not in STATES_WITHOUT_SERVICE
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=f"practice_type_code is required to create a practice in status '{practice.status}'",
+        )
+    practice.practice_type_code = practice_type_code
+
     try:
         async with db_pool.acquire() as conn:
             # Get practice_type_id from code
             practice_type_row = await conn.fetchrow(
                 "SELECT id, base_price, category, name FROM practice_types WHERE code = $1",
-                practice.practice_type_code,
+                practice_type_code,
             )
 
             if not practice_type_row:
                 raise HTTPException(
                     status_code=404,
-                    detail=f"Practice type '{practice.practice_type_code}' not found",
+                    detail=f"Practice type '{practice_type_code}' not found",
                 )
 
             # If family_member_id is set, verify it belongs to the same client.
@@ -1012,8 +1034,10 @@ async def get_practice_types_catalog(
                        typical_duration_days
                 FROM practice_types
                 WHERE is_active = true
+                  AND code <> $1
                 ORDER BY category, name
-                """
+                """,
+                OPEN_INQUIRY_TYPE_CODE,
             )
 
             categories: dict[str, list[dict[str, Any]]] = {}
@@ -1151,15 +1175,18 @@ async def update_practice(
             old_discount_amount: Decimal | None = None
             old_metadata: dict | None = None
             old_quoted_price: Decimal | None = None
+            old_practice_type_code: str | None = None
             try:
                 old_row = await conn.fetchrow(
                     """
                     SELECT p.status, p.client_id, p.client_visible, p.created_by,
                            p.assigned_to, p.start_date, p.completion_date,
                            p.discount_amount, p.metadata, p.quoted_price,
-                           c.assigned_to AS client_lead
+                           c.assigned_to AS client_lead,
+                           pt.code AS practice_type_code
                     FROM practices p
                     LEFT JOIN clients c ON p.client_id = c.id
+                    LEFT JOIN practice_types pt ON pt.id = p.practice_type_id
                     WHERE p.id = $1
                     """,
                     practice_id,
@@ -1187,6 +1214,7 @@ async def update_practice(
                     else:
                         old_metadata = raw_meta or {}
                     old_quoted_price = old_row.get("quoted_price")
+                    old_practice_type_code = old_row.get("practice_type_code")
             except Exception as e:
                 # Backward compatibility: client_visible column may not exist yet.
                 if getattr(e, "sqlstate", None) == "42703":
@@ -1239,6 +1267,13 @@ async def update_practice(
                 normalized_old = normalize_state(old_status)
                 try:
                     validate_transition(normalized_old, updates.status, current_user)
+                    # An open inquiry (placeholder service) may not advance
+                    # until a real service is chosen — in this same PATCH or
+                    # an earlier one.
+                    validate_service_selected(
+                        updates.status,
+                        updates.practice_type_code or old_practice_type_code,
+                    )
                 except InvalidTransitionError as e:
                     raise HTTPException(
                         status_code=400,
@@ -1249,6 +1284,26 @@ async def update_practice(
             update_fields: list[str] = []
             params: list[Any] = []
             param_index = 1
+
+            # practice_type_code → practice_type_id (the column the row stores).
+            # Resolved up-front so an unknown/inactive code fails before any SQL.
+            update_set = updates.dict(exclude_unset=True)
+            new_practice_type_code = update_set.pop("practice_type_code", None)
+            if "practice_type_code" in updates.model_fields_set and not new_practice_type_code:
+                raise HTTPException(status_code=400, detail="practice_type_code cannot be null")
+            if new_practice_type_code:
+                new_type_row = await conn.fetchrow(
+                    "SELECT id FROM practice_types WHERE code = $1 AND is_active = true",
+                    new_practice_type_code,
+                )
+                if not new_type_row:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Practice type '{new_practice_type_code}' not found",
+                    )
+                update_fields.append(f"practice_type_id = ${param_index}")
+                params.append(new_type_row["id"])
+                param_index += 1
 
             # Map of allowed fields to database columns
             field_mapping = {
@@ -1272,7 +1327,6 @@ async def update_practice(
                 "missing_documents": "missing_documents",
             }
 
-            update_set = updates.dict(exclude_unset=True)
             for field, value in update_set.items():
                 if field not in field_mapping:
                     raise HTTPException(status_code=400, detail=f"Invalid field name: {field}")

--- a/apps/backend-rag/backend/db/migrations_v2/311_practice_types_open_inquiry.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/311_practice_types_open_inquiry.sql
@@ -1,0 +1,48 @@
+-- Migration 311: `open_inquiry` placeholder practice type
+--
+-- Purpose (Ari's proposal, 2026-09-11): at kita.balizero.com/process/new the
+-- team no longer has to pick a service category to open an INQUIRY. The
+-- practice is created against this placeholder type and the real service is
+-- chosen later, before the practice moves to `waiting_documents`
+-- (gate enforced in crm_practices.update_practice).
+--
+-- Why a placeholder row instead of practice_type_id = NULL: ~40 read paths
+-- (kanban, portal, analytics, shared memory) INNER JOIN practice_types, so a
+-- NULL type would silently hide the inquiry everywhere. A real row keeps
+-- every JOIN intact.
+--
+-- category = 'inquiry' is deliberately NOT in CATEGORY_ORDER, and the
+-- catalog endpoint also filters the code explicitly, so the placeholder never
+-- appears in the service dropdown.
+--
+-- Idempotent: ON CONFLICT(code) DO UPDATE, same pattern as migrations 148/220.
+
+INSERT INTO practice_types (
+    code, name, description, category, base_price,
+    typical_duration_days, is_active
+)
+VALUES
+    (
+        'open_inquiry',
+        'Open Inquiry (service to be defined)',
+        'Placeholder while the inquiry is open. Pick the real service before moving to Waiting Documents.',
+        'inquiry',
+        NULL,
+        NULL,
+        true
+    )
+ON CONFLICT (code) DO UPDATE SET
+    name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    category = EXCLUDED.category,
+    base_price = EXCLUDED.base_price,
+    typical_duration_days = EXCLUDED.typical_duration_days,
+    is_active = true,
+    updated_at = CURRENT_TIMESTAMP;
+
+-- === ROLLBACK ===
+-- Soft-disable only: practices may already reference the row via
+-- practice_type_id. Hidden from the catalog, referential integrity preserved.
+UPDATE practice_types
+SET is_active = false
+WHERE code = 'open_inquiry';

--- a/apps/backend-rag/backend/services/crm/practice_state_machine.py
+++ b/apps/backend-rag/backend/services/crm/practice_state_machine.py
@@ -34,6 +34,14 @@ ADMIN_ONLY_TRANSITIONS: set[tuple[str, str]] = {
 # All valid states
 ALL_STATES = frozenset(VALID_TRANSITIONS.keys())
 
+# Placeholder practice type used when an inquiry is opened WITHOUT a service
+# (migration 311). The real service must be chosen before the practice leaves
+# the inquiry stage — see `validate_service_selected`.
+OPEN_INQUIRY_TYPE_CODE = "open_inquiry"
+
+# States a practice may sit in while its service is still undefined.
+STATES_WITHOUT_SERVICE: frozenset[str] = frozenset({"inquiry", "cancelled"})
+
 
 class InvalidTransitionError(Exception):
     """Raised when a practice status transition is not allowed."""
@@ -100,6 +108,27 @@ def validate_transition(
 
     logger.debug("State transition validated: %s → %s", from_state, to_state)
     return True
+
+
+def validate_service_selected(to_state: str, practice_type_code: str | None) -> bool:
+    """
+    Gate: a practice cannot move past the inquiry stage while its service is
+    still the `open_inquiry` placeholder.
+
+    Raises:
+        InvalidTransitionError: target state needs a service and none is chosen
+    """
+    if to_state in STATES_WITHOUT_SERVICE:
+        return True
+    # Only the explicit placeholder is blocked: legacy rows with a NULL /
+    # unknown type keep advancing exactly as before this gate existed.
+    if practice_type_code != OPEN_INQUIRY_TYPE_CODE:
+        return True
+    raise InvalidTransitionError(
+        "inquiry",
+        to_state,
+        f"select a service before moving to '{to_state}'",
+    )
 
 
 # Legacy state mapping for migration

--- a/apps/backend-rag/backend/tests/services/crm/test_practice_state_machine.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_practice_state_machine.py
@@ -11,9 +11,12 @@ from backend.services.crm.practice_state_machine import (
     ADMIN_ONLY_TRANSITIONS,
     ALL_STATES,
     LEGACY_STATE_MAP,
+    OPEN_INQUIRY_TYPE_CODE,
+    STATES_WITHOUT_SERVICE,
     VALID_TRANSITIONS,
     InvalidTransitionError,
     normalize_state,
+    validate_service_selected,
     validate_transition,
 )
 
@@ -195,3 +198,31 @@ class TestStructuralIntegrity:
 
     def test_exactly_six_states(self) -> None:
         assert len(ALL_STATES) == 6  # 5 workflow + cancelled
+
+
+# ─── Service-selection gate (open inquiry, migration 311) ───────────────────
+
+
+class TestValidateServiceSelected:
+    """An open inquiry (placeholder service) may not leave the inquiry stage."""
+
+    @pytest.mark.parametrize("to_state", sorted(ALL_STATES - STATES_WITHOUT_SERVICE))
+    def test_placeholder_blocks_every_state_past_inquiry(self, to_state: str) -> None:
+        with pytest.raises(InvalidTransitionError, match="select a service"):
+            validate_service_selected(to_state, OPEN_INQUIRY_TYPE_CODE)
+
+    @pytest.mark.parametrize("to_state", sorted(STATES_WITHOUT_SERVICE))
+    def test_placeholder_allowed_in_inquiry_and_cancelled(self, to_state: str) -> None:
+        assert validate_service_selected(to_state, OPEN_INQUIRY_TYPE_CODE) is True
+
+    def test_real_service_passes(self) -> None:
+        assert validate_service_selected("waiting_documents", "kitas_working_onshore") is True
+
+    def test_unknown_or_null_type_is_not_blocked(self) -> None:
+        # Legacy rows with practice_type_id NULL keep advancing as before.
+        assert validate_service_selected("waiting_documents", None) is True
+        assert validate_service_selected("on_process", "") is True
+
+    def test_states_without_service_is_inquiry_and_cancelled(self) -> None:
+        assert STATES_WITHOUT_SERVICE == frozenset({"inquiry", "cancelled"})
+        assert OPEN_INQUIRY_TYPE_CODE == "open_inquiry"

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_practices.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_practices.py
@@ -34,6 +34,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -229,12 +230,27 @@ class TestPracticeCreate:
             PracticeCreate(client_id=1, practice_type_code="x", quoted_price=Decimal("-100"))
 
 
+    def test_practice_type_code_is_optional_for_open_inquiry(self) -> None:
+        from backend.app.routers.crm_practices import PracticeCreate
+
+        p = PracticeCreate(client_id=1)
+        assert p.practice_type_code is None
+        assert p.status == "inquiry"
+
+
 class TestPracticeUpdate:
     def test_valid_update(self) -> None:
         from backend.app.routers.crm_practices import PracticeUpdate
 
         u = PracticeUpdate(status="completed")
         assert u.status == "completed"
+
+    def test_practice_type_code_accepted(self) -> None:
+        from backend.app.routers.crm_practices import PracticeUpdate
+
+        u = PracticeUpdate(practice_type_code="kitas_working_onshore")
+        assert u.practice_type_code == "kitas_working_onshore"
+        assert "practice_type_code" in u.model_fields_set
 
     def test_invalid_status(self) -> None:
         from backend.app.routers.crm_practices import PracticeUpdate
@@ -744,6 +760,186 @@ class TestGetPractice:
         assert "client_email" not in result
         assert "client_phone" not in result
         assert "client_lead" not in result
+
+
+# ---------------------------------------------------------------------------
+# Open inquiry: create without a service, gate on leaving inquiry
+# ---------------------------------------------------------------------------
+
+
+class TestOpenInquiry:
+    @pytest.mark.asyncio
+    async def test_create_without_service_uses_placeholder_type(
+        self, mock_db_pool: MagicMock, mock_db_conn: AsyncMock, admin_user: dict
+    ) -> None:
+        """No practice_type_code → the row is created against `open_inquiry`."""
+        from backend.app.routers.crm_practices import PracticeCreate, create_practice
+        from backend.services.crm.practice_state_machine import OPEN_INQUIRY_TYPE_CODE
+
+        practice = PracticeCreate(client_id=42)
+        with pytest.raises(HTTPException) as exc_info:
+            # First fetchrow = practice type lookup. Returning None makes the
+            # handler 404 right after the lookup, which is enough to observe
+            # WHICH code it resolved without simulating the full insert.
+            mock_db_conn.fetchrow = AsyncMock(return_value=None)
+            await create_practice(
+                request=MagicMock(),
+                practice=practice,
+                background_tasks=MagicMock(),
+                db_pool=mock_db_pool,
+                current_user=admin_user,
+            )
+        assert exc_info.value.status_code == 404
+        lookup_args = mock_db_conn.fetchrow.call_args_list[0].args
+        assert lookup_args[1] == OPEN_INQUIRY_TYPE_CODE
+        assert OPEN_INQUIRY_TYPE_CODE in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_create_without_service_refused_past_inquiry(
+        self, mock_db_pool: MagicMock, mock_db_conn: AsyncMock, admin_user: dict
+    ) -> None:
+        from backend.app.routers.crm_practices import PracticeCreate, create_practice
+
+        practice = PracticeCreate(client_id=42, status="waiting_documents")
+        with pytest.raises(HTTPException) as exc_info:
+            await create_practice(
+                request=MagicMock(),
+                practice=practice,
+                background_tasks=MagicMock(),
+                db_pool=mock_db_pool,
+                current_user=admin_user,
+            )
+        assert exc_info.value.status_code == 400
+        assert "practice_type_code is required" in exc_info.value.detail
+        mock_db_conn.fetchrow.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_to_waiting_documents_blocked_on_placeholder(
+        self, mock_db_pool: MagicMock, mock_db_conn: AsyncMock, admin_user: dict
+    ) -> None:
+        from backend.app.routers.crm_practices import PracticeUpdate, update_practice
+
+        old_row = {
+            "status": "inquiry",
+            "client_id": 42,
+            "client_visible": True,
+            "created_by": "admin@balizero.com",
+            "assigned_to": "team@balizero.com",
+            "practice_type_code": "open_inquiry",
+        }
+        mock_db_conn.fetchrow = AsyncMock(return_value=old_row)
+        mock_db_conn.execute = AsyncMock(return_value=None)
+
+        with (
+            patch("backend.app.routers.crm_practices.is_crm_admin", return_value=True),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await update_practice(
+                request=MagicMock(),
+                practice_id=1,
+                updates=PracticeUpdate(status="waiting_documents"),
+                db_pool=mock_db_pool,
+                current_user=admin_user,
+            )
+        assert exc_info.value.status_code == 400
+        assert "select a service" in exc_info.value.detail
+        mock_db_conn.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_sets_service_and_advances_in_one_patch(
+        self, mock_db_pool: MagicMock, mock_db_conn: AsyncMock, admin_user: dict
+    ) -> None:
+        """practice_type_code in the same PATCH satisfies the gate and is
+        written as practice_type_id (never as a raw column)."""
+        from backend.app.routers.crm_practices import PracticeUpdate, update_practice
+
+        old_row = {
+            "status": "inquiry",
+            "client_id": 42,
+            "client_visible": True,
+            "created_by": "admin@balizero.com",
+            "assigned_to": "team@balizero.com",
+            "practice_type_code": "open_inquiry",
+        }
+        type_row = {"id": 24}
+        canonical_row = {
+            "id": 1,
+            "status": "waiting_documents",
+            "client_visible": True,
+            "practice_type_id": 24,
+            "client_id": 42,
+            "practice_type_code": "kitas_working_onshore",
+            "practice_type_name": "Working KITAS (Altus/Onshore)",
+            "completion_date": None,
+        }
+        mock_db_conn.fetchrow = AsyncMock(side_effect=[old_row, type_row, canonical_row])
+        mock_db_conn.execute = AsyncMock(return_value=None)
+
+        with (
+            patch("backend.app.routers.crm_practices.is_crm_admin", return_value=True),
+            patch("backend.app.routers.crm_practices.invalidate_cache", new=AsyncMock()),
+            patch("backend.app.routers.crm_practices.to_jsonb", return_value="{}"),
+        ):
+            result = await update_practice(
+                request=MagicMock(),
+                practice_id=1,
+                updates=PracticeUpdate(
+                    status="waiting_documents",
+                    practice_type_code="kitas_working_onshore",
+                ),
+                db_pool=mock_db_pool,
+                current_user=admin_user,
+            )
+
+        assert result["practice_type_code"] == "kitas_working_onshore"
+        type_lookup = mock_db_conn.fetchrow.call_args_list[1].args
+        assert "FROM practice_types" in type_lookup[0]
+        assert type_lookup[1] == "kitas_working_onshore"
+        update_sql = mock_db_conn.fetchrow.call_args_list[2].args[0]
+        assert "practice_type_id = $" in update_sql
+        assert "practice_type_code = $" not in update_sql
+
+    @pytest.mark.asyncio
+    async def test_update_unknown_service_is_404(
+        self, mock_db_pool: MagicMock, mock_db_conn: AsyncMock, admin_user: dict
+    ) -> None:
+        from backend.app.routers.crm_practices import PracticeUpdate, update_practice
+
+        old_row = {
+            "status": "inquiry",
+            "client_id": 42,
+            "client_visible": True,
+            "created_by": "admin@balizero.com",
+            "assigned_to": "team@balizero.com",
+            "practice_type_code": "open_inquiry",
+        }
+        mock_db_conn.fetchrow = AsyncMock(side_effect=[old_row, None])
+
+        with (
+            patch("backend.app.routers.crm_practices.is_crm_admin", return_value=True),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await update_practice(
+                request=MagicMock(),
+                practice_id=1,
+                updates=PracticeUpdate(practice_type_code="nope"),
+                db_pool=mock_db_pool,
+                current_user=admin_user,
+            )
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_catalog_hides_placeholder(
+        self, mock_db_pool: MagicMock, mock_db_conn: AsyncMock, admin_user: dict
+    ) -> None:
+        from backend.app.routers.crm_practices import get_practice_types_catalog
+        from backend.services.crm.practice_state_machine import OPEN_INQUIRY_TYPE_CODE
+
+        mock_db_conn.fetch = AsyncMock(return_value=[])
+        await get_practice_types_catalog(db_pool=mock_db_pool, current_user=admin_user)
+        sql, code = mock_db_conn.fetch.call_args.args
+        assert "code <> $1" in sql
+        assert code == OPEN_INQUIRY_TYPE_CODE
 
 
 # ---------------------------------------------------------------------------

--- a/apps/mouth/src/app/(workspace)/process/[id]/SelectServiceCard.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/SelectServiceCard.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, ChevronDown, Loader2, Tag } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api";
+import type { Practice } from "@/lib/api/crm/crm.types";
+import { logger } from "@/lib/logger";
+import { toError } from "@/lib/types/common";
+
+/**
+ * Shown on an OPEN INQUIRY (practice_type_code === "open_inquiry"): the team
+ * opened the process without picking a service and must choose it here
+ * before the practice can move to Waiting Documents. The backend enforces
+ * the same gate (practice_state_machine.validate_service_selected); this card
+ * is the UI path that satisfies it.
+ */
+
+interface ServiceItem {
+  code: string;
+  name: string;
+  base_price: number | null;
+}
+
+interface ServiceCategory {
+  code: string;
+  label: string;
+  services: ServiceItem[];
+}
+
+interface SelectServiceCardProps {
+  practiceId: number;
+  onSaved: (practice: Practice) => void;
+}
+
+const selectClass =
+  "w-full rounded-lg px-3 py-2 text-sm appearance-none cursor-pointer pr-10 focus:outline-none";
+const selectStyle = {
+  border: "1px solid var(--bz-border)",
+  background: "var(--bz-card)",
+  color: "var(--bz-text-1)",
+} as const;
+
+function formatPrice(price: number): string {
+  return new Intl.NumberFormat("id-ID").format(price);
+}
+
+export function SelectServiceCard({
+  practiceId,
+  onSaved,
+}: SelectServiceCardProps) {
+  const [catalog, setCatalog] = useState<ServiceCategory[]>([]);
+  const [isLoadingCatalog, setIsLoadingCatalog] = useState(true);
+  const [category, setCategory] = useState("");
+  const [serviceCode, setServiceCode] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.crm
+      .getPracticeTypesCatalog()
+      .then((data) => {
+        if (!cancelled) setCatalog(data.categories);
+      })
+      .catch((err) => {
+        logger.error(
+          "Failed to load practice types catalog",
+          { component: "SelectServiceCard", action: "loadCatalog" },
+          toError(err),
+        );
+        toast.error("Failed to load service catalog");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingCatalog(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const services = useMemo(
+    () => catalog.find((c) => c.code === category)?.services ?? [],
+    [catalog, category],
+  );
+  const selected = useMemo(
+    () => services.find((s) => s.code === serviceCode) ?? null,
+    [services, serviceCode],
+  );
+
+  const save = async () => {
+    if (!selected) return;
+    setIsSaving(true);
+    try {
+      const updated = await api.crm.updatePractice(practiceId, {
+        practice_type_code: selected.code,
+        ...(selected.base_price ? { quoted_price: selected.base_price } : {}),
+      });
+      onSaved(updated);
+      toast.success("Service set", { description: selected.name });
+    } catch (err) {
+      toast.error("Failed to set service", {
+        description: (err as Error).message,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="rounded-xl p-5 mb-6"
+      style={{
+        border: "1px solid var(--state-warning)",
+        background:
+          "color-mix(in srgb, var(--state-warning) 8%, var(--bz-card))",
+      }}
+      data-testid="select-service-card"
+    >
+      <div className="flex items-start gap-3 mb-4">
+        <AlertCircle
+          className="w-5 h-5 mt-0.5 flex-shrink-0"
+          style={{ color: "var(--state-warning)" }}
+        />
+        <div>
+          <h2
+            className="text-base font-semibold"
+            style={{ color: "var(--bz-text-1)" }}
+          >
+            Open inquiry — service not chosen yet
+          </h2>
+          <p className="text-sm mt-0.5" style={{ color: "var(--bz-text-2)" }}>
+            Pick the service to move this process to Waiting Documents.
+          </p>
+        </div>
+      </div>
+
+      {isLoadingCatalog ? (
+        <div
+          className="flex items-center gap-2 text-sm py-2"
+          style={{ color: "var(--bz-text-2)" }}
+        >
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Loading services...
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-3 items-end">
+          <div className="relative">
+            <Tag
+              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none"
+              style={{ color: "var(--bz-text-2)" }}
+            />
+            <ChevronDown
+              className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none"
+              style={{ color: "var(--bz-text-2)" }}
+            />
+            <select
+              aria-label="Service category"
+              value={category}
+              onChange={(e) => {
+                setCategory(e.target.value);
+                setServiceCode("");
+              }}
+              className={`${selectClass} pl-9`}
+              style={selectStyle}
+            >
+              <option value="">-- Select category --</option>
+              {catalog.map((cat) => (
+                <option key={cat.code} value={cat.code}>
+                  {cat.label} ({cat.services.length})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="relative">
+            <ChevronDown
+              className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none"
+              style={{ color: "var(--bz-text-2)" }}
+            />
+            <select
+              aria-label="Service"
+              value={serviceCode}
+              onChange={(e) => setServiceCode(e.target.value)}
+              disabled={!category}
+              className={`${selectClass} ${!category ? "opacity-50 cursor-not-allowed" : ""}`}
+              style={selectStyle}
+            >
+              <option value="">
+                {category ? "-- Select service --" : "Select category first"}
+              </option>
+              {services.map((svc) => (
+                <option key={svc.code} value={svc.code}>
+                  {svc.name}
+                  {svc.base_price
+                    ? ` — Rp ${formatPrice(svc.base_price)}`
+                    : " — Quote"}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            onClick={save}
+            disabled={!selected || isSaving}
+          >
+            {isSaving ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+            Set service
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
@@ -31,8 +31,10 @@ import { api } from "@/lib/api";
 import { ApiError } from "@/lib/api/error-handler";
 import type { Practice } from "@/lib/api/crm/crm.types";
 import {
+  OPEN_INQUIRY_TYPE_CODE,
   STATUS_LABELS as STATUS_DROPDOWN_LABELS,
   getAllowedNextStatuses,
+  needsServiceBefore,
   type PracticeStatus,
 } from "@/lib/api/crm/state-machine";
 import { casesMetrics } from "@/lib/metrics/cases-metrics";
@@ -44,6 +46,7 @@ import {
   getStatusColumn,
 } from "@/components/process/kanban-colors";
 import { RequiredDocumentsCard } from "./RequiredDocumentsCard";
+import { SelectServiceCard } from "./SelectServiceCard";
 import { useTeamMemberOptions } from "@/hooks/useTeamMembers";
 import { useInvalidateClient } from "@/hooks/useClientDetail";
 import { initialsOf } from "@/data/team-roster";
@@ -377,6 +380,16 @@ export default function CaseDetailPage() {
       isJumpingStatus
     )
       return;
+    // Open inquiry: the backend refuses to leave the inquiry stage until a
+    // service is chosen (validate_service_selected). Say so before the
+    // round-trip and point at the picker card.
+    if (needsServiceBefore(newStatus, practice.practice_type_code)) {
+      toast.error(
+        "Select a service first",
+        "This is an open inquiry — pick the service above before moving on.",
+      );
+      return;
+    }
     setIsJumpingStatus(newStatus);
     try {
       const user = await api.getProfile();
@@ -1099,6 +1112,11 @@ export default function CaseDetailPage() {
           </div>
         );
       })()}
+
+      {/* Open inquiry: service still to be chosen (required before Documents) */}
+      {caseId && practice.practice_type_code === OPEN_INQUIRY_TYPE_CODE && (
+        <SelectServiceCard practiceId={caseId} onSaved={applyPracticeUpdate} />
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main Content */}

--- a/apps/mouth/src/app/(workspace)/process/new/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/new/page.tsx
@@ -333,14 +333,12 @@ export default function NewPracticePage() {
     e.preventDefault();
     setFieldErrors({});
 
-    if (!selectedServiceCode) {
-      setFieldErrors({ service: "Select a service" });
-      return;
-    }
-
+    // Service is optional at Inquiry (Ari, 2026-09-11): with no selection the
+    // backend opens the process against the `open_inquiry` placeholder and
+    // the team picks the real service before Waiting Documents.
     const result = createPracticeSchema.safeParse({
       client_id: formData.client_id,
-      practice_type_code: selectedServiceCode,
+      practice_type_code: selectedServiceCode || undefined,
       notes: formData.title,
       family_member_id: formData.family_member_id
         ? Number(formData.family_member_id)
@@ -376,11 +374,12 @@ export default function NewPracticePage() {
 
       // Duplicate check — may fail with 403 if RBAC denies access (non-admin
       // creating process for a client assigned to someone else). Skip check
-      // on failure rather than blocking creation entirely.
+      // on failure rather than blocking creation entirely. An open inquiry
+      // (no service yet) has nothing to collide with, so it is skipped.
       try {
-        const existingPractices = await api.crm.getClientPractices(
-          result.data.client_id,
-        );
+        const existingPractices = result.data.practice_type_code
+          ? await api.crm.getClientPractices(result.data.client_id)
+          : [];
         // A "duplicate" is the same practice_type AND the same family_member
         // target — one investor KITAS for the sponsor plus three dependent
         // KITAS for Violet/River/Tessa are four distinct processes, not four
@@ -426,7 +425,9 @@ export default function NewPracticePage() {
 
       const backendData = {
         client_id: result.data.client_id,
-        practice_type_code: result.data.practice_type_code,
+        ...(result.data.practice_type_code
+          ? { practice_type_code: result.data.practice_type_code }
+          : {}),
         status: "inquiry",
         priority: formData.priority,
         notes: result.data.notes,
@@ -475,7 +476,7 @@ export default function NewPracticePage() {
       const caseId = createdPractice?.id || 0;
       casesMetrics.trackCaseCreation(
         caseId,
-        result.data.practice_type_code,
+        result.data.practice_type_code ?? "open_inquiry",
         result.data.client_id,
         user.email,
       );
@@ -483,7 +484,9 @@ export default function NewPracticePage() {
 
       toast.success(
         "Process Created",
-        `${selectedService?.name || "Process"} created successfully.`,
+        selectedService
+          ? `${selectedService.name} created successfully.`
+          : "Open inquiry created — pick the service before Waiting Documents.",
       );
       if (preselectedClientId) {
         await invalidatePreselectedClient();
@@ -666,7 +669,10 @@ export default function NewPracticePage() {
           {/* Service Selection — 2 levels */}
           <div className="space-y-4">
             <label className={labelClass}>
-              Service <span className="text-[var(--state-danger)]">*</span>
+              Service{" "}
+              <span className="text-[var(--foreground-muted)] font-normal">
+                (optional at Inquiry — required before Waiting Documents)
+              </span>
             </label>
             {catalogLoading ? (
               <div className="flex items-center gap-2 text-sm text-[var(--foreground-muted)] py-2">
@@ -748,9 +754,12 @@ export default function NewPracticePage() {
               </div>
             )}
 
-            {fieldErrors.service && (
-              <p className="text-xs text-[var(--state-danger)]">
-                {fieldErrors.service}
+            {!catalogLoading && !selectedServiceCode && (
+              <p className="text-xs text-[var(--foreground-muted)]">
+                No service selected: the process opens as an{" "}
+                <span className="font-medium">open inquiry</span>. The service
+                must be chosen on the process page before it can move to Waiting
+                Documents.
               </p>
             )}
             {fieldErrors.practice_type_code && (

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -459,6 +459,7 @@ export class CrmApi {
     practiceId: number,
     updates: Partial<{
       status: string;
+      practice_type_code: string; // pick/change the service after creation
       priority: string;
       quoted_price: number;
       actual_price: number;

--- a/apps/mouth/src/lib/api/crm/crm.schemas.ts
+++ b/apps/mouth/src/lib/api/crm/crm.schemas.ts
@@ -163,7 +163,9 @@ export type CreateClientOutput = z.output<typeof createClientSchema>;
 export const createPracticeSchema = z
   .object({
     client_id: z.number().positive("Invalid client ID"),
-    practice_type_code: practiceTypeCodeEnum,
+    // Optional since 2026-09-11: an inquiry may be opened without a service
+    // (backend stores it against the `open_inquiry` placeholder type).
+    practice_type_code: practiceTypeCodeEnum.optional(),
     status: practiceStatusEnum.default("inquiry"),
     priority: practicePriorityEnum.default("normal"),
     notes: emptyToUndefined,

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -977,7 +977,7 @@ export interface RenewalAlert {
 
 export interface CreatePracticeParams {
   client_id: number; // Required by backend
-  practice_type_code: string;
+  practice_type_code?: string; // Omit to open an inquiry without a service
   status?: string; // inquiry, quotation_sent, in_progress, completed, etc.
   priority?: string; // normal, high, urgent
   notes?: string; // Maps from frontend "title"

--- a/apps/mouth/src/lib/api/crm/state-machine.test.ts
+++ b/apps/mouth/src/lib/api/crm/state-machine.test.ts
@@ -16,6 +16,8 @@ import {
   VALID_TRANSITIONS,
   getAllowedNextStatuses,
   type PracticeStatus,
+  OPEN_INQUIRY_TYPE_CODE,
+  needsServiceBefore,
 } from "./state-machine";
 
 describe("VALID_TRANSITIONS — backend snapshot", () => {
@@ -135,8 +137,34 @@ describe("getAllowedNextStatuses", () => {
     expect(getAllowedNextStatuses("in_progress" as PracticeStatus)).toEqual([
       "in_progress",
     ]);
-    expect(getAllowedNextStatuses("payment_pending" as PracticeStatus)).toEqual([
-      "payment_pending",
-    ]);
+    expect(getAllowedNextStatuses("payment_pending" as PracticeStatus)).toEqual(
+      ["payment_pending"],
+    );
+  });
+});
+
+describe("needsServiceBefore — open inquiry gate (backend mirror)", () => {
+  it("blocks every state past inquiry while the placeholder is set", () => {
+    for (const target of [
+      "waiting_documents",
+      "sending_invoice",
+      "on_process",
+      "completed",
+    ]) {
+      expect(needsServiceBefore(target, OPEN_INQUIRY_TYPE_CODE)).toBe(true);
+    }
+  });
+
+  it("lets the placeholder stay in inquiry or be cancelled", () => {
+    expect(needsServiceBefore("inquiry", OPEN_INQUIRY_TYPE_CODE)).toBe(false);
+    expect(needsServiceBefore("cancelled", OPEN_INQUIRY_TYPE_CODE)).toBe(false);
+  });
+
+  it("never blocks a real or unknown service", () => {
+    expect(
+      needsServiceBefore("waiting_documents", "kitas_working_onshore"),
+    ).toBe(false);
+    expect(needsServiceBefore("waiting_documents", undefined)).toBe(false);
+    expect(needsServiceBefore("waiting_documents", null)).toBe(false);
   });
 });

--- a/apps/mouth/src/lib/api/crm/state-machine.ts
+++ b/apps/mouth/src/lib/api/crm/state-machine.ts
@@ -24,7 +24,10 @@ export type PracticeStatus =
  * Allowed forward transitions: from → set of valid `to` states.
  * Mirrors `VALID_TRANSITIONS` in the backend module.
  */
-export const VALID_TRANSITIONS: Record<PracticeStatus, readonly PracticeStatus[]> = {
+export const VALID_TRANSITIONS: Record<
+  PracticeStatus,
+  readonly PracticeStatus[]
+> = {
   inquiry: ["waiting_documents", "cancelled"],
   waiting_documents: ["sending_invoice", "inquiry", "cancelled"],
   sending_invoice: ["on_process", "waiting_documents", "cancelled"],
@@ -37,7 +40,9 @@ export const VALID_TRANSITIONS: Record<PracticeStatus, readonly PracticeStatus[]
  * Transitions that require an admin role on the user object.
  * Mirrors `ADMIN_ONLY_TRANSITIONS` in the backend module.
  */
-export const ADMIN_ONLY_TRANSITIONS: ReadonlyArray<readonly [PracticeStatus, PracticeStatus]> = [
+export const ADMIN_ONLY_TRANSITIONS: ReadonlyArray<
+  readonly [PracticeStatus, PracticeStatus]
+> = [
   ["completed", "cancelled"],
   ["cancelled", "inquiry"],
 ] as const;
@@ -53,6 +58,27 @@ export const STATUS_LABELS: Record<PracticeStatus, string> = {
 };
 
 const ALL_STATES = new Set<string>(Object.keys(VALID_TRANSITIONS));
+
+/**
+ * Placeholder practice type for an inquiry opened WITHOUT a service.
+ * Mirrors `OPEN_INQUIRY_TYPE_CODE` / `STATES_WITHOUT_SERVICE` in the backend
+ * module: the backend refuses to move such a practice past the inquiry stage
+ * until a real service is chosen (migration 311, 2026-09-11).
+ */
+export const OPEN_INQUIRY_TYPE_CODE = "open_inquiry";
+
+const STATES_WITHOUT_SERVICE = new Set<string>(["inquiry", "cancelled"]);
+
+/** True when moving to `target` requires a real service to be chosen first. */
+export function needsServiceBefore(
+  target: PracticeStatus | string,
+  practiceTypeCode: string | null | undefined,
+): boolean {
+  return (
+    practiceTypeCode === OPEN_INQUIRY_TYPE_CODE &&
+    !STATES_WITHOUT_SERVICE.has(target)
+  );
+}
 
 /**
  * Return the list of states the user can transition INTO from `current`,


### PR DESCRIPTION
## What

Ari's proposal for the CRM at kita.balizero.com: when the team creates a process in the **Inquiry** step, the service category is no longer required. The service becomes **mandatory when the practice moves to Waiting Documents**.

### Backend (`apps/backend-rag`)
- Migration **311**: `open_inquiry` placeholder practice type (category `inquiry`, excluded from `/types/catalog`). A real row instead of `practice_type_id = NULL` keeps the ~40 `INNER JOIN practice_types` read paths intact (kanban, portal, analytics, shared memory).
- `POST /api/crm/practices/`: `practice_type_code` optional → resolved to the placeholder; refused (400) if the initial status is past inquiry.
- `PATCH /api/crm/practices/{id}/`: accepts `practice_type_code` → resolved to `practice_type_id` (404 on unknown/inactive code).
- `validate_service_selected` in the state machine: leaving `inquiry`/`cancelled` with the placeholder → 400 "select a service before moving to '…'". Legacy rows with NULL type (2 in prod) are not blocked.

### Frontend (`apps/mouth`)
- `/process/new`: Service picker optional; no selection → open inquiry (hint text explains the rule).
- `/process/[id]`: new `SelectServiceCard` on open inquiries (category + service → PATCH `practice_type_code` + base price as `quoted_price`); the stepper refuses to jump past Inquiry until a service is chosen (`needsServiceBefore` mirrors the backend).

## Tests
- backend: `test_practice_state_machine.py` + `test_crm_practices.py` → 156 passed (new: create without service → placeholder; create past inquiry refused; PATCH to waiting_documents blocked on placeholder; PATCH with service + status in one call; unknown service 404; catalog excludes placeholder).
- mouth: vitest `state-machine.test.ts`, `process/new/page.test.tsx`, `process/[id]/page.test.tsx`, `crm.api.test.ts` → green; `tsc --noEmit` clean.

## Bites
**Consumer:** kita.balizero.com `/process/new` (team) and `/process/[id]` (stepper + SelectServiceCard) against `nuzantara-rag.fly.dev`.
**Observation after merge (backend merge = deploy):** `SELECT code, is_active FROM practice_types WHERE code='open_inquiry'` returns one active row (migration 311 applied by the release command); `GET /api/crm/practices/types/catalog` does not list `open_inquiry`; `POST /api/crm/practices/` without `practice_type_code` returns a practice with `practice_type_code = "open_inquiry"`, and `PATCH {status: "waiting_documents"}` on it returns 400 `select a service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKrWYqGFyH1LjYds8kTSHJ
