### PR TITLE
fix(harness): the pre-flip root-brief self-test must pin its date

### DIFF
--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -3061,6 +3061,7 @@ def lint(
     source_path: str | None = None,
     measured_commits: int | None = None,
     brief_source_path: str | None = None,
+    today: datetime.date | None = None,
 ) -> tuple[int, list[str]]:
     """Returns (exit_code, violations). exit_code: 0 clean, 1 guilty, 2 blind.
 
@@ -3072,7 +3073,12 @@ def lint(
     corrected 2026-08-27, was a cancelable per-file Σ|added−deleted| before
     the round-2 refuter fix), not the ceiling's pre-summed global net, so
     the two parameters are independent and neither substitutes for the
-    other."""
+    other.
+
+    `today` is the SAME seam `check_brief_not_at_deprecated_root` already
+    exposes, threaded one level up so an end-to-end test can pin which side of
+    a flip date it is asserting. Default None means the real UTC date, which is
+    what every CLI and CI caller gets."""
     if not pack_path.exists():
         return 2, [f"BLIND: evidence pack not found at {pack_path}"]
     try:
@@ -3153,7 +3159,7 @@ def lint(
     # judge a brief against the pack's constant, which is precisely the
     # blind spot this rule exists to close.
     brief_root_violations, brief_root_notice = check_brief_not_at_deprecated_root(
-        brief_source_path, repo_root
+        brief_source_path, repo_root, today=today
     )
     violations += brief_root_violations
     if brief_root_notice:

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -2790,10 +2790,37 @@ def test_brief_root_end_to_end_notice_pre_flip_does_not_fail(tmp_repo):
             tmp_path,
             None,
             brief_source_path="evidence/brief.yml",
+            today=_BRIEF_ROOT_PRE_FLIP,
         )
     assert rc == 0
     assert not any("evidence_root_brief_deprecated" in v for v in viol)
     assert "evidence_root_brief_deprecated" in err.getvalue()
+
+
+def test_brief_root_end_to_end_violation_post_flip_fails(tmp_repo):
+    """The post-flip twin, end-to-end through lint(): on/after the flip date the
+    same root brief is a VIOLATION and the run exits 1, with nothing on stderr.
+
+    It exists because its pre-flip sibling asserts only the notice side, and a
+    rule wired to notice forever would keep that sibling green. Both pin their
+    date explicitly: a test whose verdict depends on the day it runs is not a
+    test, and this pair used to flip the whole repo's merge queue red at
+    2026-09-12T00:00Z on its own."""
+    tmp_path, write_brief, write_pack = tmp_repo
+    write_brief(gear=1)
+    write_pack()
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        rc, viol = lint(
+            tmp_path / "evidence" / "pack.yml",
+            tmp_path,
+            None,
+            brief_source_path="evidence/brief.yml",
+            today=_BRIEF_ROOT_POST_FLIP,
+        )
+    assert rc == 1
+    assert any("evidence_root_brief_deprecated" in v for v in viol)
+    assert "evidence_root_brief_deprecated" not in err.getvalue()
 
 
 def test_brief_root_resolver_seam_produces_diff_relative_paths_not_the_staged_name():


### PR DESCRIPTION
## What

`scripts/tests/test_evidence_pack_lint.py::test_brief_root_end_to_end_notice_pre_flip_does_not_fail` asserted rule 12's **pre-flip** behaviour while reading the **real** date. `EVIDENCE_ROOT_BRIEF_DEPRECATION_DATE` is `2026-09-12`, so at `2026-09-12T00:00Z` the test inverted by itself: the same root brief became a violation, `lint()` returned 1, and the test demanding 0 went red.

That is a repo-wide merge-queue stop, not a defect of any one PR: the `Guard conformance / Every guard proves guilt AND innocence` job runs this suite in every `merge_group`. PR #6267 was ejected from the queue at 02:22:10Z by this test, with a diff that touches none of it.

## Fix

The unit-level cases at this rule already pin their side (`today=_BRIEF_ROOT_PRE_FLIP` / `_BRIEF_ROOT_POST_FLIP`). Only the end-to-end case could not, because `lint()` did not expose the seam `check_brief_not_at_deprecated_root` already had.

- `lint()` takes `today: datetime.date | None = None` and threads it to the rule. `None` still means the real UTC date — every CLI and CI caller is unchanged.
- the pre-flip case pins `_BRIEF_ROOT_PRE_FLIP`.
- **new post-flip twin** `test_brief_root_end_to_end_violation_post_flip_fails`: the same root brief must be a violation, rc 1, nothing on stderr. Without it, a rule wired to notice forever would keep the pre-flip case green — the pair has to hold both sides, which is the whole point of this suite.

No rule, date or threshold is changed. The deprecation still flips on 2026-09-12 for real callers.

## Guilt + innocence, measured

| Mutation | Result |
|---|---|
| rule forced to notice forever (`if True:`) | post-flip twin **FAILS** |
| date un-pinned again in the pre-flip case | pre-flip case **FAILS** (today is past the flip) |
| unmutated | **593 passed**, `evidence_pack_lint.py --selftest` **PASS** |

Reproduced first on fresh `origin/main` (`70b43c5459`): 1 failed, same assertion.

## Bites

The CONSUMER is the `Every guard proves guilt AND innocence` job in `.github/workflows/guard-conformance.yml`, which runs `pytest scripts/tests/test_evidence_pack_lint.py -q` and `evidence_pack_lint.py --selftest`. It ships in this same PR — the observation is that job **green on this PR**, where it is red on today's `origin/main`.

Gear 1 (measured: `evidence_pack_lint.py --print-floor` = 1 on this changed-file set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiFaywEkp34RCsg8vnVJD7