### PR TITLE
data(regulatory): 2026-09-12 daily delta — 1 new, NB auth still down

### DIFF
--- a/research/regulatory/2026-09-12-delta.json
+++ b/research/regulatory/2026-09-12-delta.json
@@ -1,0 +1,54 @@
+{
+  "run_at": "2026-09-12T09:15:00+08:00",
+  "today": "2026-09-12",
+  "yesterday_seen_count": 24,
+  "yesterday_file_used": "2026-09-11-delta.json",
+  "new_today_count": 1,
+  "partial": true,
+  "unreachable_sources": [
+    {"url": "https://www.hukumonline.com/berita/", "reason": "http_403", "note": "HTTP 403 on fetch"},
+    {"url": "https://muc.co.id/article", "reason": "http_403", "note": "HTTP 403 on fetch"},
+    {"url": "https://ortax.org/news", "reason": "empty_shell", "note": "Soft-404 \"Artikel tidak ditemukan\", no dated content"},
+    {"url": "https://ikpi.or.id/articles", "reason": "empty_shell", "note": "Nuxt SPA shell, \"Menampilkan 0 berita & artikel\", zero static entries"},
+    {"url": "https://jdih.kemenkeu.go.id/peraturan", "reason": "empty_shell", "note": "Nav/institutional content only, no dated regulation entries"}
+  ],
+  "sources_checked_no_delta": [
+    {"url": "https://peraturan.go.id", "reason": "outside_window", "note": "Newest entry 2026-09-04 (Permen KKP 9/2026), not a matching reg-type either"},
+    {"url": "https://peraturan.bpk.go.id/Search?type=PerundangUndangan&jenis=PMK&tahun=2026", "reason": "checked_no_new", "note": "Content read (285 pages, 2026 index) but jenis=PMK filter surfaced only UU entries, likely JS-paginated"},
+    {"url": "https://www.imigrasi.go.id", "reason": "outside_window", "note": "Newest Siaran Pers dated 2026-09-04, no Permenimigrasi/Permenkumham citation"},
+    {"url": "https://www.pajak.go.id/peraturan", "reason": "outside_window", "note": "Newest entry KEP-185/PJ/2026 dated 2026-09-02, predates 48h window"},
+    {"url": "https://jdih.kemnaker.go.id/peraturan", "reason": "outside_window", "note": "Newest shown entry UU Nomor 2 Tahun 2026 dated 2026-04-30, far outside window"}
+  ],
+  "nb_query_errors": [
+    {"nb": "NB-INTEL-Regulation — Daily Regulatory Intelligence", "reason": "timeout", "note": "nlm query notebook via cached UUID, exit 124 after 20-25s; consistent with account-wide nlm auth expired since 2026-09-06"},
+    {"nb": "NB-INTEL-Press — Daily Press Intelligence", "reason": "timeout", "note": "Same timeout pattern, cached UUID"},
+    {"nb": "NB-INTEL-Immigration — Daily Immigration Intelligence", "reason": "timeout", "note": "Same timeout pattern, cached UUID"},
+    {"nb": "NB-INTEL-Tax — Daily Tax/Fiscal Intelligence", "reason": "timeout", "note": "Same timeout pattern, cached UUID"}
+  ],
+  "deltas": [
+    {
+      "citation": "PER-10/BC/2026",
+      "title_id": "DJBC Terbitkan Aturan Baru Pengelolaan BTD, BDN, dan BMMN",
+      "title_en": "DGCE Issues New Regulation on Management of BTD, BDN, and BMMN",
+      "service_line": ["tax"],
+      "severity": "low",
+      "confidence": "medium",
+      "impact_note": "Narrow relevance: governs Directorate General of Customs and Excise (DJBC) management of bonded/state-controlled/state-owned goods categories (BTD/BDN/BMMN) — affects PT PMA clients operating bonded warehouses or import-heavy KBLI, not the general visa/individual-tax client base. Single-source (DDTC), regulation full text not accessible from the article page — flagging the citation only, not asserting substantive content beyond the headline.",
+      "summary": "DDTC reports DJBC issued PER-10/BC/2026 on management of BTD (Barang Tidak Dikuasai), BDN (Barang Dikuasai Negara) and BMMN (Barang Milik Negara/Musnah). Article body not retrievable from the fetch — no deadline/fee/procedure detail confirmed beyond the headline.",
+      "source": "DDTC | https://news.ddtc.co.id/berita/nasional/1822393/djbc-terbitkan-aturan-baru-pengelolaan-btd-bdn-dan-bmmn",
+      "verbatim_excerpt": "DJBC Terbitkan Aturan Baru Pengelolaan BTD, BDN, dan BMMN",
+      "first_seen_at": "2026-09-12T09:15:00+08:00"
+    }
+  ],
+  "seen_citations": [
+    "PMK Nomor 28 Tahun 2026","PMK Nomor 40 Tahun 2026","PMK Nomor 41 Tahun 2026","PMK Nomor 42 Tahun 2026",
+    "PMK Nomor 43 Tahun 2026","PMK Nomor 44 Tahun 2026","PMK Nomor 55 Tahun 2026","PMK Nomor 57 Tahun 2026",
+    "PMK Nomor 61 Tahun 2026","PP Nomor 20 Tahun 2026","PP Nomor 24 Tahun 2026",
+    "Peraturan Direktur Jenderal Pajak Nomor PER-8/PJ/2026","Peraturan Menteri Hukum Nomor 13 Tahun 2026",
+    "Permen PMK/Badan PMI Nomor 5 Tahun 2026","Permenaker No. 12 Tahun 2026; BN 2026 (598)",
+    "Permenaker Nomor 7 Tahun 2026","Permenaker Nomor 8 Tahun 2026","Permenaker Nomor 9 Tahun 2026",
+    "Permenkes Nomor 6 Tahun 2026","Perpres Nomor 26 Tahun 2026","Perpres Nomor 27 Tahun 2026",
+    "Perpres Nomor 3 Tahun 2026","UU Nomor 4 Tahun 2026","UU Nomor 5 Tahun 2026",
+    "PER-10/BC/2026"
+  ]
+}


### PR DESCRIPTION
Daily regulatory-watcher run for 2026-09-12 (WITA), executed inline per agent spec `~/.claude/agents/regulatory-watcher.md`.

## Summary
- `new_today_count`: 1 — **PER-10/BC/2026** (DJBC bonded-warehouse mgmt: BTD/BDN/BMMN), single-source (DDTC), confidence `medium`, severity `low`.
- `nb_query_errors`: 4/4 — all NB-INTEL notebooks timeout on direct cached-UUID query (`nlm query notebook`, exit 124). Consistent with account-wide `nlm` auth expired since 2026-09-06 ([[fact_nlm_auth_expired_2026_09_06]]), unchanged since 2026-09-10/09-11 runs.
- Web primary (5): 2× `http_403` (hukumonline, muc.co.id), 3× `empty_shell` (ortax, ikpi.or.id, jdih.kemenkeu.go.id) — same pattern as prior runs.
- Web backup (5, triggered because primary yielded <3 deltas): all `outside_window` or `checked_no_new`.
- `partial: true` — NB path fully down this run.

## Bites
Consumer: Antonello, reading `research/regulatory/2026-09-12-delta.json` directly + the Telegram alert sent for the 1 new delta. Observation: file present on disk with valid JSON (`python3 -m json.tool` passed pre-commit), Telegram `sendMessage` returned `ok:true` (see follow-up comment after send).

🤖 Generated with [Claude Code](https://claude.com/claude-code)