### PR TITLE
feat(mouth): service optional on New Process; SelectServiceCard on open inquiries

### DIFF
--- a/apps/mouth/src/app/(workspace)/process/[id]/SelectServiceCard.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/SelectServiceCard.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, ChevronDown, Loader2, Tag } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api";
+import type { Practice } from "@/lib/api/crm/crm.types";
+import { logger } from "@/lib/logger";
+import { toError } from "@/lib/types/common";
+
+/**
+ * Shown on an OPEN INQUIRY (practice_type_code === "open_inquiry"): the team
+ * opened the process without picking a service and must choose it here
+ * before the practice can move to Waiting Documents. The backend enforces
+ * the same gate (practice_state_machine.validate_service_selected); this card
+ * is the UI path that satisfies it.
+ */
+
+interface ServiceItem {
+  code: string;
+  name: string;
+  base_price: number | null;
+}
+
+interface ServiceCategory {
+  code: string;
+  label: string;
+  services: ServiceItem[];
+}
+
+interface SelectServiceCardProps {
+  practiceId: number;
+  onSaved: (practice: Practice) => void;
+}
+
+const selectClass =
+  "w-full rounded-lg px-3 py-2 text-sm appearance-none cursor-pointer pr-10 focus:outline-none";
+const selectStyle = {
+  border: "1px solid var(--bz-border)",
+  background: "var(--bz-card)",
+  color: "var(--bz-text-1)",
+} as const;
+
+function formatPrice(price: number): string {
+  return new Intl.NumberFormat("id-ID").format(price);
+}
+
+export function SelectServiceCard({
+  practiceId,
+  onSaved,
+}: SelectServiceCardProps) {
+  const [catalog, setCatalog] = useState<ServiceCategory[]>([]);
+  const [isLoadingCatalog, setIsLoadingCatalog] = useState(true);
+  const [category, setCategory] = useState("");
+  const [serviceCode, setServiceCode] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.crm
+      .getPracticeTypesCatalog()
+      .then((data) => {
+        if (!cancelled) setCatalog(data.categories);
+      })
+      .catch((err) => {
+        logger.error(
+          "Failed to load practice types catalog",
+          { component: "SelectServiceCard", action: "loadCatalog" },
+          toError(err),
+        );
+        toast.error("Failed to load service catalog");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingCatalog(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const services = useMemo(
+    () => catalog.find((c) => c.code === category)?.services ?? [],
+    [catalog, category],
+  );
+  const selected = useMemo(
+    () => services.find((s) => s.code === serviceCode) ?? null,
+    [services, serviceCode],
+  );
+
+  const save = async () => {
+    if (!selected) return;
+    setIsSaving(true);
+    try {
+      const updated = await api.crm.updatePractice(practiceId, {
+        practice_type_code: selected.code,
+        ...(selected.base_price ? { quoted_price: selected.base_price } : {}),
+      });
+      onSaved(updated);
+      toast.success("Service set", { description: selected.name });
+    } catch (err) {
+      toast.error("Failed to set service", {
+        description: (err as Error).message,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="rounded-xl p-5 mb-6"
+      style={{
+        border: "1px solid var(--state-warning)",
+        background:
+          "color-mix(in srgb, var(--state-warning) 8%, var(--bz-card))",
+      }}
+      data-testid="select-service-card"
+    >
+      <div className="flex items-start gap-3 mb-4">
+        <AlertCircle
+          className="w-5 h-5 mt-0.5 flex-shrink-0"
+          style={{ color: "var(--state-warning)" }}
+        />
+        <div>
+          <h2
+            className="text-base font-semibold"
+            style={{ color: "var(--bz-text-1)" }}
+          >
+            Open inquiry — service not chosen yet
+          </h2>
+          <p className="text-sm mt-0.5" style={{ color: "var(--bz-text-2)" }}>
+            Pick the service to move this process to Waiting Documents.
+          </p>
+        </div>
+      </div>
+
+      {isLoadingCatalog ? (
+        <div
+          className="flex items-center gap-2 text-sm py-2"
+          style={{ color: "var(--bz-text-2)" }}
+        >
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Loading services...
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-3 items-end">
+          <div className="relative">
+            <Tag
+              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none"
+              style={{ color: "var(--bz-text-2)" }}
+            />
+            <ChevronDown
+              className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none"
+              style={{ color: "var(--bz-text-2)" }}
+            />
+            <select
+              aria-label="Service category"
+              value={category}
+              onChange={(e) => {
+                setCategory(e.target.value);
+                setServiceCode("");
+              }}
+              className={`${selectClass} pl-9`}
+              style={selectStyle}
+            >
+              <option value="">-- Select category --</option>
+              {catalog.map((cat) => (
+                <option key={cat.code} value={cat.code}>
+                  {cat.label} ({cat.services.length})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="relative">
+            <ChevronDown
+              className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none"
+              style={{ color: "var(--bz-text-2)" }}
+            />
+            <select
+              aria-label="Service"
+              value={serviceCode}
+              onChange={(e) => setServiceCode(e.target.value)}
+              disabled={!category}
+              className={`${selectClass} ${!category ? "opacity-50 cursor-not-allowed" : ""}`}
+              style={selectStyle}
+            >
+              <option value="">
+                {category ? "-- Select service --" : "Select category first"}
+              </option>
+              {services.map((svc) => (
+                <option key={svc.code} value={svc.code}>
+                  {svc.name}
+                  {svc.base_price
+                    ? ` — Rp ${formatPrice(svc.base_price)}`
+                    : " — Quote"}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            onClick={save}
+            disabled={!selected || isSaving}
+          >
+            {isSaving ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+            Set service
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
@@ -31,8 +31,10 @@ import { api } from "@/lib/api";
 import { ApiError } from "@/lib/api/error-handler";
 import type { Practice } from "@/lib/api/crm/crm.types";
 import {
+  OPEN_INQUIRY_TYPE_CODE,
   STATUS_LABELS as STATUS_DROPDOWN_LABELS,
   getAllowedNextStatuses,
+  needsServiceBefore,
   type PracticeStatus,
 } from "@/lib/api/crm/state-machine";
 import { casesMetrics } from "@/lib/metrics/cases-metrics";
@@ -44,6 +46,7 @@ import {
   getStatusColumn,
 } from "@/components/process/kanban-colors";
 import { RequiredDocumentsCard } from "./RequiredDocumentsCard";
+import { SelectServiceCard } from "./SelectServiceCard";
 import { useTeamMemberOptions } from "@/hooks/useTeamMembers";
 import { useInvalidateClient } from "@/hooks/useClientDetail";
 import { initialsOf } from "@/data/team-roster";
@@ -377,6 +380,16 @@ export default function CaseDetailPage() {
       isJumpingStatus
     )
       return;
+    // Open inquiry: the backend refuses to leave the inquiry stage until a
+    // service is chosen (validate_service_selected). Say so before the
+    // round-trip and point at the picker card.
+    if (needsServiceBefore(newStatus, practice.practice_type_code)) {
+      toast.error(
+        "Select a service first",
+        "This is an open inquiry — pick the service above before moving on.",
+      );
+      return;
+    }
     setIsJumpingStatus(newStatus);
     try {
       const user = await api.getProfile();
@@ -1099,6 +1112,11 @@ export default function CaseDetailPage() {
           </div>
         );
       })()}
+
+      {/* Open inquiry: service still to be chosen (required before Documents) */}
+      {caseId && practice.practice_type_code === OPEN_INQUIRY_TYPE_CODE && (
+        <SelectServiceCard practiceId={caseId} onSaved={applyPracticeUpdate} />
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main Content */}

--- a/apps/mouth/src/app/(workspace)/process/new/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/new/page.tsx
@@ -333,14 +333,12 @@ export default function NewPracticePage() {
     e.preventDefault();
     setFieldErrors({});
 
-    if (!selectedServiceCode) {
-      setFieldErrors({ service: "Select a service" });
-      return;
-    }
-
+    // Service is optional at Inquiry (Ari, 2026-09-11): with no selection the
+    // backend opens the process against the `open_inquiry` placeholder and
+    // the team picks the real service before Waiting Documents.
     const result = createPracticeSchema.safeParse({
       client_id: formData.client_id,
-      practice_type_code: selectedServiceCode,
+      practice_type_code: selectedServiceCode || undefined,
       notes: formData.title,
       family_member_id: formData.family_member_id
         ? Number(formData.family_member_id)
@@ -376,11 +374,12 @@ export default function NewPracticePage() {
 
       // Duplicate check — may fail with 403 if RBAC denies access (non-admin
       // creating process for a client assigned to someone else). Skip check
-      // on failure rather than blocking creation entirely.
+      // on failure rather than blocking creation entirely. An open inquiry
+      // (no service yet) has nothing to collide with, so it is skipped.
       try {
-        const existingPractices = await api.crm.getClientPractices(
-          result.data.client_id,
-        );
+        const existingPractices = result.data.practice_type_code
+          ? await api.crm.getClientPractices(result.data.client_id)
+          : [];
         // A "duplicate" is the same practice_type AND the same family_member
         // target — one investor KITAS for the sponsor plus three dependent
         // KITAS for Violet/River/Tessa are four distinct processes, not four
@@ -426,7 +425,9 @@ export default function NewPracticePage() {
 
       const backendData = {
         client_id: result.data.client_id,
-        practice_type_code: result.data.practice_type_code,
+        ...(result.data.practice_type_code
+          ? { practice_type_code: result.data.practice_type_code }
+          : {}),
         status: "inquiry",
         priority: formData.priority,
         notes: result.data.notes,
@@ -475,7 +476,7 @@ export default function NewPracticePage() {
       const caseId = createdPractice?.id || 0;
       casesMetrics.trackCaseCreation(
         caseId,
-        result.data.practice_type_code,
+        result.data.practice_type_code ?? "open_inquiry",
         result.data.client_id,
         user.email,
       );
@@ -483,7 +484,9 @@ export default function NewPracticePage() {
 
       toast.success(
         "Process Created",
-        `${selectedService?.name || "Process"} created successfully.`,
+        selectedService
+          ? `${selectedService.name} created successfully.`
+          : "Open inquiry created — pick the service before Waiting Documents.",
       );
       if (preselectedClientId) {
         await invalidatePreselectedClient();
@@ -666,7 +669,10 @@ export default function NewPracticePage() {
           {/* Service Selection — 2 levels */}
           <div className="space-y-4">
             <label className={labelClass}>
-              Service <span className="text-[var(--state-danger)]">*</span>
+              Service{" "}
+              <span className="text-[var(--foreground-muted)] font-normal">
+                (optional at Inquiry — required before Waiting Documents)
+              </span>
             </label>
             {catalogLoading ? (
               <div className="flex items-center gap-2 text-sm text-[var(--foreground-muted)] py-2">
@@ -748,9 +754,12 @@ export default function NewPracticePage() {
               </div>
             )}
 
-            {fieldErrors.service && (
-              <p className="text-xs text-[var(--state-danger)]">
-                {fieldErrors.service}
+            {!catalogLoading && !selectedServiceCode && (
+              <p className="text-xs text-[var(--foreground-muted)]">
+                No service selected: the process opens as an{" "}
+                <span className="font-medium">open inquiry</span>. The service
+                must be chosen on the process page before it can move to Waiting
+                Documents.
               </p>
             )}
             {fieldErrors.practice_type_code && (

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -459,6 +459,7 @@ export class CrmApi {
     practiceId: number,
     updates: Partial<{
       status: string;
+      practice_type_code: string; // pick/change the service after creation
       priority: string;
       quoted_price: number;
       actual_price: number;

--- a/apps/mouth/src/lib/api/crm/crm.schemas.ts
+++ b/apps/mouth/src/lib/api/crm/crm.schemas.ts
@@ -163,7 +163,9 @@ export type CreateClientOutput = z.output<typeof createClientSchema>;
 export const createPracticeSchema = z
   .object({
     client_id: z.number().positive("Invalid client ID"),
-    practice_type_code: practiceTypeCodeEnum,
+    // Optional since 2026-09-11: an inquiry may be opened without a service
+    // (backend stores it against the `open_inquiry` placeholder type).
+    practice_type_code: practiceTypeCodeEnum.optional(),
     status: practiceStatusEnum.default("inquiry"),
     priority: practicePriorityEnum.default("normal"),
     notes: emptyToUndefined,

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -977,7 +977,7 @@ export interface RenewalAlert {
 
 export interface CreatePracticeParams {
   client_id: number; // Required by backend
-  practice_type_code: string;
+  practice_type_code?: string; // Omit to open an inquiry without a service
   status?: string; // inquiry, quotation_sent, in_progress, completed, etc.
   priority?: string; // normal, high, urgent
   notes?: string; // Maps from frontend "title"

--- a/apps/mouth/src/lib/api/crm/state-machine.test.ts
+++ b/apps/mouth/src/lib/api/crm/state-machine.test.ts
@@ -16,6 +16,8 @@ import {
   VALID_TRANSITIONS,
   getAllowedNextStatuses,
   type PracticeStatus,
+  OPEN_INQUIRY_TYPE_CODE,
+  needsServiceBefore,
 } from "./state-machine";
 
 describe("VALID_TRANSITIONS — backend snapshot", () => {
@@ -135,8 +137,34 @@ describe("getAllowedNextStatuses", () => {
     expect(getAllowedNextStatuses("in_progress" as PracticeStatus)).toEqual([
       "in_progress",
     ]);
-    expect(getAllowedNextStatuses("payment_pending" as PracticeStatus)).toEqual([
-      "payment_pending",
-    ]);
+    expect(getAllowedNextStatuses("payment_pending" as PracticeStatus)).toEqual(
+      ["payment_pending"],
+    );
+  });
+});
+
+describe("needsServiceBefore — open inquiry gate (backend mirror)", () => {
+  it("blocks every state past inquiry while the placeholder is set", () => {
+    for (const target of [
+      "waiting_documents",
+      "sending_invoice",
+      "on_process",
+      "completed",
+    ]) {
+      expect(needsServiceBefore(target, OPEN_INQUIRY_TYPE_CODE)).toBe(true);
+    }
+  });
+
+  it("lets the placeholder stay in inquiry or be cancelled", () => {
+    expect(needsServiceBefore("inquiry", OPEN_INQUIRY_TYPE_CODE)).toBe(false);
+    expect(needsServiceBefore("cancelled", OPEN_INQUIRY_TYPE_CODE)).toBe(false);
+  });
+
+  it("never blocks a real or unknown service", () => {
+    expect(
+      needsServiceBefore("waiting_documents", "kitas_working_onshore"),
+    ).toBe(false);
+    expect(needsServiceBefore("waiting_documents", undefined)).toBe(false);
+    expect(needsServiceBefore("waiting_documents", null)).toBe(false);
   });
 });

--- a/apps/mouth/src/lib/api/crm/state-machine.ts
+++ b/apps/mouth/src/lib/api/crm/state-machine.ts
@@ -24,7 +24,10 @@ export type PracticeStatus =
  * Allowed forward transitions: from → set of valid `to` states.
  * Mirrors `VALID_TRANSITIONS` in the backend module.
  */
-export const VALID_TRANSITIONS: Record<PracticeStatus, readonly PracticeStatus[]> = {
+export const VALID_TRANSITIONS: Record<
+  PracticeStatus,
+  readonly PracticeStatus[]
+> = {
   inquiry: ["waiting_documents", "cancelled"],
   waiting_documents: ["sending_invoice", "inquiry", "cancelled"],
   sending_invoice: ["on_process", "waiting_documents", "cancelled"],
@@ -37,7 +40,9 @@ export const VALID_TRANSITIONS: Record<PracticeStatus, readonly PracticeStatus[]
  * Transitions that require an admin role on the user object.
  * Mirrors `ADMIN_ONLY_TRANSITIONS` in the backend module.
  */
-export const ADMIN_ONLY_TRANSITIONS: ReadonlyArray<readonly [PracticeStatus, PracticeStatus]> = [
+export const ADMIN_ONLY_TRANSITIONS: ReadonlyArray<
+  readonly [PracticeStatus, PracticeStatus]
+> = [
   ["completed", "cancelled"],
   ["cancelled", "inquiry"],
 ] as const;
@@ -53,6 +58,27 @@ export const STATUS_LABELS: Record<PracticeStatus, string> = {
 };
 
 const ALL_STATES = new Set<string>(Object.keys(VALID_TRANSITIONS));
+
+/**
+ * Placeholder practice type for an inquiry opened WITHOUT a service.
+ * Mirrors `OPEN_INQUIRY_TYPE_CODE` / `STATES_WITHOUT_SERVICE` in the backend
+ * module: the backend refuses to move such a practice past the inquiry stage
+ * until a real service is chosen (migration 311, 2026-09-11).
+ */
+export const OPEN_INQUIRY_TYPE_CODE = "open_inquiry";
+
+const STATES_WITHOUT_SERVICE = new Set<string>(["inquiry", "cancelled"]);
+
+/** True when moving to `target` requires a real service to be chosen first. */
+export function needsServiceBefore(
+  target: PracticeStatus | string,
+  practiceTypeCode: string | null | undefined,
+): boolean {
+  return (
+    practiceTypeCode === OPEN_INQUIRY_TYPE_CODE &&
+    !STATES_WITHOUT_SERVICE.has(target)
+  );
+}
 
 /**
  * Return the list of states the user can transition INTO from `current`,


### PR DESCRIPTION
## What

kita.balizero.com half of Ari's proposal (backend landed in #6251, migration 311 + `open_inquiry` placeholder + service gate): the team can open a process in **Inquiry** without picking a service; the service becomes **mandatory before Waiting Documents**.

- `/process/new`: the Service picker is optional. With no selection the form omits `practice_type_code` and the backend opens the process as an open inquiry (hint text explains the rule). Duplicate check skipped for open inquiries.
- `/process/[id]`: an open inquiry shows **SelectServiceCard** (category + service from the catalog → `PATCH practice_type_code`, base price as `quoted_price`). The stepper refuses to jump past Inquiry until a service is chosen (`needsServiceBefore` mirrors the backend gate, backend still enforces).
- `state-machine.ts`: `OPEN_INQUIRY_TYPE_CODE` + `needsServiceBefore`, with drift-detector tests next to the transition table.

298 net lines, `apps/mouth` only.

## Tests
vitest: `state-machine.test.ts` (+3 gate cases), `process/new/page.test.tsx`, `process/[id]/page.test.tsx`, `crm.api.test.ts` → green; `tsc --noEmit` clean (pre-commit typecheck ran on the mouth files).

## Bites
**Consumer:** the team at kita.balizero.com. **Prerequisite observed before arming:** prod `practice_types` carries `open_inquiry|inquiry|t` after the #6251 deploy (0 rows before).
**Observation after merge (Vercel deploy on main):** on `/process/new` the Service label reads "(optional at Inquiry — required before Waiting Documents)" and submitting with no service creates a process whose detail page shows the "Open inquiry — service not chosen yet" card; clicking the Documents step on it shows the "Select a service first" toast instead of a 400 from the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKrWYqGFyH1LjYds8kTSHJ
