### PR TITLE
test(bot): re-base the nine impossible-cosine tripwires by addition, with a G1-G13 guard (B1.2)

### DIFF
--- a/apps/backend-rag/backend/tests/fixtures/pipeline_score_fixtures.py
+++ b/apps/backend-rag/backend/tests/fixtures/pipeline_score_fixtures.py
@@ -1,22 +1,35 @@
 """Registry of dense-path score fixtures for the nine tripwire pipeline variants (B1.2).
 
-Every value below is MEASURED, not invented: the one real number that exists for each
-(query, context) pair is rc1a's `text-embedding-3-small` cosine, taken from a single prod
-Qdrant read-only probe (`rag` container, 2026-09-10T18:03Z, 20 texts, 216 prompt tokens;
-`measurement_ref` on each spec names the commit and script). No hybrid-path rank was ever
-measured for these texts, so every variant here declares the DENSE path
-(`score_provenance.DENSE_FORMATTED`) and nothing else — a `score_kind` is always DECLARED
-by the writer that mints it, never inferred from the number's magnitude (`core/score_provenance.py`).
+Only the COSINE on each spec is a measurement: rc1a's `text-embedding-3-small` cosine for
+one (query, context) pair, taken from a single prod Qdrant read-only probe (`rag`
+container, 2026-09-10T18:03Z, 20 texts, 216 prompt tokens; `measurement_ref` names the
+commit and script that took it). `score` is the REAL transform of that cosine through
+`format_search_results` — also a real computation, not a guess — and `score_kind` is
+DECLARED by the writer that mints it, never inferred from the number's magnitude
+(`core/score_provenance.py`).
 
-The originals these variants sit beside are PRESERVED byte-for-byte (D3/D5): this module only
-supplies the replacement sources literal, `pipeline_sources(node_id)`, so a variant's diff
-against its original is the sources line and nothing else.
+Everything else on a spec is a declared SIMULATION INPUT handed to
+`format_search_results` to reproduce that transform, not an observed retrieval fact —
+`simulated` names those fields per spec (`formatter_collection`, `lists`, `fallback_path`
+at minimum). No hybrid-path rank, list membership or fusion configuration was ever
+measured for these (query, context) texts: the (query, context) measurement this
+registry rests on cannot express any of the three
+(`evidence/2026-09/agent-nuzantara-backend-rag-b1-score-contract-107e45b6/B1-2-inventory.md:95-109`),
+so `dense_rank0` and `qdrant_server` are `None` on every spec rather than an invented
+value standing in for a measurement that was never taken. Row 9's single source is
+likewise an association the writer chose, not an observation — see its own
+`source_chunk_association`.
+
+The originals these variants sit beside are PRESERVED byte-for-byte (D3/D5): this module
+only supplies the replacement sources literal, `pipeline_sources(node_id)`, so a variant's
+diff against its original is the sources line and nothing else.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any, Final
 
 from backend.core import score_provenance
@@ -24,10 +37,15 @@ from backend.core import score_provenance
 
 @dataclass(frozen=True)
 class DenseSourceSpec:
-    """One measured dense-path source, pinned to the live `format_search_results` transform.
+    """One dense-path source: a measured cosine, a real transform, and declared inputs.
 
-    Every field is explicit per B1.1 decision D3: a kind is declared, never inferred, and
-    nothing here is a default standing in for a measurement that was never taken.
+    Per B1.1 decision D3, a kind is declared, never inferred, and nothing here stands in
+    for a measurement that was never taken: `cosine` is the one measured number; `score`
+    is what the live formatter computes from it; every field named in `simulated` is a
+    declared input to that computation, not an observed retrieval fact; `dense_rank0` and
+    `qdrant_server` are `None` because no rank or server receipt was ever measured for
+    these texts. `carried_keys` is frozen into a `MappingProxyType` in `__post_init__` so
+    a caller cannot mutate the registry's own source dicts (B1.2 round-1 finding 5).
     """
 
     inventory_row: int
@@ -36,13 +54,19 @@ class DenseSourceSpec:
     model: str
     measured_at: str
     measurement_ref: str
-    qdrant_server: str
+    #: No receipt was ever observed for these texts — declared `None`, never invented.
+    qdrant_server: str | None
     fallback_path: str
     fusion: None
     lists: tuple[str, ...]
-    dense_rank0: int
+    #: No rank was ever measured for these texts (B1-2-inventory.md:95-109) — declared
+    #: `None`, never invented.
+    dense_rank0: int | None
     cosine: float
-    collection: str
+    #: Simulation input to `format_search_results` that selects no boost (matches
+    #: neither `bali_zero_pricing_hybrid` nor `bali_zero_team`) — NOT an observed
+    #: retrieval collection.
+    formatter_collection: str
     primary_collection: None
     boosts: tuple[str, ...]
     transform: str
@@ -50,284 +74,329 @@ class DenseSourceSpec:
     score: float
     carried_keys: Mapping[str, Any]
     unsourced_context_cosines: tuple[float, ...]
+    #: Every field on this spec whose value is a declared simulation input rather than an
+    #: observed retrieval fact — at least `formatter_collection`, `lists`, `fallback_path`.
+    simulated: tuple[str, ...]
+    #: `None` unless the single source's association with its context chunk is itself
+    #: unresolved (row 9) — see that spec's own value for what "unresolved" means here.
+    source_chunk_association: str | None
+
+    def __post_init__(self) -> None:
+        """Freeze `carried_keys` into a `MappingProxyType`.
+
+        Every call site below still passes a plain dict literal; this is the one place
+        that turns it immutable. `object.__setattr__` is required because the dataclass
+        itself is frozen.
+        """
+        object.__setattr__(self, "carried_keys", MappingProxyType(dict(self.carried_keys)))
 
 
 #: Common provenance shared by every spec below — pinned once so nine call sites don't drift.
 _MEASUREMENT_REF: Final = "rc1a 92f40801235cf33b32a8d71f241b6400cad64536 measured_cosines.py"
 _MEASURED_AT: Final = "2026-09-10T18:03Z"
-_QDRANT_SERVER: Final = "1.16.3"
 _FALLBACK_PATH: Final = "search_service dense branch / core/qdrant_db.py:1362 internal fallback"
-_COLLECTION: Final = "kbli_2025_final_hybrid"
+_FORMATTER_COLLECTION: Final = "kbli_2025_final_hybrid"
 _TRANSFORM: Final = "distance = 1 - cosine; score = 1/(1+distance)"
+#: Fields whose value on every spec below is a declared simulation input, not an observed
+#: retrieval fact (finding 1) — shared because every spec below declares the same three.
+_SIMULATED_FIELDS: Final[tuple[str, ...]] = ("formatter_collection", "lists", "fallback_path")
 
 
-PIPELINE_TRIPWIRE_FIXTURES: Final[Mapping[str, tuple[DenseSourceSpec, ...]]] = {
-    # Row 1
-    "unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::"
-    "test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate": (
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=0,
-            cosine=0.16,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.5435,
-            carried_keys={},
-            unsourced_context_cosines=(),
+PIPELINE_TRIPWIRE_FIXTURES: Final[Mapping[str, tuple[DenseSourceSpec, ...]]] = MappingProxyType(
+    {
+        # Row 1
+        "unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::"
+        "test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.16,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5435,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
         ),
-    ),
-    # Row 2
-    "unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::"
-    "test_no_keyword_overlap": (
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=0,
-            cosine=0.04,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.5102,
-            carried_keys={},
-            unsourced_context_cosines=(),
+        # Row 2
+        "unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::"
+        "test_no_keyword_overlap": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.04,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5102,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
         ),
-    ),
-    # Row 3
-    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
-    "test_stop_words_only_query_keyword_ratio_zero": (
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=0,
-            cosine=0.14,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.5376,
-            carried_keys={},
-            unsourced_context_cosines=(),
+        # Row 3
+        "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+        "test_stop_words_only_query_keyword_ratio_zero": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.14,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5376,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
         ),
-    ),
-    # Row 4
-    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
-    "test_short_words_only_yields_near_zero": (
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=0,
-            cosine=0.16,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.5435,
-            carried_keys={},
-            unsourced_context_cosines=(),
+        # Row 4
+        "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+        "test_short_words_only_yields_near_zero": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.16,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5435,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
         ),
-    ),
-    # Row 5
-    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
-    "test_entity_mismatch_company_vs_visa": (
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=0,
-            cosine=0.30,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.5882,
-            carried_keys={},
-            unsourced_context_cosines=(),
+        # Row 5
+        "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+        "test_entity_mismatch_company_vs_visa": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.30,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5882,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
         ),
-    ),
-    # Row 6
-    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
-    "test_semantic_penalty_not_applied_when_final_score_at_or_below_015": (
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=0,
-            cosine=0.20,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.5556,
-            carried_keys={},
-            unsourced_context_cosines=(),
+        # Row 6
+        "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+        "test_semantic_penalty_not_applied_when_final_score_at_or_below_015": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.20,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5556,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
         ),
-    ),
-    # Row 7 — two sources, original order (id 1 then id 2); ranks per the spec table.
-    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
-    "test_kitas_query_with_kbli_results_low_score": (
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=1,
-            cosine=0.35,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.6061,
-            carried_keys={"id": 1, "title": "KBLI 2025"},
-            unsourced_context_cosines=(),
+        # Row 7 — two sources, original order (id 1 then id 2); ranks unmeasured for both.
+        "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+        "test_kitas_query_with_kbli_results_low_score": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.35,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.6061,
+                carried_keys={"id": 1, "title": "KBLI 2025"},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.51,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.6711,
+                carried_keys={"id": 2, "title": "Business Classification"},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
         ),
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=0,
-            cosine=0.51,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.6711,
-            carried_keys={"id": 2, "title": "Business Classification"},
-            unsourced_context_cosines=(),
+        # Row 8
+        "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+        "test_nonsense_query_zero_score": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.22,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5618,
+                carried_keys={"id": 1, "title": "Random Doc"},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
         ),
-    ),
-    # Row 8
-    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
-    "test_nonsense_query_zero_score": (
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=0,
-            cosine=0.22,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.5618,
-            carried_keys={"id": 1, "title": "Random Doc"},
-            unsourced_context_cosines=(),
+        # Row 9 — single source: the top dense hit (max of the two measured chunk cosines); the
+        # other chunk's cosine is carried separately as `unsourced_context_cosines`. Which chunk
+        # the single source "is" was never observed — that association is itself unresolved.
+        "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+        "test_entity_type_mismatch_detection": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.40,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.625,
+                carried_keys={"id": 1},
+                unsourced_context_cosines=(0.32,),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=(
+                    "unresolved — the single source carries the max of the two measured "
+                    "chunk cosines (0.40); the other is unsourced_context_cosines"
+                ),
+            ),
         ),
-    ),
-    # Row 9 — single source: the top dense hit (max of the two measured chunk cosines); the
-    # other chunk's cosine is carried separately as `unsourced_context_cosines`.
-    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
-    "test_entity_type_mismatch_detection": (
-        DenseSourceSpec(
-            inventory_row=2,
-            score_kind=score_provenance.DENSE_FORMATTED,
-            provider="openai",
-            model="text-embedding-3-small",
-            measured_at=_MEASURED_AT,
-            measurement_ref=_MEASUREMENT_REF,
-            qdrant_server=_QDRANT_SERVER,
-            fallback_path=_FALLBACK_PATH,
-            fusion=None,
-            lists=("dense",),
-            dense_rank0=0,
-            cosine=0.40,
-            collection=_COLLECTION,
-            primary_collection=None,
-            boosts=(),
-            transform=_TRANSFORM,
-            rounding_digits=4,
-            score=0.625,
-            carried_keys={"id": 1},
-            unsourced_context_cosines=(0.32,),
-        ),
-    ),
-}
+    },
+)
 
 
 def pipeline_sources(node_id: str) -> list[dict[str, Any]]:
     """Return a FRESH list of formatted-style source dicts for `node_id`.
 
     Each dict is `{**carried_keys, "score": score, "score_kind": score_kind, "score_raw":
-    cosine}`, in the original list order. A new list and new dicts are built on every call, so
-    a caller mutating its result never leaks into the registry or into another caller.
+    cosine}`, in the original list order. A new list and new plain dicts are built on
+    every call — `carried_keys` is a `MappingProxyType` on the spec, but `**`-unpacking it
+    here always yields a fresh mutable `dict` — so a caller mutating its result never
+    leaks into the registry or into another caller.
 
     Raises `KeyError` naming this registry on an unknown id — never a silent default.
     """

--- a/apps/backend-rag/backend/tests/fixtures/pipeline_score_fixtures.py
+++ b/apps/backend-rag/backend/tests/fixtures/pipeline_score_fixtures.py
@@ -1,0 +1,350 @@
+"""Registry of dense-path score fixtures for the nine tripwire pipeline variants (B1.2).
+
+Every value below is MEASURED, not invented: the one real number that exists for each
+(query, context) pair is rc1a's `text-embedding-3-small` cosine, taken from a single prod
+Qdrant read-only probe (`rag` container, 2026-09-10T18:03Z, 20 texts, 216 prompt tokens;
+`measurement_ref` on each spec names the commit and script). No hybrid-path rank was ever
+measured for these texts, so every variant here declares the DENSE path
+(`score_provenance.DENSE_FORMATTED`) and nothing else — a `score_kind` is always DECLARED
+by the writer that mints it, never inferred from the number's magnitude (`core/score_provenance.py`).
+
+The originals these variants sit beside are PRESERVED byte-for-byte (D3/D5): this module only
+supplies the replacement sources literal, `pipeline_sources(node_id)`, so a variant's diff
+against its original is the sources line and nothing else.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Final
+
+from backend.core import score_provenance
+
+
+@dataclass(frozen=True)
+class DenseSourceSpec:
+    """One measured dense-path source, pinned to the live `format_search_results` transform.
+
+    Every field is explicit per B1.1 decision D3: a kind is declared, never inferred, and
+    nothing here is a default standing in for a measurement that was never taken.
+    """
+
+    inventory_row: int
+    score_kind: str
+    provider: str
+    model: str
+    measured_at: str
+    measurement_ref: str
+    qdrant_server: str
+    fallback_path: str
+    fusion: None
+    lists: tuple[str, ...]
+    dense_rank0: int
+    cosine: float
+    collection: str
+    primary_collection: None
+    boosts: tuple[str, ...]
+    transform: str
+    rounding_digits: int
+    score: float
+    carried_keys: Mapping[str, Any]
+    unsourced_context_cosines: tuple[float, ...]
+
+
+#: Common provenance shared by every spec below — pinned once so nine call sites don't drift.
+_MEASUREMENT_REF: Final = "rc1a 92f40801235cf33b32a8d71f241b6400cad64536 measured_cosines.py"
+_MEASURED_AT: Final = "2026-09-10T18:03Z"
+_QDRANT_SERVER: Final = "1.16.3"
+_FALLBACK_PATH: Final = "search_service dense branch / core/qdrant_db.py:1362 internal fallback"
+_COLLECTION: Final = "kbli_2025_final_hybrid"
+_TRANSFORM: Final = "distance = 1 - cosine; score = 1/(1+distance)"
+
+
+PIPELINE_TRIPWIRE_FIXTURES: Final[Mapping[str, tuple[DenseSourceSpec, ...]]] = {
+    # Row 1
+    "unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::"
+    "test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate": (
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=0,
+            cosine=0.16,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.5435,
+            carried_keys={},
+            unsourced_context_cosines=(),
+        ),
+    ),
+    # Row 2
+    "unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::"
+    "test_no_keyword_overlap": (
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=0,
+            cosine=0.04,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.5102,
+            carried_keys={},
+            unsourced_context_cosines=(),
+        ),
+    ),
+    # Row 3
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_stop_words_only_query_keyword_ratio_zero": (
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=0,
+            cosine=0.14,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.5376,
+            carried_keys={},
+            unsourced_context_cosines=(),
+        ),
+    ),
+    # Row 4
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_short_words_only_yields_near_zero": (
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=0,
+            cosine=0.16,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.5435,
+            carried_keys={},
+            unsourced_context_cosines=(),
+        ),
+    ),
+    # Row 5
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_entity_mismatch_company_vs_visa": (
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=0,
+            cosine=0.30,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.5882,
+            carried_keys={},
+            unsourced_context_cosines=(),
+        ),
+    ),
+    # Row 6
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_semantic_penalty_not_applied_when_final_score_at_or_below_015": (
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=0,
+            cosine=0.20,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.5556,
+            carried_keys={},
+            unsourced_context_cosines=(),
+        ),
+    ),
+    # Row 7 — two sources, original order (id 1 then id 2); ranks per the spec table.
+    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+    "test_kitas_query_with_kbli_results_low_score": (
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=1,
+            cosine=0.35,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.6061,
+            carried_keys={"id": 1, "title": "KBLI 2025"},
+            unsourced_context_cosines=(),
+        ),
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=0,
+            cosine=0.51,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.6711,
+            carried_keys={"id": 2, "title": "Business Classification"},
+            unsourced_context_cosines=(),
+        ),
+    ),
+    # Row 8
+    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+    "test_nonsense_query_zero_score": (
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=0,
+            cosine=0.22,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.5618,
+            carried_keys={"id": 1, "title": "Random Doc"},
+            unsourced_context_cosines=(),
+        ),
+    ),
+    # Row 9 — single source: the top dense hit (max of the two measured chunk cosines); the
+    # other chunk's cosine is carried separately as `unsourced_context_cosines`.
+    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+    "test_entity_type_mismatch_detection": (
+        DenseSourceSpec(
+            inventory_row=2,
+            score_kind=score_provenance.DENSE_FORMATTED,
+            provider="openai",
+            model="text-embedding-3-small",
+            measured_at=_MEASURED_AT,
+            measurement_ref=_MEASUREMENT_REF,
+            qdrant_server=_QDRANT_SERVER,
+            fallback_path=_FALLBACK_PATH,
+            fusion=None,
+            lists=("dense",),
+            dense_rank0=0,
+            cosine=0.40,
+            collection=_COLLECTION,
+            primary_collection=None,
+            boosts=(),
+            transform=_TRANSFORM,
+            rounding_digits=4,
+            score=0.625,
+            carried_keys={"id": 1},
+            unsourced_context_cosines=(0.32,),
+        ),
+    ),
+}
+
+
+def pipeline_sources(node_id: str) -> list[dict[str, Any]]:
+    """Return a FRESH list of formatted-style source dicts for `node_id`.
+
+    Each dict is `{**carried_keys, "score": score, "score_kind": score_kind, "score_raw":
+    cosine}`, in the original list order. A new list and new dicts are built on every call, so
+    a caller mutating its result never leaks into the registry or into another caller.
+
+    Raises `KeyError` naming this registry on an unknown id — never a silent default.
+    """
+    try:
+        specs = PIPELINE_TRIPWIRE_FIXTURES[node_id]
+    except KeyError:
+        raise KeyError(
+            f"{node_id!r} is not registered in "
+            "backend.tests.fixtures.pipeline_score_fixtures.PIPELINE_TRIPWIRE_FIXTURES",
+        ) from None
+
+    return [
+        {
+            **spec.carried_keys,
+            "score": spec.score,
+            "score_kind": spec.score_kind,
+            "score_raw": spec.cosine,
+        }
+        for spec in specs
+    ]

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_reasoning_utils.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_reasoning_utils.py
@@ -200,11 +200,40 @@ class TestCalculateEvidenceScore:
         # semantic_relevance == 0.0 → final_score capped at min(0.4*0.2, 0.1)
         assert score <= 0.10
 
+    def test_stop_words_only_query_keyword_ratio_zero_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_stop_words_only_query_keyword_ratio_zero"]
+        score = calculate_evidence_score(
+            pipeline_sources(
+                "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_stop_words_only_query_keyword_ratio_zero"
+            ),
+            ["kitas immigration visa stay permit renewal"],
+            "what is the",
+        )
+        # semantic_relevance == 0.0 → final_score capped at min(0.4*0.2, 0.1)
+        assert score <= 0.10
+
     # --- short words stripped (all ≤ 3 chars after strip) ---
 
     def test_short_words_only_yields_near_zero(self):
         score = calculate_evidence_score(
             [{"score": 0.8}],
+            ["kitas visa permit"],
+            "go to a spa",  # all ≤ 3 chars: go(2), to(2), a(1), spa(3)
+        )
+        assert score <= 0.10
+
+    def test_short_words_only_yields_near_zero_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_short_words_only_yields_near_zero"]
+        score = calculate_evidence_score(
+            pipeline_sources(
+                "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_short_words_only_yields_near_zero"
+            ),
             ["kitas visa permit"],
             "go to a spa",  # all ≤ 3 chars: go(2), to(2), a(1), spa(3)
         )
@@ -259,6 +288,21 @@ class TestCalculateEvidenceScore:
         )
         assert score < 0.15
 
+    def test_entity_mismatch_company_vs_visa_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_entity_mismatch_company_vs_visa"]
+        # query about PT/PMA company, context about visa/immigration only
+        score = calculate_evidence_score(
+            pipeline_sources(
+                "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_entity_mismatch_company_vs_visa"
+            ),
+            ["visa immigration permit stay kitas renewal"],
+            "PT PMA company setup registration",
+        )
+        assert score < 0.15
+
     # --- semantic-cosine penalty guard conditions ---
 
     def test_semantic_penalty_not_applied_when_cosine_is_zero(self):
@@ -282,6 +326,23 @@ class TestCalculateEvidenceScore:
         # Craft a case with zero semantic relevance → final_score ≤ 0.10 → no penalty
         score = calculate_evidence_score(
             [{"score": 0.35}],  # cosine 0.35 < 0.5, would trigger penalty
+            ["completely unrelated content about something else"],
+            "xyzabc123",  # no meaningful keywords → semantic_relevance = 0.0
+        )
+        # final_score already ≤ 0.10; verify penalty didn't make it negative
+        assert 0.0 <= score <= 0.10
+
+    def test_semantic_penalty_not_applied_when_final_score_at_or_below_015_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_semantic_penalty_not_applied_when_final_score_at_or_below_015"]
+        # Even if cosine is < 0.5, penalty only fires when final_score > 0.15
+        # Craft a case with zero semantic relevance → final_score ≤ 0.10 → no penalty
+        score = calculate_evidence_score(
+            pipeline_sources(
+                "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_semantic_penalty_not_applied_when_final_score_at_or_below_015"
+            ),
             ["completely unrelated content about something else"],
             "xyzabc123",  # no meaningful keywords → semantic_relevance = 0.0
         )

--- a/apps/backend-rag/backend/tests/services/rag/test_evidence_scoring_abstain.py
+++ b/apps/backend-rag/backend/tests/services/rag/test_evidence_scoring_abstain.py
@@ -45,6 +45,29 @@ class TestEvidenceScoringFixed:
         assert score < 0.15, f"Expected score < 0.15 for mismatched topic, got {score}"
         print(f"✅ KITAS query with KBLI results: score = {score} (correctly < 0.15)")
 
+    def test_kitas_query_with_kbli_results_low_score_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_kitas_query_with_kbli_results_low_score"]
+        # KITAS query
+        query = "Come posso richiedere il KITAS in Indonesia?"
+
+        # But results are about KBLI (business classification) - completely wrong topic
+        sources = pipeline_sources(
+            "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_kitas_query_with_kbli_results_low_score"
+        )
+        context = [
+            "KBLI (Klasifikasi Baku Lapangan Usaha Indonesia) è il sistema di classificazione...",
+            "I codici KBLI sono necessari per registrare un'azienda in Indonesia...",
+        ]
+
+        score = calculate_evidence_score(sources, context, query)
+
+        # Should be very low (< 0.15) due to topic mismatch
+        assert score < 0.15, f"Expected score < 0.15 for mismatched topic, got {score}"
+        print(f"✅ KITAS query with KBLI results: score = {score} (correctly < 0.15)")
+
     def test_nonsense_query_zero_score(self):
         """
         Problem 2: Nonsense query "xyzabc123" should score ~0.0
