### PR TITLE
chore(secrets): audit the finalSpecSha256 digest quoted in the #6243 gate report (Detect Secrets residue of #6254)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67084,6 +67084,16 @@
         "line_number": 5,
         "is_secret": false
       }
+    ],
+    "evidence/2026-09/agent-air-m5-mouth-shweb-w1-tech-20260911-1bf4ea22/reviews/gate-opus5-fresh-report.md": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-air-m5-mouth-shweb-w1-tech-20260911-1bf4ea22/reviews/gate-opus5-fresh-report.md",
+        "hashed_secret": "88a106393b870b88787b66b5085dd18b875832e8",
+        "is_verified": false,
+        "line_number": 262,
+        "is_secret": false
+      }
     ]
   },
   "version": "1.5.0"


### PR DESCRIPTION
## What

One audited row added to `.secrets.baseline` (+10 lines, nothing else): the Hex High Entropy String at line 262 of `evidence/2026-09/agent-air-m5-mouth-shweb-w1-tech-20260911-1bf4ea22/reviews/gate-opus5-fresh-report.md`, `hashed_secret 88a106393b870b88787b66b5085dd18b875832e8`, `is_secret: false`.

## Why

`Detect Secrets` → "Check for unaudited findings" was RED on both heads of #6254 (`922dd9c626`, `8d7333b419`): auto-triage 12 findings, 11 auto-approved, 1 residue with no rule matched. The residue is the `finalSpecSha256` value of `contract-lock.json` that the fresh Opus 5 gate quotes to prove the deleted pinned spec is still anchored (delta check 4). It is the public sha256 of a repo file, not a credential, and the same digest is already audited where it lives in `contract-lock.json` (#6243). The check is not required, so #6254 merged through the queue (`0141b8130a`, 16:47Z) with the finding unaudited; left as is, the nightly full-tree scan alerts on it.

## Verification (local, on this head)

- `python3 scripts/detect_secrets_check_unaudited.py` → `All findings audited (8160 total)` (main: 8159).
- Scratch-copy scan (`detect-secrets scan --baseline <copy> <report.md>`) keeps the entry at line 262 with `is_secret: false` and adds nothing unaudited. The real baseline was never scanned in place (a scan with explicit files prunes every unscanned file — re-hit once this session on a throwaway branch, restored with `git checkout`).

Mission: SHWEB-20260911, imperator session. Gear 1 (one audited baseline row, no product code). Perimeter: `.secrets.baseline` only.

Bites: the `Detect Secrets` check on this PR's head — its "Check for unaudited findings" step, red on #6254 for exactly this finding, is green here (observed on this PR before merge); after merge, the nightly full-tree scan's `Telegram alert` step stays skipped for this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ev6fXgQRAFkHen3rv9NCVr