### PR TITLE
fix(garuda-voa): make actor_id a required keyword on DocumentStorePort

### DIFF
--- a/apps/backend-rag/backend/app/routers/garuda_documents_router.py
+++ b/apps/backend-rag/backend/app/routers/garuda_documents_router.py
@@ -31,8 +31,18 @@ must not pretend to: `get_document_store()` below defaults to
 in that path (the store rejection happens before `service.submit_document` gets
 to the OCR call). The moment L1 ships a real `DocumentStorePort` adapter and (2)
 is resolved, swapping `app.state.garuda_document_store` in `service_initializer.py`
-is the only change needed — no router or contract edit — exactly the seam
-`garuda_flow/public_api.py`'s own module docstring describes for CheckStore.
+is what wires it in — exactly the seam `garuda_flow/public_api.py`'s own module
+docstring describes for CheckStore.
+
+That seam is NOT signature-stable, and this file no longer claims it is. It used
+to say a store swap needed "no router or contract edit"; that stopped being true
+when `ports.py` made `actor_id` a required, non-defaulted keyword on
+`DocumentStorePort` to close a cross-actor idempotency-key collision. Three call
+sites here speak that Protocol — `_UnconfiguredDocumentStore`'s two methods,
+`_ReplayTrackingStore`'s two, and `upload_intake_document`'s
+`service.submit_document` call — and a `DocumentStorePort` signature change has
+to revisit all three. The CONTRACT is untouched by any of it: `openapi.yaml`
+knows nothing about this Protocol.
 """
 
 from __future__ import annotations
@@ -185,12 +195,28 @@ class _UnconfiguredDocumentStore:
     router papers over); it is this router's own minimal extension so
     `listIntakeDocuments` has something to call, structurally satisfied by
     duck typing rather than a change to L5's frozen `ports.py`.
+
+    `actor_id` is accepted and never read — every call raises before it could
+    matter — purely so this Protocol-shaped fake stays callable the same way
+    `service.py` calls a real `DocumentStorePort`. `ports.py` makes `actor_id`
+    a REQUIRED keyword (a bare `idempotency_key` is a client-chosen string with
+    no uniqueness guarantee across actors), and a fake missing the parameter
+    raises `TypeError` AT THE CALL SITE, before its body ever raises
+    `_PersistenceUnavailable` — which reaches the caller as a raw 500, not this
+    store's documented 503. `test_garuda_documents_router.py` pins that: the
+    unconfigured store still answers 503 SERVICE_UNAVAILABLE, never 500.
     """
 
-    async def get_existing(self, _idempotency_key: str, _payload_hash: str) -> DocumentOutcome | None:
+    async def get_existing(
+        self, _idempotency_key: str, _payload_hash: str, *, actor_id: str
+    ) -> DocumentOutcome | None:
+        del actor_id  # unused — every call raises before it would matter
         raise _PersistenceUnavailable()
 
-    async def commit(self, _idempotency_key: str, _payload_hash: str, _outcome: DocumentOutcome) -> bool:
+    async def commit(
+        self, _idempotency_key: str, _payload_hash: str, _outcome: DocumentOutcome, *, actor_id: str
+    ) -> bool:
+        del actor_id  # unused — every call raises before it would matter
         raise _PersistenceUnavailable()
 
     async def list_for_actor(self, _actor: str) -> list[dict]:
@@ -224,20 +250,29 @@ class _ReplayTrackingStore:
     second `get_existing` call after `commit` loses a race) — correct: the response
     the caller receives there IS a previously (concurrently) committed outcome, not
     freshly produced by this call, which is exactly what the header promises.