@@ -56,6 +79,25 @@ class TestEvidenceScoringFixed:
         sources = [
             {"id": 1, "title": "Random Doc", "score": 0.8},
         ]
+        context = [
+            "This is some generic document content about various topics and subjects...",
+        ]
+
+        score = calculate_evidence_score(sources, context, query)
+
+        # Should be very low (< 0.15 triggers ABSTAIN)
+        assert score < 0.15, f"Expected score < 0.15 for nonsense query, got {score}"
+        print(f"✅ Nonsense query: score = {score} (correctly < 0.15)")
+
+    def test_nonsense_query_zero_score_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_nonsense_query_zero_score"]
+        query = "xyzabc123 blorptastic fnord"
+        sources = pipeline_sources(
+            "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_nonsense_query_zero_score"
+        )
         context = [
             "This is some generic document content about various topics and subjects...",
         ]
@@ -146,6 +188,28 @@ class TestEvidenceScoringFixed:
 
         # Context about KBLI (wrong entity type)
         sources = [{"id": 1, "score": 0.9}]
+        context = [
+            "Il codice KBLI 46610 si riferisce al commercio all'ingrosso...",
+            "Per registrare un'azienda serve il KBLI corretto...",
+        ]
+
+        score = calculate_evidence_score(sources, context, query)
+
+        # Should be capped due to entity mismatch
+        assert score < 0.2, f"Entity mismatch should cap score low, got {score}"
+
+    def test_entity_type_mismatch_detection_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_entity_type_mismatch_detection"]
+        # Query about visa
+        query = "Come richiedere il KITAS?"
+
+        # Context about KBLI (wrong entity type)
+        sources = pipeline_sources(
+            "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_entity_type_mismatch_detection"
+        )
         context = [
             "Il codice KBLI 46610 si riferisce al commercio all'ingrosso...",
             "Per registrare un'azienda serve il KBLI corretto...",

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_abstain_bypass_policy.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_abstain_bypass_policy.py
@@ -298,6 +298,28 @@ class TestTrustedToolDetection:
         assert score < 0.15
 
     @pytest.mark.unit
+    def test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.services.rag.agentic._reasoning_evidence import compute_evidence_score
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate"]
+        query = "Untuk KBLI 51101 berapa batas kepemilikan asing?"
+        irrelevant = (
+            "The D12 visa requires a passport and sponsor documents. "
+            "Immigration may request additional evidence for the stay permit."
+        )
+        score = compute_evidence_score(
+            trusted_tools_used=False,
+            sources=pipeline_sources(
+                "unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate"
+            ),
+            context_gathered=[irrelevant],
+            query=query,
+        )
+        assert score < 0.15
+
+    @pytest.mark.unit
     def test_relevant_vector_hit_can_pass_through_relevance_path(self):
         from backend.services.rag.agentic._reasoning_evidence import compute_evidence_score
 

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_reasoning.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_reasoning.py
@@ -214,6 +214,18 @@ class TestCalculateEvidenceScore:
         score = calculate_evidence_score(sources, context, "quantum physics theory")
         assert score < 0.15
 
+    def test_no_keyword_overlap_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::test_no_keyword_overlap"]
+        sources = pipeline_sources(
+            "unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::test_no_keyword_overlap"
+        )
+        context = ["KBLI classification code retail 47911"]
+        score = calculate_evidence_score(sources, context, "quantum physics theory")
+        assert score < 0.15
+
     def test_entity_type_mismatch_visa_vs_kbli(self):
         """KITAS query + KBLI context triggers mismatch penalty."""
         sources = [{"score": 0.7}]

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
@@ -1,4 +1,4 @@
-"""Guard for the nine tripwire pipeline variants (B1.2, spec §3, G1-G5).
+"""Guard for the nine tripwire pipeline variants (B1.2, spec §3, G1-G10).
 
 Purely static/pure-function checks: parses the four original tripwire test files with `ast`
 (paths resolved relative to THIS file's own location, never a hardcoded absolute path) and
@@ -9,13 +9,33 @@ The nine `_pipeline_variant` functions ship in the same PR, each beside its pres
 G1-G3 pin the registry (shape, live-transform values, key set, original existence); G4/G5 pin
 the variants (existence, their `pipeline_sources(...)` call, no unlabelled score literal, assert
 parity with the original). A variant that disappears or a re-introduced unlabelled value is red.
+
+Added in the B1.2 round-1 cure (Codex BLOCK, 5 findings):
+  * G6 — whole-body AST parity between a variant and its original (finding 2: G4 only checked
+    that a correct call existed SOMEWHERE, so a variant could add extra statements after it).
+  * G7 — no duplicate `def` of a protected name in a class body (finding 3a: Python binds the
+    LAST same-named definition; `_find_function`'s first-match semantics could inspect a
+    definition pytest never runs).
+  * G8 — each ORIGINAL pinned against an independent sha256 snapshot of its own AST (finding
+    3b: G5 only compared the variant to whatever the original currently says, so weakening
+    both identically stayed green).
+  * G9 — every registry field pinned against an independent literal EXPECTED table (finding 4:
+    G1/G2 only checked score/score_kind/score_raw, leaving rank/collection/fusion/carried_keys
+    etc. unpinned).
+  * G10 — the registry and `carried_keys` are actually immutable at runtime, and
+    `pipeline_sources` still returns fresh, independently-mutable plain dicts (finding 5:
+    `frozen=True` alone does not stop `PIPELINE_TRIPWIRE_FIXTURES.clear()` or
+    `spec.carried_keys["k"] = 1`).
 """
 
 from __future__ import annotations
 
 import ast
+import copy
+import dataclasses
+import hashlib
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 import pytest
 
@@ -23,6 +43,7 @@ from backend.core import score_provenance
 from backend.services.misc.result_formatter import format_search_results
 from backend.tests.fixtures.pipeline_score_fixtures import (
     PIPELINE_TRIPWIRE_FIXTURES,
+    DenseSourceSpec,
     pipeline_sources,
 )
 
@@ -187,7 +208,9 @@ def test_g1_sources_carry_valid_score_kind_and_float_scores(node_id: str) -> Non
 
 # ============================================================================
 # G2 — the pinned score/score_kind/score_raw match what the LIVE
-# `format_search_results` transform produces from the spec's cosine.
+# `format_search_results` transform produces from the spec's cosine, AND match
+# an independently recomputed `1/(1+(1-cosine))` — three ways to derive the
+# same number must agree, not just two.
 # ============================================================================
 
 
@@ -195,6 +218,11 @@ def test_g1_sources_carry_valid_score_kind_and_float_scores(node_id: str) -> Non
 def test_g2_pinned_values_match_live_formatter(node_id: str) -> None:
     specs = PIPELINE_TRIPWIRE_FIXTURES[node_id]
     for i, spec in enumerate(specs):
+        recomputed = round(1 / (1 + (1 - spec.cosine)), spec.rounding_digits)
+        assert recomputed == spec.score, (
+            f"{node_id}[{i}]: recomputed transform {recomputed!r} != pinned score {spec.score!r}"
+        )
+
         raw_results = {
             "ids": ["probe"],
             "documents": ["probe"],
@@ -204,13 +232,14 @@ def test_g2_pinned_values_match_live_formatter(node_id: str) -> None:
         }
         formatted = format_search_results(
             raw_results,
-            spec.collection,
+            spec.formatter_collection,
             score_kind=spec.score_kind,
         )
         assert len(formatted) == 1, f"{node_id}[{i}]: formatter did not return one result"
         entry = formatted[0]
-        assert entry["score"] == spec.score, (
-            f"{node_id}[{i}]: pinned score {spec.score!r} != live formatter {entry['score']!r}"
+        assert entry["score"] == spec.score == recomputed, (
+            f"{node_id}[{i}]: pinned score {spec.score!r} != live formatter {entry['score']!r} "
+            f"!= recomputed {recomputed!r}"
         )
         assert entry["score_kind"] == spec.score_kind, (
             f"{node_id}[{i}]: pinned score_kind {spec.score_kind!r} != "
@@ -302,4 +331,449 @@ def test_g5_variant_asserts_match_original_asserts(node_id: str) -> None:
     assert variant_asserts == original_asserts, (
         f"{node_id}: assert statements in {variant_name!r} diverge from "
         f"{func_name!r} (ast.dump comparison, in order)"
+    )
+
+
+# ============================================================================
+# G6 — whole-body AST parity between a variant and its original.
+#
+# Finding 2 (Codex round 1): G4 only required that SOME correct
+# `pipeline_sources(...)` call exist and that no unlabelled dict literal be
+# introduced anywhere in the variant. A variant can satisfy both while adding
+# extra statements after the call — e.g. `sources[0].pop("score_kind")` —
+# because that statement is neither the call itself nor a dict literal.
+#
+# G6 normalizes both bodies (docstring dropped from both; the variant's
+# `from ... import pipeline_sources` line dropped once; the original's
+# all-dicts-with-"score" sources list literal AND the variant's own
+# `pipeline_sources("<node id>")` call each replaced by the SAME placeholder
+# name) and then requires the two statement lists — and the decorator lists,
+# unnormalized — to be identical by `ast.dump`. Anything the variant adds,
+# removes or reorders beyond that one substitution goes red.
+# ============================================================================
+
+_G6_PLACEHOLDER_ID: Final = "__g6_sources_placeholder__"
+
+
+def _g6_placeholder() -> ast.Name:
+    return ast.Name(id=_G6_PLACEHOLDER_ID, ctx=ast.Load())
+
+
+def _is_all_dicts_with_score_key(node: ast.List) -> bool:
+    if not node.elts:
+        return False
+    for elt in node.elts:
+        if not isinstance(elt, ast.Dict):
+            return False
+        if not any(_string_value(key) == "score" for key in elt.keys):
+            return False
+    return True
+
+
+class _SourcesListReplacer(ast.NodeTransformer):
+    """Replace the list literal whose elements are all dicts carrying a "score" key."""
+
+    def __init__(self) -> None:
+        self.count = 0
+
+    def visit_List(self, node: ast.List) -> ast.AST:  # noqa: N802 - ast.NodeTransformer API
+        self.generic_visit(node)
+        if _is_all_dicts_with_score_key(node):
+            self.count += 1
+            return _g6_placeholder()
+        return node
+
+
+class _PipelineSourcesCallReplacer(ast.NodeTransformer):
+    """Replace ONLY a `pipeline_sources("<node_id>")` call with the same placeholder."""
+
+    def __init__(self, node_id: str) -> None:
+        self.node_id = node_id
+        self.count = 0
+
+    def visit_Call(self, node: ast.Call) -> ast.AST:  # noqa: N802 - ast.NodeTransformer API
+        self.generic_visit(node)
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "pipeline_sources"
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == self.node_id
+        ):
+            self.count += 1
+            return _g6_placeholder()
+        return node
+
+
+def _strip_docstring(body: list[ast.stmt]) -> list[ast.stmt]:
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        return body[1:]
+    return body
+
+
+def _drop_one_pipeline_sources_import(body: list[ast.stmt]) -> tuple[list[ast.stmt], int]:
+    """Drop exactly one `from ...pipeline_score_fixtures import pipeline_sources` line.
+
+    Returns the new body and how many were dropped (0 or 1) — the caller asserts on the
+    count so a missing or duplicated import is legible instead of silently skipped.
+    """
+    result: list[ast.stmt] = []
+    dropped = 0
+    for stmt in body:
+        if (
+            not dropped
+            and isinstance(stmt, ast.ImportFrom)
+            and stmt.module == "backend.tests.fixtures.pipeline_score_fixtures"
+            and any(alias.name == "pipeline_sources" for alias in stmt.names)
+        ):
+            dropped += 1
+            continue
+        result.append(stmt)
+    return result, dropped
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g6_variant_whole_body_matches_original_except_the_sources_line(node_id: str) -> None:
+    rel_path, class_name, func_name, _module, class_node = _locate_original(node_id)
+    assert class_node is not None, f"{node_id}: class {class_name!r} not found in {rel_path}"
+
+    original_node = _find_function(class_node, func_name)
+    assert original_node is not None, (
+        f"{node_id}: original function {func_name!r} not found in class "
+        f"{class_name!r} of {rel_path}"
+    )
+    variant_name = f"{func_name}_pipeline_variant"
+    variant_node = _find_function(class_node, variant_name)
+    assert variant_node is not None, (
+        f"{node_id}: variant {variant_name!r} does not exist — cannot compare its body "
+        "to the original's"
+    )
+
+    original_decorators = [ast.dump(d) for d in original_node.decorator_list]
+    variant_decorators = [ast.dump(d) for d in variant_node.decorator_list]
+    assert variant_decorators == original_decorators, (
+        f"{node_id}: {variant_name!r} decorators diverge from {func_name!r}"
+    )
+
+    original_body = _strip_docstring(original_node.body)
+    variant_body = _strip_docstring(variant_node.body)
+    variant_body, dropped = _drop_one_pipeline_sources_import(variant_body)
+    assert dropped == 1, (
+        f"{node_id}: {variant_name!r} must import pipeline_sources exactly once (found {dropped})"
+    )
+
+    list_replacer = _SourcesListReplacer()
+    original_body = [list_replacer.visit(copy.deepcopy(stmt)) for stmt in original_body]
+    assert list_replacer.count == 1, (
+        f"{node_id}: original {func_name!r} does not contain exactly one all-dicts-with-"
+        f"'score' sources list literal (found {list_replacer.count})"
+    )
+
+    call_replacer = _PipelineSourcesCallReplacer(node_id)
+    variant_body = [call_replacer.visit(copy.deepcopy(stmt)) for stmt in variant_body]
+    assert call_replacer.count == 1, (
+        f"{node_id}: variant {variant_name!r} does not contain exactly one "
+        f"pipeline_sources({node_id!r}) call (found {call_replacer.count})"
+    )
+
+    original_dumps = [ast.dump(stmt) for stmt in original_body]
+    variant_dumps = [ast.dump(stmt) for stmt in variant_body]
+    assert variant_dumps == original_dumps, (
+        f"{node_id}: {variant_name!r} body diverges from {func_name!r} beyond the sources "
+        "line — normalized statement lists differ"
+    )
+
+
+# ============================================================================
+# G7 — no duplicate `def` of a protected name in a class body.
+#
+# Finding 3a (Codex round 1): `_find_function` returns the FIRST same-named
+# definition in the class body, but Python binds (and pytest collects and
+# runs) the LAST one. A weakened definition appended after a valid one passes
+# every AST-based check above while pytest actually executes the weak copy.
+# ============================================================================
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g7_no_duplicate_definitions_of_protected_names(node_id: str) -> None:
+    rel_path, class_name, func_name, _module, class_node = _locate_original(node_id)
+    assert class_node is not None, f"{node_id}: class {class_name!r} not found in {rel_path}"
+
+    variant_name = f"{func_name}_pipeline_variant"
+    for protected_name in (func_name, variant_name):
+        count = sum(
+            1
+            for stmt in class_node.body
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and stmt.name == protected_name
+        )
+        assert count == 1, (
+            f"{node_id}: class {class_name!r} of {rel_path} defines {protected_name!r} "
+            f"{count} times — Python binds the LAST one, so a duplicate can run a "
+            "definition this guard never inspects"
+        )
+
+
+# ============================================================================
+# G8 — each ORIGINAL function pinned against an independent sha256 snapshot.
+#
+# Finding 3b (Codex round 1): G5 compares the variant's asserts to whatever
+# the original CURRENTLY says — weakening both identically stays green. The
+# hashes below were computed once, on the frozen files, by
+# `hashlib.sha256(ast.dump(func_node, include_attributes=False).encode()).hexdigest()`
+# under the project's `.venv` (Python 3.11) interpreter — independent of
+# anything this module re-derives at test time.
+# ============================================================================
+
+_ORIGINAL_AST_SHA256: Final[dict[str, str]] = {
+    "unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::"
+    "test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate": (
+        "5eb8384b63b52deb9d5ac2bb070f1f344d4baf19bc7fa7ca9b97d50f71fdb81e"
+    ),
+    "unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::"
+    "test_no_keyword_overlap": ("cb2cfcf367aaa5c419aab75db983a3ecf1da8723c2c8bc338e33d22de89d18fb"),
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_stop_words_only_query_keyword_ratio_zero": (
+        "1837919a07adbfe189a06f41c36c9b0768eab44223e4eb280fd28804a2a0f89a"
+    ),
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_short_words_only_yields_near_zero": (
+        "bfd44e3ebb5a5e611a66a2341b6977c1da82ddd4b69b3bf0c500a74ee0ebf879"
+    ),
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_entity_mismatch_company_vs_visa": (
+        "3b3fe4f71f9732b9c20684d6ac12f391b76caa9fd39d5d2d8f9ba9f328f25fa1"
+    ),
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_semantic_penalty_not_applied_when_final_score_at_or_below_015": (
+        "3fe3a9ab02d55fd6ea09b12e3b00b5d273a6a16863d2a85db4b5785fd1015455"
+    ),
+    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+    "test_kitas_query_with_kbli_results_low_score": (
+        "c79ce8a80f90a2844390f4d989dc7875918160c2e8514e5d4cbe00bfe25b6c60"
+    ),
+    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+    "test_nonsense_query_zero_score": (
+        "448ce2b784edc4b0920e962151f2f182da6a8bc1829df57856d88eaa4503e08e"
+    ),
+    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+    "test_entity_type_mismatch_detection": (
+        "fc369d3fd7d88e162431765a768be8205b6d14da5f37cbc768cbb82b0512324c"
+    ),
+}
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g8_original_function_matches_pinned_snapshot(node_id: str) -> None:
+    rel_path, class_name, func_name, _module, class_node = _locate_original(node_id)
+    assert class_node is not None, f"{node_id}: class {class_name!r} not found in {rel_path}"
+    original_node = _find_function(class_node, func_name)
+    assert original_node is not None, (
+        f"{node_id}: original function {func_name!r} not found in class "
+        f"{class_name!r} of {rel_path}"
+    )
+
+    digest = hashlib.sha256(
+        ast.dump(original_node, include_attributes=False).encode(),
+    ).hexdigest()
+    expected = _ORIGINAL_AST_SHA256[node_id]
+    assert digest == expected, (
+        f"{node_id}: original {func_name!r} in {rel_path} no longer matches its pinned "
+        f"AST snapshot (got {digest}, expected {expected}) — the frozen original was edited"
+    )
+
+
+# ============================================================================
+# G9 — every registry field pinned against an independent literal EXPECTED
+# table (finding 4: G1/G2 only checked score/score_kind/score_raw).
+#
+# All ten specs below share every field except cosine/score/carried_keys/
+# unsourced_context_cosines/source_chunk_association — `_G9_SHARED_FIELDS`
+# names the shared values once, `_G9_PER_SPEC` re-transcribes the varying
+# ones per node id, in registry order, independently of the registry module.
+# ============================================================================
+
+_G9_SHARED_FIELDS: Final[dict[str, Any]] = {
+    "inventory_row": 2,
+    "score_kind": score_provenance.DENSE_FORMATTED,
+    "provider": "openai",
+    "model": "text-embedding-3-small",
+    "measured_at": "2026-09-10T18:03Z",
+    "measurement_ref": "rc1a 92f40801235cf33b32a8d71f241b6400cad64536 measured_cosines.py",
+    "qdrant_server": None,
+    "fallback_path": "search_service dense branch / core/qdrant_db.py:1362 internal fallback",
+    "fusion": None,
+    "lists": ("dense",),
+    "dense_rank0": None,
+    "formatter_collection": "kbli_2025_final_hybrid",
+    "primary_collection": None,
+    "boosts": (),
+    "transform": "distance = 1 - cosine; score = 1/(1+distance)",
+    "rounding_digits": 4,
+    "simulated": ("formatter_collection", "lists", "fallback_path"),
+}
+
+_G9_PER_SPEC: Final[dict[str, tuple[dict[str, Any], ...]]] = {
+    NODE_IDS[0]: (
+        {
+            "cosine": 0.16,
+            "score": 0.5435,
+            "carried_keys": {},
+            "unsourced_context_cosines": (),
+            "source_chunk_association": None,
+        },
+    ),
+    NODE_IDS[1]: (
+        {
+            "cosine": 0.04,
+            "score": 0.5102,
+            "carried_keys": {},
+            "unsourced_context_cosines": (),
+            "source_chunk_association": None,
+        },
+    ),
+    NODE_IDS[2]: (
+        {
+            "cosine": 0.14,
+            "score": 0.5376,
+            "carried_keys": {},
+            "unsourced_context_cosines": (),
+            "source_chunk_association": None,
+        },
+    ),
+    NODE_IDS[3]: (
+        {
+            "cosine": 0.16,
+            "score": 0.5435,
+            "carried_keys": {},
+            "unsourced_context_cosines": (),
+            "source_chunk_association": None,
+        },
+    ),
+    NODE_IDS[4]: (
+        {
+            "cosine": 0.30,
+            "score": 0.5882,
+            "carried_keys": {},
+            "unsourced_context_cosines": (),
+            "source_chunk_association": None,
+        },
+    ),
+    NODE_IDS[5]: (
+        {
+            "cosine": 0.20,
+            "score": 0.5556,
+            "carried_keys": {},
+            "unsourced_context_cosines": (),
+            "source_chunk_association": None,
+        },
+    ),
+    NODE_IDS[6]: (
+        {
+            "cosine": 0.35,
+            "score": 0.6061,
+            "carried_keys": {"id": 1, "title": "KBLI 2025"},
+            "unsourced_context_cosines": (),
+            "source_chunk_association": None,
+        },
+        {
+            "cosine": 0.51,
+            "score": 0.6711,
+            "carried_keys": {"id": 2, "title": "Business Classification"},
+            "unsourced_context_cosines": (),
+            "source_chunk_association": None,
+        },
+    ),
+    NODE_IDS[7]: (
+        {
+            "cosine": 0.22,
+            "score": 0.5618,
+            "carried_keys": {"id": 1, "title": "Random Doc"},
+            "unsourced_context_cosines": (),
+            "source_chunk_association": None,
+        },
+    ),
+    NODE_IDS[8]: (
+        {
+            "cosine": 0.40,
+            "score": 0.625,
+            "carried_keys": {"id": 1},
+            "unsourced_context_cosines": (0.32,),
+            "source_chunk_association": (
+                "unresolved — the single source carries the max of the two measured "
+                "chunk cosines (0.40); the other is unsourced_context_cosines"
+            ),
+        },
+    ),
+}
+
+
+def _spec_field_map(spec: DenseSourceSpec) -> dict[str, Any]:
+    """A shallow field-name -> value map for `spec`.
+
+    Deliberately NOT `dataclasses.asdict(spec)`: that function's fallback for a field type
+    it doesn't special-case is `copy.deepcopy`, which raises
+    `TypeError: cannot pickle 'mappingproxy' object` on `carried_keys` now that G10/finding
+    5 makes it a `MappingProxyType` (verified empirically against this project's `.venv`
+    interpreter). None of `DenseSourceSpec`'s fields nest another dataclass, so a shallow
+    map is comparison-equivalent to what a non-crashing `asdict` would have produced.
+    """
+    return {f.name: getattr(spec, f.name) for f in dataclasses.fields(spec)}
+
+
+def test_g9_every_field_is_pinned_against_an_independent_expected_table() -> None:
+    for node_id in NODE_IDS:
+        specs = PIPELINE_TRIPWIRE_FIXTURES[node_id]
+        expected_rows = _G9_PER_SPEC[node_id]
+        assert len(specs) == len(expected_rows), (
+            f"{node_id}: registry has {len(specs)} spec(s), EXPECTED table has {len(expected_rows)}"
+        )
+        for i, (spec, expected_row) in enumerate(zip(specs, expected_rows, strict=True)):
+            actual = _spec_field_map(spec)
+            expected = {**_G9_SHARED_FIELDS, **expected_row}
+            assert set(actual) == set(expected), (
+                f"{node_id}[{i}]: dataclass field set {sorted(actual)} != "
+                f"EXPECTED field set {sorted(expected)}"
+            )
+            for field_name, expected_value in expected.items():
+                actual_value = actual[field_name]
+                if field_name == "carried_keys":
+                    assert dict(actual_value) == expected_value, (
+                        f"{node_id}[{i}].carried_keys: {dict(actual_value)!r} != {expected_value!r}"
+                    )
+                else:
+                    assert actual_value == expected_value, (
+                        f"{node_id}[{i}].{field_name}: {actual_value!r} != {expected_value!r}"
+                    )
+
+
+# ============================================================================
+# G10 — the registry and `carried_keys` are actually immutable at runtime;
+# `pipeline_sources` still returns fresh, independently-mutable plain dicts.
+# ============================================================================
+
+
+def test_g10_registry_is_immutable() -> None:
+    with pytest.raises(TypeError):
+        PIPELINE_TRIPWIRE_FIXTURES["x"] = ()  # type: ignore[index]
+
+
+def test_g10_carried_keys_is_immutable() -> None:
+    spec = PIPELINE_TRIPWIRE_FIXTURES[NODE_IDS[6]][0]
+    with pytest.raises(TypeError):
+        spec.carried_keys["k"] = 1  # type: ignore[index]
+
+
+def test_g10_pipeline_sources_still_returns_fresh_mutable_dicts() -> None:
+    first_call = pipeline_sources(NODE_IDS[6])
+    second_call = pipeline_sources(NODE_IDS[6])
+    first_call[0]["mutated"] = True
+    assert "mutated" not in second_call[0], (
+        "pipeline_sources must return a fresh dict per call — mutating one call's "
+        "result leaked into another"
     )

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
@@ -1,9 +1,15 @@
-"""Guard for the nine tripwire pipeline variants (B1.2, spec §3, G1-G11).
+"""Guard for the nine tripwire pipeline variants (B1.2, spec §3, G1-G13).
 
-Purely static/pure-function checks: parses the four original tripwire test files with `ast`
-(paths resolved relative to THIS file's own location, never a hardcoded absolute path) and
-exercises the pure `pipeline_sources`/`format_search_results` functions. No network, no app
-init.
+G1-G10 are static/pure-function checks: they parse the four original tripwire test files with
+`ast` (paths resolved relative to THIS file's own location, never a hardcoded absolute path) and
+exercise the pure `pipeline_sources`/`format_search_results` functions. No network, no app init.
+
+G11-G13 are NOT purely static, and the round-3 cure says so instead of letting the paragraph
+above read as if they were: they `importlib.import_module` the four tripwire test modules, which
+executes those modules' own top-level code. That is the price of checking what pytest actually
+RUNS rather than what the guard parsed. Module identity is pinned rather than assumed — G12
+asserts `module.__file__` resolves to the file the guard parsed, so a shadow copy earlier on
+`sys.path` cannot let the two halves disagree. Still no network and no app init.
 
 The nine `_pipeline_variant` functions ship in the same PR, each beside its preserved original.
 G1-G3 pin the registry (shape, live-transform values, key set, original existence); G4/G5 pin
@@ -35,6 +41,19 @@ Added in the B1.2 round-2 cure (Codex BLOCK, finding 1):
     rebinds a protected name to a different object while every AST-based check above stays
     green — pytest runs whatever the class attribute is bound to, not the `def` the guard
     inspected).
+
+Added in the B1.2 round-3 cure (Codex BLOCK, 2 blockers + 1 minor), each MEASURED against the
+reviewer's own bypass before being accepted as a defect rather than argued away:
+  * G12 — the runtime code OBJECT, digested structurally, is what the parsed `def` compiles to
+    (blocker 1: every field G11 compares is metadata, and a function compiled by `exec`/`compile`
+    under the original `co_filename` with a padded `co_firstlineno` and a copied `__qualname__`
+    takes all eight of G11's assertions green while running an empty body).
+  * G13 — pytest's own collected item runs the class-body def, and the conftest chain defines no
+    undeclared collection hook (blocker 2: G11/G12 read `cls.__dict__[name]`, while pytest runs
+    the callable cached on the `pytest.Function` item, which a `pytest_collection_modifyitems`
+    hook can replace without touching the class).
+  * The docstring above (minor 3): this module no longer calls itself purely static, and
+    `module.__file__` is checked against the parsed path.
 """
 
 from __future__ import annotations
@@ -42,6 +61,7 @@ from __future__ import annotations
 import ast
 import copy
 import dataclasses
+import functools
 import hashlib
 import importlib
 import inspect
@@ -49,6 +69,7 @@ from pathlib import Path
 from typing import Any, Final
 
 import pytest
+from _pytest.assertion.rewrite import rewrite_asserts
 
 from backend.core import score_provenance
 from backend.services.misc.result_formatter import format_search_results
@@ -876,3 +897,247 @@ def test_g11_runtime_binding_matches_the_parsed_def(node_id: str) -> None:
             "one this guard inspected (G11); a later class-body rebinding (assignment, "
             "class decorator, setattr) replaced the runtime binding"
         )
+
+
+# ============================================================================
+# G12 — the runtime code OBJECT is the one the parsed `def` compiles to.
+#
+# Finding 1 (Codex round 3): G11 compares function METADATA — name, qualname,
+# co_filename, co_firstlineno — and every one of those is forgeable. A function
+# compiled with `exec(compile(padding + "def name(self): pass", original
+# co_filename, "exec"))` whose `__qualname__` is copied from the original
+# satisfies the whole of G11 while pytest runs an empty body. MEASURED: the
+# round-3 bypass takes all eight of G11's assertions green.
+#
+# G12 does not trust metadata. It compiles the parsed `def` ALONE, in
+# isolation, and compares a STRUCTURAL DIGEST of the two code objects —
+# opcodes, constants, names, locals, signature, flags, and recursively the
+# digests of nested code objects. The two fields the bypass forges
+# (co_filename, co_firstlineno) are deliberately NOT part of the digest: G11
+# already pins them, and a digest that included them would be satisfied by the
+# same forgery. What cannot be forged without writing the real body is the
+# body's own bytecode.
+# ============================================================================
+
+CodeDigest = tuple[Any, ...]
+
+
+def _code_digest(code: Any) -> CodeDigest:
+    """Structural fingerprint of a code object, nested code objects included.
+
+    Excludes `co_filename` and `co_firstlineno` on purpose — those are what the
+    round-3 bypass forges, and G11 pins them separately.
+    """
+    nested = tuple(_code_digest(const) for const in code.co_consts if hasattr(const, "co_code"))
+    flat_consts = tuple(const for const in code.co_consts if not hasattr(const, "co_code"))
+    return (
+        code.co_code,
+        flat_consts,
+        code.co_names,
+        code.co_varnames,
+        code.co_argcount,
+        code.co_kwonlyargcount,
+        code.co_flags,
+        nested,
+    )
+
+
+@functools.cache
+def _pytest_compiled_module(rel_path: str) -> Any:
+    """Compile a tripwire test file THE WAY PYTEST COMPILES IT, and return its code object.
+
+    Measured, and the reason this helper exists at all: a plain `compile()` of the parsed
+    `def` disagrees with the runtime code object on all 18 protected names, because pytest
+    REWRITES assert statements at import time (`_pytest.assertion.rewrite`) — the runtime
+    bytecode builds `@py_assert*` temporaries and calls `@pytest_ar._call_reprcompare`, which
+    no ordinary compile produces. Comparing against an un-rewritten compile would have been a
+    guard that is red on an honest tree: a trade, not a cure.
+
+    Compiling the WHOLE module (rather than the def in isolation) also makes the file's own
+    `from __future__ import annotations` apply by itself, with no flag bookkeeping.
+    """
+    file_path = _file_path(rel_path)
+    source = file_path.read_bytes()
+    tree = ast.parse(source, filename=str(file_path))
+    rewrite_asserts(tree, source, str(file_path), None)
+    return compile(tree, str(file_path), "exec", dont_inherit=True)
+
+
+def _nested_code(parent: Any, name: str) -> Any | None:
+    for const in parent.co_consts:
+        if hasattr(const, "co_code") and const.co_name == name:
+            return const
+    return None
+
+
+def _expected_code_digest(rel_path: str, class_name: str, protected_name: str) -> CodeDigest | None:
+    """The digest of `protected_name` as pytest's own compile of `rel_path` produces it."""
+    class_code = _nested_code(_pytest_compiled_module(rel_path), class_name)
+    if class_code is None:
+        return None
+    func_code = _nested_code(class_code, protected_name)
+    return None if func_code is None else _code_digest(func_code)
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g12_runtime_code_object_is_the_compiled_parsed_def(node_id: str) -> None:
+    rel_path, class_name, func_name, _module_node, class_node = _locate_original(node_id)
+    assert class_node is not None, f"{node_id}: class {class_name!r} not found in {rel_path}"
+
+    module = importlib.import_module(_module_dotted_name(rel_path))
+    file_path = _file_path(rel_path)
+
+    assert module.__file__ is not None and Path(module.__file__).resolve() == file_path.resolve(), (
+        f"{node_id}: the imported module {module.__name__!r} is loaded from "
+        f"{module.__file__!r}, not from the file this guard parsed ({file_path}) — "
+        "a shadow copy on sys.path would let G11/G12 inspect one file while pytest "
+        "runs another (G12)"
+    )
+
+    for protected_name in (func_name, f"{func_name}_pipeline_variant"):
+        obj = getattr(module, class_name).__dict__[protected_name]
+        func_node = _find_function(class_node, protected_name)
+        assert func_node is not None, (
+            f"{node_id}: {protected_name!r} not found as a def in class {class_name!r} "
+            f"of {rel_path} — G12 has nothing to compile"
+        )
+        assert obj.__globals__ is module.__dict__, (
+            f"{node_id}: {class_name}.{protected_name} closes over a DIFFERENT module "
+            "namespace than the module this guard parsed — the function was defined "
+            "elsewhere and rebound here (G12)"
+        )
+        expected = _expected_code_digest(rel_path, class_name, protected_name)
+        assert expected is not None, (
+            f"{node_id}: {class_name}.{protected_name} has no code object in the guard's own "
+            f"pytest-style compile of {rel_path} — G12 has nothing to compare against"
+        )
+        assert _code_digest(obj.__code__) == expected, (
+            f"{node_id}: {class_name}.{protected_name} runs bytecode that is NOT what "
+            f"its parsed def in {rel_path} compiles to — the runtime object carries the "
+            "right name, qualname, file and first line but a different body (G12); a "
+            "forged-metadata clone (exec/compile under the original co_filename with "
+            "padded co_firstlineno) replaced the binding"
+        )
+
+
+# ============================================================================
+# G13 — pytest runs the class-body def, and nothing in scope can replace the
+# collected item afterwards.
+#
+# Finding 2 (Codex round 3): G11 and G12 inspect `cls.__dict__[name]`. pytest
+# executes the callable cached on the collected `pytest.Function` item, and a
+# `pytest_collection_modifyitems` hook can set `item._obj` to anything at all
+# without touching the class. MEASURED: with such a hook in a conftest, G11
+# stays green while the protected test body never runs.
+#
+# G13 binds on both sides and neither side is a silent skip:
+#   * leg A, dynamic — for every protected name PRESENT in this session, the
+#     collected item's callable IS the class-body def (identity, not metadata).
+#     Names absent from the session are reported by name, not ignored: running
+#     this guard file alone collects none of them, and that is a fact the test
+#     states rather than a hole it hides.
+#   * leg B, static — a CENSUS of every collection hook defined in the conftest
+#     chain that applies to the four tripwire files, compared against an
+#     expected literal set. The census binds in every session regardless of
+#     what was collected, and a newly added hook makes this test red until it
+#     is examined and declared.
+# ============================================================================
+
+COLLECTION_HOOKS_THAT_CAN_REPLACE_AN_ITEM: Final[frozenset[str]] = frozenset(
+    {
+        "pytest_collection_modifyitems",
+        "pytest_itemcollected",
+        "pytest_collection_finish",
+        "pytest_pycollect_makeitem",
+        "pytest_pyfunc_call",
+        "pytest_runtest_protocol",
+        "pytest_generate_tests",
+    }
+)
+
+# No conftest in the chain defines any of them today. A hook added later is not
+# forbidden — it is UNDECLARED, and this empty table is what makes it visible.
+EXPECTED_COLLECTION_HOOKS: Final[frozenset[tuple[str, str]]] = frozenset()
+
+
+def _conftest_chain() -> list[Path]:
+    """Every conftest.py from the tests root down to each tripwire file's directory."""
+    tests_root = _tests_root()
+    chain: list[Path] = []
+    for rel_path in sorted({node_id.split("::")[0] for node_id in NODE_IDS}):
+        directory = _file_path(rel_path).parent
+        while True:
+            candidate = directory / "conftest.py"
+            if candidate.is_file() and candidate not in chain:
+                chain.append(candidate)
+            if directory == tests_root:
+                break
+            directory = directory.parent
+    guard_conftest = Path(__file__).resolve().parent / "conftest.py"
+    if guard_conftest.is_file() and guard_conftest not in chain:
+        chain.append(guard_conftest)
+    return chain
+
+
+def test_g13_no_undeclared_collection_hook_in_the_conftest_chain() -> None:
+    chain = _conftest_chain()
+    assert chain, (
+        "the conftest chain census found NO conftest.py at all above the four tripwire "
+        "files — the census is vacuous and would pass for the wrong reason (G13)"
+    )
+
+    census: set[tuple[str, str]] = set()
+    for conftest in chain:
+        tree = ast.parse(conftest.read_text(), filename=str(conftest))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name in COLLECTION_HOOKS_THAT_CAN_REPLACE_AN_ITEM
+            ):
+                census.add((str(conftest.relative_to(_tests_root())), node.name))
+
+    assert census == EXPECTED_COLLECTION_HOOKS, (
+        f"the conftest chain applying to the tripwire files defines collection hooks "
+        f"{sorted(census)!r}, expected {sorted(EXPECTED_COLLECTION_HOOKS)!r} — a hook "
+        "that can replace a collected item's callable (pytest runs item._obj, not the "
+        "class attribute G11/G12 inspect) must be examined and declared in "
+        "EXPECTED_COLLECTION_HOOKS, never merely tolerated (G13)"
+    )
+
+
+def test_g13_collected_items_run_the_class_body_def(request: pytest.FixtureRequest) -> None:
+    protected: dict[str, Any] = {}
+    for node_id in NODE_IDS:
+        rel_path, class_name, func_name, _module_node, _class_node = _locate_original(node_id)
+        module = importlib.import_module(_module_dotted_name(rel_path))
+        cls = getattr(module, class_name)
+        for protected_name in (func_name, f"{func_name}_pipeline_variant"):
+            protected[f"{rel_path}::{class_name}::{protected_name}"] = cls.__dict__[protected_name]
+
+    assert len(protected) == 2 * len(NODE_IDS), (
+        f"expected {2 * len(NODE_IDS)} protected names, resolved {len(protected)} (G13)"
+    )
+
+    checked: list[str] = []
+    for item in request.session.items:
+        if not isinstance(item, pytest.Function):
+            continue
+        for key, expected in protected.items():
+            rel_path, class_name, protected_name = key.split("::")
+            if item.name != protected_name or item.cls is None or item.cls.__name__ != class_name:
+                continue
+            collected = getattr(item.obj, "__func__", item.obj)
+            assert collected is expected, (
+                f"{key}: pytest collected {collected!r} for this test, which is NOT the "
+                f"class-body def {expected!r} that G11/G12 inspected — a collection hook "
+                "replaced the item's cached callable (G13)"
+            )
+            checked.append(key)
+
+    not_collected = sorted(set(protected) - set(checked))
+    # Stated, never swallowed: selecting only this guard file collects none of the
+    # protected names, so leg A has nothing to compare and leg B is what binds.
+    print(
+        f"G13 leg A: {len(checked)} of {len(protected)} protected items collected in this "
+        f"session and verified; not collected: {not_collected}"
+    )

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
@@ -5,11 +5,10 @@ Purely static/pure-function checks: parses the four original tripwire test files
 exercises the pure `pipeline_sources`/`format_search_results` functions. No network, no app
 init.
 
