### PR TITLE
test(bot): the nine dense-path tripwire variants, by addition (B1.2 PR-A)

### DIFF
--- a/apps/backend-rag/backend/tests/fixtures/pipeline_score_fixtures.py
+++ b/apps/backend-rag/backend/tests/fixtures/pipeline_score_fixtures.py
@@ -1,0 +1,419 @@
+"""Registry of dense-path score fixtures for the nine tripwire pipeline variants (B1.2).
+
+Only the COSINE on each spec is a measurement: rc1a's `text-embedding-3-small` cosine for
+one (query, context) pair, taken from a single prod Qdrant read-only probe (`rag`
+container, 2026-09-10T18:03Z, 20 texts, 216 prompt tokens; `measurement_ref` names the
+commit and script that took it). `score` is the REAL transform of that cosine through
+`format_search_results` — also a real computation, not a guess — and `score_kind` is
+DECLARED by the writer that mints it, never inferred from the number's magnitude
+(`core/score_provenance.py`).
+
+Everything else on a spec is a declared SIMULATION INPUT handed to
+`format_search_results` to reproduce that transform, not an observed retrieval fact —
+`simulated` names those fields per spec (`formatter_collection`, `lists`, `fallback_path`
+at minimum). No hybrid-path rank, list membership or fusion configuration was ever
+measured for these (query, context) texts: the (query, context) measurement this
+registry rests on cannot express any of the three
+(`evidence/2026-09/agent-nuzantara-backend-rag-b1-score-contract-107e45b6/B1-2-inventory.md:95-109`),
+so `dense_rank0` and `qdrant_server` are `None` on every spec rather than an invented
+value standing in for a measurement that was never taken. Row 9's single source is
+likewise an association the writer chose, not an observation — see its own
+`source_chunk_association`.
+
+The originals these variants sit beside are PRESERVED byte-for-byte (D3/D5): this module
+only supplies the replacement sources literal, `pipeline_sources(node_id)`, so a variant's
+diff against its original is the sources line and nothing else.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final
+
+from backend.core import score_provenance
+
+
+@dataclass(frozen=True)
+class DenseSourceSpec:
+    """One dense-path source: a measured cosine, a real transform, and declared inputs.
+
+    Per B1.1 decision D3, a kind is declared, never inferred, and nothing here stands in
+    for a measurement that was never taken: `cosine` is the one measured number; `score`
+    is what the live formatter computes from it; every field named in `simulated` is a
+    declared input to that computation, not an observed retrieval fact; `dense_rank0` and
+    `qdrant_server` are `None` because no rank or server receipt was ever measured for
+    these texts. `carried_keys` is frozen into a `MappingProxyType` in `__post_init__` so
+    a caller cannot mutate the registry's own source dicts (B1.2 round-1 finding 5).
+    """
+
+    inventory_row: int
+    score_kind: str
+    provider: str
+    model: str
+    measured_at: str
+    measurement_ref: str
+    #: No receipt was ever observed for these texts — declared `None`, never invented.
+    qdrant_server: str | None
+    fallback_path: str
+    fusion: None
+    lists: tuple[str, ...]
+    #: No rank was ever measured for these texts (B1-2-inventory.md:95-109) — declared
+    #: `None`, never invented.
+    dense_rank0: int | None
+    cosine: float
+    #: Simulation input to `format_search_results` that selects no boost (matches
+    #: neither `bali_zero_pricing_hybrid` nor `bali_zero_team`) — NOT an observed
+    #: retrieval collection.
+    formatter_collection: str
+    primary_collection: None
+    boosts: tuple[str, ...]
+    transform: str
+    rounding_digits: int
+    score: float
+    carried_keys: Mapping[str, Any]
+    unsourced_context_cosines: tuple[float, ...]
+    #: Every field on this spec whose value is a declared simulation input rather than an
+    #: observed retrieval fact — at least `formatter_collection`, `lists`, `fallback_path`.
+    simulated: tuple[str, ...]
+    #: `None` unless the single source's association with its context chunk is itself
+    #: unresolved (row 9) — see that spec's own value for what "unresolved" means here.
+    source_chunk_association: str | None
+
+    def __post_init__(self) -> None:
+        """Freeze `carried_keys` into a `MappingProxyType`.
+
+        Every call site below still passes a plain dict literal; this is the one place
+        that turns it immutable. `object.__setattr__` is required because the dataclass
+        itself is frozen.
+        """
+        object.__setattr__(self, "carried_keys", MappingProxyType(dict(self.carried_keys)))
+
+
+#: Common provenance shared by every spec below — pinned once so nine call sites don't drift.
+_MEASUREMENT_REF: Final = "rc1a 92f40801235cf33b32a8d71f241b6400cad64536 measured_cosines.py"
+_MEASURED_AT: Final = "2026-09-10T18:03Z"
+_FALLBACK_PATH: Final = "search_service dense branch / core/qdrant_db.py:1362 internal fallback"
+_FORMATTER_COLLECTION: Final = "kbli_2025_final_hybrid"
+_TRANSFORM: Final = "distance = 1 - cosine; score = 1/(1+distance)"
+#: Fields whose value on every spec below is a declared simulation input, not an observed
+#: retrieval fact (finding 1) — shared because every spec below declares the same three.
+_SIMULATED_FIELDS: Final[tuple[str, ...]] = ("formatter_collection", "lists", "fallback_path")
+
+
+PIPELINE_TRIPWIRE_FIXTURES: Final[Mapping[str, tuple[DenseSourceSpec, ...]]] = MappingProxyType(
+    {
+        # Row 1
+        "unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::"
+        "test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.16,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5435,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+        ),
+        # Row 2
+        "unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::"
+        "test_no_keyword_overlap": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.04,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5102,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+        ),
+        # Row 3
+        "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+        "test_stop_words_only_query_keyword_ratio_zero": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.14,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5376,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+        ),
+        # Row 4
+        "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+        "test_short_words_only_yields_near_zero": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.16,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5435,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+        ),
+        # Row 5
+        "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+        "test_entity_mismatch_company_vs_visa": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.30,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5882,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+        ),
+        # Row 6
+        "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::"
+        "test_semantic_penalty_not_applied_when_final_score_at_or_below_015": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.20,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5556,
+                carried_keys={},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+        ),
+        # Row 7 — two sources, original order (id 1 then id 2); ranks unmeasured for both.
+        "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+        "test_kitas_query_with_kbli_results_low_score": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.35,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.6061,
+                carried_keys={"id": 1, "title": "KBLI 2025"},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.51,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.6711,
+                carried_keys={"id": 2, "title": "Business Classification"},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+        ),
+        # Row 8
+        "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+        "test_nonsense_query_zero_score": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.22,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.5618,
+                carried_keys={"id": 1, "title": "Random Doc"},
+                unsourced_context_cosines=(),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=None,
+            ),
+        ),
+        # Row 9 — single source: the top dense hit (max of the two measured chunk cosines); the
+        # other chunk's cosine is carried separately as `unsourced_context_cosines`. Which chunk
+        # the single source "is" was never observed — that association is itself unresolved.
+        "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::"
+        "test_entity_type_mismatch_detection": (
+            DenseSourceSpec(
+                inventory_row=2,
+                score_kind=score_provenance.DENSE_FORMATTED,
+                provider="openai",
+                model="text-embedding-3-small",
+                measured_at=_MEASURED_AT,
+                measurement_ref=_MEASUREMENT_REF,
+                qdrant_server=None,
+                fallback_path=_FALLBACK_PATH,
+                fusion=None,
+                lists=("dense",),
+                dense_rank0=None,
+                cosine=0.40,
+                formatter_collection=_FORMATTER_COLLECTION,
+                primary_collection=None,
+                boosts=(),
+                transform=_TRANSFORM,
+                rounding_digits=4,
+                score=0.625,
+                carried_keys={"id": 1},
+                unsourced_context_cosines=(0.32,),
+                simulated=_SIMULATED_FIELDS,
+                source_chunk_association=(
+                    "unresolved — the single source carries the max of the two measured "
+                    "chunk cosines (0.40); the other is unsourced_context_cosines"
+                ),
+            ),
+        ),
+    },
+)
+
+
+def pipeline_sources(node_id: str) -> list[dict[str, Any]]:
+    """Return a FRESH list of formatted-style source dicts for `node_id`.
+
+    Each dict is `{**carried_keys, "score": score, "score_kind": score_kind, "score_raw":
+    cosine}`, in the original list order. A new list and new plain dicts are built on
+    every call — `carried_keys` is a `MappingProxyType` on the spec, but `**`-unpacking it
+    here always yields a fresh mutable `dict` — so a caller mutating its result never
+    leaks into the registry or into another caller.
+
+    Raises `KeyError` naming this registry on an unknown id — never a silent default.
+    """
+    try:
+        specs = PIPELINE_TRIPWIRE_FIXTURES[node_id]
+    except KeyError:
+        raise KeyError(
+            f"{node_id!r} is not registered in "
+            "backend.tests.fixtures.pipeline_score_fixtures.PIPELINE_TRIPWIRE_FIXTURES",
+        ) from None
+
+    return [
+        {
+            **spec.carried_keys,
+            "score": spec.score,
+            "score_kind": spec.score_kind,
+            "score_raw": spec.cosine,
+        }
+        for spec in specs
+    ]

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_reasoning_utils.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_reasoning_utils.py
@@ -200,11 +200,40 @@ class TestCalculateEvidenceScore:
         # semantic_relevance == 0.0 → final_score capped at min(0.4*0.2, 0.1)
         assert score <= 0.10
 
+    def test_stop_words_only_query_keyword_ratio_zero_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_stop_words_only_query_keyword_ratio_zero"]
+        score = calculate_evidence_score(
+            pipeline_sources(
+                "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_stop_words_only_query_keyword_ratio_zero"
+            ),
+            ["kitas immigration visa stay permit renewal"],
+            "what is the",
+        )
+        # semantic_relevance == 0.0 → final_score capped at min(0.4*0.2, 0.1)
+        assert score <= 0.10
+
     # --- short words stripped (all ≤ 3 chars after strip) ---
 
     def test_short_words_only_yields_near_zero(self):
         score = calculate_evidence_score(
             [{"score": 0.8}],
+            ["kitas visa permit"],
+            "go to a spa",  # all ≤ 3 chars: go(2), to(2), a(1), spa(3)
+        )
+        assert score <= 0.10
+
+    def test_short_words_only_yields_near_zero_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_short_words_only_yields_near_zero"]
+        score = calculate_evidence_score(
+            pipeline_sources(
+                "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_short_words_only_yields_near_zero"
+            ),
             ["kitas visa permit"],
             "go to a spa",  # all ≤ 3 chars: go(2), to(2), a(1), spa(3)
         )
@@ -259,6 +288,21 @@ class TestCalculateEvidenceScore:
         )
         assert score < 0.15
 
+    def test_entity_mismatch_company_vs_visa_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_entity_mismatch_company_vs_visa"]
+        # query about PT/PMA company, context about visa/immigration only
+        score = calculate_evidence_score(
+            pipeline_sources(
+                "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_entity_mismatch_company_vs_visa"
+            ),
+            ["visa immigration permit stay kitas renewal"],
+            "PT PMA company setup registration",
+        )
+        assert score < 0.15
+
     # --- semantic-cosine penalty guard conditions ---
 
     def test_semantic_penalty_not_applied_when_cosine_is_zero(self):
@@ -282,6 +326,23 @@ class TestCalculateEvidenceScore:
         # Craft a case with zero semantic relevance → final_score ≤ 0.10 → no penalty
         score = calculate_evidence_score(
             [{"score": 0.35}],  # cosine 0.35 < 0.5, would trigger penalty
+            ["completely unrelated content about something else"],
+            "xyzabc123",  # no meaningful keywords → semantic_relevance = 0.0
+        )
+        # final_score already ≤ 0.10; verify penalty didn't make it negative
+        assert 0.0 <= score <= 0.10
+
+    def test_semantic_penalty_not_applied_when_final_score_at_or_below_015_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_semantic_penalty_not_applied_when_final_score_at_or_below_015"]
+        # Even if cosine is < 0.5, penalty only fires when final_score > 0.15
+        # Craft a case with zero semantic relevance → final_score ≤ 0.10 → no penalty
+        score = calculate_evidence_score(
+            pipeline_sources(
+                "services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_semantic_penalty_not_applied_when_final_score_at_or_below_015"
+            ),
             ["completely unrelated content about something else"],
             "xyzabc123",  # no meaningful keywords → semantic_relevance = 0.0
         )

--- a/apps/backend-rag/backend/tests/services/rag/test_evidence_scoring_abstain.py
+++ b/apps/backend-rag/backend/tests/services/rag/test_evidence_scoring_abstain.py
@@ -45,6 +45,29 @@ class TestEvidenceScoringFixed:
         assert score < 0.15, f"Expected score < 0.15 for mismatched topic, got {score}"
         print(f"✅ KITAS query with KBLI results: score = {score} (correctly < 0.15)")
 
+    def test_kitas_query_with_kbli_results_low_score_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_kitas_query_with_kbli_results_low_score"]
+        # KITAS query
+        query = "Come posso richiedere il KITAS in Indonesia?"
+
+        # But results are about KBLI (business classification) - completely wrong topic
+        sources = pipeline_sources(
+            "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_kitas_query_with_kbli_results_low_score"
+        )
+        context = [
+            "KBLI (Klasifikasi Baku Lapangan Usaha Indonesia) è il sistema di classificazione...",
+            "I codici KBLI sono necessari per registrare un'azienda in Indonesia...",
+        ]
+
+        score = calculate_evidence_score(sources, context, query)
+
+        # Should be very low (< 0.15) due to topic mismatch
+        assert score < 0.15, f"Expected score < 0.15 for mismatched topic, got {score}"
+        print(f"✅ KITAS query with KBLI results: score = {score} (correctly < 0.15)")
+
     def test_nonsense_query_zero_score(self):
         """
         Problem 2: Nonsense query "xyzabc123" should score ~0.0
