### PR TITLE
fix(backend): accept a generator cap that falls after the whole certified Intelligence block (PR-B0)

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_qdrant_pma_sync.py
+++ b/apps/backend-rag/backend/scripts/kbli_qdrant_pma_sync.py
@@ -451,7 +451,17 @@ def _truncated_section_matches_reviewed_prefix(
     # it into one list element and the final join turns those into physical
     # lines, so compare the same physical representation stored in Qdrant.
     reviewed_physical_lines = "\n".join(reviewed_lines).split("\n")
-    return actual_prefix == reviewed_physical_lines[: len(actual_prefix)]
+    reviewed_len = len(reviewed_physical_lines)
+    if len(actual_prefix) <= reviewed_len:
+        return actual_prefix == reviewed_physical_lines[: len(actual_prefix)]
+    # The cap can also fall AFTER the whole reviewed block (a record whose
+    # per_skala rows grew, e.g. 21022 on the 2026-09-11 L2 re-ingestion): the
+    # section is then the exact reviewed block followed only by the blank
+    # separator the generator writes before the marker. Anything non-blank
+    # after the block is content nobody reviewed and is still refused.
+    return actual_prefix[:reviewed_len] == reviewed_physical_lines and all(
+        not line.strip() for line in actual_prefix[reviewed_len:]
+    )
 
 
 def certified_intelligence_block(

--- a/apps/backend-rag/backend/tests/scripts/test_kbli_qdrant_pma_sync.py
+++ b/apps/backend-rag/backend/tests/scripts/test_kbli_qdrant_pma_sync.py
@@ -689,6 +689,48 @@ def test_a_truncated_legacy_gap_with_unsafe_editorial_is_refused():
     assert rewrite_pma_prose(rec, truncated) is None
 
 
+def test_a_cap_that_falls_after_the_whole_reviewed_block_is_accepted():
+    """The generator cap used to be accepted only INSIDE the reviewed block. A
+    record whose per_skala rows grow (21022 on the 2026-09-11 L2 re-ingestion:
+    16,606 -> 20,013 chars) pushes the cap past the block, leaving the exact
+    reviewed lines plus the blank separator before the marker — a complete,
+    unaltered certified section that the repair refused as unshaped."""
+    from backend.scripts.kbli_qdrant_pma_sync import (
+        _INTEL_HEADING,
+        _TRUNCATION_MARKER,
+        _truncated_section_matches_reviewed_prefix,
+    )
+
+    reviewed = [_INTEL_HEADING, "- reviewed line one", "- reviewed line two"]
+    whole_block_then_blank = "\n".join(
+        ["# head", *reviewed, "", _TRUNCATION_MARKER]
+    )
+    assert _truncated_section_matches_reviewed_prefix(
+        whole_block_then_blank, _INTEL_HEADING, reviewed
+    )
+    # the pre-existing shape — the cap inside the block — still passes
+    inside = "\n".join(["# head", *reviewed[:2], _TRUNCATION_MARKER])
+    assert _truncated_section_matches_reviewed_prefix(inside, _INTEL_HEADING, reviewed)
+
+
+def test_unreviewed_content_after_the_whole_block_is_still_refused():
+    """Innocence for the rule above: a non-blank line after the reviewed block
+    is content nobody certified, and a diverging prefix is still a divergence."""
+    from backend.scripts.kbli_qdrant_pma_sync import (
+        _INTEL_HEADING,
+        _TRUNCATION_MARKER,
+        _truncated_section_matches_reviewed_prefix,
+    )
+
+    reviewed = [_INTEL_HEADING, "- reviewed line one", "- reviewed line two"]
+    extra = "\n".join(["# head", *reviewed, "- a line nobody reviewed", _TRUNCATION_MARKER])
+    assert not _truncated_section_matches_reviewed_prefix(extra, _INTEL_HEADING, reviewed)
+    diverging = "\n".join(
+        ["# head", _INTEL_HEADING, "- reviewed line one", "- CHANGED", "", _TRUNCATION_MARKER]
+    )
+    assert not _truncated_section_matches_reviewed_prefix(diverging, _INTEL_HEADING, reviewed)
+
+
 def test_a_point_whose_blob_already_tells_the_truth_is_not_rewritten():
     """Innocence: the repair must be a no-op on a truthful blob, or every run
     would rewrite the whole collection and the diff would stop meaning anything."""


### PR DESCRIPTION
Predecessor of PR-B (`docs/specs/2026-09-11-kbli-l2-oss-resnapshot-reingest-spec.md`), shipped alone so the data PR stays data-only.

`_truncated_section_matches_reviewed_prefix` in `apps/backend-rag/backend/scripts/kbli_qdrant_pma_sync.py` accepted the generator cap only *inside* the reviewed Intelligence block. A record whose `per_skala` rows grow pushes the cap past the block, leaving the exact reviewed lines plus the generator's blank separator before the marker — a complete, unaltered certified section that the repair refused as unshaped. On the v11.0 canonical (September L2 re-ingestion) this is 21022: fresh embedding text 16,606 → 20,013 chars, the certified block is intact (`certified_intelligence_block` still returns its 8 lines), and `test_the_prose_repair_matches_the_real_generator_on_real_canonical_records` goes red. Non-blank content after the block is still refused; a diverging prefix is still a divergence. Two tests, guilt and innocence.

Backward compatible: on main's data the file passes 55/55 (the cap never falls after a block today).

**Bites:** consumer = `backend/tests/scripts/test_kbli_qdrant_pma_sync.py::test_the_prose_repair_matches_the_real_generator_on_real_canonical_records`, which is what decides whether the PMA resync may touch a point. Observation: with `KBLI_REPO_ROOT` pointed at the v11.0 worktree (`kbli-l2-pr-b-policy`, local, 12 commits) it fails on `origin/main`'s module and passes on this branch (`1 passed, 54 deselected`); on merge the backend deploys and PR-B inherits a green prose gate — the registry-sha gate stays the editorial owner's (certified ∩ tier-changed = {47221, 50122}).

🤖 Generated with [Claude Code](https://claude.com/claude-code)