+
+    Forwards `actor_id` unchanged. This wrapper adds observation only; the
+    scoping decision belongs to the store underneath it, and a wrapper that
+    silently dropped a required keyword would break every call with a
+    `TypeError` rather than a documented error shape.
     """
 
     def __init__(self, inner: DocumentStorePort) -> None:
         self._inner = inner
         self.replayed = False
 
-    async def get_existing(self, idempotency_key: str, payload_hash: str) -> DocumentOutcome | None:
-        existing = await self._inner.get_existing(idempotency_key, payload_hash)
+    async def get_existing(
+        self, idempotency_key: str, payload_hash: str, *, actor_id: str
+    ) -> DocumentOutcome | None:
+        existing = await self._inner.get_existing(idempotency_key, payload_hash, actor_id=actor_id)
         if existing is not None:
             self.replayed = True
         return existing
 
-    async def commit(self, idempotency_key: str, payload_hash: str, outcome: DocumentOutcome) -> bool:
-        return await self._inner.commit(idempotency_key, payload_hash, outcome)
+    async def commit(
+        self, idempotency_key: str, payload_hash: str, outcome: DocumentOutcome, *, actor_id: str
+    ) -> bool:
+        return await self._inner.commit(idempotency_key, payload_hash, outcome, actor_id=actor_id)
 
 
 async def _require_magic_session_actor(request: Request) -> str:
@@ -278,10 +313,18 @@ def _require_owned_result(result_id: str, actor: str) -> None:
 
 def _scoped_key(*, actor: str, result_id: str, raw_key: str) -> str:
     """Local scoping (LANES.md discipline: no cross-lane import of
-    `garuda_orders.idempotency`) — `DocumentStorePort` itself has no actor/result
-    concept (`ports.py` keys purely on the caller-supplied string), so without this
-    two different customers' documents could collide on the same literal
-    client-supplied Idempotency-Key value.
+    `garuda_orders.idempotency`), folding in the two dimensions the port does NOT
+    know about: `result_id` and the operation name. Without it, one customer's two
+    different eligibility checks could collide on the same literal client-supplied
+    Idempotency-Key value.
+
+    `actor` is folded in here too and ALSO passed to the store as `actor_id` — that
+    is deliberate belt-and-braces, not an oversight. `ports.py` now requires every
+    implementation to scope on `actor_id` itself, because a store cannot assume its
+    caller pre-scoped the key; this router keeps its own folding because the
+    resulting digest is also what a store's `key_sha256` ends up covering, and
+    dropping it would silently weaken every deployment whose store trusted this
+    router's scoping.
     """
     digest = hashlib.sha256()
     for part in (actor, result_id, "uploadIntakeDocument", raw_key):
@@ -497,6 +540,7 @@ async def upload_intake_document(
             declared_media_type=declared_media_type,
             document_kind=document_kind,
             idempotency_key=scoped_key,
+            actor_id=actor,
         )
     except UnsupportedMediaTypeError as exc:
         raise HTTPException(

--- a/apps/backend-rag/backend/app/routers/garuda_documents_router.py
+++ b/apps/backend-rag/backend/app/routers/garuda_documents_router.py
@@ -203,8 +203,10 @@ class _UnconfiguredDocumentStore:
     no uniqueness guarantee across actors), and a fake missing the parameter
     raises `TypeError` AT THE CALL SITE, before its body ever raises
     `_PersistenceUnavailable` — which reaches the caller as a raw 500, not this
-    store's documented 503. `test_garuda_documents_router.py` pins that: the
-    unconfigured store still answers 503 SERVICE_UNAVAILABLE, never 500.
+    store's documented 503. `test_garuda_documents_router.py` pins both of this
+    store's documented 503 shapes against that: 503
+    PERSISTENCE_POLICY_UNAVAILABLE on `uploadIntakeDocument`, 503
+    SERVICE_UNAVAILABLE on `listIntakeDocuments` — never a 500.
     """
 
     async def get_existing(
@@ -313,18 +315,22 @@ def _require_owned_result(result_id: str, actor: str) -> None:
 
 def _scoped_key(*, actor: str, result_id: str, raw_key: str) -> str:
     """Local scoping (LANES.md discipline: no cross-lane import of
-    `garuda_orders.idempotency`), folding in the two dimensions the port does NOT
-    know about: `result_id` and the operation name. Without it, one customer's two
-    different eligibility checks could collide on the same literal client-supplied
-    Idempotency-Key value.
+    `garuda_orders.idempotency`), folding in the operation name alongside the actor
+    and the result.
 
-    `actor` is folded in here too and ALSO passed to the store as `actor_id` — that
-    is deliberate belt-and-braces, not an oversight. `ports.py` now requires every
-    implementation to scope on `actor_id` itself, because a store cannot assume its
-    caller pre-scoped the key; this router keeps its own folding because the
-    resulting digest is also what a store's `key_sha256` ends up covering, and
-    dropping it would silently weaken every deployment whose store trusted this
-    router's scoping.
+    What this actually buys TODAY is narrower than it looks, and saying so is the
+    point: `actor` IS the session's own `result_id` (`_require_magic_session_actor`),
+    and `_require_owned_result` rejects any request whose path `result_id` differs —
+    so "one customer's two different eligibility checks colliding on one literal key"
+    is not a reachable state through this router. The folding is defence in depth for
+    a store that receives keys from somewhere other than this call path, and the
+    operation name is the one dimension neither the actor nor `ports.py`'s scoping
+    covers.
+
+    `actor` is folded in here AND passed separately to the store as `actor_id`.
+    That is deliberate: `ports.py` requires every implementation to scope on
+    `actor_id` itself, because a store cannot assume its caller pre-scoped the key.
+    Neither layer is load-bearing on the other.
     """
     digest = hashlib.sha256()
     for part in (actor, result_id, "uploadIntakeDocument", raw_key):

--- a/apps/backend-rag/backend/services/garuda_documents/ports.py
+++ b/apps/backend-rag/backend/services/garuda_documents/ports.py
@@ -21,22 +21,37 @@ from backend.services.garuda_documents.models import DocumentOutcome
 class DocumentStorePort(Protocol):
     """Idempotency-key-scoped storage for one intake document's outcome.
 
-    Mirrors the contract's Idempotency-Key semantics (openapi.yaml top-level description):
-    an exact scoped key plus the same canonical payload replays the original outcome with
-    no repeated side effect; a different payload under the same key is an
+    Mirrors the contract's Idempotency-Key semantics (openapi.yaml top-level description
+    AND the `IdempotencyKey` parameter description: "Scoped to actor and operation"): an
+    exact scoped key plus the same canonical payload replays the original outcome with no
+    repeated side effect; a different payload under the same key is an
     IDEMPOTENCY_CONFLICT, which this port signals by raising `IdempotencyConflictError` —
     `service.py` never has to special-case a store implementation's own exceptions.
+
+    `actor_id` is required on every call, never defaulted: a bare `idempotency_key` is a
+    client-chosen string with no uniqueness guarantee ACROSS actors, so a store that keyed
+    only on it would let two different actors who happen to reuse the same literal key
+    collide — one actor's `commit` becoming readable (or un-replayable-around) by another.
+    Implementations must fold `actor_id` into whatever they use as the storage key, not
+    merely accept and ignore it.
     """
 
-    async def get_existing(self, idempotency_key: str, payload_hash: str) -> DocumentOutcome | None:
-        """Returns the previously committed outcome for an exact key+payload replay, or
-        None if this is a first-time submission for this key. Raises
-        `IdempotencyConflictError` if the key is already bound to a DIFFERENT payload hash.
+    async def get_existing(
+        self, idempotency_key: str, payload_hash: str, *, actor_id: str
+    ) -> DocumentOutcome | None:
+        """Returns the previously committed outcome for an exact key+payload replay by
+        THIS SAME actor, or None if this is a first-time submission for this
+        (actor, key) pair. Raises `IdempotencyConflictError` if the key is already bound
+        (for this actor) to a DIFFERENT payload hash. A different actor reusing the same
+        `idempotency_key` string is a distinct binding, not a replay and not a conflict.
         """
         ...
 
-    async def commit(self, idempotency_key: str, payload_hash: str, outcome: DocumentOutcome) -> bool:
-        """Atomically persists `outcome` iff no outcome is yet committed for this key —
+    async def commit(
+        self, idempotency_key: str, payload_hash: str, outcome: DocumentOutcome, *, actor_id: str
+    ) -> bool:
+        """Atomically persists `outcome` iff no outcome is yet committed for this
+        (actor, key) pair —
         a compare-and-set, not a blind write. Returns True when THIS call performed the
         commit (the caller is the one that should fire any at-most-once side effect, like
         a staff work-item notification); returns False when a concurrent call already won
@@ -69,10 +84,16 @@ class InMemoryDocumentStore:
     """
 
     def __init__(self) -> None:
-        self._by_key: dict[str, tuple[str, DocumentOutcome]] = {}
+        # Keyed by (actor_id, idempotency_key) -- NOT idempotency_key alone -- so this
+        # reference implementation actually exercises the actor-scoping contract
+        # `DocumentStorePort` documents, rather than silently passing tests that a real
+        # cross-actor collision would fail.
+        self._by_key: dict[tuple[str, str], tuple[str, DocumentOutcome]] = {}
 
-    async def get_existing(self, idempotency_key: str, payload_hash: str) -> DocumentOutcome | None:
-        existing = self._by_key.get(idempotency_key)
+    async def get_existing(
+        self, idempotency_key: str, payload_hash: str, *, actor_id: str
+    ) -> DocumentOutcome | None:
+        existing = self._by_key.get((actor_id, idempotency_key))
         if existing is None:
             return None
         existing_hash, outcome = existing
@@ -80,8 +101,10 @@ class InMemoryDocumentStore:
             raise IdempotencyConflictError(idempotency_key)
         return outcome
 
-    async def commit(self, idempotency_key: str, payload_hash: str, outcome: DocumentOutcome) -> bool:
-        winning = self._by_key.setdefault(idempotency_key, (payload_hash, outcome))
+    async def commit(
+        self, idempotency_key: str, payload_hash: str, outcome: DocumentOutcome, *, actor_id: str
+    ) -> bool:
+        winning = self._by_key.setdefault((actor_id, idempotency_key), (payload_hash, outcome))
         if winning[0] != payload_hash:
             raise IdempotencyConflictError(idempotency_key)
         return winning[1] is outcome

--- a/apps/backend-rag/backend/services/garuda_documents/ports.py
+++ b/apps/backend-rag/backend/services/garuda_documents/ports.py
@@ -104,7 +104,13 @@ class InMemoryDocumentStore:
     async def commit(
         self, idempotency_key: str, payload_hash: str, outcome: DocumentOutcome, *, actor_id: str
     ) -> bool:
-        winning = self._by_key.setdefault((actor_id, idempotency_key), (payload_hash, outcome))
+        # The winner is decided by the identity of the CANDIDATE ENTRY this call built,
+        # not of `outcome`. Comparing `winning[1] is outcome` looks equivalent and is not:
+        # two calls that happen to carry the SAME outcome instance would both be told they
+        # won, and both would fire the at-most-once side effect `commit`'s contract says
+        # exactly one caller may fire. A fresh tuple per call has no such collision.
+        candidate = (payload_hash, outcome)
+        winning = self._by_key.setdefault((actor_id, idempotency_key), candidate)
         if winning[0] != payload_hash:
             raise IdempotencyConflictError(idempotency_key)
-        return winning[1] is outcome
+        return winning is candidate

--- a/apps/backend-rag/backend/services/garuda_documents/service.py
+++ b/apps/backend-rag/backend/services/garuda_documents/service.py
@@ -81,6 +81,7 @@ class DocumentIntakeService:
         declared_media_type: str,
         document_kind: DocumentKind,
         idempotency_key: str,
+        actor_id: str,
     ) -> DocumentOutcome:
         # Stateless request-shape checks first: deterministic on the payload alone, so
         # replaying them is always safe and they never need idempotency tracking.
