### PR TITLE
feat(visaoracle): dedicated EN/ID copy for every review-reason code (PR-O2)

### DIFF
--- a/apps/mouth/e2e/visa-oracle-fullstack.spec.ts
+++ b/apps/mouth/e2e/visa-oracle-fullstack.spec.ts
@@ -243,16 +243,15 @@ test.describe("Visa Oracle real full-stack smoke", () => {
         name: translate("en", "verdict.headline.HUMAN_REVIEW_REQUIRED"),
       }),
     ).toBeVisible({ timeout: 30_000 });
-    // DECISIVE_SOURCE_FRESHNESS_UNKNOWN has no curated copy yet (QW-4b): it is
-    // listed in engine-adapter.test.ts's own KNOWN_UNMAPPED_REVIEW_REASON_CODES,
-    // so reviewReason() deliberately renders GENERIC_REVIEW_REASON for it, never
-    // a raw "Verified reason: <code>" dump (that fallback belongs to a different
-    // function, reasonMessage(), for candidate-eligibility reasons — review
-    // reasons never go through it). Assert the real current copy. When QW-4b
-    // lands curated text for this code, tighten this assertion to that text.
+    // DECISIVE_SOURCE_FRESHNESS_UNKNOWN has curated copy as of PR-O2 (QW-4b):
+    // it is a key in engine-adapter.ts's REVIEW_REASON_COPY, so reviewReason()
+    // renders that dedicated sentence rather than GENERIC_REVIEW_REASON (never
+    // a raw "Verified reason: <code>" dump either — that fallback belongs to a
+    // different function, reasonMessage(), for candidate-eligibility reasons —
+    // review reasons never go through it). Assert the curated text verbatim.
     await expect(
       page.getByText(
-        "Some of your answers need a person's judgment before we can confirm a path.",
+        "This result relies on a regulatory source whose currency could not be established automatically — confirming whether that source is still current is what a person must do before this result can stand.",
       ),
     ).toBeVisible({ timeout: 30_000 });
     const initialRequest = {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -806,8 +806,11 @@ describe("review reasons cover every code the current pack can emit", () => {
     // Guard the guard: a glob/parse that silently found nothing would make
     // every assertion below vacuously true. 20 pack (16 HUMAN_REVIEW-stage +
     // 4 HARD_FILTER with on_unknown=HUMAN_REVIEW, PR-O2) + 18
-    // pack-independent = 38, all of them mapped as of PR-O2.
-    expect(allRealCodes.length).toBeGreaterThanOrEqual(32);
+    // pack-independent = 38, all of them mapped as of PR-O2. Floor raised
+    // from 32 to the measured 38 (round-1 refuter finding, Gemini 3.1 Pro +
+    // Kimi K3): 32 would still pass a regression that silently dropped up
+    // to 5 real codes.
+    expect(allRealCodes.length).toBeGreaterThanOrEqual(38);
 
     const unaccounted = allRealCodes.filter(
       (code) =>

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -723,10 +723,21 @@ describe("review reasons cover every code the current pack can emit", () => {
     const codes = new Set<string>();
     for (const rule of payload.rules ?? []) {
       const effect = rule.effect as Record<string, unknown> | undefined;
+      if (!effect || typeof effect.reason_code !== "string") continue;
+      // A HUMAN_REVIEW-stage rule contributes its reason on a definite TRUE
+      // (`evaluator.py::evaluate_product`, `_true_reasons`). A HARD_FILTER
+      // rule ALSO contributes its reason — the SAME `effect.reason_code`,
+      // via `_reason_from_rule` — when its own condition is UNKNOWN and it
+      // declares `on_unknown: "HUMAN_REVIEW"`
+      // (`_partition_unknowns_by_policy` + `_reason_from_rule`,
+      // evaluator.py:355-410, 741-751): a rule author asking for human
+      // judgment on an uncertain exclusion outranks merely asking the
+      // applicant for more facts. Support-stage (ELIGIBILITY) on_unknown
+      // escalation feeds SUPPORT_REASON_COPY instead, not this map, so it is
+      // deliberately not included here.
       if (
-        rule.stage === "HUMAN_REVIEW" &&
-        effect &&
-        typeof effect.reason_code === "string"
+        rule.stage === "HUMAN_REVIEW" ||
+        (rule.stage === "HARD_FILTER" && rule.on_unknown === "HUMAN_REVIEW")
       ) {
         codes.add(effect.reason_code);
       }
@@ -778,43 +789,14 @@ describe("review reasons cover every code the current pack can emit", () => {
   // entry here stops naming a real code (renamed/retired upstream) — this
   // list is not exempt from going stale the same way REVIEW_REASON_COPY's
   // keys were.
-  const KNOWN_UNMAPPED_REVIEW_REASON_CODES = [
-    // From rulepack-prod-007+ (HUMAN_REVIEW stage):
-    "E28B_USD_THRESHOLD_MANUAL_CHECK",
-    "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK",
-    "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK",
-    "E28F_IKN_THRESHOLD_MANUAL_CHECK",
-    "E33B_EXPERTISE_QUALIFICATION_CHECK",
-    "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP",
-    // `E33G_INCOME_EVIDENCE_REVIEW` was here from the E5 increment 3 seq-9
-    // fold (2026-08-19) until the seq-20 decisiveness fold retired the rule
-    // that emitted it: `review.e33g.income-evidence`'s `when` was a
-    // byte-for-byte copy of `el.e33g.remote-work`'s, so it vetoed E33G on
-    // the product's own success condition and E33G could never be
-    // recommended (2026-09-06 investigation §2.3 L3-b). It is removed here,
-    // not merely left unmapped, because the test below fails on a gap-list
-    // entry naming a code the highest-sequence pack no longer emits.
-    "E33_WORK_RANGKAP_KEGIATAN_GATED",
-    "GOVT_INVITATION_REQUIRED",
-    // Pack-independent (evaluate_path.py):
-    "CONFLICTING_IMMIGRATION_STATUS_REVIEW",
-    "DECISIVE_PRIMARY_SOURCE_NOT_APPLICABLE",
-    "DECISIVE_SOURCE_FRESHNESS_UNKNOWN",
-    "DECISIVE_SOURCE_STALE",
-    "DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW",
-    "DISCLOSED_CRIMINAL_RECORD_REVIEW",
-    "DISCLOSED_DIPLOMATIC_PASSPORT_REVIEW",
-    "DISCLOSED_HEALTH_CONCERN_REVIEW",
-    "DISCLOSED_MULTI_PURPOSE_TRIP_REVIEW",
-    "DISCLOSED_PEP_OR_SANCTIONS_REVIEW",
-    "DISCLOSED_PRIOR_VISA_REFUSAL_REVIEW",
-    "DISCLOSED_SOURCE_OF_FUNDS_REVIEW",
-    "DISCLOSED_UNCERTAINTY_REVIEW",
-    "MINOR_GUARDIAN_PRIVACY_REVIEW",
-    "SAFETY_CRITICAL_PRIMARY_SOURCE_NOT_APPLICABLE",
-    "SAFETY_CRITICAL_SOURCE_FRESHNESS_UNKNOWN",
-    "SAFETY_CRITICAL_SOURCE_STALE",
-  ];
+  //
+  // Emptied by PR-O2 (QW-4b, D1, 2026-09-12): all 29 codes below now have
+  // dedicated copy in REVIEW_REASON_COPY. The historical note that used to
+  // sit here about `E33G_INCOME_EVIDENCE_REVIEW`'s seq-20 retirement (a
+  // THIRD, already-removed code, never part of this 29) had no entry left to
+  // attach to once the list emptied, so it went with it rather than sit
+  // orphaned in an empty array.
+  const KNOWN_UNMAPPED_REVIEW_REASON_CODES: string[] = [];
 
   it("names every code the current pack + backend can emit, mapped or in the known gap", () => {
     const allRealCodes = [
@@ -822,7 +804,9 @@ describe("review reasons cover every code the current pack can emit", () => {
       ...PACK_INDEPENDENT_REVIEW_REASON_CODES,
     ].sort();
     // Guard the guard: a glob/parse that silently found nothing would make
-    // every assertion below vacuously true. 14 pack + 18 pack-independent.
+    // every assertion below vacuously true. 20 pack (16 HUMAN_REVIEW-stage +
+    // 4 HARD_FILTER with on_unknown=HUMAN_REVIEW, PR-O2) + 18
+    // pack-independent = 38, all of them mapped as of PR-O2.
     expect(allRealCodes.length).toBeGreaterThanOrEqual(32);
 
     const unaccounted = allRealCodes.filter(

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -414,54 +414,271 @@ function reason(
 // cover yet), and every code the current pack can emit is accounted for,
 // either here or in that known-gap list.
 export const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
+  // D2-bis (owner ruling, 2026-09-12 20:50 WITA): every HUMAN_REVIEW string
+  // must (1) name the specific fact/answer, in the applicant's own terms,
+  // that the signed rules cannot decide, (2) state authoritatively that the
+  // case is held deliberately for that named reason, and (3) name what
+  // resolves it. Applies to these 9 pre-existing entries too, revised below.
   CALLING_VISA_REVIEW: text(
-    "Your nationality is on the Calling Visa list, which always requires manual review before a visa can be confirmed.",
-    "Kewarganegaraan Anda termasuk dalam daftar Calling Visa, yang selalu memerlukan peninjauan manual sebelum visa dapat dikonfirmasi.",
+    "Your nationality is on Indonesia's Calling Visa list, so this case is held for the calling-visa clearance that nationality requires before any visa can be confirmed.",
+    "Kewarganegaraan Anda termasuk dalam daftar Calling Visa Indonesia, sehingga kasus ini ditahan untuk proses persetujuan calling visa yang disyaratkan bagi kewarganegaraan tersebut sebelum visa dapat dikonfirmasi.",
   ),
   ACTIVE_OVERSTAY: text(
-    "An active overstay on record needs a person to review before any path can be confirmed.",
-    "Overstay aktif yang tercatat memerlukan peninjauan oleh seseorang sebelum jalur apa pun dapat dikonfirmasi.",
+    "You reported active overstay days on your immigration record, so a person needs to review it — clearing the overstay is what resolves it.",
+    "Anda melaporkan adanya hari overstay yang masih berjalan pada catatan keimigrasian Anda, sehingga memerlukan peninjauan oleh seseorang — menyelesaikan overstay tersebut adalah yang akan menyelesaikannya.",
   ),
   // Renamed from CITIZENSHIP_EVIDENCE_CONFLICT (QW-4a, 2026-08-17): that key
   // named no code in any pack from seq-6 onward. CITIZENSHIP_LIST_DIVERGENCE
   // is its current name (services/visa_engine/contracts/packs/
-  // rulepack-prod-007.source.json). Copy text unchanged — only the key moved.
+  // rulepack-prod-007.source.json). Fires only when the declared
+  // nationalities themselves span two different eligibility categories
+  // (rule.when, review.citizenship-conflict) — single cause, revised for
+  // D2-bis below.
   CITIZENSHIP_LIST_DIVERGENCE: text(
-    "Your answers about citizenship do not fully agree with each other and need a person to confirm.",
-    "Jawaban Anda tentang kewarganegaraan tidak sepenuhnya cocok satu sama lain dan memerlukan konfirmasi dari seseorang.",
+    "You declared more than one nationality, and they fall into different eligibility categories — a person needs to confirm which passport you will use to apply.",
+    "Anda mencantumkan lebih dari satu kewarganegaraan yang termasuk dalam kategori kelayakan yang berbeda — diperlukan konfirmasi oleh seseorang mengenai paspor mana yang akan Anda gunakan untuk mengajukan permohonan.",
   ),
+  // review.minor-without-guardian: derived.is_minor == true AND
+  // family.sponsor_confirmed == false — confirming the sponsor is the fact
+  // that resolves it (the same fact the rule tests).
   MINOR_WITHOUT_CONFIRMED_GUARDIAN: text(
-    "This case involves a minor without a confirmed guardian on file and needs a person to review it.",
-    "Kasus ini melibatkan anak di bawah umur tanpa wali yang terkonfirmasi dan memerlukan peninjauan oleh seseorang.",
+    "This case involves a minor whose sponsor has not yet been confirmed, and a person needs to review it — confirming the sponsor is what resolves it.",
+    "Kasus ini melibatkan anak di bawah umur yang sponsornya belum dikonfirmasi, dan memerlukan peninjauan oleh seseorang — konfirmasi sponsor adalah yang akan menyelesaikannya.",
   ),
-  // Wording follows the pack's own product names verbatim — "Foreign Diplomat
-  // House Assistant (E23U)" / "Asisten Rumah Tangga Diplomat Asing" and "Trade
-  // and Economic Office (E23V)" / "Kantor Dagang dan Ekonomi". An adversarial
-  // review of the first draft caught it narrowing E23V to "trade representative
-  // office", dropping "and Economic": the applicant would then be told about a
-  // category that is not the one the rule actually names.
+  // Wording follows the pack's own product names verbatim — "Working Visa —
+  // Foreign Diplomat House Assistant (E23U)" / "Visa Kerja Asisten Rumah
+  // Tangga Diplomat Asing" and "Working Visa — Trade and Economic Office
+  // (E23V)" / "Visa Kerja Kantor Dagang dan Ekonomi". An adversarial review
+  // of the first draft caught it narrowing E23V to "trade representative
+  // office", dropping "and Economic": the applicant would then be told about
+  // a category that is not the one the rule actually names. Both rules fire
+  // unconditionally for their product code (no distinguishing fact beyond
+  // the product itself), so naming the product IS the specific cause.
   E23U_DIPLOMATIC_HOUSEHOLD_STAFF_REVIEW: text(
-    "This case involves a house assistant employed by a foreign diplomat and needs a person to review it.",
-    "Kasus ini melibatkan asisten rumah tangga yang dipekerjakan oleh diplomat asing dan memerlukan peninjauan oleh seseorang.",
+    "Every application for the Working Visa — Foreign Diplomat House Assistant (E23U) is reviewed manually to confirm the household-employment relationship with the diplomat before it can be confirmed.",
+    "Setiap permohonan Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U) ditinjau secara manual untuk memastikan hubungan kerja rumah tangga dengan diplomat tersebut sebelum dapat dikonfirmasi.",
   ),
   E23V_TRADE_OFFICE_STAFF_REVIEW: text(
-    "This case involves staff of a trade and economic office and needs a person to review it.",
-    "Kasus ini melibatkan staf kantor dagang dan ekonomi dan memerlukan peninjauan oleh seseorang.",
+    "Every application for the Working Visa — Trade and Economic Office (E23V) is reviewed manually to confirm the staff relationship with that trade and economic office before it can be confirmed.",
+    "Setiap permohonan Visa Kerja Kantor Dagang dan Ekonomi (E23V) ditinjau secara manual untuk memastikan hubungan kerja dengan kantor dagang dan ekonomi tersebut sebelum dapat dikonfirmasi.",
   ),
   // Renamed from STATUS_BRIDGING_REVIEW (QW-4a, 2026-08-17): same stale
   // situation — BRIDGING_ADVERSE_HISTORY is the current name for this rule
-  // in rulepack-prod-007+. Copy text unchanged.
+  // in rulepack-prod-007+. review.bridging.adverse-history fires on ANY of 4
+  // distinct violation_history values (OVERSTAY / DEPORTATION / BLACKLIST /
+  // IMMIGRATION_INVESTIGATION) or on that fact being unknown — one code,
+  // several distinct causes with different real-world resolutions. Named all
+  // 4 rather than guessing one; flagged as a split candidate in the PR-O2
+  // report.
   BRIDGING_ADVERSE_HISTORY: text(
-    "Bridging between immigration statuses needs a person to check the timing and conditions involved.",
-    "Peralihan antar status keimigrasian memerlukan pemeriksaan oleh seseorang atas waktu dan ketentuan yang berlaku.",
+    "Your immigration record while in Indonesia shows one or more of overstay, deportation, blacklist, or an open investigation, so a person needs to check the timing and conditions before the Bridging Visa — Transitional Stay Permit can be confirmed.",
+    "Catatan keimigrasian Anda selama berada di Indonesia menunjukkan satu atau lebih dari overstay, deportasi, daftar hitam (blacklist), atau investigasi yang masih berjalan, sehingga memerlukan pemeriksaan waktu dan ketentuan oleh seseorang sebelum Izin Tinggal Peralihan dapat dipastikan.",
   ),
   LOCAL_MARKET_ACTIVITY_REVIEW: text(
-    "The activity you described needs a person to confirm it does not cross into locally reserved business.",
-    "Aktivitas yang Anda jelaskan memerlukan konfirmasi oleh seseorang agar tidak melanggar bidang usaha yang dicadangkan untuk lokal.",
+    "You said your remote work serves Indonesian clients, and the Second Home Visa — Remote Worker (E33G) is for income from outside Indonesia only — a person needs to confirm your work does not cross into locally reserved business.",
+    "Anda menyatakan bahwa pekerjaan jarak jauh Anda melayani klien di Indonesia, sedangkan Visa Rumah Kedua Pekerja Jarak Jauh (E33G) hanya untuk penghasilan dari luar Indonesia — diperlukan konfirmasi oleh seseorang bahwa pekerjaan Anda tidak melanggar bidang usaha yang dicadangkan untuk lokal.",
   ),
+  // fact-mapper.ts::hasUndecidableActivityAnswer raises this ONE code from 7
+  // distinct question ids (business_activity, investment_vehicle,
+  // retirement_basis, diaspora_connection, diaspora_documents,
+  // other_purpose, other_paid_activity) whenever any of them holds an
+  // answer value the signed pack cannot decide — the OutcomeReason carries
+  // no field to say which. Old copy ("sits close to a legal boundary") was
+  // ruled no longer acceptable (D2-bis) for being generic; named the
+  // question DIMENSIONS below as the most specific honest statement
+  // available, and flagged as a split candidate in the PR-O2 report.
   DISCLOSED_ACTIVITY_BOUNDARY_REVIEW: text(
-    "The activity you disclosed sits close to a legal boundary that needs a person to confirm.",
-    "Aktivitas yang Anda ungkapkan berada dekat batas hukum yang memerlukan konfirmasi dari seseorang.",
+    "One of your answers about your planned activity, investment vehicle, retirement basis, or diaspora connection is not one the signed rules can decide on their own, so a person needs to confirm it before a path can be confirmed.",
+    "Salah satu jawaban Anda mengenai aktivitas yang direncanakan, kendaraan investasi, dasar pensiun, atau hubungan diaspora bukan jawaban yang dapat diputuskan sendiri oleh aturan yang telah disahkan, sehingga memerlukan konfirmasi oleh seseorang sebelum jalur dapat dipastikan.",
+  ),
+
+  // --- QW-4b (PR-O2, D1): the 29 codes that previously fell back to
+  // GENERIC_REVIEW_REASON. Product names are copied verbatim from each
+  // rule's `product_version_ids` entry in rulepack-prod-020.source.json
+  // (`names.en` / `names.id`) — never shortened or re-described. Every
+  // string below is written to D2-bis's three rules too: name the specific
+  // fact, state the hold authoritatively, name what resolves it.
+
+  // 8 codes from rulepack-prod-020 (rulepack-prod-007+ lineage), stage
+  // HUMAN_REVIEW — each rule fires unconditionally for its product/purpose
+  // combination (no numeric threshold is modeled as a fact, hence "manual"),
+  // so naming the requested product IS the specific cause; the resolution is
+  // the manual check the code name itself describes.
+  E28B_USD_THRESHOLD_MANUAL_CHECK: text(
+    "You requested the Investor Golden Visa — Company Establishment (E28B), which always has its required USD investment amount checked manually — confirming that amount against your documents is what resolves it.",
+    "Anda mengajukan Visa Investor Pendirian Perusahaan (E28B), yang jumlah investasi USD yang disyaratkan selalu diperiksa secara manual — konfirmasi jumlah tersebut terhadap dokumen Anda adalah yang akan menyelesaikannya.",
+  ),
+  E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK: text(
+    "You requested the Investor Golden Visa — Capital Market (E28C), which always has its USD investment amount and financial instrument checked manually — confirming both against your documents is what resolves it.",
+    "Anda mengajukan Visa Investor Tanpa Mendirikan Perusahaan (E28C), yang jumlah investasi USD dan instrumen keuangannya selalu diperiksa secara manual — konfirmasi keduanya terhadap dokumen Anda adalah yang akan menyelesaikannya.",
+  ),
+  E28D_USD_THRESHOLD_AND_TURNOVER_CHECK: text(
+    "You requested the Investor Golden Visa — Branch or Subsidiary (E28D), which always has its USD investment amount and company turnover checked manually — confirming both against your documents is what resolves it.",
+    "Anda mengajukan Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D), yang jumlah investasi USD dan omzet perusahaannya selalu diperiksa secara manual — konfirmasi keduanya terhadap dokumen Anda adalah yang akan menyelesaikannya.",
+  ),
+  E28F_IKN_THRESHOLD_MANUAL_CHECK: text(
+    "You requested the Investor Golden Visa — New Capital (IKN) Subsidiary (E28F), which always has its IKN investment threshold checked manually — confirming that amount against your documents is what resolves it.",
+    "Anda mengajukan Visa Investor Anak Perusahaan Ibukota Nusantara (E28F), yang ambang batas investasi IKN-nya selalu diperiksa secara manual — konfirmasi jumlah tersebut terhadap dokumen Anda adalah yang akan menyelesaikannya.",
+  ),
+  E33B_EXPERTISE_QUALIFICATION_CHECK: text(
+    "You requested the Second Home Golden Visa — Special-Expertise Collaboration (E33B), which always has the applicant's expertise checked manually — confirming your qualification against your documents is what resolves it.",
+    "Anda mengajukan Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B), yang keahlian pemohonnya selalu diperiksa secara manual — konfirmasi kualifikasi Anda terhadap dokumen Anda adalah yang akan menyelesaikannya.",
+  ),
+  E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP: text(
+    "You said you have committed to PT PMA company ownership, and the Second Home Visa — Remote Worker (E33G) excludes local company ownership — a person needs to confirm your PT PMA commitment before this can be resolved.",
+    "Anda menyatakan telah berkomitmen pada kepemilikan perusahaan PT PMA, sedangkan Visa Rumah Kedua Pekerja Jarak Jauh (E33G) mengecualikan kepemilikan perusahaan lokal — diperlukan konfirmasi oleh seseorang atas komitmen PT PMA Anda sebelum hal ini dapat diselesaikan.",
+  ),
+  E33_WORK_RANGKAP_KEGIATAN_GATED: text(
+    "You selected both a Second Home Visa (E33) purpose and an employment purpose, and a person needs to confirm how the two combine before this case can be resolved.",
+    "Anda memilih tujuan Visa Rumah Kedua (E33) sekaligus tujuan bekerja, dan diperlukan konfirmasi oleh seseorang mengenai bagaimana keduanya digabungkan sebelum kasus ini dapat diselesaikan.",
+  ),
+  // Fires identically for two products (E33A, E33C) that share this reason
+  // code — both name their own product verbatim rather than picking one.
+  GOVT_INVITATION_REQUIRED: text(
+    "You requested the Second Home Visa — Special-Expertise Government Invitation (E33A) or the Second Home Golden Visa — World-Figure Government Invitation (E33C), both issued only on a central government invitation — confirming that invitation is what resolves it.",
+    "Anda mengajukan Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A) atau Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C), yang keduanya hanya diterbitkan berdasarkan undangan pemerintah pusat — konfirmasi undangan tersebut adalah yang akan menyelesaikannya.",
+  ),
+
+  // 4 codes from rulepack-prod-020, stage HARD_FILTER with
+  // `on_unknown: "HUMAN_REVIEW"` (hf.bridging.offshore / .from-visit-itk /
+  // .to-bridging / hf.b1.not-voa-nationality). When the underlying fact is
+  // KNOWN these rules EXCLUDE the product outright; when it is UNKNOWN,
+  // `evaluator.py::_partition_unknowns_by_policy` + `_reason_from_rule`
+  // escalate to REVIEW and reuse the SAME reason_code (see
+  // evaluator.py:355-410, 741-751) — so this copy must never read as an
+  // exclusion, only as a fact still to be established; naming that missing
+  // fact doubles as naming what resolves it (confirming the fact).
+  BRIDGING_ONSHORE_ONLY: text(
+    "This case is held because whether you are currently in Indonesia has not been established, which the Bridging Visa — Transitional Stay Permit requires — confirming your current location is what resolves it.",
+    "Kasus ini ditahan karena belum dapat dipastikan apakah Anda saat ini berada di Indonesia, padahal Izin Tinggal Peralihan mensyaratkan hal itu — konfirmasi lokasi Anda saat ini adalah yang akan menyelesaikannya.",
+  ),
+  BRIDGING_FROM_VISIT_ITK_PROHIBITED: text(
+    "This case is held because your current immigration status code has not been established, and the Bridging Visa — Transitional Stay Permit cannot be issued from certain visit-based statuses — confirming your current status code is what resolves it.",
+    "Kasus ini ditahan karena kode status keimigrasian Anda saat ini belum dapat dipastikan, sedangkan Izin Tinggal Peralihan tidak dapat diterbitkan dari status berbasis kunjungan tertentu — konfirmasi kode status Anda saat ini adalah yang akan menyelesaikannya.",
+  ),
+  BRIDGING_TO_BRIDGING_PROHIBITED: text(
+    "This case is held because your current immigration status code has not been established, and a Bridging Visa — Transitional Stay Permit cannot follow one already active — confirming your current status code is what resolves it.",
+    "Kasus ini ditahan karena kode status keimigrasian Anda saat ini belum dapat dipastikan, sedangkan Izin Tinggal Peralihan tidak dapat mengikuti izin peralihan yang masih aktif — konfirmasi kode status Anda saat ini adalah yang akan menyelesaikannya.",
+  ),
+  VOA_NATIONALITY_ONLY: text(
+    "This case is held because your nationality has not been established, and the Visa on Arrival — Tourism (B1) is issued only for listed nationalities — confirming your nationality is what resolves it.",
+    "Kasus ini ditahan karena kewarganegaraan Anda belum dapat dipastikan, sedangkan Visa Saat Kedatangan Wisata (B1) hanya diterbitkan untuk kewarganegaraan yang terdaftar — konfirmasi kewarganegaraan Anda adalah yang akan menyelesaikannya.",
+  ),
+
+  // 17 pack-independent codes emitted by evaluate_path.py directly.
+  //
+  // CONFLICTING_IMMIGRATION_STATUS_REVIEW is a DisclosedReviewFlag
+  // (api_models.py) with no current trigger in fact-mapper.ts — unlike
+  // CITIZENSHIP_LIST_DIVERGENCE's precise nationality-list logic, there is
+  // no `when` clause to read for which two status answers conflict. Named
+  // as specifically as the code allows; flagged in the PR-O2 report as
+  // meaning not fully pinned to a specific fact pair (not a split
+  // candidate — there is no enumerable second cause to split out).
+  CONFLICTING_IMMIGRATION_STATUS_REVIEW: text(
+    "Your answers about your current immigration status conflict with each other — a person needs to confirm which status is correct before a path can be confirmed.",
+    "Jawaban Anda tentang status keimigrasian Anda saat ini saling bertentangan — diperlukan konfirmasi oleh seseorang mengenai status mana yang benar sebelum jalur dapat dipastikan.",
+  ),
+  // `_apply_decisive_source_authority_hold` (evaluate_path.py:1097-1198):
+  // abstains an otherwise-conclusive result when a citation the decision
+  // itself relies on isn't authoritative/applicable, or its freshness is
+  // unknown/stale. About the SOURCE behind the result, not an applicant
+  // answer — D2-bis rule 1's "applicant's own terms" framing does not fit
+  // this category, since nothing the applicant said caused this; named the
+  // source mechanism as specifically as the code allows instead.
+  DECISIVE_PRIMARY_SOURCE_NOT_APPLICABLE: text(
+    "This result relies on a regulatory source that could not be confirmed as valid and currently applicable — verifying that source is what a person must do before this result can stand.",
+    "Hasil ini bergantung pada sumber regulasi yang tidak dapat dikonfirmasi valid dan berlaku saat ini — memverifikasi sumber tersebut adalah yang harus dilakukan oleh seseorang sebelum hasil ini dapat dipastikan.",
+  ),
+  DECISIVE_SOURCE_FRESHNESS_UNKNOWN: text(
+    "This result relies on a regulatory source whose currency could not be established automatically — confirming whether that source is still current is what a person must do before this result can stand.",
+    "Hasil ini bergantung pada sumber regulasi yang keberlakuannya belum dapat dipastikan secara otomatis — memastikan apakah sumber tersebut masih berlaku adalah yang harus dilakukan oleh seseorang sebelum hasil ini dapat dipastikan.",
+  ),
+  DECISIVE_SOURCE_STALE: text(
+    "This result relies on a regulatory source confirmed out of date — replacing it with a current source is what a person must do before this result can stand.",
+    "Hasil ini bergantung pada sumber regulasi yang telah dipastikan usang — menggantinya dengan sumber yang berlaku saat ini adalah yang harus dilakukan oleh seseorang sebelum hasil ini dapat dipastikan.",
+  ),
+  // `_DISCLOSED_REVIEW_REASON_CODES` (evaluate_path.py:1014-1027) +
+  // `_apply_disclosed_review_flags` (1304-1354): applicant self-disclosures,
+  // never a legal eligibility claim — carry no source_refs by design.
+  //
+  // Owner-directed wording (D2-bis, deliberately against the example
+  // offered): do NOT assert the sponsor's nationality as the cause. A
+  // parallel PR (D2) is narrowing this code's trigger from "any
+  // sponsor-status answer" to "answered unsure about the sponsor, or the
+  // product itself is sponsor-dependent" — naming nationality would go
+  // FALSE the day that merges. "The sponsor's own stay permit could not be
+  // established from the answers given" stays true under both the current
+  // trigger and the narrowed one.
+  DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW: text(
+    "The sponsor's own stay permit could not be established from the answers given, so a person needs to confirm it before this case can be resolved.",
+    "Izin tinggal sponsor itu sendiri tidak dapat dipastikan dari jawaban yang diberikan, sehingga memerlukan konfirmasi oleh seseorang sebelum kasus ini dapat diselesaikan.",
+  ),
+  DISCLOSED_CRIMINAL_RECORD_REVIEW: text(
+    "You flagged a criminal record concern in your disclosures, and a person needs to review the details before any path can be confirmed.",
+    "Anda menandai adanya masalah catatan kriminal dalam pengungkapan Anda, dan memerlukan peninjauan detail oleh seseorang sebelum jalur apa pun dapat dikonfirmasi.",
+  ),
+  DISCLOSED_DIPLOMATIC_PASSPORT_REVIEW: text(
+    "You flagged holding a diplomatic passport in your disclosures, and a person needs to review the details before any path can be confirmed.",
+    "Anda menandai kepemilikan paspor diplomatik dalam pengungkapan Anda, dan memerlukan peninjauan detail oleh seseorang sebelum jalur apa pun dapat dikonfirmasi.",
+  ),
+  DISCLOSED_HEALTH_CONCERN_REVIEW: text(
+    "You flagged a health concern in your disclosures, and a person needs to review the details before any path can be confirmed.",
+    "Anda menandai adanya masalah kesehatan dalam pengungkapan Anda, dan memerlukan peninjauan detail oleh seseorang sebelum jalur apa pun dapat dikonfirmasi.",
+  ),
+  // fact-mapper.ts: raised when trip_scope === "multiple".
+  DISCLOSED_MULTI_PURPOSE_TRIP_REVIEW: text(
+    "You said your trip serves more than one purpose, and a person needs to review how those purposes combine before a path can be confirmed.",
+    "Anda menyatakan bahwa perjalanan Anda memiliki lebih dari satu tujuan, dan memerlukan peninjauan oleh seseorang mengenai bagaimana tujuan-tujuan tersebut digabungkan sebelum jalur dapat dipastikan.",
+  ),
+  DISCLOSED_PEP_OR_SANCTIONS_REVIEW: text(
+    "You flagged a politically-exposed-person or sanctions-list concern in your disclosures, and a person needs to review the details before any path can be confirmed.",
+    "Anda menandai adanya masalah terkait status politically exposed person atau daftar sanksi dalam pengungkapan Anda, dan memerlukan peninjauan detail oleh seseorang sebelum jalur apa pun dapat dikonfirmasi.",
+  ),
+  DISCLOSED_PRIOR_VISA_REFUSAL_REVIEW: text(
+    "You flagged a prior visa refusal in your disclosures, and a person needs to review the details before any path can be confirmed.",
+    "Anda menandai adanya penolakan visa sebelumnya dalam pengungkapan Anda, dan memerlukan peninjauan detail oleh seseorang sebelum jalur apa pun dapat dikonfirmasi.",
+  ),
+  DISCLOSED_SOURCE_OF_FUNDS_REVIEW: text(
+    "You flagged an unclear source of funds in your disclosures, and a person needs to review the details before any path can be confirmed.",
+    "Anda menandai sumber dana yang tidak jelas dalam pengungkapan Anda, dan memerlukan peninjauan detail oleh seseorang sebelum jalur apa pun dapat dikonfirmasi.",
+  ),
+  // fact-mapper.ts: raised when ANY answer across the interview equals
+  // "unsure" — the OutcomeReason carries no field for which question. One
+  // code, as many potential causes as there are questions; flagged as a
+  // split candidate in the PR-O2 report.
+  DISCLOSED_UNCERTAINTY_REVIEW: text(
+    'One of your answers was marked "unsure," and a person needs to confirm that answer before any path can be confirmed.',
+    'Salah satu jawaban Anda ditandai "tidak yakin," dan memerlukan konfirmasi oleh seseorang atas jawaban tersebut sebelum jalur apa pun dapat dikonfirmasi.',
+  ),
+  // `_apply_minor_privacy_hold` (evaluate_path.py:1033-1094): a categorical
+  // privacy-policy hold on ANY known minor, distinct from the pack's own
+  // MINOR_WITHOUT_CONFIRMED_GUARDIAN rule (`family.sponsor_confirmed ==
+  // false`) — this one fires because the public evaluation contract has no
+  // guardian-identity/consent fact at all, so no automated supported
+  // outcome can ever be safe for a minor here, regardless of what the pack
+  // itself concluded. Resolution is necessarily off-platform (a person
+  // reviewing guardian identity/consent directly) since this adapter "may
+  // only abstain" by its own docstring.
+  MINOR_GUARDIAN_PRIVACY_REVIEW: text(
+    "This case involves a minor, and this tool cannot confirm guardian consent on its own — a person needs to review the guardian's identity and consent directly before this case can be resolved.",
+    "Kasus ini melibatkan anak di bawah umur, dan alat ini tidak dapat mengonfirmasi persetujuan wali dengan sendirinya — diperlukan peninjauan langsung oleh seseorang atas identitas dan persetujuan wali sebelum kasus ini dapat diselesaikan.",
+  ),
+  // `_apply_safety_critical_source_hold` (evaluate_path.py:1201-1301): same
+  // source-integrity pattern as the DECISIVE_* trio above, but global to
+  // every currently active `safety_critical: true` rule rather than only
+  // the specific citations a given result relied on. Same D2-bis rule 1
+  // caveat as the DECISIVE_* trio: not an applicant-fact code.
+  SAFETY_CRITICAL_PRIMARY_SOURCE_NOT_APPLICABLE: text(
+    "One of the safety-critical rules used in this evaluation relies on a source that could not be confirmed as valid and currently applicable — verifying that source is what a person must do before this result can stand.",
+    "Salah satu aturan safety-critical yang digunakan dalam evaluasi ini bergantung pada sumber yang tidak dapat dikonfirmasi valid dan berlaku saat ini — memverifikasi sumber tersebut adalah yang harus dilakukan oleh seseorang sebelum hasil ini dapat dipastikan.",
+  ),
+  SAFETY_CRITICAL_SOURCE_FRESHNESS_UNKNOWN: text(
+    "One of the safety-critical rules used in this evaluation relies on a source whose currency could not be established automatically — confirming whether that source is still current is what a person must do before this result can stand.",
+    "Salah satu aturan safety-critical yang digunakan dalam evaluasi ini bergantung pada sumber yang keberlakuannya belum dapat dipastikan secara otomatis — memastikan apakah sumber tersebut masih berlaku adalah yang harus dilakukan oleh seseorang sebelum hasil ini dapat dipastikan.",
+  ),
+  SAFETY_CRITICAL_SOURCE_STALE: text(
+    "One of the safety-critical rules used in this evaluation relies on a source confirmed out of date — replacing it with a current source is what a person must do before this result can stand.",
+    "Salah satu aturan safety-critical yang digunakan dalam evaluasi ini bergantung pada sumber yang telah dipastikan usang — menggantinya dengan sumber yang berlaku saat ini adalah yang harus dilakukan oleh seseorang sebelum hasil ini dapat dipastikan.",
   ),
 };
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -466,13 +466,20 @@ export const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
   // situation — BRIDGING_ADVERSE_HISTORY is the current name for this rule
   // in rulepack-prod-007+. review.bridging.adverse-history fires on ANY of 4
   // distinct violation_history values (OVERSTAY / DEPORTATION / BLACKLIST /
-  // IMMIGRATION_INVESTIGATION) or on that fact being unknown — one code,
-  // several distinct causes with different real-world resolutions. Named all
-  // 4 rather than guessing one; flagged as a split candidate in the PR-O2
-  // report.
+  // IMMIGRATION_INVESTIGATION) OR on that fact being unknown (on_unknown:
+  // "HUMAN_REVIEW") — one code, several distinct causes with different
+  // real-world resolutions. Named all 4 rather than guessing one; flagged as
+  // a split candidate in the PR-O2 report. Round-1 refuter fix (Gemini 3.1
+  // Pro + Kimi K3, converged independently): the first draft asserted the
+  // record "shows" one of the four even on the UNKNOWN-fact trigger path —
+  // false the moment the hold is raised because the record hasn't been
+  // established at all, not because a specific violation was found. Rewritten
+  // to cover both paths without asserting any of the four exists, matching
+  // the "not yet established" pattern already used for the 4 HARD_FILTER
+  // codes above.
   BRIDGING_ADVERSE_HISTORY: text(
-    "Your immigration record while in Indonesia shows one or more of overstay, deportation, blacklist, or an open investigation, so a person needs to check the timing and conditions before the Bridging Visa — Transitional Stay Permit can be confirmed.",
-    "Catatan keimigrasian Anda selama berada di Indonesia menunjukkan satu atau lebih dari overstay, deportasi, daftar hitam (blacklist), atau investigasi yang masih berjalan, sehingga memerlukan pemeriksaan waktu dan ketentuan oleh seseorang sebelum Izin Tinggal Peralihan dapat dipastikan.",
+    "This case is held to check your immigration record while in Indonesia for an overstay, deportation, blacklist entry, or open investigation, or because that record has not been established. Confirming your record is what resolves it before the Bridging Visa — Transitional Stay Permit can be confirmed.",
+    "Kasus ini ditahan untuk memeriksa catatan keimigrasian Anda selama berada di Indonesia terkait overstay, deportasi, entri daftar hitam (blacklist), atau investigasi yang masih berjalan, atau karena catatan tersebut belum dapat dipastikan. Konfirmasi catatan Anda adalah yang akan menyelesaikannya sebelum Izin Tinggal Peralihan dapat dipastikan.",
   ),
   LOCAL_MARKET_ACTIVITY_REVIEW: text(
     "You said your remote work serves Indonesian clients, and the Second Home Visa — Remote Worker (E33G) is for income from outside Indonesia only — a person needs to confirm your work does not cross into locally reserved business.",
@@ -601,17 +608,24 @@ export const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
   // `_apply_disclosed_review_flags` (1304-1354): applicant self-disclosures,
   // never a legal eligibility claim — carry no source_refs by design.
   //
-  // Owner-directed wording (D2-bis, deliberately against the example
-  // offered): do NOT assert the sponsor's nationality as the cause. A
-  // parallel PR (D2) is narrowing this code's trigger from "any
+  // Owner-directed wording, revised twice (both rounds deliberately against
+  // an example offered — do NOT assert the sponsor's nationality as the
+  // cause; a parallel PR, D2, is narrowing this code's trigger from "any
   // sponsor-status answer" to "answered unsure about the sponsor, or the
-  // product itself is sponsor-dependent" — naming nationality would go
-  // FALSE the day that merges. "The sponsor's own stay permit could not be
-  // established from the answers given" stays true under both the current
-  // trigger and the narrowed one.
+  // product itself is sponsor-dependent", so anything naming nationality
+  // would go FALSE the day that merges). Round 2 (owner's ruling on a
+  // refuter objection to round 1, ACCEPTED — not dissent, adopted): round
+  // 1's "the sponsor's own stay permit could not be established from the
+  // answers given" implied a permit is needed at all, which is false when
+  // the sponsor is an Indonesian citizen who holds no stay permit and needs
+  // none. "Whether your sponsor holds a stay permit of their own has not
+  // been established HERE" (owner's exact approved phrase) stays true under
+  // the current trigger, the narrowed D2 trigger, AND the Indonesian-sponsor
+  // case — it says the question wasn't settled by this tool, never that a
+  // permit exists or is required.
   DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW: text(
-    "The sponsor's own stay permit could not be established from the answers given, so a person needs to confirm it before this case can be resolved.",
-    "Izin tinggal sponsor itu sendiri tidak dapat dipastikan dari jawaban yang diberikan, sehingga memerlukan konfirmasi oleh seseorang sebelum kasus ini dapat diselesaikan.",
+    "This case is held because whether your sponsor holds a stay permit of their own has not been established here — confirming the sponsor's own stay permit is what resolves it.",
+    "Kasus ini ditahan karena belum dapat dipastikan di sini apakah sponsor Anda memiliki izin tinggal sendiri — konfirmasi izin tinggal sponsor tersebut adalah yang akan menyelesaikannya.",
   ),
   DISCLOSED_CRIMINAL_RECORD_REVIEW: text(
     "You flagged a criminal record concern in your disclosures, and a person needs to review the details before any path can be confirmed.",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -419,9 +419,15 @@ export const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
   // that the signed rules cannot decide, (2) state authoritatively that the
   // case is held deliberately for that named reason, and (3) name what
   // resolves it. Applies to these 9 pre-existing entries too, revised below.
+  // review.calling-visa carries on_unknown: "HUMAN_REVIEW" (verified in
+  // rulepack-prod-020.signed.json), so the identical code fires when
+  // nationality itself is UNKNOWN, not only when it is confirmed on the
+  // list — the round-2 refuter gate caught the first draft asserting the
+  // list membership outright, false on that path. Worded to be true on
+  // both without losing the list's own specificity.
   CALLING_VISA_REVIEW: text(
-    "Your nationality is on Indonesia's Calling Visa list, so this case is held for the calling-visa clearance that nationality requires before any visa can be confirmed.",
-    "Kewarganegaraan Anda termasuk dalam daftar Calling Visa Indonesia, sehingga kasus ini ditahan untuk proses persetujuan calling visa yang disyaratkan bagi kewarganegaraan tersebut sebelum visa dapat dikonfirmasi.",
+    "This case is held because your nationality is on Indonesia's Calling Visa list, or because your nationality has not been established. The calling-visa clearance that list requires is what resolves it before any visa can be confirmed.",
+    "Kasus ini ditahan karena kewarganegaraan Anda termasuk dalam daftar Calling Visa Indonesia, atau karena kewarganegaraan Anda belum dapat dipastikan. Proses persetujuan calling visa yang disyaratkan oleh daftar tersebut adalah yang akan menyelesaikannya sebelum visa dapat dikonfirmasi.",
   ),
   ACTIVE_OVERSTAY: text(
     "You reported active overstay days on your immigration record, so a person needs to review it — clearing the overstay is what resolves it.",
@@ -430,13 +436,16 @@ export const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
   // Renamed from CITIZENSHIP_EVIDENCE_CONFLICT (QW-4a, 2026-08-17): that key
   // named no code in any pack from seq-6 onward. CITIZENSHIP_LIST_DIVERGENCE
   // is its current name (services/visa_engine/contracts/packs/
-  // rulepack-prod-007.source.json). Fires only when the declared
-  // nationalities themselves span two different eligibility categories
-  // (rule.when, review.citizenship-conflict) — single cause, revised for
-  // D2-bis below.
+  // rulepack-prod-007.source.json). review.citizenship-conflict ALSO carries
+  // on_unknown: "HUMAN_REVIEW" (verified in rulepack-prod-020.signed.json),
+  // so the identical code fires when nationality is entirely UNKNOWN, not
+  // only when multiple declared nationalities are known to diverge — the
+  // round-2 refuter gate caught the first draft asserting "you declared
+  // more than one nationality" outright, false on the unknown path. Worded
+  // to be true on both without losing the known-path specificity.
   CITIZENSHIP_LIST_DIVERGENCE: text(
-    "You declared more than one nationality, and they fall into different eligibility categories — a person needs to confirm which passport you will use to apply.",
-    "Anda mencantumkan lebih dari satu kewarganegaraan yang termasuk dalam kategori kelayakan yang berbeda — diperlukan konfirmasi oleh seseorang mengenai paspor mana yang akan Anda gunakan untuk mengajukan permohonan.",
+    "This case is held because you declared more than one nationality that falls into different eligibility categories, or because your nationality has not been established. Confirming which passport you will use to apply is what resolves it.",
+    "Kasus ini ditahan karena Anda mencantumkan lebih dari satu kewarganegaraan yang termasuk dalam kategori kelayakan yang berbeda, atau karena kewarganegaraan Anda belum dapat dipastikan. Konfirmasi paspor mana yang akan Anda gunakan untuk mengajukan permohonan adalah yang akan menyelesaikannya.",
   ),
   // review.minor-without-guardian: derived.is_minor == true AND
   // family.sponsor_confirmed == false — confirming the sponsor is the fact

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -426,8 +426,8 @@ export const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
   // list membership outright, false on that path. Worded to be true on
   // both without losing the list's own specificity.
   CALLING_VISA_REVIEW: text(
-    "This case is held because your nationality is on Indonesia's Calling Visa list, or because your nationality has not been established. The calling-visa clearance that list requires is what resolves it before any visa can be confirmed.",
-    "Kasus ini ditahan karena kewarganegaraan Anda termasuk dalam daftar Calling Visa Indonesia, atau karena kewarganegaraan Anda belum dapat dipastikan. Proses persetujuan calling visa yang disyaratkan oleh daftar tersebut adalah yang akan menyelesaikannya sebelum visa dapat dikonfirmasi.",
+    "This case is held because your nationality is on Indonesia's Calling Visa list, or because your nationality has not been established. Confirming your nationality, and the calling-visa clearance that list requires if it applies, is what resolves it before any visa can be confirmed.",
+    "Kasus ini ditahan karena kewarganegaraan Anda termasuk dalam daftar Calling Visa Indonesia, atau karena kewarganegaraan Anda belum dapat dipastikan. Konfirmasi kewarganegaraan Anda, beserta proses persetujuan calling visa yang disyaratkan oleh daftar tersebut apabila berlaku, adalah yang akan menyelesaikannya sebelum visa apa pun dapat dikonfirmasi.",
   ),
   ACTIVE_OVERSTAY: text(
     "You reported active overstay days on your immigration record, so a person needs to review it — clearing the overstay is what resolves it.",

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
@@ -9,11 +9,23 @@ gear_reason: >-
   returns 2, source `size` — the diff crosses SIZE_GEAR2_THRESHOLD (400). Declaring 1 against a
   floor of 2 is exactly why #6240 was rejected; declared 2 here. Re-run both invocations to
   check. Only frontend files touched, both under apps/mouth/src/app/(visa-oracle)/ — not a
-  HOTZONE_PATTERNS path — plus this brief.
+  HOTZONE_PATTERNS path — plus this brief and the e2e spec F2 added (PR-O2 round 3).
+
+  On the per-file churn figure specifically (F3, PR-O2 round 3): do not trust a number typed
+  here — this file is itself in the diff it would be describing, so any digit written into it is
+  stale the moment a later commit (this one included) touches the described file again. The
+  re-runnable, self-correcting command is:
+  `git diff --numstat 9233a860d6..HEAD -- 'apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts'`
+  — run it against the actual HEAD at read time, not against a figure quoted from an earlier
+  round of this same PR.
 scope:
   - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
   - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
   - evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
+  # Added PR-O2 round 3 (F2, gate #6318 REWORK-BUILD): the fullstack e2e's own
+  # assertion referenced the generic fallback text this PR replaced. Perimeter
+  # growth authorized by the orchestrator, not a scope violation.
+  - apps/mouth/e2e/visa-oracle-fullstack.spec.ts
 l_level: L2
 gate_class: opus
 objective: >-
@@ -108,6 +120,22 @@ acceptance:
       assert hits == expected, hits
       print('OK', hits)
       "
+  - text: >-
+      WHEN every rule in the signed pack with `on_unknown == "HUMAN_REVIEW"` (any stage) is
+      enumerated THEN it SHALL be exactly the 7 codes this PR has already worded for the unknown
+      path — the on_unknown sweep from gate #6318's F1, re-run against rulepack-prod-020.signed.json
+      (the same file the gate itself cited) rather than the .source.json this PR read earlier, to
+      close any doubt the two could diverge.
+    probe: |
+      /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -c "
+      import json
+      data = json.load(open('apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-020.signed.json'))
+      rules = data['payload']['rules']
+      hits = sorted(r['effect']['reason_code'] for r in rules if r.get('on_unknown') == 'HUMAN_REVIEW')
+      expected = ['BRIDGING_ADVERSE_HISTORY', 'BRIDGING_FROM_VISIT_ITK_PROHIBITED', 'BRIDGING_ONSHORE_ONLY', 'BRIDGING_TO_BRIDGING_PROHIBITED', 'CALLING_VISA_REVIEW', 'CITIZENSHIP_LIST_DIVERGENCE', 'VOA_NATIONALITY_ONLY']
+      assert hits == expected, hits
+      print('OK', hits)
+      "
 consumer_map:
   - >-
     OutcomeSheet.tsx (via engine-adapter.ts's buildEngineOutcome/reviewReason) — the ONLY reader
@@ -153,6 +181,47 @@ review_record: |
   their own has not been established here"), true under the current trigger, the narrowed D2
   trigger, and the Indonesian-sponsor case alike. Applied in the same commit as the two fixes
   above.
+
+  Round 3 (fresh on-disk gate, #6318: REWORK-BUILD — 36/38 strings conform, 13/13 product names
+  verbatim, narrow finding): F1 (HIGH) — CALLING_VISA_REVIEW and CITIZENSHIP_LIST_DIVERGENCE are
+  HUMAN_REVIEW-stage rules that ALSO carry on_unknown="HUMAN_REVIEW" (verified independently
+  against rulepack-prod-020.signed.json), so both fired the identical code on an UNKNOWN
+  nationality while their strings stated the fact outright. STATUS: ACCEPTED — both rewritten to
+  the "held because X, or because the fact has not been established" pattern already used for
+  BRIDGING_ADVERSE_HISTORY, keeping the known-path specificity (the named list, the named
+  eligibility-category divergence). Full on_unknown sweep run against ALL 109 rules in both
+  rulepack-prod-020.signed.json and .source.json (identical result from each): exactly 7 codes
+  carry on_unknown="HUMAN_REVIEW" — BRIDGING_ADVERSE_HISTORY, BRIDGING_FROM_VISIT_ITK_PROHIBITED,
+  BRIDGING_ONSHORE_ONLY, BRIDGING_TO_BRIDGING_PROHIBITED, CALLING_VISA_REVIEW,
+  CITIZENSHIP_LIST_DIVERGENCE, VOA_NATIONALITY_ONLY. 5 of the 7 were already correctly worded (4
+  HARD_FILTER codes from PR-O2's first commit, BRIDGING_ADVERSE_HISTORY from round 1); F1's 2 are
+  the only ones the sweep found needing this fix. No pack-independent (evaluate_path.py) code
+  carries an equivalent unknown-escalation-with-the-same-code mechanism: the DISCLOSED_* codes are
+  explicit applicant checkbox disclosures (not an UNKNOWN-fact escalation), MINOR_GUARDIAN_PRIVACY_
+  REVIEW's is_minor==UNKNOWN path routes to a DIFFERENT state (NEEDS_INPUT, not this code — read
+  `_apply_minor_privacy_hold`, evaluate_path.py:1043-1069) before this code's own check even runs,
+  and DECISIVE_*/SAFETY_CRITICAL_* codes ARE themselves the "fact is unknown" case already (their
+  strings already say "could not be established" / "currency could not be established
+  automatically"). Swept; found none beyond the 2 named in F1.
+
+  F2 (HIGH) — apps/mouth/e2e/visa-oracle-fullstack.spec.ts:246-257 asserted the pre-PR-O2 generic
+  fallback sentence for DECISIVE_SOURCE_FRESHNESS_UNKNOWN and its own comment said the code had no
+  curated copy yet. STATUS: ACCEPTED — perimeter growth into this one e2e file is per the
+  orchestrator's own authorization in the F2 finding. Assertion tightened to the curated EN string;
+  comment rewritten to state the code now has curated copy. Not runnable locally by this
+  implementer seat (VISA_ORACLE_FULLSTACK=1 needs a disposable Postgres DB this seat cannot raise,
+  and apps/mouth's node_modules/.bin has no local playwright binary under the --no-install
+  constraint this seat operates under) — verified instead via `tsc --noEmit` (exit 0, the file
+  type-checks) and by grep confirming no other file in apps/mouth/ still references the generic
+  fallback text for this code.
+
+  F3 (LOW) — a per-file numstat figure for engine-adapter.ts, cited by the gate as wrong
+  (+259/-28, not +257/-26), was not found anywhere in the CURRENT brief.yml by this implementer
+  (checked via `git log --all -p` over this file's full history — no match for those digits at
+  any point) — it likely lived in PR-body text the orchestrator authored separately from this
+  brief. STATUS: ACCEPTED as a standing discipline regardless of where the stale digit lived —
+  added an explicit re-runnable `git diff --numstat` command to gear_reason above instead of any
+  static figure, since this file is itself in the diff it would be describing.
 grader: |
   Independent gate dispatched separately by the orchestrating (Opus 5) session — generator !=
   grader: this session wrote the diff and this brief, and does not post its own verdict.

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
@@ -1,0 +1,132 @@
+task_id: shweb-w-oracle-o2-review-reason-copy
+gear: 1
+ts: 2026-09-12T20:58:49+08:00
+gear_reason: >-
+  Computed, not chosen: `git diff --name-only 9233a860d6..HEAD > /tmp/o2-changed.txt &&
+  /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python scripts/evidence_pack_lint.py
+  --changed-files-file /tmp/o2-changed.txt --print-floor` returns 1 (re-runnable; the script is
+  not directly executable on this checkout — verified by first trying it bare and getting
+  "Permission denied", then invoking it through the venv interpreter). Only two files touched,
+  both under apps/mouth/src/app/(visa-oracle)/ — not a HOTZONE_PATTERNS path — and the diff (268
+  insertions / 67 deletions per `git diff --numstat 9233a860d6..HEAD`, this commit's own
+  numstat, not a figure re-typed here as a fact) stays under every size threshold. The same
+  invocation with `--print-floor-source` returns "none".
+l_level: L2
+gate_class: opus
+objective: >-
+  PR-O2 of mandate SHWEB-20260911 / W-ORACLE, decision D1: give dedicated EN/ID copy to the 29
+  Visa Oracle HUMAN_REVIEW reason codes that previously fell back to GENERIC_REVIEW_REASON in
+  apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts's REVIEW_REASON_COPY.
+  25 of the 29 were already named in engine-adapter.test.ts's KNOWN_UNMAPPED_REVIEW_REASON_CODES
+  gap list (8 rulepack-prod-007+ HUMAN_REVIEW-stage codes + 17 pack-independent
+  evaluate_path.py codes); the other 4 (BRIDGING_ONSHORE_ONLY, BRIDGING_FROM_VISIT_ITK_PROHIBITED,
+  BRIDGING_TO_BRIDGING_PROHIBITED, VOA_NATIONALITY_ONLY) were not visible to that list at all,
+  because reviewReasonCodesInPack() only scanned stage===HUMAN_REVIEW rules — these 4 are
+  rulepack-prod-020 stage HARD_FILTER rules with on_unknown="HUMAN_REVIEW", which
+  evaluator.py's _partition_unknowns_by_policy + _reason_from_rule (lines 355-410, 741-751)
+  escalate to a HUMAN_REVIEW state using the SAME effect.reason_code when the gating fact is
+  UNKNOWN rather than known-false. Verified by reading rulepack-prod-020.source.json directly
+  (`python -c` one-liner filtering rules by stage/on_unknown, reproduced below) before writing
+  any copy for them. Extended reviewReasonCodesInPack() to also collect
+  stage===HARD_FILTER && on_unknown==="HUMAN_REVIEW" rules, so the exhaustiveness test's
+  allRealCodes now genuinely covers all 38 real codes (20 pack + 18 pack-independent) instead of
+  34. KNOWN_UNMAPPED_REVIEW_REASON_CODES now ends empty, as D1 requires.
+
+  Mid-task, the owner issued a binding follow-up ruling (D2-bis) requiring every HUMAN_REVIEW
+  string, EN and ID — including the 9 pre-existing entries, now in scope — to (1) name the
+  specific fact/answer the signed rules cannot decide, in the applicant's own terms, (2) state
+  the hold authoritatively rather than generically, and (3) name what resolves it. All 38
+  entries were revised or written to this standard in the same commit (dd1eb0e5c3). One entry
+  (DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW) uses wording the owner specified verbatim rather than the
+  example offered, because a parallel PR (D2) is narrowing that code's trigger and a
+  nationality-based sentence would go false the day it merges.
+constraints:
+  - >-
+    Perimeter held to exactly what the brief named: REVIEW_REASON_COPY, the test file's
+    KNOWN_UNMAPPED_REVIEW_REASON_CODES + reviewReasonCodesInPack() (the latter's extension was
+    necessary to keep the exhaustiveness test internally consistent with the 4 newly-copied
+    HARD_FILTER codes — otherwise "never lets a stale key sit in the copy map" fails on them),
+    plus this evidence directory. No change to oracle.css, the question tree, evaluate_path.py,
+    the evaluator, any pack file, or OutcomeSheet.tsx.
+  - >-
+    Product names copied verbatim from each rule's product_version_ids entry in
+    rulepack-prod-020.source.json (names.en / names.id) — never shortened or re-described (the
+    repo's own prior scar: E23V narrowed to "trade representative office" in an earlier round).
+  - >-
+    No new price, no new timeline, no new legal claim. UNKNOWN is never written as an exclusion
+    — the 4 HARD_FILTER/on_unknown codes name the fact as "not yet established", never as
+    ineligibility. DISCLOSED_ACTIVITY_BOUNDARY_REVIEW and DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW do
+    not presuppose D2 (no claim that either hold is too wide, being narrowed, or a defect).
+  - >-
+    Two codes could not honestly carry ONE specific cause without inventing one: names the most
+    specific true statement the code allows and lists as split candidates rather than guessing —
+    BRIDGING_ADVERSE_HISTORY (rule review.bridging.adverse-history fires on any of 4 distinct
+    violation_history values — OVERSTAY/DEPORTATION/BLACKLIST/IMMIGRATION_INVESTIGATION — or on
+    that fact being unknown) and DISCLOSED_ACTIVITY_BOUNDARY_REVIEW (fact-mapper.ts's
+    hasUndecidableActivityAnswer raises this one code from 7 distinct question ids, with no field
+    saying which). DISCLOSED_UNCERTAINTY_REVIEW is the same shape (any interview answer marked
+    "unsure" fires it, no field names which) and is listed alongside them.
+    CONFLICTING_IMMIGRATION_STATUS_REVIEW is a DisclosedReviewFlag with no current
+    fact-mapper.ts trigger at all — named as specifically as the code allows, flagged separately
+    as meaning not fully pinned to a fact pair rather than as a split candidate (there is no
+    second enumerable cause to split out).
+acceptance:
+  - text: >-
+      WHEN the full visa-oracle vitest suite is run THEN every test SHALL pass, including the
+      exhaustiveness test with an empty KNOWN_UNMAPPED_REVIEW_REASON_CODES.
+    probe: |
+      cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)' --maxWorkers=2
+  - text: >-
+      WHEN the review-reasons exhaustiveness describe block is run in isolation THEN all 4 of
+      its tests (exhaustive coverage, no stale copy key, no already-mapped gap entry, no phantom
+      gap entry) SHALL pass.
+    probe: |
+      cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' -t "review reasons cover every code" --maxWorkers=2
+  - text: WHEN the mouth app is typechecked THEN it SHALL exit 0 with no errors.
+    probe: |
+      cd apps/mouth && npx --no-install tsc --noEmit -p .
+  - text: >-
+      WHEN the 4 HARD_FILTER-with-on_unknown-HUMAN_REVIEW codes are looked up directly in the
+      signed pack THEN exactly BRIDGING_ONSHORE_ONLY, BRIDGING_FROM_VISIT_ITK_PROHIBITED,
+      BRIDGING_TO_BRIDGING_PROHIBITED and VOA_NATIONALITY_ONLY SHALL be found, corroborating the
+      objective's traceability claim independently of this PR's own code.
+    probe: |
+      /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -c "
+      import json
+      data = json.load(open('apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-020.source.json'))
+      hits = sorted(
+          (r['effect']['reason_code'])
+          for r in data['rules']
+          if r.get('stage') == 'HARD_FILTER' and r.get('on_unknown') == 'HUMAN_REVIEW'
+      )
+      expected = ['BRIDGING_FROM_VISIT_ITK_PROHIBITED', 'BRIDGING_ONSHORE_ONLY', 'BRIDGING_TO_BRIDGING_PROHIBITED', 'VOA_NATIONALITY_ONLY']
+      assert hits == expected, hits
+      print('OK', hits)
+      "
+consumer_map:
+  - >-
+    OutcomeSheet.tsx (via engine-adapter.ts's buildEngineOutcome/reviewReason) — the ONLY reader
+    of REVIEW_REASON_COPY: every applicant who lands on a HUMAN_REVIEW_REQUIRED outcome for one
+    of these 29 codes now sees the dedicated sentence in place of the generic fallback, in both
+    languages the UI serves (en/id).
+risks:
+  - >-
+    DECISIVE_*/SAFETY_CRITICAL_* (6 codes) and CONFLICTING_IMMIGRATION_STATUS_REVIEW are not
+    applicant-fact-driven (source-integrity holds or a currently-untriggered disclosed flag) —
+    D2-bis rule 1's "applicant's own terms" framing does not literally fit; named the mechanism
+    (which source / which status conflict) as specifically as each code's own logic allows
+    instead of forcing an applicant-facing frame that would misstate the mechanism.
+  - >-
+    Extending reviewReasonCodesInPack() (test-only, not runtime) goes slightly beyond the
+    file-list's literal "KNOWN_UNMAPPED_REVIEW_REASON_CODES must end EMPTY" framing, but was
+    necessary for internal consistency: without it, adding copy for the 4 HARD_FILTER codes
+    would fail the "never lets a stale key sit in the copy map" test (they would not be in
+    allRealCodes). Cross-validated against the brief's own census math (9 existing + 29 new = 38
+    total; 8+4+17=29) before making the change, not assumed.
+grader: |
+  Independent gate dispatched separately by the orchestrating (Opus 5) session — generator !=
+  grader: this session wrote the diff and this brief, and does not post its own verdict.
+budget: |
+  Single-lane content PR. Flat-subscription seat only (Sonnet 5 IMPLEMENTER); no metered API
+  spend, no external LLM call, no network call.
+pii: none

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
@@ -39,10 +39,12 @@ objective: >-
   string, EN and ID — including the 9 pre-existing entries, now in scope — to (1) name the
   specific fact/answer the signed rules cannot decide, in the applicant's own terms, (2) state
   the hold authoritatively rather than generically, and (3) name what resolves it. All 38
-  entries were revised or written to this standard in the same commit (dd1eb0e5c3). One entry
-  (DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW) uses wording the owner specified verbatim rather than the
-  example offered, because a parallel PR (D2) is narrowing that code's trigger and a
-  nationality-based sentence would go false the day it merges.
+  entries were revised or written to this standard in the same commit (dd1eb0e5c3).
+
+  DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW went through two owner-directed wordings — see
+  `review_record` below for both rounds and why the second superseded the first. The string
+  currently in REVIEW_REASON_COPY is the second (owner-approved 2026-09-12): "whether your
+  sponsor holds a stay permit of their own has not been established here."
 constraints:
   - >-
     Perimeter held to exactly what the brief named: REVIEW_REASON_COPY, the test file's
@@ -126,6 +128,31 @@ risks:
     would fail the "never lets a stale key sit in the copy map" test (they would not be in
     allRealCodes). Cross-validated against the brief's own census math (9 existing + 29 new = 38
     total; 8+4+17=29) before making the change, not assumed.
+review_record: |
+  SELF-REPORT (not independently verified evidence — a claim about what reviewers said and how
+  it was resolved, per this brief's own rule that lanes/dissent/the review record are self-reports).
+
+  Round 1 (Gemini 3.1 Pro: REWORK; Kimi K3: REWORK — converged independently on one substantive
+  finding + one hardening item; everything else checked came back clean): BRIDGING_ADVERSE_HISTORY
+  was FALSE on the on_unknown="HUMAN_REVIEW" trigger path — it asserted the record "shows" one of
+  overstay/deportation/blacklist/investigation even when the hold was raised because the record
+  had not been established at all (rule 5/6 violation: an unknown fact written as established).
+  Separately, the exhaustiveness floor (`toBeGreaterThanOrEqual(32)`) sat below the measured 38,
+  so a regression silently dropping up to 5 real codes would still pass it. STATUS: ACCEPTED,
+  applied in THIS commit (self-referential SHA avoided on purpose — this file is part of the same
+  commit as the fix, so its own hash cannot be known while writing it; `git log --oneline -1` on
+  the resulting commit is the re-runnable check) — BRIDGING_ADVERSE_HISTORY rewritten to name both
+  trigger paths (the 4 named causes, or the record not established) without asserting any of the
+  4 exists; floor raised 32 -> 38.
+
+  A separate objection on DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW's round-1 wording ("the sponsor's own
+  stay permit could not be established from the answers given") was escalated to the owner rather
+  than acted on directly. Owner's ruling: ACCEPTED — that wording implied a stay permit is needed
+  at all, which is false when the sponsor is an Indonesian citizen who holds no permit and needs
+  none. Owner supplied the exact replacement clause ("whether your sponsor holds a stay permit of
+  their own has not been established here"), true under the current trigger, the narrowed D2
+  trigger, and the Indonesian-sponsor case alike. Applied in the same commit as the two fixes
+  above.
 grader: |
   Independent gate dispatched separately by the orchestrating (Opus 5) session — generator !=
   grader: this session wrote the diff and this brief, and does not post its own verdict.

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
@@ -1,16 +1,19 @@
 task_id: shweb-w-oracle-o2-review-reason-copy
-gear: 1
-ts: 2026-09-12T20:58:49+08:00
+gear: 2
+ts: 2026-09-12T21:20:00+08:00
 gear_reason: >-
-  Computed, not chosen: `git diff --name-only 9233a860d6..HEAD > /tmp/o2-changed.txt &&
-  /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python scripts/evidence_pack_lint.py
-  --changed-files-file /tmp/o2-changed.txt --print-floor` returns 1 (re-runnable; the script is
-  not directly executable on this checkout — verified by first trying it bare and getting
-  "Permission denied", then invoking it through the venv interpreter). Only two files touched,
-  both under apps/mouth/src/app/(visa-oracle)/ — not a HOTZONE_PATTERNS path — and the diff (268
-  insertions / 67 deletions per `git diff --numstat 9233a860d6..HEAD`, this commit's own
-  numstat, not a figure re-typed here as a fact) stays under every size threshold. The same
-  invocation with `--print-floor-source` returns "none".
+  Computed with the SAME inputs CI uses, which is where the first measurement went wrong: the
+  floor was taken with `--changed-files-file` only and returned 1 / source `none`. CI's harness
+  step passes `--numstat-file` as well, and with it
+  `scripts/evidence_pack_lint.py --print-floor --changed-files-file <f> --numstat-file <n>`
+  returns 2, source `size` — the diff crosses SIZE_GEAR2_THRESHOLD (400). Declaring 1 against a
+  floor of 2 is exactly why #6240 was rejected; declared 2 here. Re-run both invocations to
+  check. Only frontend files touched, both under apps/mouth/src/app/(visa-oracle)/ — not a
+  HOTZONE_PATTERNS path — plus this brief.
+scope:
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+  - evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-o2-20260912-af438b83/brief.yml
 l_level: L2
 gate_class: opus
 objective: >-


### PR DESCRIPTION
## What

**PR-O2 of SHWEB-20260911 / W-ORACLE** — every review-reason code the engine can emit now has its own EN/ID explanation. Frontend only: no runtime logic, no rule pack, no backend, no `oracle.css`, no question tree. Perimeter is **four files** — the copy map, its test, the evidence brief, and one e2e spec whose assertion pinned the old generic sentence (see the gate section).

When the engine holds a case for human review it emits a reason code, and the frontend maps that code to the sentence the visitor reads. 29 of the 38 codes had no entry and fell back to one generic sentence. This PR writes copy for all 29, revises the 9 that existed, and empties the known-gap list.

Decisions in force: **D1** (Zero: the window writes the copy, refuters and the gate judge it), **D2-bis** (Zero: what that copy must do), and the owner's round-1 ruling recorded below.

## The copy rules this is judged against (D2-bis)

Every string must (1) name the **specific uncertainty in the applicant's own terms** — which answer, which fact; (2) be **authoritative** — the case was evaluated against the full signed rule base and is held deliberately, out of caution, for that named reason; (3) say **what resolves it**. Plus: no new legal claims, no prices, no timelines, product names verbatim from the pack, Indonesian a faithful translation, and **UNKNOWN is never written as an exclusion**.

One further test, adopted by the owner as general after this PR raised it: **a sentence must stay true if its trigger later narrows to the unresolved fact itself.** That is why the sponsor string names the unresolved fact and not the sponsor's nationality — a parallel PR (D2) narrows exactly that trigger, and nationality-as-cause would have gone false the day it merged.

## Measured, at base `9233a860d6`

`census.json`, clock `signed_at`: 72 rows = the 67-walk corpus + 5 declared edge cases (the audit README: "I 5 casi limite restano fuori dal 67").

| | before | after |
|---|---|---|
| codes with dedicated copy | 9 | **38** |
| known-gap list | 29 codes | **empty** |
| 67-walk corpus: rows in review whose every code renders a dedicated cause | 13 / 29 | **29 / 29** |
| 5 edge cases: same | 0 / 5 | **5 / 5** |

The 67-walk census itself is unchanged by this PR — copy does not move a verdict: 31 SUPPORTED / 7 NO_SUPPORTED_PATH / 29 HUMAN_REVIEW with real flags, 55 / 10 / 2 without.

**The honest nuance**: only **5 of the 29** codes are exercised by this corpus (`DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW` ×16, `DISCLOSED_UNCERTAINTY_REVIEW` ×5, and the three `BRIDGING_*` ×1 each). The other 24 get copy that no walk in the corpus reaches. The audit README warns explicitly against presenting 38 as proof that every code is reachable from the current funnel, and this PR does not present it that way.

Numbers are anchored to this PR's base on purpose: PR-D2 moves the review count from 29 to 13, so these figures are true at `9233a860d6` and will read differently after it lands. Neither PR should "correct" the other's measurement.

## Codes needing a split — for a later PR, not this one

Three codes carry several distinct causes, so no single sentence can name *which* one fired. Per the owner's ruling, they ship with the most specific enumerating copy the code honestly allows, and are listed here rather than split:

| code | distinct causes |
|---|---|
| `DISCLOSED_ACTIVITY_BOUNDARY_REVIEW` | 7 undecidable question ids |
| `DISCLOSED_UNCERTAINTY_REVIEW` | any interview answer of "unsure"; the code names no field |
| `BRIDGING_ADVERSE_HISTORY` | 4 `violation_history` values, plus the unknown case |

The fix is **D3-6** (trigger-aware copy: the frontend already knows the question and answer that raised the flag, so the outcome can render the code's copy with them named). No backend split, no new wire codes.

Also recorded, not hidden: `CONFLICTING_IMMIGRATION_STATUS_REVIEW` has no trigger in `fact-mapper.ts` yet, and the six `DECISIVE_*` / `SAFETY_CRITICAL_*` codes are source-integrity holds rather than applicant answers, so D2-bis rule 1 does not apply to them literally. Both are documented in code comments.

## Adversarial review (generator ≠ grader)

| round | seats | verdict | disposition |
|---|---|---|---|
| 1 | `agy` Gemini 3.1 Pro (High) — refuter · `kimi -m kimi-code/k3` — second reader. Both with the diff inline; Codex is dead on this host on both accounts | **REWORK** (both, converging) | Two findings, both **ACCEPTED** and cured in `71f203c6dc` |

**The finding that mattered**, raised independently by both seats: `BRIDGING_ADVERSE_HISTORY` asserted *"Your immigration record … **shows** one or more of overstay, deportation, blacklist, or an open investigation"*, while the emitting rule also fires when `violation_history` is **unknown**. On that path the sentence told a real person their record shows a deportation the engine does not know exists — D2-bis rule 5. Rewritten to the "has not been established" form the four HARD_FILTER strings in this same diff already used.

Gemini additionally objected that the sponsor string ("the sponsor's own stay permit could not be established from the answers given") is false when the sponsor is an Indonesian citizen, who has no stay permit to establish. Escalated to the owner rather than decided here, since that wording was his. **Ruled: accepted** — the string now reads *"whether your sponsor holds a stay permit of their own has not been established here"*, which is true under both the current and the narrowed trigger and implies no permit is required.

Two further flags were checked against the source and **closed without a change**: the E23U/E23V Indonesian product names ARE verbatim (`names.id` in `rulepack-prod-020.source.json` carries the `(E23U)` / `(E23V)` suffix — the code comment had abbreviated them), and a suspected missing map key turned out to be a bad regex in the orchestrator's own check, not a gap.

One hardening taken from the same round: the exhaustiveness guard sat at `>= 32` while the census proves 38, so a regression silently dropping five codes would have passed. Now `>= 38`.

## The on_unknown rule, and why it is a rule and not three fixes

A rule carrying `on_unknown: HUMAN_REVIEW` re-emits its own `reason_code` when the fact is unknown, so one string serves both paths. A sentence that asserts the fact is then FALSE whenever the engine simply does not know it — it tells a real person their record shows something, or that they are on a list, on no evidence.

Three separate review rounds found this same defect in three different strings: `BRIDGING_ADVERSE_HISTORY` (round 1, both refuters), then `CALLING_VISA_REVIEW` and `CITIZENSHIP_LIST_DIVERGENCE` (the on-disk gate). It is a family, so it is now a standing rule for this mandate: **any code reachable through `on_unknown` must be worded for the unknown path**, keeping the specificity of the known path.

A sweep of the signed pack settles the scope, run by the implementer and re-run independently by the orchestrator: across **109 rules**, exactly **7** distinct codes are reachable via `on_unknown: HUMAN_REVIEW` — `hf.bridging.offshore`, `hf.bridging.from-visit-itk`, `hf.bridging.to-bridging`, `hf.b1.not-voa-nationality`, `review.bridging.adverse-history`, `review.calling-visa`, `review.citizenship-conflict`. Five were already written for the unknown path; the two named above are fixed here. No others exist — the pack-independent codes reach review by a different mechanism, and the `DECISIVE_*` / `SAFETY_CRITICAL_*` codes *are* the unknown case.

## The e2e assertion this PR had to move

`apps/mouth/e2e/visa-oracle-fullstack.spec.ts` asserted the generic fallback sentence for `DECISIVE_SOURCE_FRESHNESS_UNKNOWN`, and its own comment said to tighten it when curated text landed. This PR is that landing, so the spec was red on the previous head for exactly that locator. The assertion now pins the curated string and the stale comment is rewritten. Verified byte-for-byte: the asserted text and `REVIEW_REASON_COPY`'s entry are an exact match (the e2e itself needs `VISA_ORACLE_FULLSTACK=1` and a disposable database, so CI runs it, not this seat).

## Gates, measured at head `845e82fbe3`

- full `visa-oracle` vitest suite → exit 0, **688/688**
- all 5 brief probes (one added for the on_unknown sweep) → exit 0
- `tsc --noEmit -p .` → exit 0
- exhaustiveness block alone → exit 0, empty gap list proven (`const KNOWN_UNMAPPED_REVIEW_REASON_CODES: string[] = []`)
- harness floor → **2**, source `size` (churn measured at this head with `git diff --numstat origin/main...HEAD`; the brief states it as a command, not a frozen digit, after the gate caught a stale figure); declared gear **2** (an earlier revision of the brief declared 1, measured without `--numstat-file` — the same mistake that got #6240 rejected; corrected in `1603b25221`)
- detect-secrets, CI-shaped on this PR's changed files → exit 0, "All findings audited"
- PII shapes in the added lines → **0**

## Bites

Bites: consumer = every visitor who reaches a HUMAN_REVIEW outcome, through `REVIEW_REASON_COPY` in `engine-adapter.ts`; observation = after merge, `git show origin/main:apps/mouth/src/app/\(visa-oracle\)/visa-oracle/_lib/engine-adapter.test.ts | grep -c 'KNOWN_UNMAPPED_REVIEW_REASON_CODES: string\[\] = \[\]'` returns 1 — the gap list is empty on main — and the exhaustiveness test is green in this PR's own CI run, which is what proves every emittable code now has copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
