### PR TITLE
docs(secondhome): discharge C1/C3/C4 (+wall_clock) of the #6271 gate

### DIFF
--- a/evidence/2026-09/agent-air-m5-mouth-shweb-w3-editorial-20260911-cc099459/build-receipts/guard-mutation-run.txt
+++ b/evidence/2026-09/agent-air-m5-mouth-shweb-w3-editorial-20260911-cc099459/build-receipts/guard-mutation-run.txt
@@ -13,7 +13,11 @@ mutated. The sandbox was verified green before and after every mutation.
 
   probe:  research/secondhome/probe-superseded-threshold.py --claims
 
-PROBE MUTATIONS — 9 applied, 9 RED
+PROBE MUTATIONS — 10 applied, 10 RED
+  (This header said "9 applied, 9 RED" while the list below it named M1 through M10. The list is
+  the measurement and the header was the slip: ten mutations were applied and ten came back red.
+  Found by the independent gate on 8ba4b4f1ed, F5. The same nine appears in the PR body, the probe
+  docstring and the pack's note; the body and the pack are corrected, the docstring in PR-1b.)
   RED   M1  restore `14. If property-based: verification with BPN records`   (the refuter's own
             counter-example, green before this round)      -> PRESENT 'BPN'
   RED   M2  Duration cell flattened from `Up to 5 years` to `5 years`        -> UNANCHORED

--- a/evidence/2026-09/agent-air-m5-mouth-shweb-w3-editorial-20260911-cc099459/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-shweb-w3-editorial-20260911-cc099459/pack.yml
@@ -12,8 +12,8 @@ brief_ref: evidence/brief.yml
 pii_scan: clean
 
 churn:
-  measured_with: "git diff --numstat 70b43c5459 HEAD | awk '{a+=$1;d+=$2} END {print a+d}' — measured on the tree as pushed: 29 files, +4212 -531 at the first frozen head, plus the two CI cures of the second push. An earlier revision of this field said 4373; that was a transposition by the author, corrected here against the measurement rather than left standing. The growth over the 3902 of the pre-refuter head is the rebuilt guard (+146 probe lines), the guard spec written instead of a fourth cure round (99 lines), and the census/disposition rows three refuter rounds and a second reader demanded."
-  total_lines: 4749
+  measured_with: "git diff --numstat 70b43c5459 8ba4b4f1ed | awk '{a+=$1;d+=$2} END {print a+d}' — measured at the FINAL head: 29 files, +4220 -531. This number was wrong twice before, and both corrections are recorded rather than overwritten: 4373 was a transposition by the author; 4749 was a real measurement taken before the third commit landed, which is why the gate on 8ba4b4f1ed read 2 more. The growth over the 3902 of the pre-refuter head is the rebuilt guard (+146 probe lines), the guard spec written instead of a fourth cure round (99 lines), and the census/disposition rows three refuter rounds and a second reader demanded."
+  total_lines: 4751
   ceiling_named_in_the_mandate: 1828
   gear_override: >-
     Declared, per the mandate's own alternative ("churn under 1828 OR a coherent Gear-3
@@ -29,7 +29,15 @@ churn:
     one deleted backend fixture (14).
 
 spend:
-  wall_clock_hours: ~2.5
+  # Measured, not estimated: first Dux transcript event (02:13:26Z) to the commit of the final
+  # head 8ba4b4f1ed (08:26:47Z). It EXCLUDES the independent gate session and the three council
+  # seats, which are not this lane's spend, and it does not grow after the merge. The two Dux
+  # sessions overlap by 0.62h across the handover, so summing their spans (8.47) would count the
+  # same time twice; the union to the final head is what is recorded. The field previously read
+  # `~2.5`, which YAML parses as a STRING — so the lint treated the dimension as unmeasured and
+  # never compared it to the ceiling of 8 in brief.yml. It was an estimate of the first session
+  # alone, and false for the mandate.
+  wall_clock_hours: 6.2
   adversarial_rounds: 3
   seats:
     - name: codex-sol
@@ -115,12 +123,12 @@ receipts:
     seat: claude-opus-5 (dux, M5)
     before: "canonical-family hits at the base commit: 68"
     after: "canonical-family 0, other-family 24, file 450,488 lines"
-  - claim: "every cure named in the disposition can be turned red by mutating it, and the four documented generator mutants die"
+  - claim: "the TEN named mutations listed in build-receipts/guard-mutation-run.txt each turn the probe red, and the four documented generator mutants die"
     cmd: "sandbox copy of the five MDX + probe --claims per mutation; vitest per generator mutant"
     exit: 0
     ts: "2026-09-12"
     seat: claude-opus-5 (dux, M5)
-    note: "9 probe mutations red, 4 generator mutants red, recorded in build-receipts/guard-mutation-run.txt; the sandbox was green before and after each"
+    note: "10 probe mutations red (M1-M10), 4 generator mutants red, recorded in build-receipts/guard-mutation-run.txt; the sandbox was green before and after each. This claim is a MEASURED LIST and deliberately not the universal 'every cure can be turned red', which this pack retracts in the codex dissent block below and which the gate on 8ba4b4f1ed proved false with an eighth evasion (answerSnippet unanchored for duration). The receipt's header said 9 while its body listed ten; ten is the measured number and the header is corrected in the same patch as this line."
   - claim: "two council seats reviewed the final tree and neither returned BLOCK"
     cmd: "python3 scripts/tp1_call.py --model qwen3.8-max --task-file <core> ; kimi -m kimi-code/k3 -p <scoped prompt>"
     exit: 0

--- a/research/secondhome/probe-guard-spec-v2.md
+++ b/research/secondhome/probe-guard-spec-v2.md
@@ -80,19 +80,40 @@ publishable article. Fixed in PR-1 (two ID translations whose dates run against 
 the spec records the rule: every sorted output gets a fixture where the correct order disagrees
 with the filesystem order, and the mutation is proved red.
 
+## R8 — Anchor the frontmatter field an answer engine actually lifts
+
+Found by the independent gate on `8ba4b4f1ed`, not by the builder and not by the refuter. The
+`answerSnippet:` frontmatter field is not duration-anchored: flattening `a stay permit of up to
+5 years` to `a stay permit of 5 years` leaves `--claims` at zero in every locale. `M2` pinned the
+duration only in the comparison table's Duration cell, and the property-condition anchor DOES reach
+the frontmatter — the gate's companion case, dropping the completed-unit condition from `excerpt:`,
+came back red — so the gap is specific to the duration claim, not to the frontmatter as a whole.
+
+This is the field an AI answer engine lifts verbatim, which makes it the highest-consequence place
+in the file for an unanchored claim: a flattened `answerSnippet` is what gets quoted, while the
+table it contradicts is not. Every claim anchored anywhere must be anchored in `answerSnippet` and
+`excerpt` too, in all five locales, not only in the body or the table.
+
+Acceptance: in PR-1b, flattening `up to 5 years` → `5 years` in `answerSnippet` of ANY locale makes
+`--claims` report ≥ 1 failure. Today it reports 0. The content itself is correct at this head — all
+five locales say "up to 5 years", verified by reading them — so this is a guard gap, not a content
+defect, and it is the eighth demonstration of the thing the docstring already says out loud.
+
 ## What "done" means for PR-1b
 
-A mutation run in the shape of `build-receipts/guard-mutation-run.txt`, extended with the seven
+A mutation run in the shape of `build-receipts/guard-mutation-run.txt`, extended with the EIGHT
 counter-examples above, every one red, and the honest paragraph in the probe docstring rewritten to
-match what the code then actually does. Until then the docstring keeps saying what it says now.
+match what the code then actually does — including its count, which today says "nine named
+mutations" where the receipt lists ten. Until then the docstring keeps saying what it says now.
 
 ## Adversarial review
 
-This spec is the OUTPUT of adversarial review, not a document awaiting one. Every requirement
-above is a counter-example that `codex-sol` executed against the working tree on 2026-09-12
-(round 3, BLOCK, findings 1-7), with the command and the result recorded in the session
-scratchpad and summarised in the PR body. R7 was additionally re-proved red in this repo after
-the fixture landed. The one judgement that is mine and not the refuter's is the choice of
+This spec is the OUTPUT of adversarial review, not a document awaiting one. R1-R7 are
+counter-examples that `codex-sol` executed against the working tree on 2026-09-12 (round 3, BLOCK,
+findings 1-7), with the command and the result recorded in the session scratchpad and summarised in
+the PR body. R7 was additionally re-proved red in this repo after the fixture landed. R8 came from a
+SECOND adversarial reader — the independent on-disk gate on `8ba4b4f1ed` (PASS-WITH-CONDITIONS, F3),
+which ran its own two cases against a sandbox copy and found one red and one green. The one judgement that is mine and not the refuter's is the choice of
 paragraph scope in R3; a reviewer who thinks the section or the whole file is the right unit
 should say so before it is implemented, because widening the scope makes allowances rotate more
 often and narrowing it reopens the evasion.


### PR DESCRIPTION
Discharges the four conditions the independent on-disk gate attached to **#6271**, which merged
and is live. The head of #6271 was frozen by ruling, so the cures land here rather than in a
fourth push to that branch.

## What the gate said, and what changed

**None of the conditions touched the shipping product.** Perimeter, content-vs-registry in five
locales, the C5 tie-break (4/4 mutants red), the i18n ratchet, the backend suite and the pack lint
all PASSED. The four below are evidence defects — three of them mine, one an eighth evasion the
gate found by attacking the guard itself.

**C1 — the retracted universal survived in one place.** `pack.yml`'s build-receipt claim asserted
*"every cure named in the disposition can be turned red by mutating it"*. That is the exact
universal the same file retracts in its codex dissent block, and that the probe docstring and
#6271's body both disown — the retraction reached three artifacts and missed the fourth. The gate
then proved the universal **false** (see C3). Replaced by the measured statement: the ten named
mutations in the receipt each turn the probe red. A measured list is not a universal, and the new
claim says so in its own note.

**C3 — an eighth evasion, found by the gate.** `answerSnippet` is not duration-anchored: flattening
`a stay permit of up to 5 years` → `5 years` leaves `--claims` at **0** in every locale. The gate's
companion case — dropping the completed-unit condition from `excerpt:` — came back **red**, so the
frontmatter is covered for the property condition and unanchored only for duration. `M2` had pinned
the duration in the comparison table's Duration cell and nowhere else. This is the field an answer
engine lifts verbatim, which makes it the highest-consequence place in the file for an unanchored
claim. **The content is correct** — all five locales say "up to 5 years" at the merged head. The
guard is not, so it becomes **R8** of `probe-guard-spec-v2.md`, the first requirement in that spec
to come from a second adversarial reader rather than from the refuter's third round.

**C4 — two arithmetic slips.** `total_lines` said 4749 against a measured 4751; and the mutation
receipt's header said *"9 applied, 9 RED"* over a list running **M1 … M10**. The nine also appears
in #6271's body and in the probe docstring. Ten is the measured number.

**Plus `wall_clock_hours`, not a gate condition.** The field was the string `~2.5`. YAML does not
parse that as a number, so `evidence_pack_lint` treated the dimension as *unmeasured* and never
compared it to the ceiling of 8 in `brief.yml` — it was invisible rather than wrong-but-checked,
and it was an estimate of the first Dux session alone. Now **6.2**, measured from the first Dux
transcript event (02:13:26Z) to the commit of the final head (08:26:47Z), with the definition and
the exclusions written beside it. The two Dux sessions overlap by 0.62h across the handover, so
summing their spans (8.47) would count the same time twice; the union is what is recorded.

## Bites

**Consumer: `scripts/evidence_pack_lint.py` under the harness-floor invocation**, plus the gate's
own acceptance greps. Every one run on this tree, after the patch:

| probe | result |
|---|---|
| `grep -c "every cure named in the disposition can be turned red" pack.yml` | **0** |
| pack `total_lines` vs `git diff --numstat 70b43c5459 8ba4b4f1ed` summed | **4751 == 4751** |
| receipt header vs its own list | **`10 applied, 10 RED`** vs **10** `M<n>` rows |
| spec carries `## R8`, naming `answerSnippet` | **1 heading, 4 mentions** |
| `wall_clock_hours` | **6.2**, and the "unmeasured" NOTICE is gone — 6.2 ≤ the ceiling of 8 |
| `evidence_pack_lint … --repo-root <staged> --changed-files-file --numstat-file --source-path --brief-source-path` | **clean** |
| `check_adversarial_review.py --diff origin/main` | **PASS — 1 research file carries a valid adversarial review** |

The only appetite line remaining is the acknowledged NOTICE on `adversarial_rounds` (declared 2,
observed 3), which is the correct outcome: the overrun is real and is acknowledged in prose.

A note on reproducing that lint locally: it needs `--source-path` and a staged tree. Without
`--source-path` it judges the staging path and emits a spurious `evidence_root_deprecated`; without
staging it resolves `brief_ref` against the **tracked** leftover `evidence/brief.yml` at the repo
root (from the merged #6241, `gear: 2`) and silently validates a stranger's pack — the gear comes
from the brief, so every Gear-3 rule evaluates as gear-2 or off. Those two root files are worth a
separate hygiene PR.

## Not fixed here, deliberately

The probe docstring still says *"Nine named mutations"*. It is a code file under `research/`,
touching it would reopen the R1 adversarial-review gate, and PR-1b rewrites that paragraph anyway —
R8's acceptance section names it so it cannot be lost. Gate F6 (two trailing-whitespace lines in
`build-receipts/llms-full-cooccurrence.txt`) stays: those lines are verbatim quotes lifted from the
built `llms-full.txt`, so the whitespace belongs to the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfWC4nUjy6qCFWuZbdEHPX
