### PR TITLE
docs(visaoracle): discharge C1 and C2 of the #6301 gate

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -45,9 +45,7 @@
         "\\.venv/.*",
         "venv/.*",
         "\\.git/.*",
-        "^docs/plans/mouth-final-20260911/evidence/(source-manifest|package-validation)\\.json$",
-        "^evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock\\.json$",
-        "^research/visa/2026-09-11-review-reason-audit/live-browser\\.json$"
+        "^docs/plans/mouth-final-20260911/evidence/(source-manifest|package-validation)\\.json$"
       ]
     }
   ],
@@ -154,6 +152,146 @@
         "hashed_secret": "a8463d954c0f5c1231855e9266779b4d4df12470",
         "is_verified": false,
         "line_number": 325,
+        "is_secret": false
+      }
+    ],
+    "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "9ffea5e79dbab3f66bbb5a253b7d546002860980",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "1531761eba87865b8ed845969e8f124b53f47a53",
+        "is_verified": false,
+        "line_number": 9,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "0e4e2e814f588ff82c42246e80f355f69d7496cb",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "ae3bc17ca154a74a3d464b26244492d0a927347e",
+        "is_verified": false,
+        "line_number": 17,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "f6a3f81688dc9b64f02441da8ef22da2d2f6393c",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "123d856200d575fe93ed6194083c715c9661fa1b",
+        "is_verified": false,
+        "line_number": 25,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "6e59df9fa50c321a91e723fb35a961397ea255eb",
+        "is_verified": false,
+        "line_number": 31,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "7ddbb4d040ed89af3897a45e396b10d4409e3d5a",
+        "is_verified": false,
+        "line_number": 37,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "dd378a5d9161e160db5ed2fce821c64dc124cdad",
+        "is_verified": false,
+        "line_number": 43,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "a81e199c1030c0a3c033e2e67d389b014dcb765d",
+        "is_verified": false,
+        "line_number": 49,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "d7be6a78b975ef159eddde80f0e8425b7c2e360f",
+        "is_verified": false,
+        "line_number": 55,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "c683eef3b8c4c5c21a1083344d52f905ba08436c",
+        "is_verified": false,
+        "line_number": 61,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "0bba7f436e8c9ad59ca7009990c81fcdf9abc467",
+        "is_verified": false,
+        "line_number": 67,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "b2f2c8e7d4ee1f5f02cc83bc4920a35e129f7a58",
+        "is_verified": false,
+        "line_number": 74,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "65509bef489a72e654dbc3cced7dca9c05db9cee",
+        "is_verified": false,
+        "line_number": 81,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+        "hashed_secret": "cb3499c67cb38707ec4caf50fd0f898e9c4927a6",
+        "is_verified": false,
+        "line_number": 82,
+        "is_secret": false
+      }
+    ],
+    "research/visa/2026-09-11-review-reason-audit/live-browser.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "research/visa/2026-09-11-review-reason-audit/live-browser.json",
+        "hashed_secret": "2b0c6b7e787b78a75c92549cb851bc36ffbdcc51",
+        "is_verified": false,
+        "line_number": 13,
         "is_secret": false
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -137,6 +137,24 @@
     }
   ],
   "results": {
+    "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml",
+        "hashed_secret": "25aff8fa41fc1cdc95cc0493d78ec651955d9015",
+        "is_verified": false,
+        "line_number": 406,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml",
+        "hashed_secret": "9613767db20fc61c30a85aaa74447596f257b621",
+        "is_verified": false,
+        "line_number": 427,
+        "is_secret": false
+      }
+    ],
     "research/visa/2026-09-11-review-reason-audit/census.json": [
       {
         "type": "Base64 High Entropy String",

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml
@@ -198,17 +198,40 @@ acceptance:
 pii: none
 supersession: >-
   this branch supersedes PR #6295, whose head c2a85b6ced was gated
-  PASS-WITH-CONDITIONS. No content changed: the 12 non-evidence files are
-  blob-identical to that head, and brief.yml and pack.yml differ from it only by
-  the three re-pins this commit makes. The commits were replayed onto
-  origin/main 7378c87fca because the repository's off-limits pre-commit gate is
-  over-inclusive on merges BY DESIGN (it reads the raw staged list so a deletion
-  of a protected file cannot hide) and therefore refuses any merge of main that
-  carries apps/backend-rag/backend/prompts/zantara_core.py — a file this branch
-  never touched and inherits unchanged. The round head_sha values below
-  (8b947103b5, 9a85b97b84, 8b63ec5326, 6f8256d640) are the commits the refuters
-  actually read and are left unrewritten: they live on #6295's branch, which is
-  not deleted, and each is content-identical to its replayed twin here.
+  PASS-WITH-CONDITIONS. What changed, measured with `git diff --name-only
+  c2a85b6ced HEAD` restricted to that PR's 15 paths: 12 files are blob-identical
+  to the gated head and THREE are not — .secrets.baseline (resolved additively
+  against main), brief.yml and pack.yml (the re-pins). An earlier wording of this
+  field said "the 12 non-evidence files are blob-identical", which was false:
+  .secrets.baseline is a non-evidence file and is one of the three that differ.
+  The commits were replayed onto origin/main 7378c87fca because the repository's
+  off-limits pre-commit gate is over-inclusive on merges BY DESIGN (it reads the
+  raw staged list so a deletion of a protected file cannot hide) and therefore
+  refuses any merge of main that carries
+  apps/backend-rag/backend/prompts/zantara_core.py — a file this branch never
+  touched and inherits unchanged.
+supersession_pin_reachability: >-
+  the round head_sha values recorded below are the commits the refuters actually
+  read and are left unrewritten. They do NOT all live on the same branch, and an
+  earlier wording of this record said they were all on #6295's branch, which is
+  wrong; the commit message of 6381af36c0 carries the same error and cannot be
+  amended after merge, so this field is the correction of record. Verify any of
+  it with `git branch -a --contains <sha>`.
+  (a) Rounds 1 and 2 — 8b947103b5 and 82d08445b3 — exist ONLY on the r1 branch
+  agent/mini-pro2/mouth/shweb-w-oracle-20260911. They predate r2 and have no
+  replayed twin anywhere.
+  (b) Rounds 4, 5 and 6 — 9a85b97b84, 8b63ec5326, 6f8256d640 — and the heads of
+  rounds 7 and 8 (69651442d4, 4b92705c56) and the gated head c2a85b6ced exist on
+  #6295's branch agent/mini-pro2/mouth/shweb-w-oracle-o0r2-20260911, each
+  content-identical to its replayed twin on the superseding branch.
+  (c) Round 3 — be45266252 — is an ancestor of main and stays reachable whatever
+  happens to the branches.
+  CONSEQUENCE for branch cleanup: neither
+  agent/mini-pro2/mouth/shweb-w-oracle-20260911 nor
+  agent/mini-pro2/mouth/shweb-w-oracle-o0r2-20260911 may be deleted while this
+  record points at them. Deleting either makes the pins above unresolvable and
+  turns this review record into prose nobody can check — which is the one
+  property it exists to have.
 adversarial_review_provenance: >-
   every round below is this session's record of a run for which this
   repository holds no transcript; it is provenance, not evidence, and the

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml
@@ -3,9 +3,16 @@ gear_override: >-
   the audit-copy diff this brief was written for computed floor 3 from the
   SIZE term (census.json's generated replay lines plus the other pinned
   copies); it landed as #6301. THIS diff is the follow-up that discharges
-  C1 and C2 of that PR's gate, and its measured floor is 1, source `none`
-  (`evidence_pack_lint.py --print-floor` with `--changed-files-file` and
-  `--numstat-file`). Gear stays 3 because a declared gear above the floor is
+  C1 and C2 of that PR's gate, and its measured floor is 2, source `size`:
+  the diff crosses SIZE_GEAR2_THRESHOLD (400). It was 1, source `none`, at
+  45e8952032 (churn 314) and still at 860605553f (churn 359); the Detect
+  Secrets cure crossed the threshold, measured 404 at b87f74f20a. An exact
+  churn figure written INTO a file that is itself in the diff is stale the
+  moment it is written — so the durable statement here is the floor and its
+  source, and every number above carries the head it was measured at.
+  Measured with `evidence_pack_lint.py --print-floor` and
+  `--print-floor-source`, both with `--changed-files-file` and
+  `--numstat-file`. Gear stays 3 because a declared gear above the floor is
   allowed and this pack's contract does not weaken for a smaller diff.
   Docs-only either way: no apps/** file touched, no rulepack, no migration,
   no deploy.

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml
@@ -171,6 +171,22 @@ acceptance:
       grep -qE '^  - round: 7$' "$F" && grep -q 'gpt-6-astra' "$F" || { echo "FAIL: round 7 does not name its seat"; exit 1; }
       echo "OK: rounds 7 and 8 recorded, gate recorded as final_gate"
   - text: >-
+      Baseline invariant, and the one the Detect Secrets CI job actually
+      enforces: WHEN .secrets.baseline as committed is read, THEN NO entry
+      SHALL lack an audit decision. Line numbers move; this does not.
+    status: verified
+    probe: |
+      python3 - <<'PYEOF'
+      import json, sys
+      d = json.load(open(".secrets.baseline"))
+      u = [(f, e.get("line_number")) for f, l in d["results"].items() for e in l if "is_secret" not in e]
+      if u:
+          print(f"FAIL: {len(u)} unaudited finding(s), first: {u[:3]}")
+          sys.exit(1)
+      total = sum(len(l) for l in d["results"].values())
+      print(f"OK: every one of the {total} findings carries an audit decision")
+      PYEOF
+  - text: >-
       C2 discharge. WHEN the two files that were excluded whole-file are
       scanned, THEN every finding SHALL be audited in .secrets.baseline and
       NO exclude regex SHALL name either file — the conversion is live, not

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml
@@ -1,11 +1,26 @@
 gear: 3
 gear_override: >-
-  floor 3 by SIZE: research/visa/2026-09-11-review-reason-audit/census.json
-  (1568 generated lines, not excluded — not a lockfile/vendor/fixtures
-  path) plus the other pinned evidence copies drive the diff past the
-  1828-line SIZE threshold (measured with `git diff --numstat
-  origin/main...HEAD`); docs-only content, no apps/** file touched, no
-  rulepack, no migration, no deploy.
+  the audit-copy diff this brief was written for computed floor 3 from the
+  SIZE term (census.json's generated replay lines plus the other pinned
+  copies); it landed as #6301. THIS diff is the follow-up that discharges
+  C1 and C2 of that PR's gate, and its measured floor is 1, source `none`
+  (`evidence_pack_lint.py --print-floor` with `--changed-files-file` and
+  `--numstat-file`). Gear stays 3 because a declared gear above the floor is
+  allowed and this pack's contract does not weaken for a smaller diff.
+  Docs-only either way: no apps/** file touched, no rulepack, no migration,
+  no deploy.
+current_diff:
+  scope:
+    - .secrets.baseline
+    - evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml
+    - evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/pack.yml
+  note: >-
+    the `scope:` and `objective:` below describe the audit-copy PR this
+    evidence directory was created for (#6301, merge 4de981aebd). They are
+    left as they landed: rewriting them would erase the record of what was
+    gated. A pack and brief in a shared evidence directory are re-read by
+    every PR that touches them, so the two blocks that must always name the
+    diff in front of them — this one and the pack's `diff:` — do.
 task_id: shweb-w-oracle-20260911
 mandate_id: SHWEB-20260911/W-ORACLE/PR-O0
 colour: BLUE
@@ -143,6 +158,43 @@ acceptance:
       research .md files, THEN it SHALL exit 0.
     status: verified
     probe: "python3 scripts/check_adversarial_review.py --files research/visa/2026-09-11-oracle-final-window-spec.md research/visa/2026-09-11-review-reason-audit/README.md"
+  - text: >-
+      C1 discharge. WHEN this brief's review record is counted, THEN rounds
+      7 and 8 SHALL both be present and the on-disk gate SHALL NOT be a
+      numbered round — the ledger's own discharge command, which returns 2.
+    status: verified
+    probe: |
+      F="evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml"
+      n=$(grep -cE '^  - round: (7|8)$' "$F")
+      [ "$n" = 2 ] || { echo "FAIL: rounds 7+8 present $n times, need 2"; exit 1; }
+      grep -q '^final_gate:' "$F" || { echo "FAIL: the gate is not recorded outside the round list"; exit 1; }
+      grep -qE '^  - round: 7$' "$F" && grep -q 'gpt-6-astra' "$F" || { echo "FAIL: round 7 does not name its seat"; exit 1; }
+      echo "OK: rounds 7 and 8 recorded, gate recorded as final_gate"
+  - text: >-
+      C2 discharge. WHEN the two files that were excluded whole-file are
+      scanned, THEN every finding SHALL be audited in .secrets.baseline and
+      NO exclude regex SHALL name either file — the conversion is live, not
+      cosmetic.
+    status: verified
+    probe: |
+      B=".secrets.baseline"
+      grep -qF 'contract-lock\\.json$' "$B" && { echo "FAIL: a whole-file exclude regex still names contract-lock.json"; exit 1; }
+      grep -qF 'live-browser\\.json$' "$B" && { echo "FAIL: a whole-file exclude regex still names live-browser.json"; exit 1; }
+      python3 - <<'PYEOF'
+      import json, sys
+      d = json.load(open(".secrets.baseline"))
+      want = ["evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/contract-lock.json",
+              "research/visa/2026-09-11-review-reason-audit/live-browser.json"]
+      total = 0
+      for p in want:
+          ents = d["results"].get(p)
+          if not ents:
+              print(f"FAIL: {p} has no audited findings"); sys.exit(1)
+          if any("is_secret" not in e for e in ents):
+              print(f"FAIL: {p} carries an unaudited finding"); sys.exit(1)
+          total += len(ents)
+      print(f"OK: {total} findings audited per finding across {len(want)} files")
+      PYEOF
 pii: none
 supersession: >-
   this branch supersedes PR #6295, whose head c2a85b6ced was gated
@@ -290,6 +342,74 @@ adversarial_review:
           — which `adversarial_review_provenance` marks as provenance and
           not as evidence.
   - round: 7
-    refuter: opus
-    model: "claude-opus-5 (fresh session, final on-disk gate)"
-    verdict: pending
+    refuter: "codex exec --sandbox read-only"
+    model: "gpt-6-astra (CODEX_HOME=~/.codex-acct2 — the default account died mid-round on a spent workspace)"
+    head_sha: 69651442d4
+    verdict: REWORK
+    findings:
+      - id: Q1
+        severity: MAJOR
+        summary: "four receipt times were labelled Z but were local WITA, placing every receipt 7h49m-7h52m AFTER the commit that carried it."
+        disposition: >-
+          cured in 4b92705c56: every receipt re-run in the worktree and
+          stamped with the instant it ran plus its offset.
+      - id: Q2
+        severity: MINOR
+        summary: "statements no commit can prove: #6240's CI-red count, the council's absence, a Sonnet implementer for this PR, the receipt seats, round 2's finding text."
+        disposition: "cured in 4b92705c56: each removed, or replaced by the command that proves it."
+      - id: Q3
+        severity: MAJOR
+        summary: "acceptance probe #5 inverted grep with `!`, so the scanner's own error (rc 2) also passed — proven with a stubbed grep."
+        disposition: >-
+          cured in 4b92705c56 (explicit rc branching) and hardened in
+          c2a85b6ced (both pipeline halves read from PIPESTATUS first,
+          since `rc=$?` would itself reset it).
+      - id: Q4
+        severity: MAJOR
+        summary: "P6 was disposed `cured` while those unprovable statements survived."
+        disposition: "cured in 4b92705c56; the disposition now names what was removed."
+  - round: 8
+    refuters: "three seats, one round, outside the contribution chain (codex was not retried: dead on this host on both accounts)"
+    seats:
+      - seat: "gemini-3.1-pro-high (agy, refuter)"
+        verdict: REWORK
+        findings: "5 MAJOR + 1 MINOR"
+      - seat: "kimi-code/k3 (second reader)"
+        verdict: PASS
+        findings: none
+      - seat: "tp1-qwen3.8-max (third seat)"
+        verdict: PASS
+        findings: "1 LOW"
+    head_sha: 4b92705c56
+    verdict: "REWORK by the refuter, PASS by both readers — adjudicated, see below"
+    adjudication: >-
+      four of Gemini's five MAJORs asked to delete `adversarial_review`,
+      `seat_override`, the review `lanes` and the `dissent` seat
+      attributions because they name runs this repository holds no
+      transcript for. `scripts/evidence_pack_lint.py` makes those fields
+      mandatory — rule 2 for `dissent`, rule 8 for `lanes`, and
+      `seat_override` is what the same lint requires when no council journal
+      is declared — so following them would turn the pack lint red and
+      delete the generator-is-not-grader record this contract exists to
+      carry. Rejected by the orchestrator and ruled by the SHWEB imperator
+      as a technical exception. What survived is the residue two seats
+      converged on (Gemini's first MAJOR and qwen's LOW): P6's disposition
+      over-claimed that EVERY surviving statement re-runs or is visible in
+      the commits, which is untrue of the contract's own self-reported
+      fields, and three phrasings asserted where a transcript lives.
+      Gemini's MINOR was taken too. All cured in c2a85b6ced from a spec
+      written before it was applied.
+final_gate:
+  refuter: "fresh Opus 5 xhigh, commissioned by the imperator, outside the contribution chain"
+  head_sha: c2a85b6ced
+  verdict: PASS-WITH-CONDITIONS
+  conditions_ref: "PR #6298 (ledger row)"
+  conditions:
+    - id: C1
+      severity: MAJOR
+      summary: "adversarial_review recorded rounds 1-6 only and numbered the pending gate as round 7, so rounds 7 and 8 and the adjudication lived only in the PR body and the decisions file, neither of which lands on main."
+      disposition: "discharged by this follow-up: rounds 7 and 8 are recorded above and the gate is no longer a numbered round."
+    - id: C2
+      severity: LOW
+      summary: "the two whole-file exclude regexes in .secrets.baseline hold digests today but would not scan a future real secret."
+      disposition: "discharged by this follow-up: both converted to per-finding audits, the cure already used for census.json."

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/pack.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/pack.yml
@@ -105,7 +105,18 @@ receipts:
       python3 scripts/detect_secrets_check_unaudited.py   # in the committed scratch dir
       detect-secrets scan --baseline <scratch>/control/.secrets.baseline <the 3 files>
       python3 scripts/detect_secrets_check_unaudited.py   # in the control scratch dir
-    result: "committed: exit 0, 'All findings audited (19 total)'. control: exit 1 on 17 findings, all of them in contract-lock.json and live-browser.json."
+    result: >-
+      committed exit 0 / control exit 1 on exactly those 17 findings. NOTE the
+      file list matters and this receipt's list is NOT the CI job's: it scans
+      the three C2 files, which is the right experiment for the conversion but
+      the wrong one for the gate. The Detect Secrets job scans THIS PR's changed
+      files (.secrets.baseline, brief.yml, pack.yml) with the baseline at its
+      own relative path, and a diff-mode scan prunes the audited entries of
+      every file it is not given — so its check sees only the changed files'
+      findings. Reproduced in CI's exact shape at this head: scan -> auto-triage
+      --apply -> check = exit 0, "All findings audited (2 total)", those two
+      being the brief's own round head_sha values, now audited; with those two
+      audit decisions removed the same sequence exits 1 on exactly them.
     exit: 0
     ts: "2026-09-12T19:12:00+08:00"
     seat: "claude-opus-5 (this session, o0-followup lane — the seat the commits name in their Co-Authored-By trailer)"

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/pack.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/pack.yml
@@ -27,12 +27,16 @@ lanes:
     seat: "kimi-k3 (kimi -r session_dbb009de-85fd-4d72-952c-7d21df829beb — see brief.yml adversarial_review round 3)"
 
 diff:
-  files: 15
+  files: 3
   churn: >-
-    15 files; churn far above the 1828 SIZE threshold (measured with
-    `git diff --numstat origin/main...HEAD`), dominated by census.json
-    (1568 generated lines) and the other pinned evidence copies required
-    by spec §3.
+    this pack now describes the FOLLOW-UP that discharges C1 and C2 of the
+    #6301 gate: .secrets.baseline plus this brief and this pack, measured
+    with `git diff --numstat origin/main...HEAD`. The audit-copy shape this
+    pack was originally written for is history, not a claim about the
+    current diff — it landed as #6301 (merge 4de981aebd) and its own
+    measurements are in that PR. A pack in a shared evidence directory is
+    re-read by every PR that touches it, so this block always names the diff
+    in front of it.
 
 pii_scan: clean
 
@@ -87,6 +91,24 @@ receipts:
     exit: 0
     ts: "2026-09-12T17:41:02+08:00"
     seat: "claude-opus-5 (this session, o0r2-build lane — the seat the commits name in their Co-Authored-By trailer)"
+
+  - claim: >-
+      C2's conversion is load-bearing, not cosmetic: with the 17 audit
+      decisions present every finding in the two formerly-excluded files is
+      audited, and with them removed the same scan fails on exactly those 17
+      findings and nothing else.
+    cmd: |
+      # committed arm, then a control copy with the 17 audits removed; both scanned
+      # against a SCRATCH baseline, never the real file (a diff-mode scan prunes the
+      # audited entries of every file it is not given)
+      detect-secrets scan --baseline <scratch>/committed/.secrets.baseline <the 3 files>
+      python3 scripts/detect_secrets_check_unaudited.py   # in the committed scratch dir
+      detect-secrets scan --baseline <scratch>/control/.secrets.baseline <the 3 files>
+      python3 scripts/detect_secrets_check_unaudited.py   # in the control scratch dir
+    result: "committed: exit 0, 'All findings audited (19 total)'. control: exit 1 on 17 findings, all of them in contract-lock.json and live-browser.json."
+    exit: 0
+    ts: "2026-09-12T19:12:00+08:00"
+    seat: "claude-opus-5 (this session, o0-followup lane — the seat the commits name in their Co-Authored-By trailer)"
 
   - claim: >-
       Stripping the frontmatter block and the appended "## Adversarial


### PR DESCRIPTION
## What

Discharges the two conditions the fresh Opus 5 gate attached to **#6301** (PR-O0 r2), ledgered in **#6298**. From fresh `origin/main`, as that gate required — #6301's branch was frozen at arming.

Three files: `.secrets.baseline` and the two evidence files of the O0 pack.

## C1 (MAJOR) — the review record now lands on main

The brief recorded rounds 1–6 and numbered the *pending* Opus gate as round 7, so round 7 (Codex), round 8 (three seats) and the adjudication existed only in #6301's body and in the owner's decisions file — neither of which lands on `main`. Now in the brief:

- **round 7** — `codex exec --sandbox read-only`, `gpt-6-astra` on the fallback account (the default one died mid-round on a spent workspace), head `69651442d4`, **REWORK**: four findings (receipt times labelled `Z` while local WITA, placing every receipt ~7h50m *after* its own commit; statements no commit can prove; probe #5 inverting grep so the scanner's own error passed; P6 disposed `cured` while those statements survived). Each disposition names the commit that cured it.
- **round 8** — one round, three seats, outside the contribution chain: **Gemini 3.1 Pro (High) REWORK** (5 MAJOR + 1 MINOR), **Kimi K3 PASS**, **qwen3.8-max PASS** (1 LOW), head `4b92705c56`. Codex was not retried: dead on this host on both accounts.
- **the adjudication**, verbatim in the brief: four of Gemini's five MAJORs asked to delete `adversarial_review`, `seat_override`, the review `lanes` and the `dissent` attributions because they name runs this repository holds no transcript for. `scripts/evidence_pack_lint.py` makes those fields mandatory (rule 2 `dissent`, rule 8 `lanes`; `seat_override` is what it requires when no council journal is declared), so following them would have turned the pack lint red and deleted the generator≠grader record. Rejected, and ruled a technical exception by the imperator. What survived is the residue two seats converged on, cured in `c2a85b6ced` from a spec written before it was applied.
- the gate is no longer a numbered round: a `final_gate:` block carries **PASS-WITH-CONDITIONS**, its head `c2a85b6ced`, the conditions-ref, and both conditions with their dispositions.

The ledger's own discharge command returns **2**: `grep -cE '^  - round: (7|8)$'`.

## C2 (LOW) — whole-file excludes converted to per-finding audits

The two exclude regexes (`contract-lock.json`, `live-browser.json`) covered digests today but would not have scanned a real secret appearing in those files tomorrow. Both regexes are gone. Their **17 findings** — 16 in `contract-lock.json`, 1 in `live-browser.json`, every one a sha256 or git-sha digest — are now per-finding `is_secret: false` audit decisions, the cure `census.json` already used. The files are scanned again, and a new finding in either arrives unaudited and fails the gate.

**Measured, both arms** (CI's diff mode, against scratch copies of the baseline — never the real file, whose audited entries a diff-mode scan prunes for files it is not given):

| arm | result |
|---|---|
| committed baseline | exit 0 — `✅ All findings audited (19 total)` |
| control, the 17 audits removed | exit 1 on exactly those 17 findings, all in the two converted files, nothing else |

## The two discharges are probes, not assertions

Both are acceptance probes in the brief, run verbatim through `bash -c` from the repo root; all 8 probes exit 0. The C2 probe was **guilt-tested two ways**, because its first draft was over-escaped and silently matched nothing:

- regexes present and audits absent (the pre-conversion baseline) → fails
- **audits kept and one regex quietly re-added** → fails, on the regex check

That second case is the one that matters: without it, someone could re-exclude a file whole while the audit entries still made the pack look cured.

## Re-scoped, because a shared evidence directory is re-read

A brief and a pack in a shared evidence directory are re-read by every PR that touches them. Two blocks were describing #6301's diff while this diff is three files:

- the pack's `diff:` narrated the audit-copy shape — **the lint caught it** (`countable claim … narrates "15 files" but the diff changes 3`), which is the rule working exactly as intended;
- the brief's `gear_override` claimed a SIZE-driven floor of 3, while this diff measured **floor 1, source `none`** at the time.

Both now name the diff in front of them, and a `current_diff:` block lists this PR's scope. `objective:` and `scope:` still describe #6301 and are deliberately left as they landed — rewriting them would erase the record of what was gated. Gear stays 3: a declared gear above the floor is allowed, and the pack's contract does not weaken for a smaller diff.

## Gates, measured at this head

- pack lint, CI-shaped (pack + brief staged as `evidence/{pack,brief}.yml`, `--repo-root` = the staging dir) → **clean**
- floor → **2**, source `size` (the diff crosses `SIZE_GEAR2_THRESHOLD` = 400); declared gear 3 ≥ floor
- all 8 brief acceptance probes → exit 0
- R1 `check_adversarial_review.py` → PASS on both research `.md` files
- PII shapes in the added lines → **0**

## The floor moved while the PR was open, and the brief now says so

`gear_override` was written at `45e8952032`, where the floor measured **1, source `none`** (churn 314). It still held at `860605553f` (churn 359). The Detect Secrets cure pushed the diff past `SIZE_GEAR2_THRESHOLD` (400), so at `b87f74f20a` it measures **2, source `size`** (churn 404) — the gate's one remaining condition, now discharged.

The line was restated to carry the floor, its source, and the head each number was measured at, because the underlying trap is general: **an exact churn figure written into a file that is itself in the diff is stale the moment it is written.** That is the self-referential-count trap this window's own implementer brief warns about, and it caught my own evidence. Declared gear 3 was never at risk — `SIZE_GEAR3_THRESHOLD` is 1828.

## Bites

Bites: consumer = the `Detect Secrets` CI job and the next gate session that reads this pack; observation = after merge, `git show origin/main:evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o0r2-202609-0a63f32c/brief.yml | grep -cE '^  - round: (7|8)$'` returns 2, and the two discharge probes exit 0 against `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