@@ -56,6 +79,25 @@ class TestEvidenceScoringFixed:
         sources = [
             {"id": 1, "title": "Random Doc", "score": 0.8},
         ]
+        context = [
+            "This is some generic document content about various topics and subjects...",
+        ]
+
+        score = calculate_evidence_score(sources, context, query)
+
+        # Should be very low (< 0.15 triggers ABSTAIN)
+        assert score < 0.15, f"Expected score < 0.15 for nonsense query, got {score}"
+        print(f"✅ Nonsense query: score = {score} (correctly < 0.15)")
+
+    def test_nonsense_query_zero_score_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_nonsense_query_zero_score"]
+        query = "xyzabc123 blorptastic fnord"
+        sources = pipeline_sources(
+            "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_nonsense_query_zero_score"
+        )
         context = [
             "This is some generic document content about various topics and subjects...",
         ]
@@ -146,6 +188,28 @@ class TestEvidenceScoringFixed:
 
         # Context about KBLI (wrong entity type)
         sources = [{"id": 1, "score": 0.9}]
+        context = [
+            "Il codice KBLI 46610 si riferisce al commercio all'ingrosso...",
+            "Per registrare un'azienda serve il KBLI corretto...",
+        ]
+
+        score = calculate_evidence_score(sources, context, query)
+
+        # Should be capped due to entity mismatch
+        assert score < 0.2, f"Entity mismatch should cap score low, got {score}"
+
+    def test_entity_type_mismatch_detection_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_entity_type_mismatch_detection"]
+        # Query about visa
+        query = "Come richiedere il KITAS?"
+
+        # Context about KBLI (wrong entity type)
+        sources = pipeline_sources(
+            "services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_entity_type_mismatch_detection"
+        )
         context = [
             "Il codice KBLI 46610 si riferisce al commercio all'ingrosso...",
             "Per registrare un'azienda serve il KBLI corretto...",

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_abstain_bypass_policy.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_abstain_bypass_policy.py
@@ -298,6 +298,28 @@ class TestTrustedToolDetection:
         assert score < 0.15
 
     @pytest.mark.unit
+    def test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.services.rag.agentic._reasoning_evidence import compute_evidence_score
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate"]
+        query = "Untuk KBLI 51101 berapa batas kepemilikan asing?"
+        irrelevant = (
+            "The D12 visa requires a passport and sponsor documents. "
+            "Immigration may request additional evidence for the stay permit."
+        )
+        score = compute_evidence_score(
+            trusted_tools_used=False,
+            sources=pipeline_sources(
+                "unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate"
+            ),
+            context_gathered=[irrelevant],
+            query=query,
+        )
+        assert score < 0.15
+
+    @pytest.mark.unit
     def test_relevant_vector_hit_can_pass_through_relevance_path(self):
         from backend.services.rag.agentic._reasoning_evidence import compute_evidence_score
 

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_reasoning.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_reasoning.py
@@ -214,6 +214,18 @@ class TestCalculateEvidenceScore:
         score = calculate_evidence_score(sources, context, "quantum physics theory")
         assert score < 0.15
 
+    def test_no_keyword_overlap_pipeline_variant(self):
+        """Pipeline variant: same inputs and assertions, dense_formatted provenance."""
+        from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources
+
+        # B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES["unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::test_no_keyword_overlap"]
+        sources = pipeline_sources(
+            "unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::test_no_keyword_overlap"
+        )
+        context = ["KBLI classification code retail 47911"]
+        score = calculate_evidence_score(sources, context, "quantum physics theory")
+        assert score < 0.15
+
     def test_entity_type_mismatch_visa_vs_kbli(self):
         """KITAS query + KBLI context triggers mismatch penalty."""
         sources = [{"score": 0.7}]

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b12a-variants-197169e6/B1-2-build-spec.md
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b12a-variants-197169e6/B1-2-build-spec.md
@@ -1,0 +1,113 @@
+# B1.2 build spec — the nine tripwires, re-based by ADDITION
+
+Mandate B1 (BLUE), PR B1.2. Base `0141b8130a192483a67865376281518ce7b69f2f` (origin/main at open,
+2026-09-11T16:58Z). Input: `evidence/2026-09/agent-nuzantara-backend-rag-b1-score-contract-107e45b6/B1-2-inventory.md`
+(on main) and rc1a commit `92f40801235cf33b32a8d71f241b6400cad64536` (never pushed; read by sha only).
+Paths below are relative to `apps/backend-rag/backend/`.
+
+## Decision (Dux): every variant is a DENSE-path fixture carrying a MEASURED cosine
+
+> **Corrected after adversarial rounds 1 and 2** (`codex-round-1-b1-2.md`, `codex-round-2-b1-2.md`):
+> only the COSINES are measured. The first draft of §1 below declared `dense_rank0` values (from the
+> cosine order), a Qdrant server version and a retrieval collection as if observed — none was measured
+> for these texts. The shipped registry therefore carries `dense_rank0=None`, `qdrant_server=None`,
+> `formatter_collection` (a simulation input to `format_search_results` that selects no boost, not an
+> observed collection), a `simulated` field naming every declared-not-observed input (`formatter_collection`,
+> `lists`, `fallback_path`), and row 9's source-to-chunk association recorded as unresolved. §1 and the
+> table are amended accordingly; the guard grew G6–G11 (whole-body parity, single definition, pinned
+> original AST, independent field table, immutability, runtime binding).
+
+The only real number that exists for these (query, context) texts is rc1a's `text-embedding-3-small`
+cosine (prod `rag` container, 2026-09-10T18:03Z, one request, 20 texts, 216 prompt tokens). On the
+hybrid path the value is a function of ranks in two lists, and no rank was ever measured for these
+texts — inventing one would be exactly what D3 forbids. So each variant declares B1.1 inventory
+row 2, `score_kind = dense_formatted`, `score_raw = cosine`, and the `score` the REAL formatter
+produces from it.
+
+Pre-measured by the Dux on the base, through `result_formatter.format_search_results(...,
+score_kind=DENSE_FORMATTED)` and the real scorer: all nine variants PASS their unchanged assertions
+(scorer output 0.0600 on every variant; originals 0.0400–0.0800).
+
+## 1. Registry — `tests/fixtures/pipeline_score_fixtures.py` (Sonnet 5)
+
+- `@dataclass(frozen=True) class DenseSourceSpec` with fields, all explicit per D3:
+  `inventory_row: int` (=2) · `score_kind: str` (=`score_provenance.DENSE_FORMATTED`) ·
+  `provider: str` (="openai") · `model: str` (="text-embedding-3-small") ·
+  `measured_at: str` (="2026-09-10T18:03Z") · `measurement_ref: str` (="rc1a 92f40801235cf33b32a8d71f241b6400cad64536 measured_cosines.py") ·
+  `qdrant_server: None` (no server receipt for these texts) · `fallback_path: str` (declared simulation input: "search_service dense branch / core/qdrant_db.py:1362 internal fallback") ·
+  `fusion: None` (dense path has no fusion) · `lists: tuple[str, ...]` (=("dense",), declared simulation input) · `dense_rank0: None` (unmeasured) ·
+  `cosine: float` (the one measured number) · `formatter_collection: str` (="kbli_2025_final_hybrid", simulation input selecting no boost, NOT an observed collection) · `primary_collection: None` ·
+  `simulated: tuple[str, ...]` (names every declared-not-observed field) · `source_chunk_association: str | None` (None except row 9, unresolved) ·
+  `boosts: tuple[str, ...]` (=() — no boost applies) · `transform: str` (="distance = 1 - cosine; score = 1/(1+distance)") ·
+  `rounding_digits: int` (=4) · `score: float` (literal, pinned) ·
+  `carried_keys: Mapping[str, Any]` (non-score keys of the original source, verbatim, e.g. id/title) ·
+  `unsourced_context_cosines: tuple[float, ...]` (=() unless stated).
+- `PIPELINE_TRIPWIRE_FIXTURES: Final[Mapping[str, tuple[DenseSourceSpec, ...]]]` keyed by the ORIGINAL node id.
+- `pipeline_sources(node_id: str) -> list[dict[str, Any]]`: a FRESH list, original list order, each
+  `{**carried_keys, "score": score, "score_kind": score_kind, "score_raw": cosine}`. Unknown id → `KeyError`
+  naming the registry (never a default).
+
+| #   | original node id (relative to `tests/`)                                                                                                                 | original sources                                                                                                 | cosine              | dense_rank0   | score                   |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------- | ------------- | ----------------------- |
+| 1   | `unit/services/rag/agentic/test_abstain_bypass_policy.py::TestTrustedToolDetection::test_successful_but_irrelevant_vector_hit_stays_below_abstain_gate` | `[{"score": 0.91}]`                                                                                              | 0.16                | 0             | 0.5435                  |
+| 2   | `unit/services/rag/agentic/test_reasoning.py::TestCalculateEvidenceScore::test_no_keyword_overlap`                                                      | `[{"score": 0.9}]`                                                                                               | 0.04                | 0             | 0.5102                  |
+| 3   | `services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_stop_words_only_query_keyword_ratio_zero`                               | `[{"score": 0.8}]`                                                                                               | 0.14                | 0             | 0.5376                  |
+| 4   | `services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_short_words_only_yields_near_zero`                                      | `[{"score": 0.8}]`                                                                                               | 0.16                | 0             | 0.5435                  |
+| 5   | `services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_entity_mismatch_company_vs_visa`                                        | `[{"score": 0.6}]`                                                                                               | 0.30                | 0             | 0.5882                  |
+| 6   | `services/rag/agentic/test_reasoning_utils.py::TestCalculateEvidenceScore::test_semantic_penalty_not_applied_when_final_score_at_or_below_015`          | `[{"score": 0.35}]`                                                                                              | 0.20                | 0             | 0.5556                  |
+| 7   | `services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_kitas_query_with_kbli_results_low_score`                                 | `[{"id": 1, "title": "KBLI 2025", "score": 0.85}, {"id": 2, "title": "Business Classification", "score": 0.75}]` | id1 0.35 · id2 0.51 | id1 1 · id2 0 | id1 0.6061 · id2 0.6711 |
+| 8   | `services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_nonsense_query_zero_score`                                               | `[{"id": 1, "title": "Random Doc", "score": 0.8}]`                                                               | 0.22                | 0             | 0.5618                  |
+| 9   | `services/rag/test_evidence_scoring_abstain.py::TestEvidenceScoringFixed::test_entity_type_mismatch_detection`                                          | `[{"id": 1, "score": 0.9}]`                                                                                      | 0.40 (top chunk)    | 0             | 0.625                   |
+
+The `dense_rank0` column is SUPERSEDED: those numbers are the cosine order, not a measured retrieval
+rank; the shipped registry carries `None` on every row.
+
+Row 7: list order is the ORIGINAL order (inputs stay byte-identical); no rank is declared.
+Row 9: one source, as in the original; it carries the larger of the two measured chunk cosines, and
+which chunk that source corresponds to is UNRESOLVED (`source_chunk_association`); the other chunk's
+cosine is `unsourced_context_cosines=(0.32,)`.
+
+Module docstring (short): what the registry is, that the cosines are measured and every other input
+is declared (never presented as observed), that a kind is declared and never inferred from magnitude,
+and that originals are PRESERVED beside the variants (D3/D5).
+
+## 2. Variants — beside each original (GLM 5.2 prepares, Dux verifies)
+
+In the same file and class, immediately after the original function, add `<original_name>_pipeline_variant`:
+
+- same decorators as the original; a one-line docstring;
+- first body line: `from backend.tests.fixtures.pipeline_score_fixtures import pipeline_sources` (local import,
+  so every touched test file diff is +N/-0);
+- one comment line: `# B1.1 inventory row 2 (dense_formatted): PIPELINE_TRIPWIRE_FIXTURES[<node id>]`;
+- the rest of the body byte-identical to the original EXCEPT the sources literal, replaced by
+  `pipeline_sources("<node id>")`. Every `assert` statement, message and `print` identical.
+
+## 3. Guard — `tests/unit/services/rag/test_tripwire_pipeline_variants_guard.py` (Sonnet 5)
+
+- G1: for every registry key, every dict from `pipeline_sources` has `score_kind` in
+  `score_provenance.SCORE_KINDS` and not `UNKNOWN`, a float `score_raw`, a float `score`.
+- G2: every spec's pinned `score`, `score_kind` and `score_raw` equal what
+  `format_search_results({"ids","documents","metadatas","distances":[1-cosine],"scores":[cosine]},
+spec.collection, score_kind=spec.score_kind)` returns — the fixture is pinned to the live transform.
+- G3: registry key set == exactly the nine node ids above; each names a function that exists (AST).
+- G4: for each original, its `_pipeline_variant` exists in the same class; AST inside the variant finds
+  a `pipeline_sources("<its node id>")` call and NO dict literal carrying a `"score"` key without a
+  `"score_kind"` constant from `SCORE_KINDS` (a re-introduced unlabelled value goes red).
+- G5: the `assert` statements of each variant equal its original's (`ast.dump` comparison, in order).
+- Parse files from the test tree relative to the guard's own `__file__`; no network, no app init.
+
+## 4. Proofs the PR body carries
+
+- Before/after pytest counts on the four touched files + guard (`PYTHONPATH=. SKIP_SENTRY_INIT=1
+.venv/bin/python -m pytest <files>` from `apps/backend-rag`), both green.
+- The assertion-line diff (scratch script, output only) — empty.
+- Guard RED under two mutations in a throwaway copy restored with `cp` (never `git checkout --`):
+  (a) drop `score_kind` from one registry entry → G1/G2 red; (b) add `{"score": 0.9}` inside a variant → G4 red.
+- Innocence: the six files of B1 §4 at their origin/main counts.
+- `git diff --numstat` on the four existing test files: deletions = 0.
+
+## Fence
+
+Writable: the registry, the guard, the four existing tripwire test files (additions only), this evidence
+dir. Nothing under `backend/services/**`, `backend/core/**`, no corner, no `zantara_core.py`, no
+`wa_codex_leg.py`, no migration, no network, no embedding/generation call.

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b12a-variants-197169e6/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b12a-variants-197169e6/brief.yml
@@ -1,0 +1,77 @@
+task_id: b12a-variants
+gear: 2
+l_level: L2
+gate_class: opus
+base_sha: 70b43c5459 # pragma: allowlist secret
+mandate: B1
+generation: 4
+colour: BLUE
+pr: "B1.2 PR-A (successor of the closed #6266, variants half)"
+supersedes: >-
+  PR #6266, gate verdict BLOCK 2026-09-12T02:10Z (harness/fable-gate=failure on
+  1a7d34092848940805d43c747a126d6f0b0f5d9a). #6266 carried the variants AND the guard in one
+  PR; its counted churn was 2050 lines against the SIZE_GEAR3 threshold of 1828, so the
+  deterministic floor was 3 while the brief declared 2. Gear 3 was not the way — it demands an
+  evidence pack with non-empty receipts and dissent plus the canonical Gemini/Codex/Kimi
+  council, and the kimi and agy seats were TIMEOUT that day. The cure the staff room directed
+  is a SPLIT into two PRs from fresh origin/main, each gear 2 and each under the threshold.
+  This is PR-A. PR-B carries the guard. Merge order: A then B, because the guard's census reads
+  the variants.
+objective: >-
+  Re-base the nine historical "impossible cosine" abstain tripwires by ADDITION, never by edit
+  (README D3/D5): each original stays byte-identical and beside it a pipeline-derived variant
+  feeds the same query, context and assertions with sources minted from a registry of measured
+  cosines. The only real number that exists for these (query, context) texts is rc1a's
+  text-embedding-3-small cosine (prod rag container, 2026-09-10T18:03Z); no hybrid rank was
+  ever measured for them, so every variant declares the DENSE path (B1.1 inventory row 2,
+  score_kind dense_formatted, score_raw = cosine) and the score the REAL result_formatter
+  transform produces from it.
+constraints:
+  - >-
+    Tests only, additions only. Writable: tests/fixtures/pipeline_score_fixtures.py (new) and
+    the four existing tripwire test files. `git diff --numstat origin/main...HEAD` reports 0
+    deletions on every file. Nothing under backend/services/**, backend/core/**, no corner, no
+    zantara_core.py, no wa_codex_leg.py, no migration, no network, no embedding or generation
+    call.
+  - >-
+    The guard that pins this registry is NOT in this PR — it is PR-B, and it lands after this
+    one. That ordering is deliberate (the guard's census reads the variants), and it is the one
+    thing a reader should hold against this PR: between A merging and B merging, the registry is
+    unguarded. B is opened at the same time as A, not "later".
+  - >-
+    Assertions of every variant are identical to its original's (AST), and each variant body is
+    equivalent to its original except the sources literal.
+  - >-
+    Nothing is invented: only the cosines are measured (rc1a). No retrieval rank, list
+    membership, fusion or Qdrant server was ever measured for these texts, so dense_rank0 and
+    qdrant_server are None; formatter_collection, lists and fallback_path are declared
+    simulation inputs (the `simulated` field names them); row 9's source-to-chunk association is
+    unresolved. The tenth regression (a behaviour gap) and the eleventh (named by count, never
+    itemised) stay UNRESOLVED as B1.1's inventory recorded them.
+acceptance:
+  - text: >-
+      A1: WHEN the four touched tripwire files are run per file SHALL each pass at its
+      post-addition count (88 / 29 / 35 / 87 against the base 84 / 26 / 34 / 86), WHERE the nine
+      originals are preserved byte-identical and each added variant is assertion-identical to
+      its original.
+    probe: >-
+      pytest the four files per file on base and head: reasoning_utils 84 -> 88,
+      evidence_scoring_abstain 26 -> 29, abstain_bypass_policy 34 -> 35, reasoning 86 -> 87
+  - text: >-
+      A2: WHEN `git diff --numstat` is read against the merge base SHALL report 0 in the
+      deletions column for every changed file, so no original tripwire body or assertion was
+      edited.
+    probe: git diff --numstat origin/main...HEAD (deletions column 0 on every file)
+  - text: >-
+      A3 (innocence): WHEN the six B1 §4 files are run SHALL report their base counts or better.
+    probe: >-
+      test_evidence_cross_language 122 passed + 2 xfailed; test_evidence_scoring_abstain 29
+      (26 + 3 variants); test_wa_package_builder 29; test_wa_greeting 64;
+      test_curated_qa_government_fee_gate 21; test_wa_finalize 79
+assumptions:
+  - status: verified
+    text: >-
+      The two TestDetectTeamQuery failures seen when the four tripwire files run together in one
+      process are pre-existing and order-dependent: the same combination on a clean base
+      checkout reports 2 failed / 228 passed, and test_reasoning_utils.py alone passes on both
+      base and head.

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b12a-variants-197169e6/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b12a-variants-197169e6/pack.yml
@@ -1,0 +1,166 @@
+brief_ref: evidence/2026-09/agent-nuzantara-backend-rag-b12a-variants-197169e6/brief.yml
+plan_ref: >-
+  B1.2 PR-A of mandate B1 generation 4. Governing record: the B1 README's D3/D5 addition-only
+  rule and B1.1's inventory row 2 (dense_formatted). Predecessor #6266 closed on the gate's
+  split direction; see brief.yml `supersedes`.
+lanes:
+  - lane: "B1.2 variant addition (mandatory external builder lane)"
+    role: build
+    seat: >-
+      tp1-glm-5.2 (3 failed tries: rc=3 truncated reasoning-only response; off-task review with
+      0 code blocks; 9 blocks none calling pipeline_sources) then tp1-qwen3.8-max (same-role
+      fallback per the seat rule), verified and corrected by claude-opus-5 (Dux)
+    state: delivered
+  - lane: "B1.2 registry"
+    role: build
+    seat: "claude-sonnet-5 (implementer child)"
+    state: delivered
+  - lane: "B1.2 adversarial rounds 1-3"
+    role: review
+    seat: "codex gpt-5.6-sol, effort high, read-only — r1 account 1 Pro, r2/r3 account 2 Mini"
+    state: >-
+      Three BLOCK verdicts, all on ONE cause that belongs to the GUARD, not to the variants:
+      whether the guard can prove the callable pytest runs under a protected name is the def it
+      parsed. The verbatim records and their cures travel with PR-B, where the cause lives. What
+      rounds 1-3 changed in THIS half is the evidence wording only (finding R1-F1, below).
+  - lane: "B1.2 on-disk gate"
+    role: review
+    seat: "fresh claude-opus-5 commissioned by the staff room (M5, isolated detached worktree)"
+    state: >-
+      BLOCK on #6266 at 2026-09-12T02:10Z, three causes. Exactly one of them is this half's:
+      the combined PR's counted churn put the deterministic floor at 3 against a declared gear
+      2. The other two (G13 leg A convicting an honest tree under double import; an unaudited
+      hex digest in the predecessor's pack) belong to PR-B and are cured there.
+seat_diversity: satisfied
+seat_diversity_note: >-
+  Builder lane is a non-Anthropic seat by mandate (tp1-glm-5.2, then tp1-qwen3.8-max); reviewer
+  is codex gpt-5.6-sol; the on-disk gate is a fresh Anthropic seat outside the contribution
+  chain. Generator is never grader in either direction.
+diff:
+  net_lines: >-
+    Additions only, zero deletions on every changed file — the exact per-file numbers are the
+    `git diff --numstat $(git merge-base origin/main HEAD)..HEAD` receipt below rather than a
+    narrated total here, because a narrated total goes stale on the next edit to this very file.
+    What matters and is stable: the counted churn sits well under SIZE_GEAR3_THRESHOLD 1828 (the
+    fixtures module is on an excluded fixtures path), and `evidence_pack_lint --print-floor`
+    computes 2 with source `size`, so the declared gear and the deterministic floor agree. That
+    agreement is the entire reason this PR exists separately from PR-B.
+  behaviour_change: >-
+    None. No shipped code path is touched: this PR adds one test-fixtures module and nine test
+    functions beside nine preserved originals. The observable change is in CI only — the four
+    tripwire files collect nine more tests each carrying honest dense provenance.
+receipts:
+  - claim: >-
+      A2 — additions only: `git diff --numstat` is read against the merge base and reports 0 in
+      the deletions column for every changed file, so no original tripwire body or assertion was
+      edited
+    cmd: >-
+      git diff --numstat origin/main...HEAD (deletions column 0 on every file) — run as
+      `git diff --numstat $(git merge-base origin/main HEAD)..HEAD`
+    result: >-
+      deletions column is 0 on every changed file. Code side: pipeline_score_fixtures.py 419/0,
+      test_reasoning_utils.py 61/0, test_evidence_scoring_abstain.py 64/0,
+      test_abstain_bypass_policy.py 22/0, test_reasoning.py 12/0. Evidence side: the build spec,
+      this pack and the brief, all new files and so all-additions by construction.
+    exit: 0
+    ts: 2026-09-12T02:15Z
+    seat: session (Dux, Pro)
+  - claim: >-
+      A1 — the four touched tripwire files are run per file and each passes at its
+      post-addition count, the nine originals preserved and each variant assertion-identical
+    cmd: >-
+      pytest the four files per file on base and head: reasoning_utils 84 -> 88,
+      evidence_scoring_abstain 26 -> 29, abstain_bypass_policy 34 -> 35, reasoning 86 -> 87 —
+      cd apps/backend-rag && PYTHONPATH=. python -m pytest <file> -o addopts= -p no:randomly -q
+    result: >-
+      test_reasoning_utils.py 88 passed · test_evidence_scoring_abstain.py 29 passed ·
+      test_abstain_bypass_policy.py 35 passed · test_reasoning.py 87 passed. The brief's
+      recorded before-counts were 84 / 26 / 34 / 86.
+    exit: 0
+    ts: 2026-09-12T02:15Z
+    seat: session (Dux, Pro)
+  - claim: "A3 innocence — the six B1 §4 files are run and report their base counts"
+    cmd: >-
+      test_evidence_cross_language 122 passed + 2 xfailed; test_evidence_scoring_abstain 29
+      (26 + 3 variants); test_wa_package_builder 29; test_wa_greeting 64;
+      test_curated_qa_government_fee_gate 21; test_wa_finalize 79 — pytest each of the six
+      files, -o addopts= -p no:randomly -q
+    result: >-
+      test_evidence_cross_language 122 passed + 2 xfailed · test_evidence_scoring_abstain 29 ·
+      test_wa_package_builder 29 · test_wa_greeting 64 · test_curated_qa_government_fee_gate 21
+      · test_wa_finalize 79.
+    exit: 0
+    ts: 2026-09-12T02:15Z
+    seat: session (Dux, Pro)
+  - claim: >-
+      The deterministic gear floor for THIS PR's changed-file list is 2, so the declared gear
+      matches — which is the whole reason the predecessor was split
+    cmd: >-
+      git diff --name-only origin/main...HEAD > /tmp/b12a-changed.txt &&
+      git diff --numstat origin/main...HEAD > /tmp/b12a-numstat.txt &&
+      python3 scripts/evidence_pack_lint.py --print-floor --print-floor-source
+      --changed-files-file /tmp/b12a-changed.txt --numstat-file /tmp/b12a-numstat.txt
+    result: "floor 2, source `size`; no hot-zone path. Quoted in the PR body on the head sha."
+    exit: 0
+    ts: 2026-09-12T02:20Z
+    seat: session (Dux, Pro)
+pii_scan: clean
+pii_scan_note: >-
+  Nothing here transcribes client data. The fixtures module carries query and context strings
+  from the pre-existing tripwire tests (synthetic: "quantum physics theory", "KBLI
+  classification code retail 47911" and similar), cosine floats, and label strings. No applicant
+  name, document number, phone or email appears in the diff, the brief or this pack.
+dissent:
+  - seat: "codex gpt-5.6-sol (adversarial round 1, read-only, effort high)"
+    objection: >-
+      F1: the brief and the build spec described retrieval RANKS as measured. They were not —
+      the only measured number is rc1a's cosine. Describing a simulated rank as measured is the
+      same class of defect the nine tripwires exist to prevent.
+    status: CONFIRMED
+    resolution: >-
+      CURED in evidence, and it is the one round-1 finding that belongs to this half. brief.yml
+      and B1-2-build-spec.md now state that ONLY cosines were measured and name rank, list
+      membership, formatter collection, fallback path and Qdrant server as unmeasured or
+      simulated; the retained rank values are marked SUPERSEDED rather than deleted, so the
+      correction is auditable instead of invisible; dense_rank0 and qdrant_server are None.
+  - seat: "codex gpt-5.6-sol (adversarial rounds 1-3)"
+    objection: >-
+      The remaining findings of all three rounds attack the GUARD's ability to prove that the
+      callable pytest runs under a protected name is the def the guard parsed (r1 F3 duplicate
+      def; r2 N1 class-body rebinding; r3 forged-metadata clone and collection hook).
+    status: CONFIRMED
+    resolution: >-
+      Cured in PR-B, where the guard lives, by G7/G11/G12/G13 — each measured against the
+      reviewer's own bypass. Named here rather than omitted, because a reader of THIS PR must
+      know the registry it adds is pinned by a guard that arrives in the next PR, not in this
+      one.
+  - seat: "session (declared limit, unresolved)"
+    objection: >-
+      Between this PR merging and PR-B merging, the registry is unguarded: nothing is red if an
+      unlabelled score literal reappears in a variant. The split that cured the floor created
+      this window.
+    status: PLAUSIBLE
+    resolution: >-
+      Left standing and labelled rather than argued away. It is bounded by opening both PRs at
+      the same time and by the merge order A-then-B, and it is strictly smaller than the status
+      quo on origin/main, where the variants do not exist at all. Settling it would mean merging
+      one PR over the floor threshold, which is what the gate refused.
+  - seat: "session (self-review)"
+    objection: >-
+      The staff room's split direction called this half "the eleven variants". There are NINE,
+      and the count matters because B1.1's inventory names eleven REGRESSIONS, of which nine are
+      re-based here.
+    status: CONFIRMED
+    resolution: >-
+      Corrected in the open rather than copied forward: nine variants ship, the tenth regression
+      (a behaviour gap) and the eleventh (named by count, never itemised) stay UNRESOLVED as
+      B1.1 recorded them. Reported to the staff room in the same checkpoint that announces this
+      PR.
+bites:
+  consumer: >-
+    The CI `Backend Tests (Python)` shards that collect the four tripwire files — the nine new
+    variants run there, in the same shards as the nine originals they sit beside.
+  observation: >-
+    Per-file counts move from 84/26/34/86 to 88/29/35/87 with zero deletions, and the six B1 §4
+    innocence files stay at 122+2xfailed/29/29/64/21/79. Measured before this PR was opened and
+    re-measured on its head; the PR body carries both.


### PR DESCRIPTION
## What this is

The **variants half** of B1.2, split out of the closed #6266. Each of the nine historical
"impossible cosine" abstain tripwires keeps its original **byte-identical**, and beside it a
pipeline-derived variant feeds the same query, context and assertions with sources minted from a
registry of measured cosines. `git diff --numstat` reports **0 deletions on every file**.

## Why there are two PRs

#6266 carried the variants *and* the guard together. The gate blocked it: counted churn 2050
against `SIZE_GEAR3_THRESHOLD` 1828, so the deterministic floor was **3** while the brief
declared 2. Gear 3 was not the way out — it demands an evidence pack with non-empty receipts and
dissent *plus* the canonical Gemini/Codex/Kimi council, and the kimi and agy seats were TIMEOUT
that day. So the work is split, each half gear 2 and under the threshold:

- **PR-A (this one)** — the nine variants, the fixtures registry, the build spec.
- **PR-B** — the `G1-G13` guard, the three verbatim reviewer records, the cure specs.

**Merge order is A then B**, because the guard's census reads the variants. Both are open now;
B is not "later work".

**The standing limit, stated rather than buried:** between A merging and B merging the registry
is **unguarded** — nothing goes red if an unlabelled score literal reappears in a variant. That
window is the price of the split the gate required, it is strictly smaller than the status quo on
`main` (where the variants do not exist at all), and it is recorded in `pack.yml` as a PLAUSIBLE
unresolved item rather than argued away.

## Provenance — round-1 finding 1 is CURED

The only real number these (query, context) texts have is rc1a's `text-embedding-3-small`
**cosine** (prod rag container, 2026-09-10T18:03Z). Round 1 found the brief and the build spec
describing retrieval **ranks as measured**; they were not. **CURED:** both now state that only
cosines were measured and name rank, list membership, formatter collection, fallback path and
Qdrant server as unmeasured or simulated; retained rank values are marked **SUPERSEDED** rather
than deleted, so the correction is auditable instead of invisible. `dense_rank0` and
`qdrant_server` are `None`, the `simulated` field names the simulation inputs, and row 9's
source-to-chunk association plus B1.1's tenth and eleventh regressions stay **UNRESOLVED**.

## Proofs

| Leg | Result |
|---|---|
| A1 — the four tripwire files, per file | **88 / 29 / 35 / 87** from the base 84 / 26 / 34 / 86 |
| A2 — additions only | deletions column **0** on every changed file |
| A3 — the six B1 §4 innocence files | 122 passed + 2 xfailed / 29 / 29 / 64 / 21 / 79, base counts |
| gear floor | `evidence_pack_lint --print-floor` = **2**, source `size`, no hot-zone path — matching the declared gear |
| pack lint | `evidence_pack_lint: clean` |

## Scope

Tests only. One new fixtures module plus additions to the four existing tripwire files. Nothing
under `backend/services/**` or `backend/core/**`, no corner, no `zantara_core.py`, no
`wa_codex_leg.py`, no migration, no network, no embedding or generation call. Every changed path
is a test or an evidence file, so **merging this does not deploy**.

`Bites:` the executable contract is
`evidence/2026-09/agent-nuzantara-backend-rag-b12a-variants-197169e6/pack.yml` → consumer = the
CI `Backend Tests (Python)` shards that collect the four tripwire files, where the nine variants
run in the same shards as the nine originals they sit beside; observation = the per-file counts
moving 84/26/34/86 → 88/29/35/87 with zero deletions, and the six innocence files unchanged.

## Correction to the split direction

The staff room's direction called this half "the eleven variants". There are **nine**. The count
matters: B1.1's inventory names eleven *regressions*, of which nine are re-based here; the tenth
is a behaviour gap and the eleventh was only ever named by count. Corrected in the open and
reported back in the same checkpoint that announces this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