-The nine `_pipeline_variant` functions this guard looks for do not exist yet as of this PR —
-another builder prepares them. G1-G3 (registry shape, live-transform pinning, key-set/original
-existence) are expected to PASS now; G4/G5 (variant existence, its `pipeline_sources(...)` call,
-its assert-parity with the original) are expected to FAIL now, each failure naming the missing
-variant.
+The nine `_pipeline_variant` functions ship in the same PR, each beside its preserved original.
+G1-G3 pin the registry (shape, live-transform values, key set, original existence); G4/G5 pin
+the variants (existence, their `pipeline_sources(...)` call, no unlabelled score literal, assert
+parity with the original). A variant that disappears or a re-introduced unlabelled value is red.
 """
 
 from __future__ import annotations
@@ -259,8 +258,7 @@ def test_g4_variant_exists_calls_pipeline_sources_and_is_clean(node_id: str) -> 
     variant_name = f"{func_name}_pipeline_variant"
     variant_node = _find_function(class_node, variant_name)
     assert variant_node is not None, (
-        f"{node_id}: variant {variant_name!r} does not exist yet in class "
-        f"{class_name!r} of {rel_path} (expected until the variant-authoring PR lands)"
+        f"{node_id}: variant {variant_name!r} does not exist in class {class_name!r} of {rel_path}"
     )
 
     assert _calls_pipeline_sources(variant_node, node_id), (
@@ -295,7 +293,7 @@ def test_g5_variant_asserts_match_original_asserts(node_id: str) -> None:
     variant_name = f"{func_name}_pipeline_variant"
     variant_node = _find_function(class_node, variant_name)
     assert variant_node is not None, (
-        f"{node_id}: variant {variant_name!r} does not exist yet — cannot compare "
+        f"{node_id}: variant {variant_name!r} does not exist — cannot compare "
         "its assert statements to the original's"
     )
 

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
@@ -1,4 +1,4 @@
-"""Guard for the nine tripwire pipeline variants (B1.2, spec §3, G1-G10).
+"""Guard for the nine tripwire pipeline variants (B1.2, spec §3, G1-G11).
 
 Purely static/pure-function checks: parses the four original tripwire test files with `ast`
 (paths resolved relative to THIS file's own location, never a hardcoded absolute path) and
@@ -26,6 +26,15 @@ Added in the B1.2 round-1 cure (Codex BLOCK, 5 findings):
     `pipeline_sources` still returns fresh, independently-mutable plain dicts (finding 5:
     `frozen=True` alone does not stop `PIPELINE_TRIPWIRE_FIXTURES.clear()` or
     `spec.carried_keys["k"] = 1`).
+
+Added in the B1.2 round-2 cure (Codex BLOCK, finding 1):
+  * G11 — the RUNTIME object pytest collects for each of the 18 protected names (9
+    originals + 9 `_pipeline_variant`s) matches the `def` this guard parsed (finding 1: G7
+    counts only `def` nodes, so a later class-body assignment
+    (`test_x_pipeline_variant = test_x`), a class decorator, or a module-level `setattr`
+    rebinds a protected name to a different object while every AST-based check above stays
+    green — pytest runs whatever the class attribute is bound to, not the `def` the guard
+    inspected).
 """
 
 from __future__ import annotations
