### PR TITLE
chore(mouth): /process — filters from the live catalog, one entry point per action on /process/[id]

### DIFF
--- a/apps/mouth/src/app/(workspace)/process/[id]/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/page.test.tsx
@@ -100,6 +100,11 @@ vi.mock("@/hooks/useTeamMembers", () => ({
         label: "Zero Tester",
         avatar: null,
       },
+      {
+        value: "asya@balizero.com",
+        label: "Asya",
+        avatar: null,
+      },
     ],
   }),
 }));
@@ -316,8 +321,12 @@ describe("CaseDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "Back" }));
     expect(mocks.back).toHaveBeenCalledTimes(1);
 
+    // The breadcrumb's client link was removed (kita-prune lot 6): the
+    // Client Information card's "Client Name" button is now the single
+    // instance, and it navigates without the `?tab=process` query param
+    // the other three duplicate instances never carried either.
     await user.click(screen.getAllByRole("button", { name: "John Doe" })[0]);
-    expect(mocks.push).toHaveBeenCalledWith("/clients/7?tab=process");
+    expect(mocks.push).toHaveBeenCalledWith("/clients/7");
     expect(mocks.trackButtonClick).toHaveBeenCalledWith(
       "Back to Process",
       "CasesDetailPage",
@@ -431,10 +440,14 @@ describe("CaseDetailPage", () => {
   });
 
   it("uses the canonical update response without a stale reload or losing joined labels", async () => {
+    // The Edit modal was reduced to status + assignee + start date
+    // (kita-prune lot 6: priority/payment/price already have their own
+    // inline editors), so this exercises the surviving assignee + start
+    // date fields instead of the removed priority + quoted-price ones.
     const original = makePractice();
     const canonicalUpdateResponse = makePractice({
-      priority: "urgent",
-      quoted_price: 2_000_000,
+      assigned_to: "asya@balizero.com",
+      start_date: "2026-03-15T00:00:00.000Z",
     });
     delete canonicalUpdateResponse.client_name;
     delete canonicalUpdateResponse.client_email;
@@ -463,28 +476,26 @@ describe("CaseDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "Edit" }));
     const modal = screen.getByRole("heading", { name: "Edit Process #42" })
       .parentElement?.parentElement as HTMLElement;
-    await user.click(within(modal).getByRole("button", { name: "🔥 Urgent" }));
-    const quotedInput = within(modal).getByDisplayValue("1500000");
-    await user.clear(quotedInput);
-    await user.type(quotedInput, "2000000");
+    await user.selectOptions(
+      within(modal).getAllByRole("combobox")[1],
+      "asya@balizero.com",
+    );
+    fireEvent.change(within(modal).getByDisplayValue("2026-02-01"), {
+      target: { value: "2026-03-15" },
+    });
     await user.click(
       within(modal).getByRole("button", { name: "Save Changes" }),
     );
 
     await waitFor(() => {
       expect(mocks.updatePractice).toHaveBeenCalledWith(42, {
-        priority: "urgent",
-        quoted_price: 2_000_000,
+        assigned_to: "asya@balizero.com",
+        start_date: "2026-03-15",
       });
     });
     expect(mocks.getPractice).toHaveBeenCalledTimes(1);
     expect(mocks.invalidateClient).toHaveBeenCalledTimes(1);
-    expect(
-      screen.getByRole("button", { name: "Cycle priority" }),
-    ).toHaveTextContent("urgent");
-    expect(
-      screen.getByRole("button", { name: "Edit quoted price" }),
-    ).toHaveTextContent("Rp 2.000.000");
+    expect(screen.getByText("Asya")).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "KITAS APPLICATION #42" }),
     ).toBeInTheDocument();
@@ -494,7 +505,7 @@ describe("CaseDetailPage", () => {
     ).toHaveAttribute("href", "mailto:john@example.com");
     expect(mocks.trackCaseUpdate).toHaveBeenCalledWith(
       42,
-      ["priority", "quoted_price"],
+      ["assigned_to", "start_date"],
       "details",
       profile.email,
     );
@@ -515,7 +526,7 @@ describe("CaseDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "Edit" }));
     const modal = screen.getByRole("heading", { name: "Edit Process #42" })
       .parentElement?.parentElement as HTMLElement;
-    await user.selectOptions(within(modal).getAllByRole("combobox")[2], "");
+    await user.selectOptions(within(modal).getAllByRole("combobox")[1], "");
     await user.clear(within(modal).getByDisplayValue("2026-02-01"));
     await user.click(
       within(modal).getByRole("button", { name: "Save Changes" }),
@@ -580,7 +591,10 @@ describe("CaseDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "Edit" }));
     const modal = screen.getByRole("heading", { name: "Edit Process #42" })
       .parentElement?.parentElement as HTMLElement;
-    await user.click(within(modal).getByRole("button", { name: "↑ High" }));
+    await user.selectOptions(
+      within(modal).getAllByRole("combobox")[1],
+      "asya@balizero.com",
+    );
     await user.click(
       within(modal).getByRole("button", { name: "Save Changes" }),
     );
@@ -600,7 +614,10 @@ describe("CaseDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "Edit" }));
     const modal = screen.getByRole("heading", { name: "Edit Process #42" })
       .parentElement?.parentElement as HTMLElement;
-    await user.click(within(modal).getByRole("button", { name: "↑ High" }));
+    await user.selectOptions(
+      within(modal).getAllByRole("combobox")[1],
+      "asya@balizero.com",
+    );
     await user.click(
       within(modal).getByRole("button", { name: "Save Changes" }),
     );
@@ -613,7 +630,10 @@ describe("CaseDetailPage", () => {
     });
   });
 
-  it("offers copy/contact actions and deletes a confirmed process", async () => {
+  it("offers a copy-link action and deletes a confirmed process", async () => {
+    // WhatsApp/Email/profile were removed from this menu (kita-prune lot 6):
+    // the Client Information card is now the single instance for all three,
+    // covered by the "renders process, client and assigned-team data" test.
     const user = await renderLoaded();
 
     await user.click(screen.getByRole("button", { name: "More options" }));
@@ -622,13 +642,6 @@ describe("CaseDetailPage", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "Copied",
       "Process link copied to clipboard",
-    );
-
-    await user.click(screen.getByRole("button", { name: "More options" }));
-    await user.click(screen.getByRole("button", { name: "WhatsApp client" }));
-    expect(window.open).toHaveBeenCalledWith(
-      "https://wa.me/62812345?text=Hi John Doe, regarding your process...",
-      "_blank",
     );
 
     await user.click(screen.getByRole("button", { name: "More options" }));

--- a/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
@@ -14,7 +14,6 @@ import {
   AlertCircle,
   Loader2,
   FileText,
-  MessageCircle,
   MoreVertical,
   Edit,
   Trash2,
@@ -110,12 +109,11 @@ export default function CaseDetailPage() {
   // Edit modal state
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  // Reduced to status + assignee + start date (kita-prune lot 6): priority,
+  // payment status and price already have their own inline editors on this
+  // page, so the modal no longer duplicates them.
   const [editForm, setEditForm] = useState({
     status: "",
-    priority: "",
-    payment_status: "",
-    quoted_price: "",
-    actual_price: "",
     assigned_to: "",
     start_date: "",
   });
@@ -425,10 +423,6 @@ export default function CaseDetailPage() {
 
     setEditForm({
       status: practice.status || "",
-      priority: practice.priority || "normal",
-      payment_status: practice.payment_status || "unpaid",
-      quoted_price: practice.quoted_price?.toString() || "",
-      actual_price: practice.actual_price?.toString() || "",
       assigned_to: practice.assigned_to || "",
       start_date: practice.start_date ? practice.start_date.split("T")[0] : "",
     });
@@ -455,23 +449,6 @@ export default function CaseDetailPage() {
 
       if (editForm.status && editForm.status !== practice.status)
         updates.status = editForm.status;
-      if (editForm.priority && editForm.priority !== practice.priority)
-        updates.priority = editForm.priority;
-      if (
-        editForm.payment_status &&
-        editForm.payment_status !== practice.payment_status
-      )
-        updates.payment_status = editForm.payment_status;
-      if (
-        editForm.quoted_price &&
-        Number(editForm.quoted_price) !== practice.quoted_price
-      )
-        updates.quoted_price = Number(editForm.quoted_price);
-      if (
-        editForm.actual_price &&
-        Number(editForm.actual_price) !== practice.actual_price
-      )
-        updates.actual_price = Number(editForm.actual_price);
       if (editForm.assigned_to !== (practice.assigned_to || ""))
         updates.assigned_to = editForm.assigned_to || null;
       const currentStartDate = practice.start_date
@@ -489,11 +466,7 @@ export default function CaseDetailPage() {
       }
 
       const fieldsUpdated = Object.keys(updates);
-      const updateType = updates.status
-        ? "status"
-        : updates.payment_status
-          ? "payment"
-          : "details";
+      const updateType = updates.status ? "status" : "details";
 
       // Log pre-request details
       logger.info(`Attempting to update case ${caseId}`, {
@@ -505,7 +478,7 @@ export default function CaseDetailPage() {
       const updatedPractice = await api.crm.updatePractice(caseId, updates);
       const apiDuration = performance.now() - apiStart;
       casesMetrics.trackApiCall(
-        "/api/crm/practices/update",
+        `/api/crm/practices/${caseId}/`,
         "PATCH",
         true,
         apiDuration,
@@ -530,7 +503,7 @@ export default function CaseDetailPage() {
     } catch (err) {
       const apiDuration = performance.now() - apiStart;
       casesMetrics.trackApiCall(
-        "/api/crm/practices/update",
+        `/api/crm/practices/${caseId}/`,
         "PATCH",
         false,
         apiDuration,
@@ -702,28 +675,9 @@ export default function CaseDetailPage() {
             <ArrowLeft className="w-4 h-4" />
             <span>Back</span>
           </button>
-          {practice.client_id && (
-            <>
-              <span
-                style={{ color: "var(--bz-text-2)" }}
-                className="opacity-30"
-              >
-                /
-              </span>
-              <button
-                onClick={() =>
-                  router.push(`/clients/${practice.client_id}?tab=process`)
-                }
-                className="flex items-center gap-1.5 transition-colors text-sm"
-                style={{ color: "var(--bz-text-2)" }}
-              >
-                <User className="w-3.5 h-3.5" />
-                <span>
-                  {practice.client_name || `Client #${practice.client_id}`}
-                </span>
-              </button>
-            </>
-          )}
+          {/* Client link lives in the Client Information card below — the
+              primary, main-content instance (kita-prune lot 6: this
+              breadcrumb duplicated the same /clients/{id} navigation). */}
         </div>
 
         <div className="flex items-start justify-between">
@@ -794,54 +748,9 @@ export default function CaseDetailPage() {
           </div>
 
           <div className="flex items-center gap-2">
-            {practice.payment_status !== undefined && (
-              <button
-                onClick={cyclePaymentStatus}
-                disabled={isUpdatingPayment}
-                title="Click to cycle payment status: unpaid → partial → paid"
-                aria-label="Cycle payment status"
-                className="flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded-lg transition-all disabled:opacity-50"
-                style={{
-                  background:
-                    practice.payment_status === "paid"
-                      ? "color-mix(in srgb, var(--state-success) 12%, transparent)"
-                      : practice.payment_status === "partial"
-                        ? "color-mix(in srgb, var(--state-warning) 12%, transparent)"
-                        : "color-mix(in srgb, var(--state-danger) 12%, transparent)",
-                  color:
-                    practice.payment_status === "paid"
-                      ? "var(--state-success)"
-                      : practice.payment_status === "partial"
-                        ? "var(--state-warning)"
-                        : "var(--state-danger)",
-                  border:
-                    practice.payment_status === "paid"
-                      ? "1px solid color-mix(in srgb, var(--state-success) 25%, transparent)"
-                      : practice.payment_status === "partial"
-                        ? "1px solid color-mix(in srgb, var(--state-warning) 25%, transparent)"
-                        : "1px solid color-mix(in srgb, var(--state-danger) 25%, transparent)",
-                }}
-              >
-                {isUpdatingPayment ? (
-                  <Loader2 className="w-3 h-3 animate-spin" />
-                ) : (
-                  <span
-                    className="w-1.5 h-1.5 rounded-full"
-                    style={{
-                      background:
-                        practice.payment_status === "paid"
-                          ? "var(--state-success)"
-                          : practice.payment_status === "partial"
-                            ? "var(--state-warning)"
-                            : "var(--state-danger)",
-                    }}
-                  />
-                )}
-                <span className="capitalize">
-                  {practice.payment_status || "unpaid"}
-                </span>
-              </button>
-            )}
+            {/* Payment status is edited from the Process Details card below
+                (kita-prune lot 6: this header duplicated the same cycle
+                button/state, `cyclePaymentStatus`, with no distinct role). */}
             {(practice.actual_price || practice.quoted_price) && (
               <div
                 className="flex items-center gap-1.5 text-xs font-semibold px-2.5 py-1.5 rounded-lg tabular-nums"
@@ -895,49 +804,8 @@ export default function CaseDetailPage() {
                     <FileText className="w-3.5 h-3.5 opacity-60" />
                     Copy link
                   </button>
-                  {practice?.client_phone && (
-                    <button
-                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--bz-text-1)] hover:bg-[var(--bz-card)] transition-colors"
-                      onClick={() => {
-                        const phone = practice.client_phone?.replace(/\D/g, "");
-                        window.open(
-                          `https://wa.me/${phone}?text=Hi ${practice.client_name}, regarding your process...`,
-                          "_blank",
-                        );
-                        setShowMoreMenu(false);
-                      }}
-                    >
-                      <MessageCircle className="w-3.5 h-3.5 text-[var(--accent-whatsapp)]" />
-                      WhatsApp client
-                    </button>
-                  )}
-                  {practice?.client_email && (
-                    <button
-                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--bz-text-1)] hover:bg-[var(--bz-card)] transition-colors"
-                      onClick={() => {
-                        window.open(
-                          `mailto:${practice.client_email}`,
-                          "_blank",
-                        );
-                        setShowMoreMenu(false);
-                      }}
-                    >
-                      <Mail className="w-3.5 h-3.5 text-[var(--state-info)]" />
-                      Email client
-                    </button>
-                  )}
-                  {practice?.client_id && (
-                    <button
-                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--bz-text-1)] hover:bg-[var(--bz-card)] transition-colors"
-                      onClick={() => {
-                        router.push(`/clients/${practice.client_id}`);
-                        setShowMoreMenu(false);
-                      }}
-                    >
-                      <User className="w-3.5 h-3.5 opacity-60" />
-                      View client profile
-                    </button>
-                  )}
+                  {/* WhatsApp/Email/profile actions live in the Client
+                      Information card (main content, kita-prune lot 6). */}
                   <div className="my-1 border-t border-[var(--bz-border)]" />
                   <button
                     className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--state-danger)] hover:bg-[color-mix(in_srgb,var(--state-danger)_10%,transparent)] transition-colors"
@@ -1170,22 +1038,12 @@ export default function CaseDetailPage() {
                 >
                   Client ID
                 </label>
-                <button
-                  onClick={() => {
-                    casesMetrics.trackButtonClick(
-                      "Client ID Link",
-                      "CasesDetailPage",
-                      caseId || undefined,
-                      `/clients/${practice.client_id}`,
-                      userEmail.current || undefined,
-                    );
-                    router.push(`/clients/${practice.client_id}`);
-                  }}
-                  className="hover:underline font-medium"
+                <p
+                  className="font-medium"
                   style={{ color: "var(--bz-accent)" }}
                 >
                   #{practice.client_id}
-                </button>
+                </p>
               </div>
 
               {practice.client_email && (
@@ -1798,82 +1656,10 @@ export default function CaseDetailPage() {
 
         {/* Sidebar */}
         <div className="space-y-6">
-          {/* Quick Actions */}
-          <div
-            className="rounded-xl p-6"
-            style={{
-              border: "1px solid var(--bz-border)",
-              background: "var(--bz-card)",
-            }}
-          >
-            <h3
-              className="text-lg font-semibold mb-4"
-              style={{ color: "var(--bz-text-1)" }}
-            >
-              Quick Actions
-            </h3>
-            <div className="space-y-2">
-              {practice.client_phone && (
-                <Button
-                  variant="outline"
-                  className="w-full justify-start"
-                  onClick={() => {
-                    casesMetrics.trackQuickAction(
-                      "whatsapp",
-                      caseId || 0,
-                      "CasesDetailPage",
-                      userEmail.current || undefined,
-                    );
-                    const phone = practice.client_phone?.replace(/\D/g, "");
-                    window.open(
-                      `https://wa.me/${phone}?text=Hi ${practice.client_name}, regarding your process...`,
-                      "_blank",
-                    );
-                  }}
-                >
-                  <MessageCircle className="w-4 h-4 mr-2" />
-                  WhatsApp Client
-                </Button>
-              )}
-
-              {practice.client_email && (
-                <Button
-                  variant="outline"
-                  className="w-full justify-start"
-                  onClick={() => {
-                    casesMetrics.trackQuickAction(
-                      "email",
-                      caseId || 0,
-                      "CasesDetailPage",
-                      userEmail.current || undefined,
-                    );
-                    window.open(`mailto:${practice.client_email}`, "_blank");
-                  }}
-                >
-                  <Mail className="w-4 h-4 mr-2" />
-                  Email Client
-                </Button>
-              )}
-
-              <Button
-                variant="outline"
-                className="w-full justify-start"
-                onClick={() => {
-                  casesMetrics.trackButtonClick(
-                    "View Client Profile",
-                    "CasesDetailPage",
-                    caseId || undefined,
-                    `/clients/${practice.client_id}`,
-                    userEmail.current || undefined,
-                  );
-                  router.push(`/clients/${practice.client_id}`);
-                }}
-              >
-                <User className="w-4 h-4 mr-2" />
-                View Client Profile
-              </Button>
-            </div>
-          </div>
+          {/* Quick Actions card removed (kita-prune lot 6): its three
+              buttons (WhatsApp, Email, View Client Profile) duplicated the
+              Client Information card in the main content column, which is
+              the primary instance for all three. */}
 
           {/* Required Documents */}
           {caseId && <RequiredDocumentsCard practiceId={caseId} />}
@@ -2052,158 +1838,6 @@ export default function CaseDetailPage() {
                 </select>
               </div>
 
-              {/* Priority */}
-              <div className="space-y-2">
-                <label
-                  className="text-sm font-medium"
-                  style={{ color: "var(--bz-text-1)" }}
-                >
-                  Priority
-                </label>
-                <div className="flex gap-2">
-                  {(
-                    [
-                      {
-                        value: "normal",
-                        label: "Normal",
-                        color: "var(--bz-text-2)",
-                        activeBg:
-                          "color-mix(in srgb, var(--bz-text-2) 20%, transparent)",
-                        activeBorder:
-                          "color-mix(in srgb, var(--bz-text-2) 40%, transparent)",
-                      },
-                      {
-                        value: "high",
-                        label: "↑ High",
-                        color: "var(--state-warning)",
-                        activeBg:
-                          "color-mix(in srgb, var(--state-warning) 20%, transparent)",
-                        activeBorder:
-                          "color-mix(in srgb, var(--state-warning) 40%, transparent)",
-                      },
-                      {
-                        value: "urgent",
-                        label: "🔥 Urgent",
-                        color: "var(--state-danger)",
-                        activeBg:
-                          "color-mix(in srgb, var(--state-danger) 20%, transparent)",
-                        activeBorder:
-                          "color-mix(in srgb, var(--state-danger) 40%, transparent)",
-                      },
-                    ] as const
-                  ).map((p) => (
-                    <button
-                      key={p.value}
-                      type="button"
-                      onClick={() =>
-                        setEditForm((prev) => ({ ...prev, priority: p.value }))
-                      }
-                      className="flex-1 py-2 rounded-lg text-sm font-medium transition-colors"
-                      style={
-                        editForm.priority === p.value
-                          ? {
-                              background: p.activeBg,
-                              border: `1px solid ${p.activeBorder}`,
-                              color: p.color,
-                            }
-                          : {
-                              background: "var(--bz-card)",
-                              border: "1px solid var(--bz-border)",
-                              color: "var(--bz-text-2)",
-                            }
-                      }
-                    >
-                      {p.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Payment Status */}
-              <div className="space-y-2">
-                <label
-                  className="text-sm font-medium"
-                  style={{ color: "var(--bz-text-1)" }}
-                >
-                  Payment Status
-                </label>
-                <select
-                  value={editForm.payment_status}
-                  onChange={(e) =>
-                    setEditForm((prev) => ({
-                      ...prev,
-                      payment_status: e.target.value,
-                    }))
-                  }
-                  className="w-full px-3 py-2 rounded-lg focus:outline-none"
-                  style={{
-                    border: "1px solid var(--bz-border)",
-                    background: "var(--bz-card)",
-                    color: "var(--bz-text-1)",
-                  }}
-                >
-                  <option value="unpaid">Unpaid</option>
-                  <option value="partial">Partial</option>
-                  <option value="paid">Paid</option>
-                </select>
-              </div>
-
-              {/* Quoted Price */}
-              <div className="space-y-2">
-                <label
-                  className="text-sm font-medium"
-                  style={{ color: "var(--bz-text-1)" }}
-                >
-                  Quoted Price (IDR)
-                </label>
-                <input
-                  type="number"
-                  value={editForm.quoted_price}
-                  onChange={(e) =>
-                    setEditForm((prev) => ({
-                      ...prev,
-                      quoted_price: e.target.value,
-                    }))
-                  }
-                  className="w-full px-3 py-2 rounded-lg focus:outline-none"
-                  style={{
-                    border: "1px solid var(--bz-border)",
-                    background: "var(--bz-card)",
-                    color: "var(--bz-text-1)",
-                  }}
-                  placeholder="0.00"
-                  step="0.01"
-                />
-              </div>
-
-              {/* Actual Price */}
-              <div className="space-y-2">
-                <label
-                  className="text-sm font-medium"
-                  style={{ color: "var(--bz-text-1)" }}
-                >
-                  Actual Price (IDR)
-                </label>
-                <input
-                  type="number"
-                  value={editForm.actual_price}
-                  onChange={(e) =>
-                    setEditForm((prev) => ({
-                      ...prev,
-                      actual_price: e.target.value,
-                    }))
-                  }
-                  className="w-full px-3 py-2 rounded-lg focus:outline-none"
-                  style={{
-                    border: "1px solid var(--bz-border)",
-                    background: "var(--bz-card)",
-                    color: "var(--bz-text-1)",
-                  }}
-                  placeholder="0.00"
-                  step="0.01"
-                />
-              </div>
-
               {/* Assigned To */}
               <div className="space-y-2">
                 <label
@@ -2228,9 +1862,11 @@ export default function CaseDetailPage() {
                   }}
                 >
                   <option value="">— unassigned —</option>
-                  <option value="zero@balizero.com">Zero</option>
-                  <option value="asya@balizero.com">Asya</option>
-                  <option value="antonellosiano@gmail.com">Antonello</option>
+                  {teamMemberOptions.map((member) => (
+                    <option key={member.value} value={member.value}>
+                      {member.label}
+                    </option>
+                  ))}
                 </select>
               </div>
 

--- a/apps/mouth/src/app/(workspace)/process/__tests__/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/process/__tests__/page.test.tsx
@@ -48,6 +48,7 @@ vi.mock("@/lib/api", () => ({
     getProfile: vi.fn(),
     crm: {
       getPractices: vi.fn(),
+      getPracticeTypesCatalog: vi.fn(),
     },
   },
 }));
@@ -138,6 +139,27 @@ describe("Cases Page", () => {
     localStorage.clear();
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(api.crm.getPractices).mockResolvedValue(mockPractices);
+    // Process Type filter now reads the live catalog (kita-prune lot 6)
+    // instead of a hardcoded legacy list; one category/service is enough
+    // to exercise the dropdown, and its code matches mockPractices above.
+    vi.mocked(api.crm.getPracticeTypesCatalog).mockResolvedValue({
+      categories: [
+        {
+          code: "kitas",
+          label: "KITAS Permits",
+          services: [
+            {
+              code: "kitas_application",
+              name: "KITAS Application",
+              description: null,
+              base_price: null,
+              typical_duration_days: null,
+            },
+          ],
+        },
+      ],
+      total_services: 1,
+    });
     vi.mocked(api.getProfile).mockResolvedValue({
       id: "1",
       email: "zero@balizero.com",
@@ -537,7 +559,12 @@ describe("Cases Page", () => {
       await user.selectOptions(statusSelect, "inquiry");
 
       const typeSelect = screen.getByLabelText(/Process Type/i);
-      await user.selectOptions(typeSelect, "kitas");
+      await waitFor(() => {
+        expect(
+          within(typeSelect).getByText("KITAS Application"),
+        ).toBeInTheDocument();
+      });
+      await user.selectOptions(typeSelect, "kitas_application");
 
       await waitFor(() => {
         // Filter count badge should show "2"

--- a/apps/mouth/src/app/(workspace)/process/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/page.tsx
@@ -143,6 +143,19 @@ type SortField =
   | "updated_at";
 type SortOrder = "asc" | "desc";
 
+// Practice type catalog — mirrors GET /api/crm/practices/types/catalog
+// (same shape consumed by process/new/page.tsx and SelectServiceCard.tsx).
+interface CatalogService {
+  code: string;
+  name: string;
+}
+
+interface CatalogCategory {
+  code: string;
+  label: string;
+  services: CatalogService[];
+}
+
 interface FilterState {
   status: string;
   type: string;
@@ -233,6 +246,9 @@ export default function PratichePage() {
   const [sortField, setSortField] = useState<SortField>("created_at");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   const [currentUserEmail, setCurrentUserEmail] = useState<string>("");
+  // Process Type filter options — live catalog, replacing the migration-066
+  // legacy codes that used to empty the list on selection (kita-prune lot 6).
+  const [typeCatalog, setTypeCatalog] = useState<CatalogCategory[]>([]);
 
   // Context Menu State
   const [selectedPractice, setSelectedPractice] = useState<Practice | null>(
@@ -323,6 +339,22 @@ export default function PratichePage() {
 
     loadPractices();
   }, [selectedMonth]);
+
+  useEffect(() => {
+    // Live "Process Type" filter options — same catalog endpoint the
+    // process-creation form uses, so the dropdown never lists a code the
+    // state machine has retired.
+    api.crm
+      .getPracticeTypesCatalog()
+      .then((data) => setTypeCatalog(data.categories))
+      .catch((err: unknown) => {
+        logger.error(
+          "[Process] Failed to load practice types catalog",
+          { component: "Process", action: "loadTypeCatalog" },
+          toError(err),
+        );
+      });
+  }, []);
 
   // Track + persist view mode changes
   useEffect(() => {
@@ -807,22 +839,9 @@ export default function PratichePage() {
           // raw `+` would string-concat and corrupt the running sum to NaN.
           const amountOf = (p: Practice) =>
             Number(p.actual_price ?? p.quoted_price ?? 0);
-          const unpaidRevenue = filteredPractices
-            .filter(
-              (p) =>
-                p.payment_status === "unpaid" || p.payment_status === "partial",
-            )
-            .reduce((s, p) => s + amountOf(p), 0);
           const totalRevenue = filteredPractices
             .filter((p) => p.payment_status === "paid")
             .reduce((s, p) => s + Number(p.paid_amount ?? amountOf(p)), 0);
-          const expiringCount = practices.filter((p) => {
-            if (!p.expiry_date) return false;
-            const d = Math.ceil(
-              (new Date(p.expiry_date).getTime() - Date.now()) / 86400000,
-            );
-            return d >= 0 && d <= 30;
-          }).length;
           return (
             <div className="flex flex-wrap gap-2 text-xs">
               <span className="flex items-center gap-1 px-2.5 py-1 rounded-full bg-[var(--surface-raised)] border border-[var(--bz-border)] text-[var(--bz-text-2)]">
@@ -850,40 +869,6 @@ export default function PratichePage() {
                   aria-label="Filter paid practices"
                 >
                   <Money compact value={totalRevenue} /> paid
-                </button>
-              )}
-              {unpaidRevenue > 0 && (
-                <button
-                  onClick={() =>
-                    setFilters((f) => ({
-                      ...f,
-                      payment_filter:
-                        f.payment_filter === "unpaid" ? "" : "unpaid",
-                    }))
-                  }
-                  className={`flex items-center gap-1 px-2.5 py-1 rounded-full border transition-colors ${
-                    filters.payment_filter === "unpaid"
-                      ? "bg-[color-mix(in_srgb,var(--state-danger)_25%,transparent)] border-[color-mix(in_srgb,var(--state-danger)_50%,transparent)] text-[var(--state-danger)]"
-                      : "bg-[color-mix(in_srgb,var(--state-danger)_10%,transparent)] border-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] text-[var(--state-danger)] hover:bg-[color-mix(in_srgb,var(--state-danger)_20%,transparent)]"
-                  }`}
-                  title="Click to filter unpaid practices"
-                  aria-label="Filter unpaid practices"
-                >
-                  <Money compact value={unpaidRevenue} /> unpaid
-                </button>
-              )}
-              {expiringCount > 0 && (
-                <button
-                  onClick={() =>
-                    setFilters((f) => ({ ...f, expiring: !f.expiring }))
-                  }
-                  className={`flex items-center gap-1 px-2.5 py-1 rounded-full border transition-colors ${
-                    filters.expiring
-                      ? "bg-[color-mix(in_srgb,var(--state-warning)_20%,transparent)] border-[color-mix(in_srgb,var(--state-warning)_40%,transparent)] text-[var(--state-warning)]"
-                      : "bg-[color-mix(in_srgb,var(--state-warning)_10%,transparent)] border-[color-mix(in_srgb,var(--state-warning)_20%,transparent)] text-[var(--state-warning)] hover:bg-[color-mix(in_srgb,var(--state-warning)_20%,transparent)]"
-                  }`}
-                >
-                  ⏰ {expiringCount} expiring
                 </button>
               )}
             </div>
@@ -1057,10 +1042,7 @@ export default function PratichePage() {
               <option value="inquiry">Inquiry</option>
               <option value="waiting_documents">Waiting Documents</option>
               <option value="sending_invoice">Sending Invoice</option>
-              <option value="waiting_payment">Waiting Payment</option>
               <option value="on_process">On Process</option>
-              <option value="submitted_to_gov">Submitted to Gov</option>
-              <option value="approved">Approved</option>
               <option value="completed">Completed</option>
             </FilterSelect>
             <FilterSelect
@@ -1071,14 +1053,15 @@ export default function PratichePage() {
               selectClassName={FILTER_SELECT_CLASS}
             >
               <option value="">All types</option>
-              <option value="kitas">KITAS Work Permit</option>
-              <option value="extension_kitas">KITAS Extension</option>
-              <option value="visa">Visa</option>
-              <option value="extension_visa">Visa Extension</option>
-              <option value="new_pt">PT PMA Setup</option>
-              <option value="revision_pt">PT Revision</option>
-              <option value="tax">Tax Consulting</option>
-              <option value="accessories">Accessories</option>
+              {typeCatalog.map((cat) => (
+                <optgroup key={cat.code} label={cat.label}>
+                  {cat.services.map((svc) => (
+                    <option key={svc.code} value={svc.code}>
+                      {svc.name}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
             </FilterSelect>
             <FilterSelect
               id="assigned-to-filter"

--- a/evidence/2026-09/agent-air-m5-frontend-kita-prune-lot6-c-ec5903a5/brief.yml
+++ b/evidence/2026-09/agent-air-m5-frontend-kita-prune-lot6-c-ec5903a5/brief.yml
@@ -1,0 +1,77 @@
+task_id: kita-prune-lot6-c-process
+gear: 2
+l_level: L2
+gate_class: opus
+base_sha: aa9a28b235604d76c172334fb9242d9cd2e66477 # pragma: allowlist secret
+# Floor for this diff: 2, source `size`. Churn 611 lines over 4 files (135 added, 476 deleted),
+# below SIZE_GEAR3_THRESHOLD. No hot-zone path, no PII path, no ground-truth path.
+objective: >-
+  Lot 6 PR-C of the kita.balizero.com surface pruning (audit shared with the owner on
+  2026-09-12): on /process, replace the hardcoded 8-code "Process Type" filter (codes
+  migration-066 disabled, so selecting one emptied the list) with the live
+  GET /api/crm/practices/types/catalog catalog, and drop the 3 "Status" filter options that
+  never matched a real kanban column; remove the two quick-stat chips that duplicated filter
+  chips below them. On /process/[id], reduce the Edit modal to status + assignee + start date
+  (dropping the priority/payment/price fields it duplicated from inline editors), wire the
+  assignee dropdown to the already-loaded useTeamMemberOptions instead of 3 hardcoded emails,
+  fix a mislabeled trackApiCall route string, and collapse the client-profile (5 instances),
+  WhatsApp (3), Email (3) and payment-status-cycle (2, post modal fix) duplicates down to one
+  primary instance each.
+constraints:
+  - >-
+    Deletions and reductions only, one concern per commit (2 commits, page.tsx + its test each).
+    No new feature, no redesign, no backend change. The one narrow exception the mandate
+    allowed: wiring the already-existing `api.crm.getPracticeTypesCatalog()` client method
+    (verified present, zero new client code needed) to the filter is a bugfix, not a feature.
+  - >-
+    The live-catalog route and the canonical 6-state status list were verified on disk before
+    use, not assumed: `grep -n "types/catalog" apps/backend-rag/backend/app/routers/*.py` found
+    the route, and `apps/mouth/src/lib/api/crm/state-machine.ts` was the pre-existing frontend
+    mirror of the backend state machine.
+  - >-
+    "Most prominent" for the 5/3/3/2 duplicate groups was judged as: main content area over
+    menu/sidebar/breadcrumb chrome. The choice and the exact removed locations are recorded in
+    the PR body's "Kept on purpose" section for the codeowner to challenge if wrong.
+appetite:
+  wall_clock_hours: 2
+  adversarial_rounds: 1
+  tokens: 400000
+acceptance:
+  - text: >-
+      A1: WHEN `tsc --noEmit` runs in apps/mouth on this head SHALL exit 0.
+    probe: cd apps/mouth && npx tsc --noEmit
+  - text: >-
+      A2: WHEN the mouth unit suite runs with its own config on this head SHALL pass every file
+      touched by this PR (process/page.test.tsx, process/[id]/page.test.tsx,
+      process/new/page.test.tsx untouched and unaffected).
+    probe: cd apps/mouth && npx vitest --run --root . --config vitest.config.ts
+  - text: >-
+      A3: WHEN `npm run build` runs in apps/mouth on this head SHALL complete `next build` and
+      SHALL print PUBLIC_LOGIN_BUNDLE_OK.
+    probe: cd apps/mouth && npm run build
+  - text: >-
+      A4 Bites: WHEN an operator opens https://kita.balizero.com/process and expands Filters,
+      the Process Type dropdown SHALL list live catalog service names grouped by category
+      (never the 8 retired legacy codes), and selecting one SHALL NOT empty the list.
+    probe: manual QA on kita.balizero.com/process post-deploy (no backend change to curl)
+assumptions:
+  - text: >-
+      `api.crm.getPracticeTypesCatalog()` already existed (used by process/new/page.tsx and
+      SelectServiceCard.tsx) with the exact category/service shape the catalog endpoint
+      returns, so /process's filter needed only a fetch-on-mount + optgroup render, not a new
+      client method.
+    status: verified
+    probe: 'grep -n "getPracticeTypesCatalog" apps/mouth/src/lib/api/crm/crm.api.ts apps/mouth/src/app/(workspace)/process/new/page.tsx'
+  - text: >-
+      The 3 removed Status filter options (waiting_payment, submitted_to_gov, approved) never
+      matched any practice: matchesStatusFilter() in kanban-colors.ts compares the selected
+      filter value directly against getStatusColumn()'s 5-value output, which those 3 strings
+      never equal.
+    status: verified
+    probe: "cat apps/mouth/src/components/process/kanban-colors.ts — matchesStatusFilter/getStatusColumn"
+  - text: >-
+      The footer "Pro Tip: right-click or use the menu on cards..." on /process is NOT
+      decorative (the audit's guess): the context menu it describes is wired via onContextMenu
+      on both the kanban card and the list row.
+    status: verified
+    probe: 'grep -n "onContextMenu" "apps/mouth/src/app/(workspace)/process/page.tsx"'


### PR DESCRIPTION
## What

- `/process`: replace the hardcoded 8-code "Process Type" filter (migration-066 disabled codes, so picking one always emptied the list) with `GET /api/crm/practices/types/catalog` via the already-existing `api.crm.getPracticeTypesCatalog()` client method, rendered as grouped `<optgroup>`s.
- `/process`: remove the 3 "Status" filter options (`waiting_payment`, `submitted_to_gov`, `approved`) that `matchesStatusFilter`/`getStatusColumn` (in `kanban-colors.ts`) can never match — keeping the 5 values that do.
- `/process`: remove the "unpaid" and "expiring" quick-stat chips — verified duplicates of the "Unpaid"/"Expiring 30d" filter chips below them (same `setFilters` toggle, same state).
- `/process/[id]`: reduce the Edit modal to status + assignee + start date, dropping the priority/payment-status/quoted-price/actual-price fields that duplicated the page's own inline editors.
- `/process/[id]`: wire the modal's assignee dropdown to `useTeamMemberOptions` (already loaded on this page at line 104) instead of 3 hardcoded emails.
- `/process/[id]`: fix `casesMetrics.trackApiCall`'s label — it said `/api/crm/practices/update`, but `crm.api.ts::updatePractice` actually calls `` `/api/crm/practices/${id}/` `` (PATCH).
- `/process/[id]`: collapse the client-profile link (was reachable 5 ways), WhatsApp (3 ways) and Email (3 ways) down to one instance each; collapse the payment-status cycle button (2 ways, post modal fix) down to one.

## Kept on purpose

- **Client profile link** — kept the Client Information card's "Client Name" button (main content area, primary). Removed: the header breadcrumb link (`?tab=process` variant — chrome, not main content), the more-menu "View client profile" item, and the entire sidebar "Quick Actions" card's "View Client Profile" button. The Client Info card's separate "Client ID" button, which pointed at the exact same route, is now plain text instead of a second identical link.
- **WhatsApp** — kept the Client Information card's `wa.me` link (main content). Removed the more-menu "WhatsApp client" item and the sidebar Quick Actions "WhatsApp Client" button.
- **Email** — kept the Client Information card's `mailto:` link (main content). Removed the more-menu "Email client" item and the sidebar Quick Actions "Email Client" button.
- **Payment-status cycle** — kept the "Process Details" card's cycle button (the same card Priority is cycled from — the one systematic location for editable fields). Removed the header badge, which called the identical `cyclePaymentStatus` handler with no distinct role.
- The sidebar "Quick Actions" card held only the three now-consolidated buttons, so the whole card is gone (not just individually neutered).
- **Kept the "Pro Tip: right-click..." footer on `/process`** — the audit guessed it was decorative, but it is not: the context menu it describes is wired via `onContextMenu` on both the kanban card and the list row. Verified before touching, then left alone.
- **Left `STATUS_OPTIONS`** (the context-menu "Update Status" list, `/process/page.tsx`) untouched — it deliberately keeps legacy status values for backward-compat relabeling of old practices; that's a different concern from the Status *filter* dropdown this PR fixes.

## Verification

- `npx tsc --noEmit` — exit 0.
- `npx vitest --run --root . --config vitest.config.ts` — exit 0 (full suite; scoped `process/` run: 3 files / 59 tests passed).
- `npm run build` — exit 0, printed `PUBLIC_LOGIN_BUNDLE_OK`.

## Bites

Consumer: kita.balizero.com operators managing processes (`/process`, `/process/[id]`). Post-deploy proof: the Process Type filter on `/process` lists live catalog service names grouped by category and selecting one no longer empties the list; the Edit modal on `/process/[id]` shows only Status/Assignee/Start Date, and its assignee dropdown lists real team members instead of 3 fixed addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