@@ -88,7 +89,7 @@ class DocumentIntakeService:
         byte_validation.validate_size(raw_bytes)
 
         payload_hash = _payload_hash(raw_bytes, document_kind)
-        existing = await self._store.get_existing(idempotency_key, payload_hash)
+        existing = await self._store.get_existing(idempotency_key, payload_hash, actor_id=actor_id)
         if existing is not None:
             return existing
 
@@ -99,9 +100,9 @@ class DocumentIntakeService:
         # its own outcome in the meantime. Whoever's commit actually wins is the one
         # outcome of record — the loser discards its own result and adopts the winner's,
         # so two racing requests can never disagree or double-fire the work-item hook.
-        won = await self._store.commit(idempotency_key, payload_hash, outcome)
+        won = await self._store.commit(idempotency_key, payload_hash, outcome, actor_id=actor_id)
         if not won:
-            winning_outcome = await self._store.get_existing(idempotency_key, payload_hash)
+            winning_outcome = await self._store.get_existing(idempotency_key, payload_hash, actor_id=actor_id)
             assert winning_outcome is not None  # commit() just told us a record exists
             return winning_outcome
 

--- a/apps/backend-rag/backend/tests/services/garuda_documents/test_ports_actor_scoping.py
+++ b/apps/backend-rag/backend/tests/services/garuda_documents/test_ports_actor_scoping.py
@@ -1,4 +1,5 @@
-"""`DocumentStorePort`'s actor scoping, proved on the reference implementation.
+"""`DocumentStorePort`'s actor scoping — at the port, through the service, and
+through the router's observing wrapper.
 
 `ports.py` makes `actor_id` a required, non-defaulted keyword on both port methods
 because an `Idempotency-Key` is a CLIENT-chosen string: nothing stops two different
@@ -11,18 +12,31 @@ database, and it is what every service-level test in this directory runs against
 IT silently ignored `actor_id`, the whole suite would keep passing while the contract went
 unenforced. These tests pin the scoping on that implementation directly.
 
-Guilt, not just innocence: reverting `InMemoryDocumentStore` to a single-string key (its
-shape before actor scoping) turns `test_two_actors_sharing_a_literal_key_do_not_collide`
-and `test_a_second_actor_cannot_read_the_first_actors_outcome` red. The two
-`same_actor_*` tests are the innocence half — scoping must not break a genuine replay.
+Guilt, measured rather than asserted. Each mutation below was run against this file:
+
+  - `InMemoryDocumentStore` reverted to a single-string key (its shape before actor
+    scoping) -> 2 failed, 3 passed. The three that stay green are the replay, conflict
+    and required-keyword checks; they are not isolation proofs and are not meant to be.
+  - the store keyed on `actor_id` ALONE, ignoring the idempotency key ->
+    `test_one_actors_two_distinct_keys_stay_independent` red. Without that test the
+    mutant passed all five of the original checks.
+  - every `actor_id=` forward in `service.py` and the router replaced by one constant
+    -> `test_service_does_not_replay_one_actors_outcome_to_another` red. Without it the
+    whole suite stayed green while the actor never actually reached the store.
+  - `_ReplayTrackingStore` substituting its own actor -> `test_replay_tracking_wrapper_
+    forwards_the_actor_it_was_given` red.
+
+The `same_actor_*` tests are the innocence half — scoping must not break a genuine replay.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from backend.services.garuda_documents.models import UnreadableOutcome
+from backend.app.routers import garuda_documents_router
+from backend.services.garuda_documents.models import DocumentKind, UnreadableOutcome
 from backend.services.garuda_documents.ports import InMemoryDocumentStore