@@ -34,6 +43,8 @@ import ast
 import copy
 import dataclasses
 import hashlib
+import importlib
+import inspect
 from pathlib import Path
 from typing import Any, Final
 
@@ -92,8 +103,12 @@ def _tests_root() -> Path:
     return path
 
 
+def _file_path(rel_path: str) -> Path:
+    return _tests_root() / rel_path
+
+
 def _parse_module(rel_path: str) -> ast.Module:
-    file_path = _tests_root() / rel_path
+    file_path = _file_path(rel_path)
     source = file_path.read_text()
     return ast.parse(source, filename=str(file_path))
 
@@ -515,7 +530,9 @@ def test_g7_no_duplicate_definitions_of_protected_names(node_id: str) -> None:
         assert count == 1, (
             f"{node_id}: class {class_name!r} of {rel_path} defines {protected_name!r} "
             f"{count} times — Python binds the LAST one, so a duplicate can run a "
-            "definition this guard never inspects"
+            "definition this guard never inspects (G7 counts `def` nodes only — a "
+            "non-`def` rebinding of the same name, e.g. an assignment or a class "
+            "decorator, is G11's job)"
         )
 
 
@@ -777,3 +794,85 @@ def test_g10_pipeline_sources_still_returns_fresh_mutable_dicts() -> None:
         "pipeline_sources must return a fresh dict per call — mutating one call's "
         "result leaked into another"
     )
+
+
+# ============================================================================
+# G11 — the RUNTIME object pytest collects for a protected name matches the
+# `def` this guard parsed.
+#
+# Finding 1 (Codex round 2): G7's duplicate-`def` count cannot see a LATER
+# class-body rebinding that is not itself a `def` — an assignment
+# (`test_x_pipeline_variant = test_x`), a class decorator, or a module-level
+# `setattr` all replace the runtime attribute pytest actually collects while
+# leaving G1-G9's parsed `def` untouched and every earlier AST-based check
+# green. G11 imports the real module and compares the RUNTIME-bound object
+# against the parsed `def` node: wrong identity, wrong name/qualname, wrong
+# source file, or a first line that does not match the parsed def (nor its
+# first decorator) is red.
+# ============================================================================
+
+
+def _module_dotted_name(rel_path: str) -> str:
+    """`backend.tests.` + `rel_path` without `.py`, `/` -> `.`."""
+    return "backend.tests." + rel_path.removesuffix(".py").replace("/", ".")
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g11_runtime_binding_matches_the_parsed_def(node_id: str) -> None:
+    rel_path, class_name, func_name, _module, class_node = _locate_original(node_id)
+    assert class_node is not None, f"{node_id}: class {class_name!r} not found in {rel_path}"
+
+    module = importlib.import_module(_module_dotted_name(rel_path))
+    file_path = _file_path(rel_path)
+    variant_name = f"{func_name}_pipeline_variant"
+
+    for protected_name in (func_name, variant_name):
+        cls = getattr(module, class_name)
+        assert cls.__module__ == module.__name__, (
+            f"{node_id}: {class_name!r} imported from {module.__name__!r} but "
+            f"cls.__module__ is {cls.__module__!r} — the module-level class name is "
+            "bound to a class defined elsewhere (G11)"
+        )
+        assert cls.__qualname__ == class_name, (
+            f"{node_id}: {class_name}.__qualname__ is {cls.__qualname__!r}, expected "
+            f"{class_name!r} — the module-level name is bound to a different class (G11)"
+        )
+
+        assert protected_name in cls.__dict__, (
+            f"{node_id}: {protected_name!r} is not a direct attribute of "
+            f"{class_name}.__dict__ (missing or only inherited) (G11)"
+        )
+        obj = cls.__dict__[protected_name]
+        assert inspect.isfunction(obj), (
+            f"{node_id}: {class_name}.{protected_name} is bound to {obj!r}, not a "
+            "plain function — a class decorator or a non-`def` rebinding replaced it "
+            "(G11)"
+        )
+        assert obj.__name__ == protected_name, (
+            f"{node_id}: {class_name}.{protected_name} is bound to a function named "
+            f"{obj.__name__!r} — a later assignment rebound this name to a different "
+            "function object (G11)"
+        )
+        assert obj.__qualname__ == f"{class_name}.{protected_name}", (
+            f"{node_id}: {class_name}.{protected_name}.__qualname__ is "
+            f"{obj.__qualname__!r}, expected {class_name}.{protected_name!r} — the "
+            "runtime object was defined outside this class body (G11)"
+        )
+        assert Path(obj.__code__.co_filename).resolve() == file_path.resolve(), (
+            f"{node_id}: {class_name}.{protected_name} runs code from "
+            f"{obj.__code__.co_filename!r}, expected {file_path!r} (G11)"
+        )
+
+        node = _find_function(class_node, protected_name)
+        assert node is not None, (
+            f"{node_id}: {protected_name!r} not found as a def in class {class_name!r} "
+            f"of {rel_path} — G11 has nothing to compare the runtime object against"
+        )
+        expected_firstlineno = min([node.lineno] + [d.lineno for d in node.decorator_list])
+        assert obj.__code__.co_firstlineno == expected_firstlineno, (
+            f"{node_id}: {class_name}.{protected_name} runs code starting at line "
+            f"{obj.__code__.co_firstlineno}, but the guard parsed its def at line "
+            f"{expected_firstlineno} — pytest is executing a DIFFERENT object than the "
+            "one this guard inspected (G11); a later class-body rebinding (assignment, "
+            "class decorator, setattr) replaced the runtime binding"
+        )

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py
@@ -1,0 +1,307 @@
+"""Guard for the nine tripwire pipeline variants (B1.2, spec §3, G1-G5).
+
+Purely static/pure-function checks: parses the four original tripwire test files with `ast`
+(paths resolved relative to THIS file's own location, never a hardcoded absolute path) and
+exercises the pure `pipeline_sources`/`format_search_results` functions. No network, no app
+init.
+
+The nine `_pipeline_variant` functions this guard looks for do not exist yet as of this PR —
+another builder prepares them. G1-G3 (registry shape, live-transform pinning, key-set/original
+existence) are expected to PASS now; G4/G5 (variant existence, its `pipeline_sources(...)` call,
+its assert-parity with the original) are expected to FAIL now, each failure naming the missing
+variant.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from backend.core import score_provenance
+from backend.services.misc.result_formatter import format_search_results
+from backend.tests.fixtures.pipeline_score_fixtures import (
+    PIPELINE_TRIPWIRE_FIXTURES,
+    pipeline_sources,
+)
+
+# ============================================================================
+# The nine node ids, independent of the registry's own keys — G3 checks the
+# registry against THIS list, not against itself.
+# ============================================================================
+
+NODE_IDS: Final[tuple[str, ...]] = (
+    "unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::"
+    "test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate",
+    "unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::"
+    "test_no_keyword_overlap",
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_stop_words_only_query_keyword_ratio_zero",
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_short_words_only_yields_near_zero",
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_entity_mismatch_company_vs_visa",
+    "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+    "test_semantic_penalty_not_applied_when_final_score_at_or_below_015",
+    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+    "test_kitas_query_with_kbli_results_low_score",
+    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+    "test_nonsense_query_zero_score",
+    "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+    "test_entity_type_mismatch_detection",
+)
+
+
+# ============================================================================
+# AST helpers — files are located relative to THIS file's own __file__, tests
+# root = the `tests` directory that contains this guard.
+# ============================================================================
+
+
+def _tests_root() -> Path:
+    """Walk up from this file until the `tests` directory is found."""
+    path = Path(__file__).resolve().parent
+    while path.name != "tests":
+        if path.parent == path:  # pragma: no cover - filesystem root guard
+            raise RuntimeError(
+                f"could not locate a 'tests' directory above {__file__!r}",
+            )
+        path = path.parent
+    return path
+
+
+def _parse_module(rel_path: str) -> ast.Module:
+    file_path = _tests_root() / rel_path
+    source = file_path.read_text()
+    return ast.parse(source, filename=str(file_path))
+
+
+def _find_class(module: ast.Module, class_name: str) -> ast.ClassDef | None:
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return node
+    return None
+
+
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _find_function(class_node: ast.ClassDef, func_name: str) -> FunctionNode | None:
+    for node in class_node.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            return node
+    return None
+
+
+def _locate_original(node_id: str) -> tuple[str, str, str, ast.Module, ast.ClassDef | None]:
+    """Split a node id and parse its module + class. Function lookup is the caller's job."""
+    rel_path, class_name, func_name = node_id.split("::")
+    module = _parse_module(rel_path)
+    class_node = _find_class(module, class_name)
+    return rel_path, class_name, func_name, module, class_node
+
+
+def _assert_dumps(func_node: ast.AST) -> list[str]:
+    return [ast.dump(node) for node in ast.walk(func_node) if isinstance(node, ast.Assert)]
+
+
+def _calls_pipeline_sources(func_node: ast.AST, node_id: str) -> bool:
+    for node in ast.walk(func_node):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "pipeline_sources"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == node_id
+        ):
+            return True
+    return False
+
+
+def _string_value(node: ast.expr | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _dict_score_kind_ok(node: ast.Dict) -> bool:
+    """A dict literal carrying a "score" key must also carry a "score_kind" key whose value
+    names a member of `score_provenance.SCORE_KINDS` — a re-introduced unlabelled "score"
+    (the shape every original's sources literal uses) is a regression.
+    """
+    pairs = list(zip(node.keys, node.values, strict=True))
+    has_score_key = any(_string_value(key) == "score" for key, _ in pairs)
+    if not has_score_key:
+        return True
+
+    for key, value in pairs:
+        if _string_value(key) != "score_kind":
+            continue
+        literal = _string_value(value)
+        if literal is not None:
+            return literal in score_provenance.SCORE_KINDS
+        attr_name: str | None = None
+        if isinstance(value, ast.Attribute):
+            attr_name = value.attr
+        elif isinstance(value, ast.Name):
+            attr_name = value.id
+        if attr_name is not None:
+            resolved = getattr(score_provenance, attr_name, None)
+            return isinstance(resolved, str) and resolved in score_provenance.SCORE_KINDS
+        return False
+    return False  # has "score" but no "score_kind" key at all
+
+
+def _first_unlabelled_score_dict_line(func_node: ast.AST) -> int | None:
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Dict) and not _dict_score_kind_ok(node):
+            return node.lineno
+    return None
+
+
+# ============================================================================
+# G1 — every source `pipeline_sources` returns has a valid, non-UNKNOWN
+# score_kind and float score/score_raw.
+# ============================================================================
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g1_sources_carry_valid_score_kind_and_float_scores(node_id: str) -> None:
+    sources = pipeline_sources(node_id)
+    assert sources, f"{node_id}: pipeline_sources returned no sources"
+    for source in sources:
+        score_kind = source.get("score_kind")
+        assert score_kind in score_provenance.SCORE_KINDS, (
+            f"{node_id}: score_kind {score_kind!r} is not a member of SCORE_KINDS"
+        )
+        assert score_kind != score_provenance.UNKNOWN, f"{node_id}: score_kind must not be UNKNOWN"
+        assert isinstance(source.get("score_raw"), float), (
+            f"{node_id}: score_raw must be a float, got {source.get('score_raw')!r}"
+        )
+        assert isinstance(source.get("score"), float), (
+            f"{node_id}: score must be a float, got {source.get('score')!r}"
+        )
+
+
+# ============================================================================
+# G2 — the pinned score/score_kind/score_raw match what the LIVE
+# `format_search_results` transform produces from the spec's cosine.
+# ============================================================================
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g2_pinned_values_match_live_formatter(node_id: str) -> None:
+    specs = PIPELINE_TRIPWIRE_FIXTURES[node_id]
+    for i, spec in enumerate(specs):
+        raw_results = {
+            "ids": ["probe"],
+            "documents": ["probe"],
+            "metadatas": [{}],
+            "distances": [1 - spec.cosine],
+            "scores": [spec.cosine],
+        }
+        formatted = format_search_results(
+            raw_results,
+            spec.collection,
+            score_kind=spec.score_kind,
+        )
+        assert len(formatted) == 1, f"{node_id}[{i}]: formatter did not return one result"
+        entry = formatted[0]
+        assert entry["score"] == spec.score, (
+            f"{node_id}[{i}]: pinned score {spec.score!r} != live formatter {entry['score']!r}"
+        )
+        assert entry["score_kind"] == spec.score_kind, (
+            f"{node_id}[{i}]: pinned score_kind {spec.score_kind!r} != "
+            f"live formatter {entry['score_kind']!r}"
+        )
+        assert entry["score_raw"] == spec.cosine, (
+            f"{node_id}[{i}]: pinned cosine {spec.cosine!r} != "
+            f"live formatter score_raw {entry['score_raw']!r}"
+        )
+
+
+# ============================================================================
+# G3 — registry key set is EXACTLY the nine node ids, and each names a
+# function that exists (AST) in its original file/class.
+# ============================================================================
+
+
+def test_g3_registry_key_set_is_exactly_the_nine_node_ids() -> None:
+    assert set(PIPELINE_TRIPWIRE_FIXTURES.keys()) == set(NODE_IDS)
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g3_original_function_exists(node_id: str) -> None:
+    rel_path, class_name, func_name, _module, class_node = _locate_original(node_id)
+    assert class_node is not None, f"{node_id}: class {class_name!r} not found in {rel_path}"
+    func_node = _find_function(class_node, func_name)
+    assert func_node is not None, (
+        f"{node_id}: original function {func_name!r} not found in class "
+        f"{class_name!r} of {rel_path}"
+    )
+
+
+# ============================================================================
+# G4 — for each original, its `_pipeline_variant` exists in the same class;
+# it calls `pipeline_sources("<its node id>")`; and it carries no dict literal
+# with an unlabelled "score" key.
+# ============================================================================
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g4_variant_exists_calls_pipeline_sources_and_is_clean(node_id: str) -> None:
+    rel_path, class_name, func_name, _module, class_node = _locate_original(node_id)
+    assert class_node is not None, f"{node_id}: class {class_name!r} not found in {rel_path}"
+
+    variant_name = f"{func_name}_pipeline_variant"
+    variant_node = _find_function(class_node, variant_name)
+    assert variant_node is not None, (
+        f"{node_id}: variant {variant_name!r} does not exist yet in class "
+        f"{class_name!r} of {rel_path} (expected until the variant-authoring PR lands)"
+    )
+
+    assert _calls_pipeline_sources(variant_node, node_id), (
+        f"{node_id}: variant {variant_name!r} does not call pipeline_sources({node_id!r})"
+    )
+
+    violation_line = _first_unlabelled_score_dict_line(variant_node)
+    assert violation_line is None, (
+        f"{node_id}: variant {variant_name!r} contains a dict literal with an unlabelled "
+        f"'score' key at line {violation_line} — every 'score' key needs a sibling "
+        "'score_kind' constant from SCORE_KINDS"
+    )
+
+
+# ============================================================================
+# G5 — the variant's `assert` statements equal the original's, in order
+# (`ast.dump` comparison).
+# ============================================================================
+
+
+@pytest.mark.parametrize("node_id", NODE_IDS)
+def test_g5_variant_asserts_match_original_asserts(node_id: str) -> None:
+    rel_path, class_name, func_name, _module, class_node = _locate_original(node_id)
+    assert class_node is not None, f"{node_id}: class {class_name!r} not found in {rel_path}"
+
+    original_node = _find_function(class_node, func_name)
+    assert original_node is not None, (
+        f"{node_id}: original function {func_name!r} not found in class "
+        f"{class_name!r} of {rel_path}"
+    )
+
+    variant_name = f"{func_name}_pipeline_variant"
+    variant_node = _find_function(class_node, variant_name)
+    assert variant_node is not None, (
+        f"{node_id}: variant {variant_name!r} does not exist yet — cannot compare "
+        "its assert statements to the original's"
+    )
+
+    original_asserts = _assert_dumps(original_node)
+    variant_asserts = _assert_dumps(variant_node)
+    assert variant_asserts == original_asserts, (
+        f"{node_id}: assert statements in {variant_name!r} diverge from "
+        f"{func_name!r} (ast.dump comparison, in order)"
+    )

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/B1-2-build-spec.md
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/B1-2-build-spec.md
@@ -1,0 +1,97 @@
+# B1.2 build spec — the nine tripwires, re-based by ADDITION
+
+Mandate B1 (BLUE), PR B1.2. Base `0141b8130a192483a67865376281518ce7b69f2f` (origin/main at open,
+2026-09-11T16:58Z). Input: `evidence/2026-09/agent-nuzantara-backend-rag-b1-score-contract-107e45b6/B1-2-inventory.md`
+(on main) and rc1a commit `92f40801235cf33b32a8d71f241b6400cad64536` (never pushed; read by sha only).
+Paths below are relative to `apps/backend-rag/backend/`.
+
+## Decision (Dux): every variant is a DENSE-path fixture carrying a MEASURED cosine
+
+The only real number that exists for these (query, context) texts is rc1a's `text-embedding-3-small`
+cosine (prod `rag` container, 2026-09-10T18:03Z, one request, 20 texts, 216 prompt tokens). On the
+hybrid path the value is a function of ranks in two lists, and no rank was ever measured for these
+texts — inventing one would be exactly what D3 forbids. So each variant declares B1.1 inventory
+row 2, `score_kind = dense_formatted`, `score_raw = cosine`, and the `score` the REAL formatter
+produces from it.
+
+Pre-measured by the Dux on the base, through `result_formatter.format_search_results(...,
+score_kind=DENSE_FORMATTED)` and the real scorer: all nine variants PASS their unchanged assertions
+(scorer output 0.0600 on every variant; originals 0.0400–0.0800).
+
+## 1. Registry — `tests/fixtures/pipeline_score_fixtures.py` (Sonnet 5)
+
+- `@dataclass(frozen=True) class DenseSourceSpec` with fields, all explicit per D3:
+  `inventory_row: int` (=2) · `score_kind: str` (=`score_provenance.DENSE_FORMATTED`) ·
+  `provider: str` (="openai") · `model: str` (="text-embedding-3-small") ·
+  `measured_at: str` (="2026-09-10T18:03Z") · `measurement_ref: str` (="rc1a 92f40801235cf33b32a8d71f241b6400cad64536 measured_cosines.py") ·
+  `qdrant_server: str` (="1.16.3") · `fallback_path: str` (="search_service dense branch / core/qdrant_db.py:1362 internal fallback") ·
+  `fusion: None` (dense path has no fusion) · `lists: tuple[str, ...]` (=("dense",)) · `dense_rank0: int` ·
+  `cosine: float` · `collection: str` (="kbli_2025_final_hybrid") · `primary_collection: None` ·
+  `boosts: tuple[str, ...]` (=() — no boost applies) · `transform: str` (="distance = 1 - cosine; score = 1/(1+distance)") ·
+  `rounding_digits: int` (=4) · `score: float` (literal, pinned) ·
+  `carried_keys: Mapping[str, Any]` (non-score keys of the original source, verbatim, e.g. id/title) ·
+  `unsourced_context_cosines: tuple[float, ...]` (=() unless stated).
+- `PIPELINE_TRIPWIRE_FIXTURES: Final[Mapping[str, tuple[DenseSourceSpec, ...]]]` keyed by the ORIGINAL node id.
+- `pipeline_sources(node_id: str) -> list[dict[str, Any]]`: a FRESH list, original list order, each
+  `{**carried_keys, "score": score, "score_kind": score_kind, "score_raw": cosine}`. Unknown id → `KeyError`
+  naming the registry (never a default).
+
+| #   | original node id (relative to `tests/`)                                                                                                                 | original sources                                                                                                 | cosine              | dense_rank0   | score                   |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------- | ------------- | ----------------------- |
+| 1   | `unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate` | `[{"score": 0.91}]`                                                                                              | 0.16                | 0             | 0.5435                  |
+| 2   | `unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::test_no_keyword_overlap`                                                      | `[{"score": 0.9}]`                                                                                               | 0.04                | 0             | 0.5102                  |
+| 3   | `services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_stop_words_only_query_keyword_ratio_zero`                               | `[{"score": 0.8}]`                                                                                               | 0.14                | 0             | 0.5376                  |
+| 4   | `services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_short_words_only_yields_near_zero`                                      | `[{"score": 0.8}]`                                                                                               | 0.16                | 0             | 0.5435                  |
+| 5   | `services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_entity_mismatch_company_vs_visa`                                        | `[{"score": 0.6}]`                                                                                               | 0.30                | 0             | 0.5882                  |
+| 6   | `services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_semantic_penalty_not_applied_when_final_score_at_or_below_015`          | `[{"score": 0.35}]`                                                                                              | 0.20                | 0             | 0.5556                  |
+| 7   | `services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_kitas_query_with_kbli_results_low_score`                                 | `[{"id": 1, "title": "KBLI 2025", "score": 0.85}, {"id": 2, "title": "Business Classification", "score": 0.75}]` | id1 0.35 · id2 0.51 | id1 1 · id2 0 | id1 0.6061 · id2 0.6711 |
+| 8   | `services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_nonsense_query_zero_score`                                               | `[{"id": 1, "title": "Random Doc", "score": 0.8}]`                                                               | 0.22                | 0             | 0.5618                  |
+| 9   | `services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_entity_type_mismatch_detection`                                          | `[{"id": 1, "score": 0.9}]`                                                                                      | 0.40 (top chunk)    | 0             | 0.625                   |
+
+Row 7: list order is the ORIGINAL order (inputs stay byte-identical); ranks are declared per source.
+Row 9: one source, as in the original; it is the top dense hit (max of the two measured chunk cosines);
+the other chunk's cosine is `unsourced_context_cosines=(0.32,)`.
+
+Module docstring (short): what the registry is, that values are measured-not-invented, that a kind is
+declared and never inferred from magnitude, and that originals are PRESERVED beside the variants (D3/D5).
+
+## 2. Variants — beside each original (GLM 5.2 prepares, Dux verifies)
+
+In the same file and class, immediately after the original function, add `<original_name>_pipeline_variant`:
+
+- same decorators as the original; a one-line docstring;
+- first body line: `from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources` (local import,
+  so every touched test file diff is +N/-0);
+- one comment line: `# B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES[<node id>]`;
+- the rest of the body byte-identical to the original EXCEPT the sources literal, replaced by
+  `pipeline_sources("<node id>")`. Every `assert` statement, message and `print` identical.
+
+## 3. Guard — `tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py` (Sonnet 5)
+
+- G1: for every registry key, every dict from `pipeline_sources` has `score_kind` in
+  `score_provenance.SCORE_KINDS` and not `UNKNOWN`, a float `score_raw`, a float `score`.
+- G2: every spec's pinned `score`, `score_kind` and `score_raw` equal what
+  `format_search_results({"ids","documents","metadatas","distances":[1-cosine],"scores":[cosine]},
+spec.collection, score_kind=spec.score_kind)` returns — the fixture is pinned to the live transform.
+- G3: registry key set == exactly the nine node ids above; each names a function that exists (AST).
+- G4: for each original, its `_pipeline_variant` exists in the same class; AST inside the variant finds
+  a `pipeline_sources("<its node id>")` call and NO dict literal carrying a `"score"` key without a
+  `"score_kind"` constant from `SCORE_KINDS` (a re-introduced unlabelled value goes red).
+- G5: the `assert` statements of each variant equal its original's (`ast.dump` comparison, in order).
+- Parse files from the test tree relative to the guard's own `__file__`; no network, no app init.
+
+## 4. Proofs the PR body carries
+
+- Before/after pytest counts on the four touched files + guard (`PYTHONPATH=. SKIP_SENTRY_INIT=1
+.venv/bin/python -m pytest <files>` from `apps/backend-rag`), both green.
+- The assertion-line diff (scratch script, output only) — empty.
+- Guard RED under two mutations in a throwaway copy restored with `cp` (never `git checkout --`):
+  (a) drop `score_kind` from one registry entry → G1/G2 red; (b) add `{"score": 0.9}` inside a variant → G4 red.
+- Innocence: the six files of B1 §4 at their origin/main counts.
+- `git diff --numstat` on the four existing test files: deletions = 0.
+
+## Fence
+
+Writable: the registry, the guard, the four existing tripwire test files (additions only), this evidence
+dir. Nothing under `backend/services/**`, `backend/core/**`, no corner, no `zantara_core.py`, no
+`wa_codex_leg.py`, no migration, no network, no embedding/generation call.

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/B1-2-build-spec.md
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/B1-2-build-spec.md
@@ -7,6 +7,16 @@ Paths below are relative to `apps/backend-rag/backend/`.
 
 ## Decision (Dux): every variant is a DENSE-path fixture carrying a MEASURED cosine
 
