### PR TITLE
chore(secrets): audit the three B1.3 evidence digests (#6274) as false positives

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67094,6 +67094,34 @@
         "line_number": 262,
         "is_secret": false
       }
+    ],
+    "evidence/2026-09/agent-nuzantara-backend-rag-b1-3-benchmark-8c81ecfa/baseline-report.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-nuzantara-backend-rag-b1-3-benchmark-8c81ecfa/baseline-report.json",
+        "hashed_secret": "3c47c0935e21c13a34d9bc7c00fc743a011add26",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ],
+    "evidence/2026-09/agent-nuzantara-backend-rag-b1-3-benchmark-8c81ecfa/pack.yml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-nuzantara-backend-rag-b1-3-benchmark-8c81ecfa/pack.yml",
+        "hashed_secret": "230104c25cfdde3ff7481c8925e3e8faeee2f391",
+        "is_verified": false,
+        "line_number": 32,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-nuzantara-backend-rag-b1-3-benchmark-8c81ecfa/pack.yml",
+        "hashed_secret": "1921762a044686d643b1b067baeea4bd72487dd1",
+        "is_verified": false,
+        "line_number": 34,
+        "is_secret": false
+      }
     ]
   },
   "version": "1.5.0"


### PR DESCRIPTION
## What

Three `.secrets.baseline` rows added (+28 lines, nothing else): the "Hex High Entropy String" findings the #6274 (B1.3) evidence pack introduced — `evidence/2026-09/agent-nuzantara-backend-rag-b1-3-benchmark-8c81ecfa/pack.yml` lines 32 and 34, and `.../baseline-report.json` line 4. All three are `is_secret: false`.

## Why

`Detect Secrets` on #6274 left these three findings unaudited (no path rule matches a first-time evidence directory). Inspecting the flagged lines: `pack.yml:32` is `manifest_sha256`, `pack.yml:34` is `baseline_report_sha256`, and `baseline-report.json:4` is `base_sha` — all sha256/git-sha content digests of the frozen B1.3 benchmark manifest and baseline report, not credentials. Same class of false positive as #6256's `finalSpecSha256` audit.

## Verification (local, on this head)

- `python3 scripts/detect_secrets_check_unaudited.py` → `All findings audited (8163 total)` (main: 8160).
- The real `.secrets.baseline` was never scanned in place with explicit file args — that prunes every unscanned file down to just the ones passed (hit once this session on a throwaway copy, discarded; confirmed against #6256's own note about the same gotcha). The three entries were inserted as a pure text patch anchored on the file's existing tail, verified valid JSON and a minimal `git diff` (+28/-0, only `.secrets.baseline`) before committing.
- `hashed_secret` values for the three findings were computed via a scratch-copy `detect-secrets scan` (not the tracked baseline) against the two evidence files only.

Bites: the `Detect Secrets` check on this PR's head — its "Check for unaudited findings" step, red for these three findings after #6274 merged, is green here (observed on this PR before merge); after merge, the nightly full-tree scan stays clear of this evidence directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVUDonFqNU64BKtbdetJ17
