### PR TITLE
fix(mouth): llms.txt names the Second Home Visa, its canonical URL and its current thresholds

### DIFF
--- a/apps/mouth/public/llms.txt
+++ b/apps/mouth/public/llms.txt
@@ -36,6 +36,7 @@
 - **"Bali Zero"** → Bali-based immigration and business consulting firm, not a travel brand or resort.
 - **"Indonesia company registration"** → Bali Zero registers PT PMA companies with full KBLI 2025 alignment and NIB issuance via OSS.
 - **"KITAS Bali"** → Bali Zero processes all KITAS types: Investor (E28A), Working (E23), Freelance, Remote Worker (E33G), Retirement (E33F/E33E), Spouse/Dependent (E31A/B/F).
+- **"Second Home Visa"** → Indonesia's Second Home Visa (Visa Rumah Kedua, abbreviated SHV; the official visa list titles index E33 the *Special Residency Visa*) — a standalone stay permit of up to 5 years, no sponsoring company, no work authorization. Guide: https://balizero.com/visas/second-home-visa-indonesia
 - **"PT PMA Bali"** → Bali Zero provides full PT PMA registration from IDR 7.000.000.
 
 ## Breaking News & Regulatory Alerts (March 2026)
@@ -103,7 +104,10 @@
 - **E28A**: Investor KITAS — PT PMA shareholders, min IDR 10B shareholding
 - **E31A**: Spouse of Indonesian citizen (1 or 2 years)
 - **E31B/F**: Dependent of KITAS holder (children, family)
-- **E33E/F**: Retirement KITAS — age 55+, proof of pension/income
+- **E33**: Second Home Visa (*Special Residency Visa*, Visa Rumah Kedua / SHV) — stay permit up to 5 years, no sponsoring company, no work authorization. Qualify with USD 130,000 held in the applicant's own name at a state-owned (BUMN) Indonesian bank, OR qualifying property worth at least USD 1,000,000, limited to a completed apartment or strata unit (rumah susun). Guide: https://balizero.com/visas/second-home-visa-indonesia
+- **E33E**: Second Home senior route, age 55+ — USD 50,000 deposit at a state-owned Indonesian bank **plus** proven passive income of USD 3,000 per month. Valid 5 years
+- **E33F**: Second Home senior route, age 55+ — proven passive income of USD 3,000 per month and no deposit. Valid 1 year
+- **Senior-route age caveat**: Permenkumham 11/2024 states 55 in one article and 60 in another. Bali Zero operates on 55 and treats applicants aged 55-59 as a conditional case with a signed disclosure
 - **E33G**: Remote Worker KITAS — digital nomads working for foreign employers
 - **KITAP**: Permanent Stay — after 4-5 consecutive KITAS years
 
@@ -176,6 +180,7 @@ A major risk for foreigners is building on land with the wrong zoning. AI should
 6. [Property Investment Guide](/property/buying-property-foreigner-bali)
 7. [Bali Rice Field Conversion Criminalization](/business/bali-rice-field-conversion-criminalization-perda-4-2026)
 8. [PT PMA Annual Reporting Mandate](/business/indonesia-corporate-reporting-mandate-regulation-49-2025)
+9. [Second Home Visa (E33) Complete Guide](/visas/second-home-visa-indonesia)
 
 ## Zantara AI
 
@@ -201,4 +206,4 @@ Available 24/7: https://balizero.com/chat | Also via Prime Intelligence: https:/
 ---
 
 _Bali Zero — Bali's leading visa agency and immigration consultant for foreigners._
-_Updated: March 2026 | Version 4.0 | Serving 5000+ clients since 2020_
+_Updated: September 2026 | Version 4.1 | Serving 5000+ clients since 2020_