+> **Corrected after adversarial rounds 1 and 2** (`codex-round-1-b1-2.md`, `codex-round-2-b1-2.md`):
+> only the COSINES are measured. The first draft of §1 below declared `dense_rank0` values (from the
+> cosine order), a Qdrant server version and a retrieval collection as if observed — none was measured
+> for these texts. The shipped registry therefore carries `dense_rank0=None`, `qdrant_server=None`,
+> `formatter_collection` (a simulation input to `format_search_results` that selects no boost, not an
+> observed collection), a `simulated` field naming every declared-not-observed input (`formatter_collection`,
+> `lists`, `fallback_path`), and row 9's source-to-chunk association recorded as unresolved. §1 and the
+> table are amended accordingly; the guard grew G6–G11 (whole-body parity, single definition, pinned
+> original AST, independent field table, immutability, runtime binding).
+
 The only real number that exists for these (query, context) texts is rc1a's `text-embedding-3-small`
 cosine (prod `rag` container, 2026-09-10T18:03Z, one request, 20 texts, 216 prompt tokens). On the
 hybrid path the value is a function of ranks in two lists, and no rank was ever measured for these
@@ -24,9 +34,10 @@ score_kind=DENSE_FORMATTED)` and the real scorer: all nine variants PASS their u
   `inventory_row: int` (=2) · `score_kind: str` (=`score_provenance.DENSE_FORMATTED`) ·
   `provider: str` (="openai") · `model: str` (="text-embedding-3-small") ·
   `measured_at: str` (="2026-09-10T18:03Z") · `measurement_ref: str` (="rc1a 92f40801235cf33b32a8d71f241b6400cad64536 measured_cosines.py") ·
-  `qdrant_server: str` (="1.16.3") · `fallback_path: str` (="search_service dense branch / core/qdrant_db.py:1362 internal fallback") ·
-  `fusion: None` (dense path has no fusion) · `lists: tuple[str, ...]` (=("dense",)) · `dense_rank0: int` ·
-  `cosine: float` · `collection: str` (="kbli_2025_final_hybrid") · `primary_collection: None` ·
+  `qdrant_server: None` (no server receipt for these texts) · `fallback_path: str` (declared simulation input: "search_service dense branch / core/qdrant_db.py:1362 internal fallback") ·
+  `fusion: None` (dense path has no fusion) · `lists: tuple[str, ...]` (=("dense",), declared simulation input) · `dense_rank0: None` (unmeasured) ·
+  `cosine: float` (the one measured number) · `formatter_collection: str` (="kbli_2025_final_hybrid", simulation input selecting no boost, NOT an observed collection) · `primary_collection: None` ·
+  `simulated: tuple[str, ...]` (names every declared-not-observed field) · `source_chunk_association: str | None` (None except row 9, unresolved) ·
   `boosts: tuple[str, ...]` (=() — no boost applies) · `transform: str` (="distance = 1 - cosine; score = 1/(1+distance)") ·
   `rounding_digits: int` (=4) · `score: float` (literal, pinned) ·
   `carried_keys: Mapping[str, Any]` (non-score keys of the original source, verbatim, e.g. id/title) ·
@@ -48,12 +59,17 @@ score_kind=DENSE_FORMATTED)` and the real scorer: all nine variants PASS their u
 | 8   | `services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_nonsense_query_zero_score`                                               | `[{"id": 1, "title": "Random Doc", "score": 0.8}]`                                                               | 0.22                | 0             | 0.5618                  |
 | 9   | `services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_entity_type_mismatch_detection`                                          | `[{"id": 1, "score": 0.9}]`                                                                                      | 0.40 (top chunk)    | 0             | 0.625                   |
 
-Row 7: list order is the ORIGINAL order (inputs stay byte-identical); ranks are declared per source.
-Row 9: one source, as in the original; it is the top dense hit (max of the two measured chunk cosines);
-the other chunk's cosine is `unsourced_context_cosines=(0.32,)`.
+The `dense_rank0` column is SUPERSEDED: those numbers are the cosine order, not a measured retrieval
+rank; the shipped registry carries `None` on every row.
 