+from backend.services.garuda_documents.service import DocumentIntakeService
 
 pytestmark = pytest.mark.asyncio
 
@@ -84,3 +98,80 @@ async def test_actor_id_is_required_not_defaulted():
         await store.get_existing(_SHARED_KEY, _PAYLOAD_A)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
         await store.commit(_SHARED_KEY, _PAYLOAD_A, UnreadableOutcome(document_id="doc-a"))  # type: ignore[call-arg]
+
+
+async def test_one_actors_two_distinct_keys_stay_independent(store: InMemoryDocumentStore):
+    """Scoping must add the actor to the key, never REPLACE it.
+
+    A store indexed on `actor_id` alone satisfies every cross-actor assertion above and is
+    still badly wrong: one customer's second, unrelated upload would come back as an
+    IdempotencyConflictError against their first. This is the test that separates the two.
+    """
+    first = UnreadableOutcome(document_id="doc-first")
+    second = UnreadableOutcome(document_id="doc-second")
+
+    assert await store.commit("key-one-0000000000000", _PAYLOAD_A, first, actor_id="actor-a")
+    assert await store.commit("key-two-0000000000000", _PAYLOAD_B, second, actor_id="actor-a")
+
+    assert await store.get_existing("key-one-0000000000000", _PAYLOAD_A, actor_id="actor-a") == first
+    assert await store.get_existing("key-two-0000000000000", _PAYLOAD_B, actor_id="actor-a") == second
+
+
+async def test_committing_the_same_outcome_instance_twice_yields_one_winner(store: InMemoryDocumentStore):
+    """`commit` returning True is the caller's permission to fire an at-most-once side
+    effect (the staff work-item hook). Exactly one caller may receive it. Deciding the
+    winner by `outcome` identity rather than by the entry this call built hands BOTH
+    callers that permission whenever they happen to share one outcome instance.
+    """
+    shared = UnreadableOutcome(document_id="doc-shared")
+
+    assert await store.commit(_SHARED_KEY, _PAYLOAD_A, shared, actor_id="actor-a") is True
+    assert await store.commit(_SHARED_KEY, _PAYLOAD_A, shared, actor_id="actor-a") is False
+
+
+async def test_service_does_not_replay_one_actors_outcome_to_another(monkeypatch):
+    """The port-level tests above call the store DIRECTLY, so they stay green even if
+    `service.py` forwards a constant instead of the caller's actor. This one goes through
+    `submit_document`, which is the only path production uses.
+
+    Deliberately uses bytes that fail `byte_validation` (an UnreadableOutcome), so no OCR
+    runs and no synthetic image is needed — the property under test is the key, not the
+    pipeline.
+    """
+    store = InMemoryDocumentStore()
+    service = DocumentIntakeService(store=store)
+    submission = {
+        "raw_bytes": b"not-an-image-at-all",
+        "declared_media_type": "image/png",
+        "document_kind": DocumentKind.PASSPORT_BIODATA,
+        "idempotency_key": _SHARED_KEY,
+    }
+
+    first = await service.submit_document(**submission, actor_id="actor-a")
+    second = await service.submit_document(**submission, actor_id="actor-b")
+
+    assert first is not second
+    assert first.document_id != second.document_id
+
+
+async def test_replay_tracking_wrapper_forwards_the_actor_it_was_given():
+    """`_ReplayTrackingStore` exists to observe replays, not to make a second scoping
+    decision. A wrapper that substituted or dropped the actor would silently undo the
+    scoping for every request that goes through the router — which is all of them.
+    """
+    seen: list[str] = []
+
+    class _RecordingStore:
+        async def get_existing(self, idempotency_key, payload_hash, *, actor_id):
+            seen.append(actor_id)
+            return None
+
+        async def commit(self, idempotency_key, payload_hash, outcome, *, actor_id):
+            seen.append(actor_id)
+            return True
+
+    wrapper = garuda_documents_router._ReplayTrackingStore(_RecordingStore())
+    await wrapper.get_existing(_SHARED_KEY, _PAYLOAD_A, actor_id="actor-from-session")
+    await wrapper.commit(_SHARED_KEY, _PAYLOAD_A, UnreadableOutcome(document_id="doc-a"), actor_id="actor-from-session")
+
+    assert seen == ["actor-from-session", "actor-from-session"]