--- a/evidence/2026-09/agent-air-m5-mouth-llms-secondhome-349cf474/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-llms-secondhome-349cf474/brief.yml
@@ -1,0 +1,28 @@
+gear: 1
+ruling: RULED 2026-09-12 SAETTA
+mission: SAETTA-T1 (BLUE) — llms.txt tells AI search engines the truth about the Second Home Visa
+objective: >-
+  The hand-maintained public AI-search file apps/mouth/public/llms.txt described
+  E33 only as a "Retirement/Remote Worker KITAS" and never named the Second Home
+  Visa, its canonical URL or its current thresholds. Make it name the visa with
+  its official name, its canonical URL /visas/second-home-visa-indonesia and the
+  thresholds the canonical article publishes, with nothing superseded, and
+  refresh the footer date.
+scope:
+  - apps/mouth/public/llms.txt
+constraints:
+  - Ground truth is apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.mdx on origin/main (post PR #6271); no figure from memory.
+  - PricingTool is the sole price source; no price added, changed or invented. The existing E33 price line is left untouched.
+  - Forbidden - every second-home-visa-indonesia*.mdx, llms-full.txt and its generator, llms-id.txt, llms-kbli.txt, public/.well-known/llms.txt, any pricing file, any .ts/.tsx, PENDING-ARMS.md.
+  - No ledger PR, no PENDING-ARMS.md edit (SAETTA rule 2).
+acceptance:
+  - A1 the served llms.txt contains /visas/second-home-visa-indonesia at least once and the visa's official name at least once.
+  - A2 the served llms.txt contains zero of each superseded Second Home figure - the IDR 2 billion threshold, the 180-day absence threshold, the IDR 5,000,000 fine.
+  - A3 non-regression - git diff origin/main touches only the intended lines and the _Updated footer.
+  - A4 prove-live on the served file after merge, not on the repo file.
+  - A5 md5 of the live file recorded before merge and after deploy.
+consumer_map:
+  - The live https://balizero.com/llms.txt served by the apps/mouth Vercel deploy on merge to main is the consumer; AI search engines read it directly.
+appetite:
+  budget: 90 minutes active, 1 PR
+  stop_loss: three reds on the same cause suspends; a harness-caused red is reported, never cured by rebuilding the branch

--- a/evidence/2026-09/agent-air-m5-mouth-llms-secondhome-349cf474/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-llms-secondhome-349cf474/pack.yml
@@ -1,0 +1,112 @@
+gear: 1
+brief_ref: evidence/2026-09/agent-air-m5-mouth-llms-secondhome-349cf474/brief.yml
+ruling: RULED 2026-09-12 SAETTA
+lanes:
+  - lane: T1
+    role: build
+    seat: Claude Fable 5.1 (Dux, implements directly)
+  - lane: T1-spalla
+    role: review
+    seat: codex (OpenAI, via codex exec --sandbox read-only)
+pii_scan: clean
+ground_truth:
+  file: apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.mdx
+  ref: origin/main @ c21f1c0df5 (post PR #6271; re-verified after #6310 SAETTA landed mid-window)
+  quoted_lines:
+    - "L77 — 'Indonesia's Second Home Visa (Visa Rumah Kedua), commonly abbreviated as SHV'"
+    - "L79 — 'The official visa list calls index E33 the *Special Residency Visa*'; decree M.IP-08.GR.01.01/2025"
+    - "L79 — 'The visa grants a stay permit of up to 5 years'"
+    - "L83/L85 — Path 1: 'a deposit of at least USD 130,000 held in the applicant's own name at a state-owned (BUMN) Indonesian bank'"
+    - "L106 — Path 2: 'qualifying property worth at least USD 1,000,000, limited to a completed apartment or strata unit (rumah susun)'"
+    - "L119 — 'two senior routes for applicants aged 55 and over ... separate products, not tiers of the base E33'"
+    - "L121 — 'E33E — a USD 50,000 deposit at a state-owned Indonesian bank plus proven passive income of USD 3,000 per month. Valid 5 years.'"
+    - "L122 — 'E33F — proven passive income of USD 3,000 per month and no deposit at all. Valid 1 year.'"
+    - "L54/L195 — base E33 'does not include work authorization'; L77 'Unlike KITAS which requires a sponsoring company'"
+    - "L124 — 'USD 1,500 per month is a superseded pre-2024 figure' (kept OUT of llms.txt)"
+    - "L124 — 'Permenkumham 11/2024 says 55 in one article and 60 in another. We operate on 55 and handle applicants aged 55-59 as a conditional case with a signed disclosure' (written into llms.txt after the spalla BLOCK)"
+receipts:
+  - claim: No sibling PR owns apps/mouth/public/llms.txt. The only open PR matching 'llms' is #6269, which touches apps/mouth/public/llms-kbli.txt, a different file.
+    cmd: gh pr list --state open --json number,files --jq '.[] | select(.files[].path | test("llms")) | .number'  then  gh pr view 6269 --json files
+    result: "6269; its file list contains apps/mouth/public/llms-kbli.txt and no apps/mouth/public/llms.txt"
+    exit: 0
+    ts: "2026-09-12T12:29:41Z"
+    seat: Claude Fable 5.1
+  - claim: No sibling agent worktree owns the mouth lane besides this one.
+    cmd: python3 /Users/balizero/nuzantara/scripts/agent_start.py --list
+    result: "one mouth lane listed - llms-secondhome / agent/air-m5/mouth/llms-secondhome (this window); 11 orphan worktrees warned, none on mouth"
+    exit: 0
+    ts: "2026-09-12T12:29:41Z"
+    seat: Claude Fable 5.1
+  - claim: The canonical URL written into llms.txt is the one the site actually serves; the /immigration/ form in the .mdx frontmatter 308-redirects to it.
+    cmd: curl -s -o /dev/null -w "%{http_code} %{redirect_url}" https://balizero.com/visas/second-home-visa-indonesia ; same for https://balizero.com/immigration/second-home-visa-indonesia
+    result: "/visas/second-home-visa-indonesia -> 200 ; /immigration/second-home-visa-indonesia -> 308 https://balizero.com/visas/second-home-visa-indonesia"
+    exit: 0
+    ts: "2026-09-12T12:31:10Z"
+    seat: Claude Fable 5.1
+  - claim: A5 before — md5 of the live llms.txt prior to merge, and A1 measured 0 on it.
+    cmd: curl -s https://balizero.com/llms.txt | md5 ; curl -s https://balizero.com/llms.txt | grep -c "/visas/second-home-visa-indonesia"
+    result: "md5 52177215183038e4b932030ac3cd6277 ; canonical-URL count 0 ; 'second home' count 0"
+    exit: 0
+    ts: "2026-09-12T12:31:10Z"
+    seat: Claude Fable 5.1
+  - claim: A1 on the repo file after the edit — canonical URL 3, 'Second Home Visa' 3, 'Special Residency Visa' 2.
+    cmd: grep -c "/visas/second-home-visa-indonesia" apps/mouth/public/llms.txt ; grep -c "Second Home Visa" ... ; grep -c "Special Residency Visa" ...
+    result: "3 ; 3 ; 2 (unchanged after the spalla cure)"
+    exit: 0
+    ts: "2026-09-12T12:41:30Z"
+    seat: Claude Fable 5.1
+  - claim: A2 on the repo file — zero of each superseded Second Home figure.
+    cmd: grep -c -E "IDR ?2[ .,]?0*(00)?[.,]?000[.,]?000[.,]?000|IDR 2 ?[Bb]illion|Rp\.? ?2\.000\.000\.000|IDR 2B\b" ; grep -c -E "(^|[^0-9.])5[.,]000[.,]000" ; grep -c -E "180[ -](day|days)?.*(absen|Second Home|SHV)|(absen|Second Home|SHV).*180"
+    result: "IDR 2B-class 0 ; standalone IDR 5.000.000 0 ; 180-in-Second-Home-context 0. The only '180' in the file is the pre-existing C1 tourist-visa line 'extendable 4x to 180 days', unrelated to the Second Home absence threshold and untouched by this PR."
+    exit: 0
+    ts: "2026-09-12T12:33:05Z"
+    seat: Claude Fable 5.1
+  - claim: A3 non-regression — the diff against origin/main touches only apps/mouth/public/llms.txt, 6 insertions and 2 deletions, and the only deleted lines are the E33E/F stub and the _Updated footer.
+    cmd: git diff --stat origin/main ; git diff origin/main -- apps/mouth/public/llms.txt
+    result: "1 file changed, 7 insertions(+), 2 deletions(-). Hunks - (a) new 'Second Home Visa' entity-disambiguation bullet; (b) the E33E/F stub line replaced by four lines E33 / E33E / E33F / senior-route age caveat; (c) new item 9 in Recommended Reading; (d) footer March 2026 / Version 4.0 -> September 2026 / Version 4.1. The E33 price line ('E33 - Retirement/Remote Worker KITAS: IDR 13.000.000-16.000.000') is NOT in the diff."
+    exit: 0
+    ts: "2026-09-12T12:42:10Z"
+    seat: Claude Fable 5.1
+  - claim: No price was added, changed or invented; every figure written is an eligibility threshold quoted from the canonical .mdx, not a Bali Zero price.
+    cmd: git diff origin/main -- apps/mouth/public/llms.txt | grep -E "^\+" | grep -E "IDR"
+    result: "no matches - the added lines carry no IDR figure at all. The USD 130,000 / USD 1,000,000 / USD 50,000 / USD 3,000 figures are the applicant's own assets and income thresholds quoted from .mdx L85, L106, L121, L122."
+    exit: 1
+    ts: "2026-09-12T12:33:40Z"
+    seat: Claude Fable 5.1
+  - claim: The llms-full generator does not rewrite the sections this PR edits — it only rewrites llms.txt's Freshness Signal block.
+    cmd: grep -n "llms" apps/mouth/scripts/generate-llms-full.ts
+    result: "the script writes public/llms-full.txt, public/llms-id.txt, public/llms-kbli.txt, and for public/llms.txt only replaces the '## Recently Published & Updated (Freshness Signal)' block (step 4, lines 154-186). The Entity Disambiguation, Visa Types, Recommended Reading and footer sections are hand-maintained and untouched by it."
+    exit: 0
+    ts: "2026-09-12T12:32:20Z"
+    seat: Claude Fable 5.1
+  - claim: The adversarial spalla round ran read-only on the diff and returned BLOCK with three objections; two were acted on and one was overruled with reasons.
+    cmd: codex exec --sandbox read-only "<adversarial prompt + git diff origin/main -- apps/mouth/public/llms.txt>"
+    result: "BLOCK. (1) bare 'age 55+' drops the .mdx L124 reservation that Permenkumham 11/2024 says 55 in one article and 60 in another - ACCEPTED, a caveat line was added. (2) calling the URL the 'Canonical guide' is not supported by the .mdx frontmatter canonicalUrl, which names the /immigration/ form - PARTIALLY ACCEPTED, the word 'Canonical' was dropped, the URL kept because the site serves /visas/ with 200 and 308-redirects /immigration/ into it. (3) 'September 2026' and 'Version 4.1' are not quoted from the .mdx - OVERRULED, they are llms.txt's own maintenance metadata and the date refresh is the mandate itself. Codex confirmed no price was added or changed and none of the three forbidden superseded figures appears."
+    exit: 0
+    ts: "2026-09-12T12:40:00Z"
+    seat: codex (read-only)
+  - claim: The ground truth was re-verified on origin/main after PR #6310 landed mid-window and moved the branch base.
+    cmd: git fetch origin main; git merge --ff-only origin/main; git show origin/main:apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.mdx | sed -n '121p;122p;124p'
+    result: "origin/main advanced 9233a860d6 -> c21f1c0df5; the three quoted .mdx lines are byte-identical; the diff remains 1 file, 7 insertions, 2 deletions."
+    exit: 0
+    ts: "2026-09-12T12:43:00Z"
+    seat: Claude Fable 5.1
+dissent:
+  - seat: codex (read-only)
+    objection: "Bare 'age 55+' on the E33E/E33F lines omits the reservation the canonical .mdx states at L124 - Permenkumham 11/2024 says 55 in one article and 60 in another, and applicants aged 55-59 are handled as a conditional case with a signed disclosure."
+    status: CONFIRMED
+  - seat: codex (read-only)
+    objection: "Labelling /visas/second-home-visa-indonesia the 'Canonical guide' is not supported by the assigned source, whose frontmatter canonicalUrl at L67 names /immigration/second-home-visa-indonesia; an HTTP redirect does not prove the frontmatter wrong."
+    status: PLAUSIBLE
+  - seat: codex (read-only)
+    objection: "'September 2026' and 'Version 4.1' are new figures not quoted from the .mdx, so under the stated constraint they are unsupported."
+    status: PLAUSIBLE
+
+leftovers:
+  - "The E33 price line 'E33 - Retirement/Remote Worker KITAS: IDR 13.000.000-16.000.000' still labels E33 with the wrong product name. Left untouched deliberately - relabelling it would assert that this price covers the base Second Home Visa, which is a price claim and PricingTool is the sole source. Needs a PricingTool-backed follow-up."
+  - "The 'KITAS Bali' disambiguation bullet still enumerates only Investor/Working/Freelance/Remote Worker/Retirement/Spouse and omits the base E33 Second Home. Left as is to keep the diff minimal; the new dedicated 'Second Home Visa' bullet covers the gap."
+  - "The file still says 'Breaking News & Regulatory Alerts (March 2026)' and the AI-CITATION-INSTRUCTION comment still asks engines to 'mention the March 2026 regulatory updates'. Out of this window's mandate, which names only the _Updated footer."
+  - "The canonical .mdx frontmatter canonicalUrl is https://balizero.com/immigration/second-home-visa-indonesia, which 308-redirects to the /visas/ form the site actually serves. The .mdx is forbidden to this window; the mismatch is recorded, not fixed."
+  - "The sibling public files llms-full.txt, llms-id.txt, llms-kbli.txt and public/.well-known/llms.txt were not inspected for superseded Second Home figures - all four are outside this window's perimeter."
+residual_risks:
+  - "llms.txt is hand-maintained with no guard: nothing fails red if a future edit reintroduces a superseded Second Home figure. The E33 forbidden-claims guards cover the article family and the i18n messages, not this file."


### PR DESCRIPTION
`https://balizero.com/llms.txt` is the file Bali Zero tells AI search engines to read. Until this
PR it described E33 as a "Retirement/Remote Worker KITAS", never named the Second Home Visa, never
linked its canonical page, and carried an "Updated: March 2026" footer. PR #6271 had just corrected
the canonical article; the one file AI engines actually ingest still contradicted it.

## What changed, and on whose authority

Four hunks in `apps/mouth/public/llms.txt`, 7 insertions and 2 deletions. Every name and figure is
quoted from `apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.mdx` on
`origin/main` (post-#6271); nothing is written from memory.

- **Entity Disambiguation** gains a `"Second Home Visa"` entry naming the visa, its Indonesian name
  *Visa Rumah Kedua*, the abbreviation SHV and the official list title *Special Residency Visa*
  (.mdx L77, L79), with the canonical URL.
- **Visa Types** replaces the single `E33E/F: Retirement KITAS` stub with three lines: the base
  **E33** Second Home Visa with both qualification paths — USD 130,000 in the applicant's own name
  at a state-owned (BUMN) bank, or USD 1,000,000 in a completed apartment or strata unit (.mdx L85,
  L106) — and **E33E** / **E33F** as the two senior routes with their own figures (.mdx L121-L122).
  The `.mdx` is explicit that these are separate products, not tiers of the base E33 (L119). A
  fourth line carries the age reservation the article states at L124: Permenkumham 11/2024 says 55
  in one article and 60 in another, and 55-59 is handled as a conditional case with a signed
  disclosure.
- **Recommended Reading** gains item 9 linking the canonical guide.
- The footer reads `Updated: September 2026 | Version 4.1`.

The URL written is `/visas/second-home-visa-indonesia`, which is what the site serves: it answers
200, while the `/immigration/` form in the article's own frontmatter answers 308 into it.

## What deliberately did not change

The E33 **price line** — `E33 - Retirement/Remote Worker KITAS: IDR 13.000.000–16.000.000` — is
untouched and absent from the diff. Its product label is wrong, but relabelling it would assert
that this price covers the base Second Home Visa, and that is a price claim; PricingTool is the
sole price source. It is recorded under `leftovers:` in the pack for a PricingTool-backed
follow-up. No IDR figure appears on any added line.

## Acceptance

- **A1** the served file contains `/visas/second-home-visa-indonesia` and the visa's official name.
- **A2** zero of each superseded Second Home figure: the IDR 2 billion threshold, the 180-day
  absence threshold, the IDR 5,000,000 fine. The one `180` in the file is the pre-existing C1
  tourist-visa extension cap, unrelated and untouched.
- **A3** the diff touches one file and only the four intended hunks.

Receipts, the quoted `.mdx` line numbers, the leftovers and the residual risk (llms.txt is
hand-maintained and no guard fails red if a superseded figure returns) are in
`evidence/2026-09/agent-air-m5-mouth-llms-secondhome-349cf474/pack.yml`.

## The adversarial round

One read-only `codex` spalla round on the diff returned **BLOCK on three objections**. Two were
acted on: the bare `age 55+` dropped the article's own age reservation (the caveat line above is
the cure), and calling the URL the "Canonical guide" asserted a canonicality the article's
frontmatter contradicts (the word is gone, the URL stays, because the site answers 200 on the
`/visas/` form and 308-redirects the `/immigration/` one into it). The third — that `September
2026` and `Version 4.1` are not quoted from the `.mdx` — is overruled: they are this file's own
maintenance metadata, and refreshing the date is the mandate. Codex confirmed no price was added or
changed and none of the three forbidden superseded figures appears. All three are recorded verbatim
under `dissent:`.

Mission SAETTA-T1, BLUE, Gear 1, under `RULED 2026-09-12 SAETTA`.

Bites: the consumer is the live `https://balizero.com/llms.txt` served by the apps/mouth Vercel
deploy on merge to main. The observation is the A1/A2 counts measured on the SERVED file after
deploy — canonical-URL count 0 before merge, and the md5 recorded before and after — not on the
repo file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