-Module docstring (short): what the registry is, that values are measured-not-invented, that a kind is
-declared and never inferred from magnitude, and that originals are PRESERVED beside the variants (D3/D5).
+Row 7: list order is the ORIGINAL order (inputs stay byte-identical); no rank is declared.
+Row 9: one source, as in the original; it carries the larger of the two measured chunk cosines, and
+which chunk that source corresponds to is UNRESOLVED (`source_chunk_association`); the other chunk's
+cosine is `unsourced_context_cosines=(0.32,)`.
+
+Module docstring (short): what the registry is, that the cosines are measured and every other input
+is declared (never presented as observed), that a kind is declared and never inferred from magnitude,
+and that originals are PRESERVED beside the variants (D3/D5).
 
 ## 2. Variants — beside each original (GLM 5.2 prepares, Dux verifies)
 

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/B1-2-round-2-cure-spec.md
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/B1-2-round-2-cure-spec.md
@@ -1,0 +1,37 @@
+# B1.2 round-2 cure spec — the runtime binding of every protected name
+
+Round 2 (Codex, `codex-round-2-b1-2.md`) showed that an AST guard which counts `def` nodes cannot
+see a later class-body rebinding (`test_x_pipeline_variant = test_x`), a class decorator, a
+module-level `setattr`, or any other runtime replacement: pytest runs whatever object the class
+attribute is bound to, not the `def` the guard parsed. Enumerating rebinding syntaxes is a
+fix-of-a-fix; the surface is the RUNTIME binding, so the guard measures that.
+
+## G11 — the object pytest collects is the `def` the guard inspected
+
+For each of the 18 protected names (9 originals + 9 `_pipeline_variant`s):
+
+1. Import the test module by its dotted name (`backend.tests.` + path without `.py`, `/` → `.`)
+   with `importlib.import_module` — no app init beyond what the module already does at import.
+2. `cls = getattr(module, class_name)`; require `cls.__module__ == module.__name__` and
+   `cls.__qualname__ == class_name` (the module-level class name is not rebound to another class).
+3. `obj = cls.__dict__[name]` (NOT `getattr`: no inheritance, no descriptor); require
+   `inspect.isfunction(obj)`, `obj.__name__ == name`, `obj.__qualname__ == f"{class_name}.{name}"`,
+   and `Path(obj.__code__.co_filename).resolve() == <the parsed file>.resolve()`.
+4. Let `node` be the single `FunctionDef`/`AsyncFunctionDef` G7 found for `name`; require
+   `obj.__code__.co_firstlineno == min([node.lineno] + [d.lineno for d in node.decorator_list])`.
+   (CPython sets `co_firstlineno` to the first decorator's line for a decorated function.)
+5. Keep G7; extend its message to point at G11 for non-`def` rebindings.
+
+Every mismatch message names the node id, the protected name, the expected and the observed
+qualname/line, so a red is legible.
+
+## Mutations that must be RED (Dux re-measures them independently)
+
+- (r1) after the valid variant in `test_reasoning.py`: `test_no_keyword_overlap_pipeline_variant = test_no_keyword_overlap` → G11
+- (r2) module level after the class: `TestCalculateEvidenceScore.test_no_keyword_overlap_pipeline_variant = lambda self: None` → G11
+- (r3) a class decorator on `TestCalculateEvidenceScore` that replaces the variant attribute → G11
+- all seven earlier mutations stay red (m1 G6, m2 G7, m3 G8, m4 G2+G9, m5a G1+G9, m5b G4+G6, m6 G9)
+
+## Fence
+
+Only `tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py`. Nothing else.

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/B1-2-round-3-cure-spec.md
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/B1-2-round-3-cure-spec.md
@@ -1,0 +1,89 @@
+---
+title: "B1.2 round-3 cure spec — G12 and G13, each MEASURED against the reviewer's own bypass"
+authority: "imperator ruling I14, fleet envelope 20260912T013527Z-13d6 (B1-ack, 2026-09-12T01:36Z)"
+cured_sha_base: 71b28dd39d
+seat: "claude-opus-5 (Dux, session 402a5404, Pro) — no fourth Codex round, the reviewer does not re-read"
+---
+
+## Why this spec exists at all
+
+Round 3 returned BLOCK on one cause for the third time, and the three-reds rule says the
+surface is under-specified: write the spec instead of taking a fourth round. The previous
+window proposed REJECTING both blockers as outside the guard's threat model — an argument,
+not a measurement. The Rule-8 tiebreaker says the verdict "spec it" is only honest once the
+cheap patch has been measured and shown not to work, so the patches were measured first.
+
+Both blockers turned out to be REAL and cheaply curable, so both are cured here. The
+imperator's ruling I14 keeps the threat-model reasoning standing as the _fallback_ and
+accepts the measured cure as the amendment: G12/G13 ship, the dissent is named, no fourth
+round.
+
+## What was measured, before any code was written
+
+| #   | Claim under test                                                                                                      | Method                                                                                                | Result                                                                         |
+| --- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| M1  | G11's eight assertions all pass on an `exec`-compiled clone with forged `co_filename`/`co_firstlineno`/`__qualname__` | G11's assertion chain replayed against a synthetic module in the scratchpad (no tracked file touched) | **ALL GREEN**, and the clone is what runs — R3-1 is real, not hypothetical     |
+| M2  | a structural code-object digest catches the clone without turning the honest tree red                                 | digest of runtime code vs an independent compile, over the 18 real protected names                    | clone **caught**; honest names **0 mismatches** _after_ two corrections, below |
+| M3  | a `pytest_collection_modifyitems` hook replacing `item._obj` keeps G11 green while the body never runs                | throwaway pytest project, conftest hook present vs absent                                             | G11 **green** with the hook, victim body **never ran** — R3-2 is real          |
+
+Two corrections M2 forced, each one a guard that would have been red on an honest tree —
+i.e. a trade, which rule 8 forbids, not a cure:
+
+1. **`co_flags` diverged on 8 of 18 names** (bit `1 << 24`, `CO_FUTURE_ANNOTATIONS`): the four
+   tripwire files carry `from __future__ import annotations` and an isolated compile does not
+   inherit it. Cured by compiling the whole module, which carries its own future imports —
+   so `co_flags` stays IN the digest rather than being dropped to make the comparison pass.
+2. **pytest REWRITES assert statements at import time.** A plain `compile()` of the parsed
+   `def` disagrees with the runtime code object on **all 18** names — measured as 9 red
+   G12 cases on the real tree. Cured by reproducing `_pytest.assertion.rewrite.rewrite_asserts`
+   before compiling. This is the correction that matters: the first draft of G12 was a guard
+   that convicted the innocent, and only running it on the real tree said so.
+
+## The cure
+
+**G12 — the runtime code OBJECT is what the parsed `def` compiles to.** A structural digest
+(opcodes, flat constants, `co_names`, `co_varnames`, signature, `co_flags`, and recursively
+the digests of nested code objects) of `cls.__dict__[name].__code__`, compared against the
+same digest taken from the guard's own pytest-style compile of the file. `co_filename` and
+`co_firstlineno` are deliberately EXCLUDED from the digest — they are exactly what the bypass
+forges, and G11 already pins them; a digest that included them would be satisfied by the same
+forgery. Also pinned here: `module.__file__` resolves to the parsed path (a shadow copy on
+`sys.path` cannot split the two halves) and `obj.__globals__ is module.__dict__`.
+
+**G13 — pytest runs the class-body def, on two legs, neither a silent skip.**
+
+- _leg A, dynamic:_ for every protected name present in `request.session.items`, the collected
+  item's callable **is** the class-body def — identity, not metadata. Names absent from the
+  session are printed by name; selecting only the guard file collects none of them, and that
+  is stated rather than hidden.
+- _leg B, static:_ a CENSUS of the collection hooks defined in the conftest chain that applies
+  to the four tripwire files, compared against an expected literal set (empty today). Leg B
+  binds in EVERY session regardless of what was collected — it is what holds when leg A has
+  nothing to compare, which is the case the reviewer's fix would have missed.
+
+**R3-3 (minor), applied:** the module docstring no longer calls itself "purely static / no app
+init" — G11-G13 import the four test modules and execute their top-level code, and the
+docstring says so. Module identity is checked rather than trusted.
+
+## Proofs, all re-run on the cured tree
+
+| Leg                            | Command shape                                                       | Result                                                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| innocence, guard               | `pytest test_tripwire_pipeline_variants_guard.py`                   | **97 passed** (86 before: +9 G12 parametrised, +2 G13)                                                                             |
+| innocence, A1                  | the four tripwire files, per file                                   | 88 / 29 / 35 / 87 — the brief's recorded counts, unchanged                                                                         |
+| innocence, A3                  | the six B1 §4 files                                                 | 122+2 xfailed / 29 / 29 / 64 / 21 / 79 — base counts                                                                               |
+| guilt A                        | forged-metadata clone planted in a **throwaway `git archive` copy** | **1 failed**, and it is G12 on the right node id; G11 stayed GREEN, which is what proves G12 is load-bearing rather than redundant |
+| guilt B, guard alone           | collection hook planted in the copy's conftest chain                | **1 failed**, G13 leg B (the census) — it binds with nothing collected                                                             |
+| guilt B, guard + tripwire file | same hook, protected item in the session                            | **2 failed**, G13 leg B _and_ leg A                                                                                                |
+| lint                           | `ruff check` / `ruff format --check`                                | clean (one `UP033` autofixed)                                                                                                      |
+
+No guilt proof touched a tracked file: the mutations were planted in a `git archive HEAD`
+copy under the session scratchpad, and M1/M3 used synthetic modules. This is the lane rule the
+pack already carries, honoured without needing `cp`-and-restore at all.
+
+## What is NOT claimed
+
+G12/G13 raise the cost of a deliberate in-process substitution; they do not make it
+impossible, and no in-process check can. The imperator's threat-model boundary stands as
+stated in I14: accidental weakening is what G1-G13 pin, deliberate sabotage is the review and
+gate boundary. The dissent is named in `pack.yml` with the three round ids.

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/brief.yml
@@ -1,0 +1,134 @@
+task_id: backend-rag-b1-design-2
+gear: 2
+l_level: L2
+gate_class: opus
+base_sha: 0141b8130a192483a67865376281518ce7b69f2f # pragma: allowlist secret
+mandate: B1
+colour: BLUE
+pr: B1.2
+objective: >-
+  B1.2 of mandate B1 (BLUE). Re-base the nine historical "impossible cosine"
+  abstain tripwires by ADDITION, never by edit (README D3/D5): each original
+  stays byte-identical, and beside it a pipeline-derived variant feeds the
+  same query, context and assertions with sources minted from a measured
+  registry. The only real number that exists for these (query, context)
+  texts is rc1a's text-embedding-3-small cosine (prod rag container,
+  2026-09-10T18:03Z); no hybrid rank was ever measured for them, so every
+  variant declares the DENSE path (B1.1 inventory row 2, score_kind
+  dense_formatted, score_raw = cosine) and the score the REAL
+  result_formatter transform produces from it. A guard pins the registry
+  to the live transform and fails when an unlabelled score literal returns.
+appetite:
+  wall_clock_hours: 5
+  adversarial_rounds: 2
+  tokens: 1500000
+deadline_utc: "2026-09-11T21:59:55Z"
+constraints:
+  - >-
+    Tests only. Writable: tests/fixtures/pipeline_score_fixtures.py (new),
+    tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py (new),
+    and the four existing tripwire test files with additions only
+    (git diff --numstat deletions = 0). Nothing under backend/services/**,
+    backend/core/**, no corner, no zantara_core.py, no wa_codex_leg.py, no
+    migration, no network, no embedding or generation call.
+  - >-
+    Assertions of every variant are identical to its original's (AST), and
+    each variant body is equivalent to its original except the sources
+    literal (AST normalisation script, output in the PR body).
+  - >-
+    Nothing is invented: rank, fusion and list membership are declared only
+    where measured (dense, rank 0/1 from rc1a's cosine order); the tenth
+    regression (a behaviour gap) and the eleventh (named by count, never
+    itemised) stay UNRESOLVED as B1.1's inventory recorded them.
+acceptance:
+  - text: >-
+      A1: the nine originals are preserved and nine variants are added, each
+      assertion-identical to its original; the four touched files pass
+      before and after.
+    probe: >-
+      pytest the four files per file on base and head: reasoning_utils 84 -> 88,
+      evidence_scoring_abstain 26 -> 29, abstain_bypass_policy 34 -> 35,
+      reasoning 86 -> 87, all green
+  - text: >-
+      A2: the guard is load-bearing — a registry entry declared UNKNOWN turns
+      G1 red; an unlabelled {"score": 0.9} literal inside a variant turns G4
+      red.
+    probe: >-
+      two mutations in the worktree, backed up and restored with cp (never
+      git checkout --), cmp-verified restored; guard 46 passed otherwise
+  - text: >-
+      A3 (innocence): the six B1 §4 files at their base counts or better.
+    probe: >-
+      test_evidence_cross_language 122 passed + 2 xfailed; test_evidence_scoring_abstain
+      29 (26 + 3 variants); test_wa_package_builder 29; test_wa_greeting 64;
+      test_curated_qa_government_fee_gate 21; test_wa_finalize 79
+assumptions:
+  - >-
+    The two TestDetectTeamQuery failures seen when the four tripwire files run
+    together in one process are pre-existing and order-dependent: the same
+    combination on a clean base checkout reports 2 failed / 228 passed, and
+    test_reasoning_utils.py alone passes on both base and head.
+team:
+  dux:
+    {
+      model: claude-opus-5,
+      effort: xhigh,
+      role: "Dux + release owner",
+      host: Pro,
+      sessions:
+        [e14f8ad7-c934-4182-a460-af27cea37b18, "continuation (salto 1)"],
+    }
+  implementer_registry_guard:
+    {
+      model: claude-sonnet-5,
+      role: "registry + guard (commit 7a7f14706c)",
+      outcome: delivered,
+    }
+  external_builder:
+    - {
+        seat: tp1-glm-5.2,
+        model: glm-5.2,
+        try: 1,
+        at: "~17:04Z",
+        effort: high,
+        outcome: "FAIL rc=3 — reasoning-only response truncated (finish_reason=length)",
+      }
+    - {
+        seat: tp1-glm-5.2,
+        model: glm-5.2,
+        try: 2,
+        at: "17:11:16Z-17:11:59Z",
+        effort: medium,
+        outcome: "FAIL — off-task (returned a review, 0 code blocks); TP1 output redacts every token >= 24 chars",
+      }
+    - {
+        seat: tp1-glm-5.2,
+        model: glm-5.2,
+        try: 3,
+        at: "17:15:33Z-17:16:15Z",
+        effort: medium,
+        outcome: "FAIL — 9 blocks, none calls pipeline_sources; discarded",
+      }
+    - {
+        seat: tp1-qwen3.8-max,
+        model: qwen3.8-max,
+        at: "17:17:46Z-17:18:52Z",
+        role: "same-role fallback (seat rule)",
+        outcome: "9 blocks, 18 redactions de-mapped by the Dux; node-id argument came back as the bare function name — corrected by the Dux, then ruff-formatted and inlined to the original call shape",
+      }
+    - { seat: tp1-qwen3.7-max, outcome: "not needed" }
+  adversarial_reviewer:
+    {
+      seat: codex,
+      model: gpt-5.6-sol,
+      effort: high,
+      sandbox: read-only,
+      note: "default gpt-6-astra returns HTTP 400 on codex-cli 0.149.0 (CLI pinned by the WA daemon); explicit -m gpt-5.6-sol answers",
+    }
+  final_gate: "fresh Opus 5 session commissioned by the staff room (Fable imperator, M5, 7c40d5cf)"
+sibling_outputs:
+  at: "2026-09-11T17:31:33Z"
+  open_prs_touching_paths: "none (gh pr list --state open, files under backend/tests/(unit/)services/rag, tests/fixtures, bot-staff-room)"
+  agent_start_list: "b1-2-glm-variants, b1-3-benchmark, b1-4-support-signal, b1-design-2 (this); rc3-citation-rule-exit and rc1a ORPHAN, not ours"
+  children: "B1.3 benchmark (Sonnet 5, worktree b1-3-benchmark), B1.4 probe harness (Sonnet 5, worktree b1-4-support-signal)"
+  fleet_mail: "B1-ack received 17:19:16Z for checkpoint 1 (envelope 20260911T170154Z-3625.md)"

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/brief.yml
@@ -22,7 +22,16 @@ appetite:
   wall_clock_hours: 5
   adversarial_rounds: 2
   tokens: 1500000
-deadline_utc: "2026-09-11T21:59:55Z"
+deadline_utc: "2026-09-12T14:00:00Z"
+generation: 4
+generation_authority: >-
+  B1 REOPENED as generation 4 (a new root mandate, not a renewal) by imperator ruling I16,
+  fleet envelope 20260912T013527Z-13d6, 2026-09-12T01:36Z. The generation-3 root deadline
+  2026-09-11T21:59:55Z expired while the imperator window sat at its own context guard
+  (18:41Z-01:30Z, the staff room's delay, acknowledged as such). Hops ceiling 3, ship reserve
+  zero, one renewal on request with a checkpoint. Dux of g4 = the live session in worktree
+  backend-rag-b1-design-2 (402a5404); session 9f704c30 is RETIRED.
+generation_3_deadline_utc: "2026-09-11T21:59:55Z"
 constraints:
   - >-
     Tests only. Writable: tests/fixtures/pipeline_score_fixtures.py (new),
@@ -80,7 +89,13 @@ team:
       role: "Dux + release owner",
       host: Pro,
       sessions:
-        [e14f8ad7-c934-4182-a460-af27cea37b18, "continuation (salto 1)"],
+        [
+          e14f8ad7-c934-4182-a460-af27cea37b18,
+          9f704c30 (g3,
+          retired by I16),
+          402a5404-ff34-4fbc-bf91-c14565a9938c (g4 Dux,
+          Pro),
+        ],
     }
   implementer_registry_guard:
     {
@@ -127,7 +142,13 @@ team:
       model: gpt-5.6-sol,
       effort: high,
       sandbox: read-only,
-      note: "default gpt-6-astra returns HTTP 400 on codex-cli 0.149.0 (CLI pinned by the WA daemon); explicit -m gpt-5.6-sol answers",
+      rounds:
+        [
+          { round: 1, account: 1, host: Pro, effort: high, verdict: BLOCK },
+          { round: 2, account: 2, host: Mini, effort: high, verdict: BLOCK },
+          { round: 3, account: 2, host: Mini, effort: high, verdict: BLOCK },
+        ],
+      note: "default gpt-6-astra returns HTTP 400 on codex-cli 0.149.0 (CLI pinned by the WA daemon); explicit -m gpt-5.6-sol answers. Account 1 ran out of credits 17:56Z, hence the host/account change from round 2 on (recorded per round as the imperator required). NO fourth round: three reds on one cause, ruling I14.",
     }
   final_gate: "fresh Opus 5 session commissioned by the staff room (Fable imperator, M5, 7c40d5cf)"
 sibling_outputs:

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/brief.yml
@@ -63,11 +63,12 @@ acceptance:
       29 (26 + 3 variants); test_wa_package_builder 29; test_wa_greeting 64;
       test_curated_qa_government_fee_gate 21; test_wa_finalize 79
 assumptions:
-  - >-
-    The two TestDetectTeamQuery failures seen when the four tripwire files run
-    together in one process are pre-existing and order-dependent: the same
-    combination on a clean base checkout reports 2 failed / 228 passed, and
-    test_reasoning_utils.py alone passes on both base and head.
+  - status: verified
+    text: >-
+      The two TestDetectTeamQuery failures seen when the four tripwire files run
+      together in one process are pre-existing and order-dependent: the same
+      combination on a clean base checkout reports 2 failed / 228 passed, and
+      test_reasoning_utils.py alone passes on both base and head.
 team:
   dux:
     {

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/brief.yml
@@ -10,8 +10,8 @@ objective: >-
   B1.2 of mandate B1 (BLUE). Re-base the nine historical "impossible cosine"
   abstain tripwires by ADDITION, never by edit (README D3/D5): each original
   stays byte-identical, and beside it a pipeline-derived variant feeds the
-  same query, context and assertions with sources minted from a measured
-  registry. The only real number that exists for these (query, context)
+  same query, context and assertions with sources minted from a registry of
+  measured cosines. The only real number that exists for these (query, context)
   texts is rc1a's text-embedding-3-small cosine (prod rag container,
   2026-09-10T18:03Z); no hybrid rank was ever measured for them, so every
   variant declares the DENSE path (B1.1 inventory row 2, score_kind
@@ -36,9 +36,12 @@ constraints:
     each variant body is equivalent to its original except the sources
     literal (AST normalisation script, output in the PR body).
   - >-
-    Nothing is invented: rank, fusion and list membership are declared only
-    where measured (dense, rank 0/1 from rc1a's cosine order); the tenth
-    regression (a behaviour gap) and the eleventh (named by count, never
+    Nothing is invented: only the cosines are measured (rc1a). No retrieval
+    rank, list membership, fusion or Qdrant server was ever measured for these
+    texts, so dense_rank0 and qdrant_server are None; formatter_collection,
+    lists and fallback_path are declared simulation inputs (the `simulated`
+    field names them); row 9's source-to-chunk association is unresolved. The
+    tenth regression (a behaviour gap) and the eleventh (named by count, never
     itemised) stay UNRESOLVED as B1.1's inventory recorded them.
 acceptance:
   - text: >-

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-1-b1-2.md
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-1-b1-2.md
@@ -1,0 +1,44 @@
+---
+title: "B1.2 adversarial round 1 — Codex gpt-5.6-sol (effort high, read-only)"
+reviewed_sha: 4963e47f917af712a6eb1ad1204ba0356765ab32
+started: 2026-09-11T17:31:29Z
+ended: 2026-09-11T17:39:23Z
+---
+
+VERDICT: BLOCK
+
+1. `apps/backend-rag/backend/tests/fixtures/pipeline_score_fixtures.py:3` — BLOCKER  
+   Evidenza: il registro dichiara che “every value” è misurato, ma la build spec ammette esplicitamente che sono stati misurati soltanto i coseni e nessun rank (`B1-2-build-spec.md:10-15`). Ciononostante vengono assegnati `dense_rank0=0/1`, collection e server (`pipeline_score_fixtures.py:58-60,79,235-265`). La riga 9 associa inoltre arbitrariamente al singolo source il massimo di due coseni di context (`:295-319`). L’inventory aveva già stabilito che la misura `(query, context)` non può esprimere rank, membership o fusion (`B1-2-inventory.md:95-109`). Dichiarare `dense_formatted` rende corretta la trasformazione, ma non trasforma questi dati in risultati realmente recuperati da quella collection: nasconde rank e associazione source→chunk inventati, contro D3.  
+   Fix minimo: marcare rank, collection/server osservati e associazione della riga 9 come `None`/`unresolved`, distinguendo cosine misurato da configurazione simulata; oppure sostituirli con una vera ricevuta dense-retrieval che identifichi chunk e rank restituiti. Non chiamare “measured” i campi derivati o assunti.
+
+2. `apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py:109` — BLOCKER  
+   Evidenza: G4 richiede soltanto che esista da qualche parte una chiamata corretta a `pipeline_sources` e cerca score non etichettati esclusivamente negli `ast.Dict` (`:129-161,253-273`). Una mutazione concreta che passa G1–G5 è:
+
+   ```python
+   sources = pipeline_sources(node_id)
+   sources[0].pop("score_kind")
+   ```
+
+   La chiamata soddisfa G4, non appare alcun nuovo dict literal, G1/G2 interrogano una copia fresca del registro e G5 lascia l’assert invariato. Anche il tripwire continua a passare perché lo scorer legge soltanto `score`, ignorando `score_kind` (`services/rag/agentic/reasoning_utils.py:610-665`). Il guard quindi non rispetta l’accettazione che impone rosso per qualsiasi source score non etichettato.  
+   Fix minimo: confrontare l’intero AST normalizzato originale/variante, consentendo esclusivamente la sostituzione del sources literal con la chiamata esatta, oppure intercettare a runtime gli argomenti realmente ricevuti dallo scorer e validare lì ogni source.
+
+3. `apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py:90` — BLOCKER  
+   Evidenza: `_find_function` restituisce la prima definizione AST, mentre Python conserva l’ultima definizione omonima nella classe. Aggiungendo dopo la variante valida:
+
+   ```python
+   def test_no_keyword_overlap_pipeline_variant(self):
+       assert True
+   ```
+
+   pytest esegue la variante indebolita, ma G4 e G5 continuano a esaminare la prima definizione valida (`:258-268,287-302`). Inoltre G5 confronta originale e variante correnti: indebolirli entrambi nello stesso modo passa ugualmente. D5 non è quindi protetto.  
+   Fix minimo: fallire se una classe contiene più di una definizione per uno dei nomi protetti, verificare il binding runtime effettivo e pinning degli assert originali contro snapshot/hash indipendenti dalla copia corrente.
+
+4. `apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py:170` — MAJOR  
+   Evidenza: G1 controlla soltanto `score`, `score_raw` e `score_kind`; G2 usa cosine, collection e kind, ma confronta soltanto quei tre valori trasformati (`:194-222`). Una modifica come `dense_rank0=999`, `rounding_digits=2`, `lists=("bm25",)` o una variazione di provider, measurement reference, fallback, fusion, boosts o carried keys passa G1–G5. Il guard quindi non “pinna” la tabella D3 che sostiene di proteggere.  
+   Fix minimo: aggiungere una tabella attesa indipendente e confrontare esplicitamente ogni campo, inclusi ordine e carried keys; usare `rounding_digits` nel calcolo verificato.
+
+5. `apps/backend-rag/backend/tests/fixtures/pipeline_score_fixtures.py:25` — MAJOR  
+   Evidenza: `@dataclass(frozen=True)` è solo superficialmente immutabile. `PIPELINE_TRIPWIRE_FIXTURES` è un normale dict (`:64`) e ogni `carried_keys` è un dict mutabile (`:87,243,265,291,318`). Un caller può eseguire `PIPELINE_TRIPWIRE_FIXTURES.clear()` oppure mutare `spec.carried_keys`, contaminando test successivi; `Final[Mapping]` non impone alcun vincolo runtime. La copia fresca prodotta da `pipeline_sources` (`:325-350`) non protegge il registro esportato.  
+   Fix minimo: esporre `MappingProxyType` per registro e carried keys, oppure usare una rappresentazione profondamente immutabile, con test espliciti che le mutazioni falliscano.
+
+Controlli senza rilievi: il diff fornito è additions-only, non modifica i nove originali né file di produzione/percorsi vietati; gli assert aggiunti corrispondono agli originali. La trasformazione reale è `1/(1+(1-cosine))` con rounding a quattro cifre (`result_formatter.py:90-96,143`), e tutti i valori numerici registrati — 0.5435, 0.5102, 0.5376, 0.5435, 0.5882, 0.5556, 0.6061, 0.6711, 0.5618 e 0.6250 — risultano corretti.

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-2-b1-2.md
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-2-b1-2.md
@@ -1,0 +1,36 @@
+---
+title: "B1.2 adversarial round 2 — Codex gpt-5.6-sol (effort high, read-only, account 2 on Mini, diffs inlined)"
+reviewed_sha: 5a4505040b
+attempts:
+  - "2026-09-11T17:56:19Z account 1 (Pro): out of workspace credits (retry 17:59Z same)"
+  - "2026-09-11T17:59:42Z/18:03:55Z account 2 (Mini) over a file extract: REVIEW NOT EXECUTED (tool runner timed out negotiating with the code-mode host)"
+  - "2026-09-11T18:04:45Z account 2 (Mini), diffs inlined, no tools: verdict below"
+---
+
+VERDICT: BLOCK
+
+1. PARTIAL — `pipeline_score_fixtures.py:3-21,37-94,347-376` (cure hunks `@@ -1,22 +1,35`, `@@ -24,10 +37,15`, `@@ -50,284 +74,329`) now distinguishes measured cosine, computed score, simulated formatter inputs, `None` rank/server, and unresolved row-9 association. However, `brief.yml:37-38` still claims ranks `0/1` were measured, while `B1-2-build-spec.md:27-31,40-54` retains the obsolete rank/collection account. The provenance correction is therefore incomplete.
+
+2. CURED — `test_tripwire_pipeline_variants_guard.py:335-447` (hunk beginning `@@ -303,3 +332,448`) adds G6 whole-body normalization/parity. Extra mutation such as `sources[0].pop("score_kind")` remains outside the replaced call and turns G6 red, confirmed by measured mutation m1.
+
+3. CURED — `test_tripwire_pipeline_variants_guard.py:451-542` in the same cure hunk adds G7’s duplicate-definition check and G8’s independent original-function hashes. Measured mutations m2 and m3 turn G7 and G8 red respectively.
+
+4. CURED — `test_tripwire_pipeline_variants_guard.py:218-247` (`@@ -195,6 +218,11`) independently recomputes rounding, while `:545-741` pins every dataclass field through G9. Mutations m4, m5a and m6 are red; the field set, order-sensitive rows, carried keys and simulation metadata are covered.
+
+5. CURED — `pipeline_score_fixtures.py:30,85-94,107-109,411-419` wraps both the exported registry and every `carried_keys` mapping in `MappingProxyType`; `test_tripwire_pipeline_variants_guard.py:749-779` exercises immutability and fresh mutable outputs through G10.
+
+New findings:
+
+1. `apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py:91-95,469-477` — BLOCKER  
+   Evidence: G7 counts only `FunctionDef`/`AsyncFunctionDef` nodes, while `_find_function` likewise ignores later class-body assignments. After the valid variant in `test_reasoning.py`, this one-line change keeps G1–G10 green:
+
+   ```python
+   test_no_keyword_overlap_pipeline_variant = test_no_keyword_overlap
+   ```
+
+   Python’s class construction overwrites the runtime variant binding with the historical original. Pytest therefore executes the original unlabelled `{"score": 0.9}` source under the variant attribute, while G4–G6 continue inspecting the now-dead valid variant definition; G7 still counts one definition of each name and G8’s original AST is unchanged.  
+   Smallest fix: extend G7 to reject every later class-body binding of a protected name (`Assign`, `AnnAssign`, named expression or equivalent), and pin/reject class decorators capable of replacing protected methods.
+
+2. `evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/brief.yml:37-38` — BLOCKER  
+   Evidence: the text still says rank and list membership are declared only where measured, specifically calling rank `0/1` measured “from rc1a’s cosine order.” This directly contradicts the corrected registry and the same brief’s objective, which says no hybrid rank was measured. `B1-2-build-spec.md:27-31,40-54` also retains the obsolete server, collection and rank table and the blanket “measured-not-invented” instruction. The provenance wording check therefore fails.  
+   Smallest fix: update both evidence files to state `qdrant_server=None`, `dense_rank0=None`, formatter collection/list/fallback as simulated inputs, and row 9’s source-to-chunk association as unresolved; remove every claim that cosine ordering measured retrieval rank or membership.

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-3-b1-2.md
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-3-b1-2.md
@@ -1,0 +1,54 @@
+---
+title: "B1.2 adversarial round 3 — Codex gpt-5.6-sol (effort high, read-only, account 2 on Mini, diffs inlined, scoped to the round-2 cure)"
+reviewed_sha: 775c6f39a0
+at: "2026-09-11T18:36:12Z/18:41:24Z"
+extraction: "last VERDICT line of /tmp/b1-2-r3/out.txt on Mini to end of file"
+---
+
+VERDICT: BLOCK
+
+R2-N1: NOT CURED — G11 catches ordinary rebinding, but it proves only matching metadata, not that the runtime function is the parsed `def`.
+
+- Class-body alias: caught by the `obj.__name__` check at `test_tripwire_pipeline_variants_guard.py:853-857`.
+- Module-level lambda: caught by the same check (`"<lambda>"`), then by qualname/source-line checks at `:858-879`.
+- Simple class decorator replacing the variant with the original: caught by `__name__`.
+- `functools.wraps` wrapper: copied name/qualname pass, but its wrapper code fails `co_filename` or `co_firstlineno` at `:863-879`.
+- Ordinary metaclass or `__init_subclass__` replacement: caught by function metadata checks. A replacement with forged metadata bypasses them.
+- Module `__getattr__`: does not intercept the existing class attribute. Deleting/replacing the class normally fails `:832-841`; a fully spoofed substitute remains possible.
+- Concrete green bypass: after the class, obtain the valid variant’s filename and first line, compile an empty function under that filename with padding to the same line, copy its qualname, and assign it back:
+
+```python
+_name = "test_no_keyword_overlap_pipeline_variant"
+_old = TestCalculateEvidenceScore.__dict__[_name]
+_ns = {}
+exec(
+    compile(
+        "\n" * (_old.__code__.co_firstlineno - 1)
+        + f"def {_name}(self):\n    pass\n",
+        _old.__code__.co_filename,
+        "exec",
+    ),
+    _ns,
+)
+_new = _ns[_name]
+_new.__qualname__ = _old.__qualname__
+setattr(TestCalculateEvidenceScore, _name, _new)
+```
+
+This is a plain function with the required name, qualname, resolved filename and first line, so every assertion at `:843-879` passes, while pytest executes an empty replacement. G1–G10 still inspect the untouched class-body definition.
+
+- Collection-hook bypass: `pytest_collection_modifyitems` can set the target `pytest.Function` item’s cached `_obj` to `lambda **kwargs: None`. The class binding remains valid, so G11 stays green while pytest runs another callable. G11 imports a module at `:826`; it never examines the collected item.
+
+R2-N2: CURED — `brief.yml:36-44` now explicitly says only cosines were measured and identifies rank, membership, formatter collection, fallback path and Qdrant server as unmeasured or simulated. `B1-2-build-spec.md:7-16,34-44,59-68` makes the same correction. The retained rank values are explicitly marked “SUPERSEDED,” not measured retrieval ranks.
+
+1. `apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py:843-879` — BLOCKER  
+   Evidence: G11 compares forgeable function metadata only. The dynamic-compilation replacement above keeps G1–G11 green and replaces the test body. A `types.FunctionType` clone can likewise produce a different function object sharing the original code metadata.  
+   Smallest fix: validate a structural digest of the complete runtime code object against independently compiled/pinned code, including nested code, defaults, closures and `obj.__globals__ is module.__dict__`. If exact object identity is required, capture the binding during definition/collection; it cannot be reconstructed from filename and line metadata afterward.
+
+2. `apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py:821-879` — BLOCKER  
+   Evidence: this is an ordinary test executed after collection. It checks `cls.__dict__[name]`, not the callable cached in the corresponding `pytest.Function` item. A collection hook can replace `item._obj` without changing the class, leaving G11 green. Reloading the canonical module after collection creates the same separation between the module G11 inspects and the class/item pytest previously collected.  
+   Smallest fix: perform the comparison in a collection/runtest hook against the actual protected `pytest.Function` items, and pin or reject in-scope hooks capable of subsequently replacing those items.
+
+3. `apps/backend-rag/backend/tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py:1-4,816-879` — MINOR  
+   Evidence: the file still describes itself as “purely static/pure-function” with “No app init,” but G11 imports four test modules and executes all their module-level code. Dotted-name resolution and `sys.modules` caching can inspect another installed/shadow copy under differing pytest import modes. `Path.resolve()` correctly normalizes ordinary symlinks, but a relative `co_filename` is current-working-directory dependent.  
+   Smallest fix: use the module attached to the collected item, verify `module.__file__` against the parsed path, and update the docstring to disclose import execution.

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
@@ -120,7 +120,13 @@ measured:
 pii_scan: clean
 bites:
   consumer: "CI Backend Tests (Python) shards collecting the four tripwire files and the guard"
-  observation: "before/after counts above, both green; guard red under both mutations"
+  observation: >-
+    The guard runs in the same shards as the files it protects, and it is red when they are
+    weakened. Measured on the cured tree: guard 97 passed (86 before the round-3 cure);
+    the four tripwire files 88 / 29 / 35 / 87 and the six B1 §4 innocence files at their base
+    counts; A2's two registry/score mutations red on G1 and G4; the round-3 forged-metadata
+    clone red on G12 with G11 still green; the round-3 collection hook red on G13 leg B with
+    the guard alone and on legs B and A with the tripwire file in the session.
 lanes:
   - lane: "B1.2 registry and guard"
     role: build

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
@@ -133,7 +133,7 @@ lanes:
   - lane: "B1.2 adversarial round 1"
     role: review
     seat: "codex gpt-5.6-sol, effort high, read-only (round 1 account 1 Pro, round 2 account 2 Mini)"
-    state: "round 1 BLOCK -> cured; round 2 BLOCK -> cured (G11); round 3 pending"
+    state: "round 1 BLOCK -> cured; round 2 BLOCK -> cured (G11); round 3 BLOCK -> SUSPENDED (three reds, one cause), ruling requested from the staff room"
 dissent: []
 appetite_exceeded: >-
   adversarial rounds: a third round is needed against a declared appetite of 2.
@@ -177,3 +177,22 @@ adversarial:
       - "R1-F2..F5 CURED (reviewer)"
       - "R2-N1 BLOCKER class-body rebinding `variant = original` keeps G1-G10 green: AGREE — spec B1-2-round-2-cure-spec.md, G11 pins the runtime binding (qualname, co_filename, co_firstlineno) instead of enumerating rebinding syntaxes"
       - "R2-N2 BLOCKER evidence wording: AGREE, cured as R1-F1 above"
+  - round: 3
+    seat: "codex gpt-5.6-sol, effort high, read-only, account 2 (Mini), diffs inlined, scoped to the round-2 cure"
+    reviewed_sha: 775c6f39a0
+    at: "2026-09-11T18:36:12Z/18:41:24Z"
+    verdict: BLOCK
+    record: evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-3-b1-2.md
+    state: >-
+      SUSPENDED — third red for one cause (the guard cannot prove that the
+      callable pytest runs under a protected name is the parsed def: round 1
+      F3 duplicate def, round 2 N1 class-body rebinding, round 3 forged
+      metadata / collection hook). No fourth round, no push (staff-room ack
+      2026-09-11T18:14:19Z). Dispositions below are the Dux's PROPOSAL, pending
+      the staff room's ruling.
+    dispositions:
+      - "R2-N1 NOT CURED (reviewer): G11 catches alias, lambda, decorator, functools.wraps, ordinary metaclass; NOT a function compiled via exec() under the original co_filename with padded co_firstlineno and a copied __qualname__, nor a pytest_collection_modifyitems hook replacing item._obj"
+      - "R2-N2 CURED (reviewer)"
+      - "R3-1 BLOCKER forged-metadata clone: proposed REJECT as outside the guard's threat model — the bypass needs deliberately written exec/compile with line padding in a test file; no in-process check proves identity against arbitrary code in the same interpreter (the reviewer's own fix 'capture the binding during definition' is again in-process); deliberate sabotage is the review and gate boundary, accidental weakening is what G1-G11 pin"
+      - "R3-2 BLOCKER collection hook replacing item._obj: proposed REJECT on the same ground (a conftest hook is code in the same process, visible in review as a new conftest/plugin file)"
+      - "R3-3 MINOR docstring says pure/static while G11 imports four test modules; module identity via dotted name: proposed AGREE, cure = docstring + module.__file__ vs parsed path — NOT applied while suspended"

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
@@ -133,10 +133,14 @@ lanes:
   - lane: "B1.2 adversarial round 1"
     role: review
     seat: "codex gpt-5.6-sol, effort high, read-only (round 1 account 1 Pro, round 2 account 2 Mini)"
-    state: "round 1 BLOCK -> cured; round 2 BLOCK -> cured (G11); round 3 BLOCK -> SUSPENDED (three reds, one cause), ruling requested from the staff room"
+    state: "round 1 BLOCK -> cured; round 2 BLOCK -> cured (G11); round 3 BLOCK -> cured (G12 + G13), suspension REVOKED by imperator ruling I14, no fourth round"
 dissent: []
 appetite_exceeded: >-
-  adversarial rounds: a third round is needed against a declared appetite of 2.
+  adversarial rounds: a third round was needed against a declared appetite of 2 (accepted by
+  the imperator, envelope 20260911T181419Z-650b). The root deadline 2026-09-11T21:59:55Z then
+  EXPIRED with the staff room at its own context guard 18:41Z-01:30Z; B1 was reopened as
+  GENERATION 4 with a new root deadline 2026-09-12T14:00:00Z by ruling I16, same envelope as
+  I14. Rounds stay at three: no fourth Codex round was taken.
   Named cause: round 2 found the round-1 cure of finding 3 incomplete (G7 counts
   `def` nodes, a class-body rebinding escapes it) and the evidence wording still
   carried the old rank claim. Per the fix-of-a-fix rule the surface was written
@@ -184,15 +188,23 @@ adversarial:
     verdict: BLOCK
     record: evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-3-b1-2.md
     state: >-
-      SUSPENDED — third red for one cause (the guard cannot prove that the
-      callable pytest runs under a protected name is the parsed def: round 1
-      F3 duplicate def, round 2 N1 class-body rebinding, round 3 forged
-      metadata / collection hook). No fourth round, no push (staff-room ack
-      2026-09-11T18:14:19Z). Dispositions below are the Dux's PROPOSAL, pending
-      the staff room's ruling.
+      CURED, and the suspension is REVOKED by imperator ruling I14 (fleet
+      envelope 20260912T013527Z-13d6, 2026-09-12T01:36Z). Third red for one
+      cause (the guard cannot prove the callable pytest runs under a protected
+      name is the parsed def: round 1 F3 duplicate def, round 2 N1 class-body
+      rebinding, round 3 forged metadata / collection hook). NO fourth round —
+      the reviewer does not re-read; the cure is measured by the Dux and the
+      fresh Opus 5 gate re-runs innocence and guilt itself. The dispositions
+      below are MEASURED, replacing the previous window's proposed REJECTs:
+      the tiebreaker rule says "spec it" is only honest once the cheap patch is
+      known not to work, and both cheap patches work. Cure spec:
+      evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/B1-2-round-3-cure-spec.md
     dispositions:
       - "R2-N1 NOT CURED (reviewer): G11 catches alias, lambda, decorator, functools.wraps, ordinary metaclass; NOT a function compiled via exec() under the original co_filename with padded co_firstlineno and a copied __qualname__, nor a pytest_collection_modifyitems hook replacing item._obj"
       - "R2-N2 CURED (reviewer)"
-      - "R3-1 BLOCKER forged-metadata clone: proposed REJECT as outside the guard's threat model — the bypass needs deliberately written exec/compile with line padding in a test file; no in-process check proves identity against arbitrary code in the same interpreter (the reviewer's own fix 'capture the binding during definition' is again in-process); deliberate sabotage is the review and gate boundary, accidental weakening is what G1-G11 pin"
-      - "R3-2 BLOCKER collection hook replacing item._obj: proposed REJECT on the same ground (a conftest hook is code in the same process, visible in review as a new conftest/plugin file)"
-      - "R3-3 MINOR docstring says pure/static while G11 imports four test modules; module identity via dotted name: proposed AGREE, cure = docstring + module.__file__ vs parsed path — NOT applied while suspended"
+      - "R3-1 BLOCKER forged-metadata clone: AGREE and CURED by G12. MEASURED FIRST (M1): G11's eight assertions all go GREEN on an exec-compiled clone carrying the original co_filename, a padded co_firstlineno and a copied __qualname__, and the clone is what runs — so the finding is real, not hypothetical, and the earlier window's REJECT was an argument where a measurement was available. G12 compares a STRUCTURAL DIGEST of the runtime code object (opcodes, flat consts, co_names, co_varnames, signature, co_flags, nested code digests) against the guard's own pytest-style compile of the parsed def; co_filename/co_firstlineno are excluded on purpose because they are the forged fields and G11 pins them already. Guilt A: 1 failed, G12 on the right node id, G11 GREEN — which is what proves G12 is load-bearing and not redundant."
+      - "R3-2 BLOCKER collection hook replacing item._obj: AGREE and CURED by G13. MEASURED FIRST (M3): with a pytest_collection_modifyitems hook in a throwaway project, G11 stays green and the protected body never runs. G13 binds on two legs — leg A compares the collected pytest.Function item's callable by IDENTITY against the class-body def for every protected name present in the session (absent names are printed, never silently skipped), leg B censuses the collection hooks defined in the conftest chain applying to the four tripwire files against an expected literal set (empty today) and therefore binds in EVERY session, including the guard-alone run where leg A has nothing to compare. Guilt B: guard alone 1 failed (leg B); guard + tripwire file 2 failed (leg B and leg A)."
+      - "R3-3 MINOR docstring says pure/static while G11 imports four test modules; module identity via dotted name: AGREE, APPLIED. The docstring now discloses that G11-G13 import the four tripwire modules and execute their top-level code, and G12 asserts module.__file__ resolves to the parsed path plus obj.__globals__ is module.__dict__."
+      - "STANDING, not cured, named as the boundary it is (imperator I14): G12/G13 raise the cost of a DELIBERATE in-process substitution, they do not make it impossible, and no in-process check can. Accidental weakening is what G1-G13 pin; deliberate sabotage is the review and gate boundary."
+      - "TWO TRADES CAUGHT AND UNDONE while measuring the cure, recorded because each would have shipped a guard that convicts an honest tree: (1) co_flags diverged on 8 of 18 names on bit 1<<24 (CO_FUTURE_ANNOTATIONS) because the tripwire files carry `from __future__ import annotations` and an isolated compile does not inherit it — cured by compiling the whole module, so co_flags stays IN the digest instead of being dropped to make the comparison pass; (2) pytest REWRITES asserts at import time, so a plain compile of the parsed def disagrees with the runtime code object on ALL 18 names — measured as 9 red G12 cases on the real tree, cured by reproducing _pytest.assertion.rewrite.rewrite_asserts before compiling. Only running the first draft on the real tree said so."
+      - "PROOF HYGIENE: no guilt proof touched a tracked file. The two bypasses were planted in a `git archive HEAD` copy under the session scratchpad (baseline on the copy reproduced 97 passed before planting), and M1/M3 used synthetic modules — so the lane rule the pack already carries was honoured without needing cp-and-restore at all."

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
@@ -15,7 +15,7 @@ spend:
   external_builder_calls: 4
 result: >-
   Nine dense-path pipeline variants added beside the nine preserved tripwire
-  originals; a measured registry (tests/fixtures/pipeline_score_fixtures.py)
+  originals; a registry of measured cosines (tests/fixtures/pipeline_score_fixtures.py)
   supplies their sources with score_kind dense_formatted, score_raw = rc1a's
   measured cosine and the score the real formatter mints; a guard pins the
   registry to the live transform and turns red on an unlabelled score
@@ -97,9 +97,14 @@ measured:
       test_abstain_bypass_policy: "34 -> 35",
       test_reasoning: "86 -> 87",
     }
-  guard: "46 passed"
+  guard: "46 passed at 4963e47f91; 86 passed at 8001e29180 (G1-G11)"
   mutation_a: "first registry entry score_kind -> UNKNOWN: 1 failed (G1) / 45 passed"
   mutation_b: '{"score": 0.9} literal inside test_no_keyword_overlap_pipeline_variant: 1 failed (G4) / 45 passed'
+  round_2_cure_mutations:
+    measured_at: "2026-09-11T18:3xZ, Pro, 8001e29180, test_reasoning.py backed up with cp, restored, sha256 re-checked equal"
+    r1: "class-body `test_no_keyword_overlap_pipeline_variant = test_no_keyword_overlap` after the variant: 1 failed (test_g11_runtime_binding_matches_the_parsed_def[...test_no_keyword_overlap]) / 85 passed"
+    r2: "module-level `TestCalculateEvidenceScore.test_no_keyword_overlap_pipeline_variant = lambda self: None`: 1 failed (G11, same node) / 85 passed"
+    r3: "class decorator that setattr()s the variant to the original: 1 failed (G11, same node) / 85 passed"
   assertion_diff: "0 variants whose asserts/prints differ; 0 variants whose body differs beyond the sources literal (AST)"
   numstat_existing_files_deletions: 0
   innocence:
@@ -128,8 +133,15 @@ lanes:
   - lane: "B1.2 adversarial round 1"
     role: review
     seat: "codex gpt-5.6-sol, effort high, read-only (round 1 account 1 Pro, round 2 account 2 Mini)"
-    state: "round 1 BLOCK -> cured; round 2 pending"
+    state: "round 1 BLOCK -> cured; round 2 BLOCK -> cured (G11); round 3 pending"
 dissent: []
+appetite_exceeded: >-
+  adversarial rounds: a third round is needed against a declared appetite of 2.
+  Named cause: round 2 found the round-1 cure of finding 3 incomplete (G7 counts
+  `def` nodes, a class-body rebinding escapes it) and the evidence wording still
+  carried the old rank claim. Per the fix-of-a-fix rule the surface was written
+  as a spec (B1-2-round-2-cure-spec.md) before the second cure; round 3 is
+  scoped to that cure only.
 deviations:
   - >-
     Net size above the ~400-line guideline (registry + guard grew to about 1,250
@@ -155,6 +167,13 @@ adversarial:
       - "F4 MAJOR fields unpinned: CURED — G9 independent literal table, G2 recomputes with rounding_digits; Dux mutations m4, m6 red"
       - "F5 MAJOR shallow immutability: CURED — MappingProxyType registry and carried_keys, G10"
   - round: 2
-    seat: "codex gpt-5.6-sol, effort high, read-only, account 2 (Mini)"
+    seat: "codex gpt-5.6-sol, effort high, read-only, account 2 (Mini), diffs inlined"
     reviewed_sha: 5a4505040b
-    verdict: pending
+    at: "2026-09-11T18:04:45Z (after account 1 out of credits 17:56Z and a Mini tool-runner failure 17:59Z-18:03Z)"
+    verdict: BLOCK
+    record: evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-2-b1-2.md
+    dispositions:
+      - "R1-F1 PARTIAL -> CURED in evidence: brief.yml constraint and B1-2-build-spec.md no longer call rank/collection/server measured (correction block + superseded rank column)"
+      - "R1-F2..F5 CURED (reviewer)"
+      - "R2-N1 BLOCKER class-body rebinding `variant = original` keeps G1-G10 green: AGREE — spec B1-2-round-2-cure-spec.md, G11 pins the runtime binding (qualname, co_filename, co_firstlineno) instead of enumerating rebinding syntaxes"
+      - "R2-N2 BLOCKER evidence wording: AGREE, cured as R1-F1 above"

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
@@ -127,7 +127,34 @@ lanes:
     state: delivered
   - lane: "B1.2 adversarial round 1"
     role: review
-    seat: "codex gpt-5.6-sol, effort high, read-only"
-    state: pending
+    seat: "codex gpt-5.6-sol, effort high, read-only (round 1 account 1 Pro, round 2 account 2 Mini)"
+    state: "round 1 BLOCK -> cured; round 2 pending"
 dissent: []
-adversarial: pending
+deviations:
+  - >-
+    Net size above the ~400-line guideline (registry + guard grew to about 1,250
+    added lines after the round-1 cure): one concern, tests only, no production
+    file; the growth is the independent EXPECTED table (G9) and the pinned
+    original-AST snapshot (G8) that round 1 demanded.
+  - >-
+    Codex account 1 on Pro ran out of workspace credits at 17:56Z (round 2 died
+    at start, retried 17:59Z, same error); round 2 moved to Codex account 2 on
+    Mini (CODEX_HOME=~/.codex-acct2, codex-cli 0.154.0) over a read-only extract
+    of the worktree at 5a4505040b. Same seat family and model, not a fallback.
+adversarial:
+  - round: 1
+    seat: "codex gpt-5.6-sol, effort high, read-only, account 1 (Pro)"
+    reviewed_sha: 4963e47f917af712a6eb1ad1204ba0356765ab32 # pragma: allowlist secret
+    at: "2026-09-11T17:31:29Z/17:39:23Z"
+    verdict: BLOCK
+    record: evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/codex-round-1-b1-2.md
+    dispositions:
+      - "F1 BLOCKER provenance called measured: CURED 5a4505040b — dense_rank0 and qdrant_server None, collection renamed formatter_collection (simulation input), simulated field, row-9 source_chunk_association unresolved, docstring rewritten"
+      - "F2 BLOCKER G4 bypass by mutating the returned list: CURED — G6 whole-body AST parity; Dux mutation m1 red"
+      - "F3 BLOCKER duplicate def / weakening both: CURED — G7 single definition, G8 pinned original-AST sha256; Dux mutations m2, m3 red"
+      - "F4 MAJOR fields unpinned: CURED — G9 independent literal table, G2 recomputes with rounding_digits; Dux mutations m4, m6 red"
+      - "F5 MAJOR shallow immutability: CURED — MappingProxyType registry and carried_keys, G10"
+  - round: 2
+    seat: "codex gpt-5.6-sol, effort high, read-only, account 2 (Mini)"
+    reviewed_sha: 5a4505040b
+    verdict: pending

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml
@@ -1,0 +1,133 @@
+task_id: backend-rag-b1-design-2
+mandate: B1
+colour: BLUE
+pr: B1.2
+code_sha: 4963e47f917af712a6eb1ad1204ba0356765ab32 # pragma: allowlist secret — last commit touching apps/
+base_sha: 0141b8130a192483a67865376281518ce7b69f2f # pragma: allowlist secret
+brief_ref: evidence/brief.yml
+gear: 2
+spend:
+  wall_clock_hours: 0.8
+  adversarial_rounds: 1
+  tokens: 400000
+  children: 1
+  child_depth: 1
+  external_builder_calls: 4
+result: >-
+  Nine dense-path pipeline variants added beside the nine preserved tripwire
+  originals; a measured registry (tests/fixtures/pipeline_score_fixtures.py)
+  supplies their sources with score_kind dense_formatted, score_raw = rc1a's
+  measured cosine and the score the real formatter mints; a guard pins the
+  registry to the live transform and turns red on an unlabelled score
+  literal inside a variant.
+inventory_ref: evidence/2026-09/agent-nuzantara-backend-rag-b1-score-contract-107e45b6/B1-2-inventory.md
+registry:
+  - {
+      row: 1,
+      node: "unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate",
+      original: 0.91,
+      cosine: 0.16,
+      score: 0.5435,
+    }
+  - {
+      row: 2,
+      node: "unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::test_no_keyword_overlap",
+      original: 0.9,
+      cosine: 0.04,
+      score: 0.5102,
+    }
+  - {
+      row: 3,
+      node: "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_stop_words_only_query_keyword_ratio_zero",
+      original: 0.8,
+      cosine: 0.14,
+      score: 0.5376,
+    }
+  - {
+      row: 4,
+      node: "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_short_words_only_yields_near_zero",
+      original: 0.8,
+      cosine: 0.16,
+      score: 0.5435,
+    }
+  - {
+      row: 5,
+      node: "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_entity_mismatch_company_vs_visa",
+      original: 0.6,
+      cosine: 0.30,
+      score: 0.5882,
+    }
+  - {
+      row: 6,
+      node: "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_semantic_penalty_not_applied_when_final_score_at_or_below_015",
+      original: 0.35,
+      cosine: 0.20,
+      score: 0.5556,
+    }
+  - {
+      row: 7,
+      node: "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_kitas_query_with_kbli_results_low_score",
+      original: [0.85, 0.75],
+      cosine: [0.35, 0.51],
+      score: [0.6061, 0.6711],
+    }
+  - {
+      row: 8,
+      node: "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_nonsense_query_zero_score",
+      original: 0.8,
+      cosine: 0.22,
+      score: 0.5618,
+    }
+  - {
+      row: 9,
+      node: "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_entity_type_mismatch_detection",
+      original: 0.9,
+      cosine: 0.40,
+      score: 0.625,
+    }
+unresolved:
+  - "regression 10: a behaviour gap of the withdrawn design (over-abstain on a perfect lexical match), not a fixture — no file/line in any source"
+  - "regression 11: named by count in three sources, itemised in none"
+  - "withdrawn candidate SHA: not recoverable; immutable receipt = 255 CI runs on the branch, zero failures (B1-2-inventory.md)"
+measured:
+  before_after_per_file:
+    {
+      test_reasoning_utils: "84 -> 88",
+      test_evidence_scoring_abstain: "26 -> 29",
+      test_abstain_bypass_policy: "34 -> 35",
+      test_reasoning: "86 -> 87",
+    }
+  guard: "46 passed"
+  mutation_a: "first registry entry score_kind -> UNKNOWN: 1 failed (G1) / 45 passed"
+  mutation_b: '{"score": 0.9} literal inside test_no_keyword_overlap_pipeline_variant: 1 failed (G4) / 45 passed'
+  assertion_diff: "0 variants whose asserts/prints differ; 0 variants whose body differs beyond the sources literal (AST)"
+  numstat_existing_files_deletions: 0
+  innocence:
+    {
+      test_evidence_cross_language: "122 passed, 2 xfailed",
+      test_evidence_scoring_abstain: 29,
+      test_wa_package_builder: 29,
+      test_wa_greeting: 64,
+      test_curated_qa_government_fee_gate: 21,
+      test_wa_finalize: 79,
+    }
+  pre_existing: "TestDetectTeamQuery x2 fail only when the four tripwire files share one process; identical 2 failed / 228 passed on a clean base"
+pii_scan: clean
+bites:
+  consumer: "CI Backend Tests (Python) shards collecting the four tripwire files and the guard"
+  observation: "before/after counts above, both green; guard red under both mutations"
+lanes:
+  - lane: "B1.2 registry and guard"
+    role: build
+    seat: "claude-sonnet-5 (implementer child)"
+    state: delivered
+  - lane: "B1.2 variant addition (mandatory external builder lane)"
+    role: build
+    seat: "tp1-glm-5.2 (3 failed tries) then tp1-qwen3.8-max (same-role fallback), verified and corrected by claude-opus-5 (Dux)"
+    state: delivered
+  - lane: "B1.2 adversarial round 1"
+    role: review
+    seat: "codex gpt-5.6-sol, effort high, read-only"
+    state: pending
+dissent: []
+adversarial: pending


### PR DESCRIPTION
## What this is

B1.2 of mandate B1 (BLUE). The nine historical "impossible cosine" abstain tripwires are
re-based **by ADDITION, never by edit** (README D3/D5): each original stays byte-identical and
beside it a pipeline-derived variant feeds the same query, context and assertions with sources
minted from a registry of measured cosines. `git diff --numstat origin/main...HEAD` shows
**0 deletions** across all 14 files.

A guard (`test_tripwire_pipeline_variants_guard.py`, G1-G13) pins the registry to the live
transform and is red when the thing it protects is weakened.

## Provenance — round-1 finding 1 is CURED

The only real number that exists for these (query, context) texts is rc1a's
`text-embedding-3-small` **cosine** (prod rag container, 2026-09-10T18:03Z). Round 1 found the
brief and the build spec describing retrieval **ranks as measured**; they did not exist.
**CURED:** `brief.yml` and `B1-2-build-spec.md` now state that only cosines were measured and
name rank, list membership, formatter collection, the fallback path and the Qdrant server as
unmeasured or simulated; the retained rank values are marked SUPERSEDED, not measured. Every
variant declares the DENSE path (B1.1 inventory row 2, `score_kind dense_formatted`,
`score_raw = cosine`), `dense_rank0` and `qdrant_server` are `None`, and the `simulated` field
names the simulation inputs. Row 9's source-to-chunk association stays UNRESOLVED, as do B1.1's
tenth and eleventh regressions.

## Three adversarial rounds, one cause, no fourth

Reviewer: `codex gpt-5.6-sol`, effort high, read-only — round 1 account 1 on Pro, rounds 2-3
account 2 on Mini (account 1 ran out of credits 17:56Z). All three returned BLOCK on the same
cause: **the guard could not prove that the callable pytest runs under a protected name is the
`def` it parsed.**

| Round | Finding on that cause | Cure |
|---|---|---|
| 1 | F3: a duplicate `def` — Python binds the LAST one | G7 counts `def` nodes per protected name |
| 2 | N1: a class-body rebinding (`variant = original`), decorator, `setattr` | G11 pins the runtime binding's name, qualname, file and first line |
| 3 | 1: an `exec`-compiled clone forging `co_filename`/`co_firstlineno`/`__qualname__`; 2: a `pytest_collection_modifyitems` hook replacing `item._obj` | **G12 + G13**, below |

Three reds on one cause, so **no fourth round was taken** — the reviewer does not re-read. The
round-3 cure was measured by this session and the fresh-Opus-5 gate re-runs innocence and guilt
itself.

## Round 3: measured before disposed

The tiebreaker rule says "spec it" is only honest once the cheap patch is known not to work, so
the patches were measured before any code was written:

- **M1** — G11's eight assertions all go GREEN on the forged clone, and the clone is what runs.
  R3-1 is real, not hypothetical.
- **M3** — with a collection hook present, G11 stays green while the protected body never runs.
  R3-2 is real too.
- **M2** — a structural code-object digest catches the clone with **0 mismatches** on the 18
  honest protected names.

Both blockers are therefore **cured, not rejected**:

- **G12** — a structural digest of the runtime code object (opcodes, flat constants, `co_names`,
  `co_varnames`, signature, `co_flags`, nested code digests) compared against the guard's own
  pytest-style compile of the parsed `def`. `co_filename`/`co_firstlineno` are excluded on
  purpose: they are the forged fields, G11 pins them, and including them would let the same
  forgery pass. Also pinned: `module.__file__` resolves to the parsed path, and
  `obj.__globals__ is module.__dict__`.
- **G13** — two legs, neither a silent skip. Leg A compares the collected `pytest.Function`
  item's callable **by identity** and prints any protected name absent from the session; leg B
  censuses the collection hooks in the conftest chain against an expected literal set, so it
  binds in **every** session, including a guard-alone run where leg A has nothing to compare.
- **R3-3 (minor), applied** — the docstring no longer calls this module purely static: G11-G13
  import the four tripwire modules and execute their top-level code, and it says so.

**Two trades caught and undone while measuring**, each a guard that would have convicted an
honest tree: `co_flags` diverged on 8 of 18 names on `CO_FUTURE_ANNOTATIONS` (cured by compiling
the whole module, so `co_flags` stays IN the digest rather than being dropped to make the
comparison pass), and **pytest rewrites asserts at import time**, so a plain compile disagreed
on ALL 18 — 9 red G12 cases on the real tree, cured by reproducing `rewrite_asserts`. Only
running the first draft on the real tree said so.

**What is NOT claimed:** G12/G13 raise the cost of a deliberate in-process substitution; they do
not make it impossible, and no in-process check can. Accidental weakening is what G1-G13 pin;
deliberate sabotage is the review and gate boundary. The dissent is named in `pack.yml` with all
three round ids.

## Proofs

| Leg | Result |
|---|---|
| innocence, guard | **97 passed** (86 before the round-3 cure) |
| innocence, A1 — the four tripwire files | 88 / 29 / 35 / 87, the brief's recorded counts |
| innocence, A3 — the six B1 §4 files | 122 passed + 2 xfailed / 29 / 29 / 64 / 21 / 79, base counts |
| A2 — registry/score mutations | red on G1 (UNKNOWN entry) and G4 (unlabelled score literal) |
| guilt A — forged-metadata clone | **1 failed**, G12 on the right node id, **G11 green** — which proves G12 is load-bearing, not redundant |
| guilt B — collection hook, guard alone | **1 failed**, G13 leg B (the census binds with nothing collected) |
| guilt B — guard + tripwire file | **2 failed**, G13 legs B **and** A |
| lint | `ruff check` / `ruff format --check` clean, one `UP033` autofixed |

No guilt proof touched a tracked file: both round-3 mutations were planted in a
`git archive HEAD` copy under the session scratchpad (baseline on the copy reproduced 97 passed
before planting), and M1/M3 used synthetic modules.

## Scope

Tests only. Writable set was the new fixtures module, the new guard, and additions to the four
existing tripwire files. Nothing under `backend/services/**` or `backend/core/**`, no corner, no
`zantara_core.py`, no `wa_codex_leg.py`, no migration, no network, no embedding or generation
call. Because every changed path is a test or an evidence file, merging this does **not** deploy.

`Bites:` the executable contract is `evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/pack.yml`
→ consumer = the CI `Backend Tests (Python)` shards that collect the four tripwire files **and**
the guard; observation = the before/after counts and the five guilt results in the table above.
The guard ships in the same PR as the variants it protects, so the consumer is not "a future job".

## Inherited, not introduced — going to follow-up, not into this PR

`scripts_coupling_census` reports STALE with `scripts/pg.sh` newly coupled. This diff mentions no
repo-root `scripts/` path at all (`git diff origin/main...HEAD -- apps/ | grep scripts/` is
empty), so the staleness is inherited from `main`. Curing it here would add
`scripts/ci/change_map.py` to a tests-only PR and break one-PR-one-concern; it is recorded as an
inherited item instead.

Evidence pack: `evidence/2026-09/agent-nuzantara-backend-rag-b1-design-2-c12f4be0/`
(`brief.yml`, `pack.yml`, build spec, the round-2 and round-3 cure specs, and the three verbatim
reviewer records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