--- a/apps/backend-rag/backend/tests/services/garuda_documents/test_ports_actor_scoping.py
+++ b/apps/backend-rag/backend/tests/services/garuda_documents/test_ports_actor_scoping.py
@@ -1,0 +1,86 @@
+"""`DocumentStorePort`'s actor scoping, proved on the reference implementation.
+
+`ports.py` makes `actor_id` a required, non-defaulted keyword on both port methods
+because an `Idempotency-Key` is a CLIENT-chosen string: nothing stops two different
+customers from picking the same literal value. A store that keyed on that string alone
+would let one customer's `get_existing` read the other's committed outcome, or let one
+customer's `commit` be reported as a lost race against the other's.
+
+`InMemoryDocumentStore` is the only implementation this lane can exercise without a
+database, and it is what every service-level test in this directory runs against — so if
+IT silently ignored `actor_id`, the whole suite would keep passing while the contract went
+unenforced. These tests pin the scoping on that implementation directly.
+
+Guilt, not just innocence: reverting `InMemoryDocumentStore` to a single-string key (its
+shape before actor scoping) turns `test_two_actors_sharing_a_literal_key_do_not_collide`
+and `test_a_second_actor_cannot_read_the_first_actors_outcome` red. The two
+`same_actor_*` tests are the innocence half — scoping must not break a genuine replay.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.garuda_documents.models import UnreadableOutcome
+from backend.services.garuda_documents.ports import InMemoryDocumentStore
+
+pytestmark = pytest.mark.asyncio
+
+_SHARED_KEY = "a-key-both-customers-happened-to-pick"
+_PAYLOAD_A = "aa" * 32
+_PAYLOAD_B = "bb" * 32
+
+
+@pytest.fixture
+def store() -> InMemoryDocumentStore:
+    return InMemoryDocumentStore()
+
+
+async def test_two_actors_sharing_a_literal_key_do_not_collide(store: InMemoryDocumentStore):
+    """Both actors must WIN their own commit under the same literal key."""
+    assert await store.commit(_SHARED_KEY, _PAYLOAD_A, UnreadableOutcome(document_id="doc-a"), actor_id="actor-a")
+    assert await store.commit(_SHARED_KEY, _PAYLOAD_B, UnreadableOutcome(document_id="doc-b"), actor_id="actor-b")
+
+
+async def test_a_second_actor_cannot_read_the_first_actors_outcome(store: InMemoryDocumentStore):
+    """A key/payload pair bound by one actor is simply ABSENT for another — not a
+    replay (that would leak the first actor's document_id) and not an
+    IdempotencyConflictError (that would confirm the key exists, an enumeration
+    oracle across customers). `None` is the only honest answer.
+    """
+    await store.commit(_SHARED_KEY, _PAYLOAD_A, UnreadableOutcome(document_id="doc-a"), actor_id="actor-a")
+
+    assert await store.get_existing(_SHARED_KEY, _PAYLOAD_A, actor_id="actor-b") is None
+    assert await store.get_existing(_SHARED_KEY, _PAYLOAD_B, actor_id="actor-b") is None
+
+
+async def test_same_actor_same_key_same_payload_still_replays(store: InMemoryDocumentStore):
+    committed = UnreadableOutcome(document_id="doc-a")
+    await store.commit(_SHARED_KEY, _PAYLOAD_A, committed, actor_id="actor-a")
+
+    replayed = await store.get_existing(_SHARED_KEY, _PAYLOAD_A, actor_id="actor-a")
+
+    assert replayed == committed
+
+
+async def test_same_actor_same_key_different_payload_still_conflicts(store: InMemoryDocumentStore):
+    from backend.services.garuda_documents.ports import IdempotencyConflictError
+
+    await store.commit(_SHARED_KEY, _PAYLOAD_A, UnreadableOutcome(document_id="doc-a"), actor_id="actor-a")
+
+    with pytest.raises(IdempotencyConflictError):
+        await store.get_existing(_SHARED_KEY, _PAYLOAD_B, actor_id="actor-a")
+    with pytest.raises(IdempotencyConflictError):
+        await store.commit(_SHARED_KEY, _PAYLOAD_B, UnreadableOutcome(document_id="doc-z"), actor_id="actor-a")
+
+
+async def test_actor_id_is_required_not_defaulted():
+    """A store that accepted a missing `actor_id` would let a stale call site keep
+    compiling while silently dropping the scoping — the failure mode this keyword
+    exists to make loud.
+    """
+    store = InMemoryDocumentStore()
+    with pytest.raises(TypeError):
+        await store.get_existing(_SHARED_KEY, _PAYLOAD_A)  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        await store.commit(_SHARED_KEY, _PAYLOAD_A, UnreadableOutcome(document_id="doc-a"))  # type: ignore[call-arg]

--- a/apps/backend-rag/backend/tests/services/garuda_documents/test_service_concurrency.py
+++ b/apps/backend-rag/backend/tests/services/garuda_documents/test_service_concurrency.py
@@ -62,6 +62,7 @@ async def test_two_concurrent_submissions_same_key_commit_exactly_once(monkeypat
             declared_media_type="image/png",
             document_kind=DocumentKind.PASSPORT_BIODATA,
             idempotency_key="race-key",
+            actor_id="actor-1",
         )
 
     task_a = asyncio.create_task(submit())
@@ -106,6 +107,7 @@ async def test_two_concurrent_low_confidence_submissions_fire_hook_exactly_once(
             declared_media_type="image/png",
             document_kind=DocumentKind.PASSPORT_BIODATA,
             idempotency_key="race-key-lowconf",
+            actor_id="actor-1",
         )
 
     task_a = asyncio.create_task(submit())

--- a/apps/backend-rag/backend/tests/services/garuda_documents/test_service_journeys.py
+++ b/apps/backend-rag/backend/tests/services/garuda_documents/test_service_journeys.py
@@ -66,6 +66,7 @@ async def test_corrupt_upload_returns_unreadable_document_outcome(store, monkeyp
         declared_media_type="image/png",
         document_kind=DocumentKind.PASSPORT_BIODATA,
         idempotency_key="key-corrupt-1",
+        actor_id="actor-1",
     )
     assert isinstance(outcome, UnreadableOutcome)
 
@@ -93,12 +94,14 @@ async def test_corrupt_upload_retry_same_key_replays_without_second_outcome(stor
         declared_media_type="image/png",
         document_kind=DocumentKind.PASSPORT_BIODATA,
         idempotency_key="key-corrupt-retry",
+        actor_id="actor-1",
     )
     second = await svc.submit_document(
         raw_bytes=payload,
         declared_media_type="image/png",
         document_kind=DocumentKind.PASSPORT_BIODATA,
         idempotency_key="key-corrupt-retry",
+        actor_id="actor-1",
     )
     assert first == second
     assert isinstance(first, UnreadableOutcome)
@@ -113,6 +116,7 @@ async def test_low_confidence_fields_are_never_silently_accepted_as_verified(sto
         declared_media_type="image/png",
         document_kind=DocumentKind.PASSPORT_BIODATA,
         idempotency_key="key-lowconf-1",
+        actor_id="actor-1",
     )
     assert isinstance(outcome, LowConfidenceOutcome)
     assert len(outcome.uncertain_fields) == len(CONFIDENT_VALUES)
@@ -138,12 +142,14 @@ async def test_low_confidence_retry_same_event_produces_no_second_mutation(store
         declared_media_type="image/png",
         document_kind=DocumentKind.PASSPORT_BIODATA,
         idempotency_key="key-lowconf-retry",
+        actor_id="actor-1",
     )
     await svc.submit_document(
         raw_bytes=payload,
         declared_media_type="image/png",
         document_kind=DocumentKind.PASSPORT_BIODATA,
         idempotency_key="key-lowconf-retry",
+        actor_id="actor-1",
     )
     assert work_item_calls == ["key-lowconf-retry"]  # exactly one, not two
 
@@ -156,6 +162,7 @@ async def test_confident_upload_returns_ready_document(store, monkeypatch):
         declared_media_type="image/png",
         document_kind=DocumentKind.PASSPORT_BIODATA,
         idempotency_key="key-ready-1",
+        actor_id="actor-1",
     )
     assert isinstance(outcome, ReadyOutcome)
     assert len(outcome.review_fields) == len(CONFIDENT_VALUES)
@@ -178,6 +185,7 @@ async def test_ready_document_never_fires_the_work_item_hook(store, monkeypatch)
         declared_media_type="image/png",
         document_kind=DocumentKind.PASSPORT_BIODATA,
         idempotency_key="key-ready-no-workitem",
+        actor_id="actor-1",
     )
     assert calls == []
 
@@ -190,6 +198,7 @@ async def test_different_payload_under_same_idempotency_key_conflicts(store, mon
         declared_media_type="image/png",
         document_kind=DocumentKind.PASSPORT_BIODATA,
         idempotency_key="shared-key",
+        actor_id="actor-1",
     )
     with pytest.raises(IdempotencyConflictError):
         await svc.submit_document(
@@ -197,6 +206,7 @@ async def test_different_payload_under_same_idempotency_key_conflicts(store, mon
             declared_media_type="image/png",
             document_kind=DocumentKind.PASSPORT_BIODATA,
             idempotency_key="shared-key",
+            actor_id="actor-1",
         )
 
 
@@ -213,7 +223,8 @@ async def test_ocr_pipeline_unavailable_raises_and_persists_nothing(store, monke
             declared_media_type="image/png",
             document_kind=DocumentKind.PASSPORT_BIODATA,
             idempotency_key="key-unavailable",
+            actor_id="actor-1",
         )
     # No outcome was ever committed for this key — a later retry once OCR is back up
     # must be free to succeed, not replay a failure.
-    assert await store.get_existing("key-unavailable", "irrelevant") is None
+    assert await store.get_existing("key-unavailable", "irrelevant", actor_id="actor-1") is None

--- a/evidence/2026-09/agent-air-m5-backend-rag-voa-store-wiring-23492b6e/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-voa-store-wiring-23492b6e/brief.yml
@@ -12,11 +12,15 @@ gate_class: opus
 objective: >-
   GARUDA VOA W1W, PR 1 of 4. Make `actor_id` a required, non-defaulted keyword on
   `DocumentStorePort` (`ports.py`) and thread it from the router through
-  `DocumentIntakeService.submit_document` to the store, so no store implementation can key
-  an outcome on the client-supplied Idempotency-Key string alone. An `Idempotency-Key` is
-  chosen by the CLIENT: two different customers can pick the same literal value, and a
-  store that ignored the actor would let one read or displace the other's committed
-  outcome. This PR carries NO storage implementation — it is the port-shape change the
+  `DocumentIntakeService.submit_document` to the store. An `Idempotency-Key` is chosen by
+  the CLIENT: two different customers can pick the same literal value, and a store that
+  ignored the actor would let one read or displace the other's committed outcome.
+  What this PR does and does NOT achieve, stated precisely because Sol refuted the looser
+  claim: a required keyword FORCES every implementation and every call site to supply the
+  actor, and makes a stale one fail loudly; it cannot stop an implementation from
+  accepting the parameter and ignoring it. Enforcement of the USE is per-implementation
+  and is proved per-implementation — here on `InMemoryDocumentStore`, in PR 2a on
+  `PostgresDocumentStore`. This PR carries NO storage implementation — it is the port-shape change the
   Postgres store (PR 2a) is written against, landed first so the adapter arrives against a
   port that already enforces the scoping.
   Spec: docs/plans/2026-09-11-garuda-voa-final-spec.md §3 row W1W. Source of the work:
@@ -69,10 +73,52 @@ acceptance:
       (TypeError at the call site, before its body raises).
     probe: "PYTHONPATH=. pytest backend/tests/app/routers/test_garuda_documents_router.py -k '503'"
   - text: >-
-      A5 (whole-lane regression): the garuda_documents service and router suites SHALL pass
+      A5: WHEN one actor submits under TWO DIFFERENT idempotency keys, THEN both SHALL
+      commit independently and each SHALL replay its own outcome. Scoping adds the actor to
+      the key; it must never replace it, or a customer's second unrelated upload would come
+      back as a conflict against their first.
+    probe: "PYTHONPATH=. pytest backend/tests/services/garuda_documents/test_ports_actor_scoping.py -k two_distinct_keys"
+  - text: >-
+      A6: WHEN two actors submit the same payload under the same literal key THROUGH
+      `DocumentIntakeService.submit_document`, THEN they SHALL receive distinct outcomes.
+      The port-level tests call the store directly and stay green even if the service
+      forwards a constant actor; this one goes through the only path production uses.
+    probe: "PYTHONPATH=. pytest backend/tests/services/garuda_documents/test_ports_actor_scoping.py -k service_does_not_replay"
+  - text: >-
+      A7: WHEN `_ReplayTrackingStore` wraps a store, THEN the actor it received SHALL reach
+      the inner store unchanged — the wrapper observes, it does not re-scope.
+    probe: "PYTHONPATH=. pytest backend/tests/services/garuda_documents/test_ports_actor_scoping.py -k wrapper_forwards"
+  - text: >-
+      A8: WHEN `commit` is called twice with the SAME outcome instance, THEN exactly one
+      call SHALL return True. True is the caller's permission to fire the at-most-once
+      staff work-item hook; two winners fire it twice.
+    probe: "PYTHONPATH=. pytest backend/tests/services/garuda_documents/test_ports_actor_scoping.py -k same_outcome_instance"
+  - text: >-
+      A9 (whole-lane regression): the garuda_documents service and router suites SHALL pass
       unchanged apart from the actor_id argument threaded into each call.
     probe: "PYTHONPATH=. pytest backend/tests/services/garuda_documents/ backend/tests/app/routers/test_garuda_documents_router.py"
 guilt_mutations:
   - "InMemoryDocumentStore keyed on idempotency_key alone (its shape before this PR) -> A1 red"
   - "_UnconfiguredDocumentStore.get_existing without the actor_id keyword -> A4 red (500, not 503)"
-  - "upload_intake_document dropping actor_id=actor -> A5 red (TypeError)"
+  - "upload_intake_document dropping actor_id=actor -> A9 red (TypeError)"
+  - "InMemoryDocumentStore keyed on actor_id alone, ignoring the key -> A5 red (Sol finding 2)"
+  - "every actor_id= forward replaced by one constant -> A6 red (Sol finding 2)"
+  - "_ReplayTrackingStore substituting its own actor -> A7 red (Sol finding 2)"
+  - "commit deciding the winner by `outcome` identity instead of the entry it built -> A8 red (Sol finding 1)"
+refuter:
+  seat: codex Sol
+  model_id: gpt-5.6-sol
+  invocation: "codex exec --sandbox read-only -c model_reasoning_effort=xhigh"
+  duration: "3m37s (2026-09-12T05:41:12Z -> 05:44:49Z), 107216 tokens"
+  verdict: CONDITION
+  findings: >-
+    6, all accepted, none disputed. 1 (MEDIUM) commit could declare two winners on a shared
+    outcome instance — cured, decided by candidate-entry identity. 2 (MEDIUM) the suite did
+    not pin actor PROPAGATION: a store keyed on actor alone, and a constant actor forwarded
+    everywhere, both passed — cured by four new tests (A5-A8). 3 (LOW) this brief claimed
+    the Protocol prevents a bad implementation — reworded above. 4 (LOW) `_scoped_key`'s
+    docstring described a collision unreachable through this router (actor IS result_id) and
+    anticipated the future adapter — rewritten. 5 (LOW) a new docstring named
+    SERVICE_UNAVAILABLE for the upload path, which answers PERSISTENCE_POLICY_UNAVAILABLE —
+    corrected. 6 (LOW) the test docstring claimed a mutation keeps the whole suite green;
+    measured it is 2 failed / 3 passed — rewritten with the measured numbers.

--- a/evidence/2026-09/agent-air-m5-backend-rag-voa-store-wiring-23492b6e/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-voa-store-wiring-23492b6e/brief.yml
@@ -1,0 +1,78 @@
+task_id: voa-store-wiring
+mandate_id: garuda-voa-w1w
+colour: BLUE
+gear: 2
+l_level: L2
+gate_class: opus
+# Deterministic floor for this diff is 1 (compute_floor: no hot-zone path, 167 net lines
+# < the 400-line size term). Gear 2 is DECLARED ABOVE the floor, not imposed by it: the
+# Imperatore's decision #24 sets a fresh Opus gate for every W1W PR at gear >= 2, and
+# declaring gear 2 is what makes that gate a required verdict on this head sha rather
+# than an optional courtesy.
+objective: >-
+  GARUDA VOA W1W, PR 1 of 4. Make `actor_id` a required, non-defaulted keyword on
+  `DocumentStorePort` (`ports.py`) and thread it from the router through
+  `DocumentIntakeService.submit_document` to the store, so no store implementation can key
+  an outcome on the client-supplied Idempotency-Key string alone. An `Idempotency-Key` is
+  chosen by the CLIENT: two different customers can pick the same literal value, and a
+  store that ignored the actor would let one read or displace the other's committed
+  outcome. This PR carries NO storage implementation — it is the port-shape change the
+  Postgres store (PR 2a) is written against, landed first so the adapter arrives against a
+  port that already enforces the scoping.
+  Spec: docs/plans/2026-09-11-garuda-voa-final-spec.md §3 row W1W. Source of the work:
+  `agent/air-m5/ops/garuda-voa-store-wiring` @ 7cc6878f07, re-applied semantically from
+  fresh main (never merged — that branch is based on c52a04c9ee, 10 days stale).
+scope:
+  - apps/backend-rag/backend/services/garuda_documents/ports.py
+  - apps/backend-rag/backend/services/garuda_documents/service.py
+  - apps/backend-rag/backend/app/routers/garuda_documents_router.py
+  - apps/backend-rag/backend/tests/services/garuda_documents/test_ports_actor_scoping.py
+  - apps/backend-rag/backend/tests/services/garuda_documents/test_service_journeys.py
+  - apps/backend-rag/backend/tests/services/garuda_documents/test_service_concurrency.py
+  - evidence/2026-09/agent-air-m5-backend-rag-voa-store-wiring-23492b6e/
+constraints:
+  - >-
+    No migration. 304 is already applied in production (measured this session:
+    _schema_versions.applied_as = 'backend_rag_v2 (session_user=backend_rag_migrator)').
+  - >-
+    No fly.toml, no .env*, no zantara_core.py, no
+    products/garuda-voa/contracts/openapi.yaml (that file belongs to W3C). The OpenAPI
+    contract is untouched by this PR and cannot be affected by it: it describes the HTTP
+    surface, not this internal Protocol.
+  - >-
+    No storage implementation here. `ReadyOutcomeValueNotPersisted` and the lost-race
+    reconciliation that the Postgres store's PII boundary requires are deliberately NOT in
+    this PR — they have no meaning until a store exists that cannot rehydrate a value.
+  - No PII in any output, log, test fixture or evidence file.
+acceptance:
+  - text: >-
+      A1: WHEN two different actors commit under the SAME literal idempotency key, THEN both
+      SHALL win their own commit, and neither SHALL be able to read the other's outcome —
+      `get_existing` for the other actor SHALL return None, not the outcome and not
+      IdempotencyConflictError (a conflict would confirm the key exists, an enumeration
+      oracle across customers).
+    probe: "PYTHONPATH=. pytest backend/tests/services/garuda_documents/test_ports_actor_scoping.py"
+  - text: >-
+      A2 (innocence): WHEN the SAME actor replays the same key with the same payload, THEN
+      the original outcome SHALL still be returned; with a DIFFERENT payload it SHALL still
+      raise IdempotencyConflictError. Actor scoping must not break a genuine replay.
+    probe: "PYTHONPATH=. pytest backend/tests/services/garuda_documents/test_ports_actor_scoping.py -k same_actor"
+  - text: >-
+      A3: WHEN `actor_id` is omitted at a call site, THEN the call SHALL raise TypeError
+      rather than silently dropping the scoping — the keyword is required, never defaulted.
+    probe: "PYTHONPATH=. pytest backend/tests/services/garuda_documents/test_ports_actor_scoping.py -k required_not_defaulted"
+  - text: >-
+      A4 (the router's two Protocol-shaped fakes keep their documented error shape): WHEN no
+      store is wired, THEN uploadIntakeDocument SHALL still answer 503
+      PERSISTENCE_POLICY_UNAVAILABLE and listIntakeDocuments 503 SERVICE_UNAVAILABLE — NOT
+      the app's generic 500, which is what a fake missing the new required keyword produces
+      (TypeError at the call site, before its body raises).
+    probe: "PYTHONPATH=. pytest backend/tests/app/routers/test_garuda_documents_router.py -k '503'"
+  - text: >-
+      A5 (whole-lane regression): the garuda_documents service and router suites SHALL pass
+      unchanged apart from the actor_id argument threaded into each call.
+    probe: "PYTHONPATH=. pytest backend/tests/services/garuda_documents/ backend/tests/app/routers/test_garuda_documents_router.py"
+guilt_mutations:
+  - "InMemoryDocumentStore keyed on idempotency_key alone (its shape before this PR) -> A1 red"
+  - "_UnconfiguredDocumentStore.get_existing without the actor_id keyword -> A4 red (500, not 503)"
+  - "upload_intake_document dropping actor_id=actor -> A5 red (TypeError)"


### PR DESCRIPTION
GARUDA VOA W1W, PR 1 of 4. Spec `docs/plans/2026-09-11-garuda-voa-final-spec.md` §3 row W1W.

An `Idempotency-Key` is chosen by the CLIENT. Nothing stops two different customers from picking the same literal value, and `DocumentStorePort` keyed purely on that string: one customer's `get_existing` could read the other's committed outcome, and one customer's `commit` could be reported as a lost race against the other's.

`actor_id` is now a **required, non-defaulted** keyword on both port methods, threaded from the router through `DocumentIntakeService.submit_document` to the store. Required rather than defaulted on purpose: a stale call site fails loudly with `TypeError` instead of silently dropping the scoping.

### What this PR does and does not achieve

Stated precisely, because the refuter rejected the looser claim: a required keyword forces every implementation and every call site to **supply** the actor. It cannot force an implementation to **use** it. Enforcement of the use is per-implementation and is proved per-implementation — here on `InMemoryDocumentStore`, in PR 2a on `PostgresDocumentStore`.

### Not in this PR, by design

No storage implementation, no migration, no contract edit. Migration 304 is already applied in production (measured: `_schema_versions.applied_as = 'backend_rag_v2 (session_user=backend_rag_migrator)'`). `ReadyOutcomeValueNotPersisted` and the lost-race reconciliation the Postgres store's PII boundary requires are deliberately absent — they have no meaning until a store exists that cannot rehydrate a value.

Serialized sequence: PR1 port shape → PR2a `PostgresDocumentStore` + real-DB harness → PR2b SECURITY DEFINER privilege proof + PII replay gap → PR3 production wiring in `service_initializer.py`.

### Three now-false claims corrected

This PR is what falsifies them, so it fixes them: the router module docstring's "a store swap needs no router or contract edit" (the Protocol is not signature-stable; the OpenAPI contract is untouched either way), `_scoped_key`'s "`DocumentStorePort` itself has no actor/result concept", and `_scoped_key`'s description of a collision unreachable through this router (`actor` IS the `result_id`, and `_require_owned_result` enforces equality).

### Refuter

codex Sol, `gpt-5.6-sol`, `codex exec --sandbox read-only -c model_reasoning_effort=xhigh`, 3m37s, **CONDITION**, 6 findings — all six accepted, none disputed, all cured in the second commit. The two that mattered: `commit` could declare two winners on a shared outcome instance (pre-existing, and `True` is the permission to fire the at-most-once work-item hook); and the suite pinned the port's SHAPE but not the actor's PROPAGATION — a store keyed on `actor_id` alone, and a constant actor forwarded everywhere, both passed the original tests. Full record in the brief under `refuter:`.

### Bites

**Consumer:** `backend/tests/services/garuda_documents/test_ports_actor_scoping.py` (new, 9 tests) plus the existing router 503 suite.

**Observation, measured:** suite `services/garuda_documents/ + app/routers/test_garuda_documents_router.py` — **56 passed / 3 skipped** before this mandate, **65 passed / 3 skipped** at this head. Two actors sharing one literal key each win their own commit and cannot read each other's outcome; one actor's two distinct keys stay independent; the unconfigured store still answers the contract's 503 (`PERSISTENCE_POLICY_UNAVAILABLE` on upload, `SERVICE_UNAVAILABLE` on listing), never the generic 500.

**Seven guilt mutations, each run, each red on exactly the test written for it:**

| mutation | result |
|---|---|
| store keyed on `idempotency_key` alone | 3 failed |
| store keyed on `actor_id` alone, ignoring the key | 1 failed (`two_distinct_keys`) |
| service forwarding a constant actor | 1 failed (`service_does_not_replay`) |
| `_ReplayTrackingStore` substituting its own actor | 1 failed (`wrapper_forwards`) |
| `commit` deciding by `outcome` identity | 1 failed (`same_outcome_instance`) |
| `_UnconfiguredDocumentStore.get_existing` without `actor_id` | 1 failed (500, not the documented 503) |
| `upload_intake_document` dropping `actor_id=actor` | 12 failed |

Deterministic floor for this diff is 1 (no hot-zone path, 394 net lines < the 400 size term). The brief declares **gear 2** above the floor, which makes a `harness/fable-gate` verdict on this head a hard requirement of Step 7c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFmHJWyngUo2uHdsAPWiMn
