### PR TITLE
fix(visaoracle): narrow the two disclosure holds so the Oracle answers where the pack is deterministic (PR-D2)

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
@@ -169,6 +169,26 @@ const WALKS: readonly WalkCase[] = [
     flags: ["ACTIVITY_BOUNDARY"],
   },
   {
+    // NARROW-2 (owner ruling SHWEB-20260911, 2026-09-12): `el.e33f.
+    // retirement` (rulepack-prod-020) decides SUPPORT off
+    // `secondhome.passive_monthly_income_usd >= 3000` and `family.
+    // sponsor_confirmed == true` alone — it never reads `retirement_basis`
+    // at all — so the table was UNDER-inclusive: this exact profile (age 25
+    // here; age 64 is the same branch replayed, see the corpus) already had
+    // a deterministic SUPPORTED E33F, and the flag deleted it.
+    name: "retirement · family_sponsor — FREED (NARROW-2): el.e33f.retirement never reads retirement_basis",
+    category: "retirement",
+    tripScope: "single",
+    branch: [
+      ["sponsor_category", "NONE"],
+      ["retirement_basis", "family_sponsor"],
+      ["secondhome_passive_income_usd", "5000"],
+      ["family_sponsor_confirmed", "yes"],
+      ["stay_days", "365"],
+    ],
+    flags: [],
+  },
+  {
     // NAME CORRECTED 2026-09-08, RELEASED SAME DAY. This row used to read
     // "HELD: CATEGORY_TO_PURPOSE emits no purpose for it", and that rationale
     // died when #5855 — merged into this very branch — added
@@ -222,6 +242,56 @@ const WALKS: readonly WalkCase[] = [
       ["stay_days", "365"],
     ],
     flags: ["ACTIVITY_BOUNDARY"],
+  },
+  {
+    // NARROW-1 (owner ruling SHWEB-20260911, 2026-09-12): a foreign sponsor
+    // used to raise AMBIGUOUS_SPONSOR for every relation, on the mere
+    // presence of `family_sponsor_status_code`/`family_sponsor_permit_
+    // basis`. `el.c1.tourism-family` (rulepack-prod-020) reads no sponsor
+    // fact at all, so this deleted a verdict the flag could never affect —
+    // the OVER-match this narrowing exists to cure. SPOUSE stands for
+    // PARENT/CHILD/SIBLING/DEPENDENT/OTHER too: none of their pack products
+    // gate on the sponsor fact with a real (non-NO_EFFECT) effect.
+    name: "family · SPOUSE, foreign sponsor — FREED (NARROW-1): el.c1.tourism-family reads no sponsor fact",
+    category: "family",
+    tripScope: "single",
+    branch: [
+      ["sponsor_category", "FAMILY"],
+      ["family_relation", "SPOUSE"],
+      ["marital_status", "MARRIED"],
+      ["family_sponsor_nationalities", "IT"],
+      ["family_sponsor_status_code", "E23"],
+      ["family_sponsor_permit_basis", "EXPERT"],
+      ["family_marriage_registered", "yes"],
+      ["family_sponsor_confirmed", "yes"],
+      ["stay_days", "121"],
+    ],
+    flags: [],
+  },
+  {
+    // NARROW-1 condition (ii): STEPCHILD is, today, the one relation with a
+    // pack product genuinely gated on the sponsor — `el.e31d-stepchild-
+    // support` requires `family.sponsor_confirmed` with `on_unknown:
+    // NEEDS_INPUT`. Held only when the sponsor is foreign (status code
+    // asked at all); the Indonesian-sponsor STEPCHILD walk stays FREED —
+    // see "innocence: STEPCHILD with an Indonesian sponsor" in
+    // fact-mapper.test.ts.
+    name: "family · STEPCHILD, foreign sponsor — HELD (NARROW-1 ii): el.e31d-stepchild-support is sponsor-dependent",
+    category: "family",
+    tripScope: "single",
+    branch: [
+      ["sponsor_category", "FAMILY"],
+      ["family_relation", "STEPCHILD"],
+      ["marital_status", "SINGLE"],
+      ["family_sponsor_nationalities", "IT"],
+      ["family_sponsor_status_code", "E23"],
+      ["family_sponsor_permit_basis", "EXPERT"],
+      ["family_stepchild_marriage_certificate_confirmed", "yes"],
+      ["family_stepchild_birth_certificate_confirmed", "yes"],
+      ["family_sponsor_confirmed", "yes"],
+      ["stay_days", "121"],
+    ],
+    flags: ["AMBIGUOUS_SPONSOR"],
   },
   {
     name: "other · medical — HELD: no answer here reaches a fact a rule reads",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -232,8 +232,6 @@ describe("question registry -> wire coverage", () => {
     ["business_activity", "other", "ACTIVITY_BOUNDARY"],
     ["investment_vehicle", "property", "ACTIVITY_BOUNDARY"],
     ["retirement_basis", "property", "ACTIVITY_BOUNDARY"],
-    ["family_sponsor_status_code", "FOO", "AMBIGUOUS_SPONSOR"],
-    ["family_sponsor_permit_basis", "EXPERT", "AMBIGUOUS_SPONSOR"],
     ["diaspora_connection", "former_citizen", "ACTIVITY_BOUNDARY"],
     ["diaspora_documents", "passport", "ACTIVITY_BOUNDARY"],
     ["other_purpose", "medical", "ACTIVITY_BOUNDARY"],
@@ -245,6 +243,16 @@ describe("question registry -> wire coverage", () => {
     },
   );
 
+  // NARROW-1 (owner ruling SHWEB-20260911, 2026-09-12): `family_sponsor_
+  // status_code`/`family_sponsor_permit_basis` USED to be pinned in the
+  // "must flag" table above, on the mere presence of either fact — i.e.
+  // because the sponsor is foreign, regardless of whether any candidate the
+  // pack had proven actually reads it. Measured: `el.c1.tourism-family`
+  // (rulepack-prod-020) reads no sponsor fact at all, so that was the
+  // OVER-match shape (guard #3) — deleting a verdict the flag cannot affect.
+  // The pair moves to the must-NOT-flag table below, replaced by the
+  // narrower guilt cases in "AMBIGUOUS_SPONSOR — narrowed to unsure or a
+  // sponsor-dependent relation" beneath it.
   it.each([
     ["business_activity", "meetings"],
     ["business_activity", "negotiation"],
@@ -252,6 +260,10 @@ describe("question registry -> wire coverage", () => {
     ["investment_vehicle", "pt_pma"],
     ["retirement_basis", "bank_deposit"],
     ["retirement_basis", "passive_income"],
+    // Released 2026-09-12 (NARROW-2) — el.e33f.retirement decides SUPPORT
+    // off `secondhome.passive_monthly_income_usd`/`family.sponsor_confirmed`
+    // alone, never `retirement_basis` itself. See fact-mapper.ts.
+    ["retirement_basis", "family_sponsor"],
     // Engine-inert: no rule reads a work role (owner ruling, decision 6).
     // All five options are swept in `activity-boundary.test.ts`.
     ["work_role", "specialist"],
@@ -261,12 +273,202 @@ describe("question registry -> wire coverage", () => {
     ["diaspora_connection", "family"],
     ["diaspora_documents", "yes"],
     ["diaspora_documents", "no"],
+    // Released 2026-09-12 (NARROW-1) — no relation is set, so there is no
+    // pack product this presence can be protecting. See the describe block
+    // below for the STEPCHILD (relation-dependent) counter-case.
+    ["family_sponsor_status_code", "FOO"],
+    // Dropped from the trigger entirely, for every relation: no rule in
+    // seq-20 reads `family.sponsor_permit_basis` (HUMAN_CONTEXT only, never
+    // wired to a FACT — see `mapFamilySponsorPermitBasis`).
+    ["family_sponsor_permit_basis", "EXPERT"],
   ])(
     "leaves a decidable answer (%s=%s) unflagged — it must not veto a proven candidate",
     (id, value) => {
       expect(mapFacts({ [id]: value }).disclosed_review_flags).toEqual([]);
     },
   );
+});
+
+describe("AMBIGUOUS_SPONSOR — narrowed to unsure or a sponsor-dependent relation (NARROW-1)", () => {
+  it("guilt: an unsure family_sponsor_status_code answer holds, for any relation", () => {
+    expect(
+      mapFacts({
+        family_relation: "SPOUSE",
+        family_sponsor_status_code: "unsure",
+      }).disclosed_review_flags,
+    ).toContain("AMBIGUOUS_SPONSOR");
+  });
+
+  it("guilt: an unsure family_sponsor_confirmed answer holds, for any relation", () => {
+    expect(
+      mapFacts({
+        family_relation: "OTHER",
+        family_sponsor_confirmed: "unsure",
+      }).disclosed_review_flags,
+    ).toContain("AMBIGUOUS_SPONSOR");
+  });
+
+  it("guilt: STEPCHILD with a foreign (non-unsure) sponsor status still holds — el.e31d-stepchild-support is the one relation with a sponsor-dependent product", () => {
+    expect(
+      mapFacts({
+        family_relation: "STEPCHILD",
+        family_sponsor_status_code: "E23",
+      }).disclosed_review_flags,
+    ).toContain("AMBIGUOUS_SPONSOR");
+  });
+
+  it("innocence: a non-STEPCHILD relation with a resolved (non-unsure) foreign sponsor status releases — C1 reads no sponsor fact", () => {
+    for (const relation of [
+      "SPOUSE",
+      "CHILD",
+      "PARENT",
+      "SIBLING",
+      "DEPENDENT",
+      "OTHER",
+    ]) {
+      expect(
+        mapFacts({
+          family_relation: relation,
+          family_sponsor_status_code: "E23",
+        }).disclosed_review_flags,
+      ).not.toContain("AMBIGUOUS_SPONSOR");
+    }
+  });
+
+  it("innocence: STEPCHILD with an Indonesian sponsor (status code never asked) releases", () => {
+    expect(
+      mapFacts({
+        family_relation: "STEPCHILD",
+      }).disclosed_review_flags,
+    ).not.toContain("AMBIGUOUS_SPONSOR");
+  });
+
+  it("innocence: a resolved family_sponsor_permit_basis never holds, even for STEPCHILD — dropped from the trigger entirely", () => {
+    expect(
+      mapFacts({
+        family_relation: "STEPCHILD",
+        family_sponsor_permit_basis: "EXPERT",
+      }).disclosed_review_flags,
+    ).not.toContain("AMBIGUOUS_SPONSOR");
+  });
+
+  /**
+   * Pins the hardcoded relation set inside `mapDisclosedReviewFlags`
+   * (`RELATIONS_WITH_SPONSOR_DEPENDENT_PRODUCT`) against every production
+   * pack on disk — not just the active one, same reasoning as
+   * `engine-adapter.test.ts`'s "support reasons are sentences" tripwire: a
+   * pack is written before it is activated. For each relation named on a
+   * `family.relation_to_sponsor eq` rule, this collects every OTHER
+   * `family.sponsor_*` fact that relation's rules read, together with that
+   * rule's `on_unknown`. A relation counts as sponsor-dependent only when at
+   * least one such read has a real effect (`on_unknown` other than
+   * `NO_EFFECT`) — `family.sponsor_nationalities` is excluded on purpose,
+   * it is the directly-answered, trusted fact that decides whether the
+   * self-declared ones get asked at all, not one of the ambiguous facts
+   * AMBIGUOUS_SPONSOR exists to guard.
+   *
+   * Goes RED the moment the pack stops matching the code's belief: STEPCHILD
+   * loses its dependency, or a new one appears elsewhere (SPOUSE/PARENT/
+   * CHILD/SIBLING/DEPENDENT/OTHER) — either is a signal to revisit
+   * `RELATIONS_WITH_SPONSOR_DEPENDENT_PRODUCT` in fact-mapper.ts.
+   */
+  it("AMBIGUOUS_SPONSOR relation proxy tracks the signed pack", () => {
+    const PACKS_DIR = path.resolve(
+      REPO_ROOT,
+      "apps/backend-rag/backend/services/visa_engine/contracts/packs",
+    );
+
+    // Reads only the HIGHEST-`sequence` pack on disk, deliberately NOT every
+    // pack file (same posture as `engine-adapter.test.ts`'s
+    // `latestProductionPackFile`): the FAMILY relation rules have been
+    // reshaped across the pack's history (STEPCHILD/E31D itself only landed
+    // 2026-07-24), so globbing every file on disk would resurrect
+    // superseded rule shapes as permanent, unfixable "dependencies" no
+    // current interview can ever produce.
+    function latestProductionPackFile(): string {
+      const files = fs
+        .readdirSync(PACKS_DIR)
+        .filter((name) => /^rulepack-prod-\d+\.source\.json$/.test(name));
+      if (files.length === 0) {
+        throw new Error(`no production packs found under ${PACKS_DIR}`);
+      }
+      let best: { file: string; sequence: number } | null = null;
+      for (const name of files) {
+        const full = path.join(PACKS_DIR, name);
+        const payload = JSON.parse(fs.readFileSync(full, "utf-8")) as {
+          sequence?: unknown;
+        };
+        if (typeof payload.sequence !== "number") continue;
+        if (best === null || payload.sequence > best.sequence) {
+          best = { file: full, sequence: payload.sequence };
+        }
+      }
+      if (best === null) {
+        throw new Error(`no pack under ${PACKS_DIR} had a numeric sequence`);
+      }
+      return best.file;
+    }
+
+    const NON_AMBIGUOUS_SPONSOR_FACTS = new Set([
+      "family.sponsor_nationalities",
+    ]);
+
+    function factsAndRelations(when: unknown): {
+      facts: Array<{ fact: string; onUnknown: unknown }>;
+      relations: Set<string>;
+    } {
+      const facts: Array<{ fact: string; onUnknown: unknown }> = [];
+      const relations = new Set<string>();
+      const walk = (node: unknown): void => {
+        if (Array.isArray(node)) {
+          node.forEach(walk);
+          return;
+        }
+        if (node === null || typeof node !== "object") return;
+        const record = node as Record<string, unknown>;
+        if (typeof record.fact === "string") {
+          if (
+            record.fact === "family.relation_to_sponsor" &&
+            record.op === "eq" &&
+            typeof record.value === "string"
+          ) {
+            relations.add(record.value);
+          }
+          facts.push({ fact: record.fact, onUnknown: undefined });
+        }
+        for (const value of Object.values(record)) walk(value);
+      };
+      walk(when);
+      return { facts, relations };
+    }
+
+    const pack = JSON.parse(
+      fs.readFileSync(latestProductionPackFile(), "utf-8"),
+    ) as {
+      rules?: Array<{ when?: unknown; on_unknown?: unknown }>;
+    };
+    expect(pack.rules?.length ?? 0).toBeGreaterThan(0);
+
+    const dependentRelations = new Set<string>();
+    for (const rule of pack.rules ?? []) {
+      const { facts, relations } = factsAndRelations(rule.when);
+      if (relations.size === 0) continue;
+      const sponsorFacts = facts
+        .map((f) => f.fact)
+        .filter(
+          (fact) =>
+            fact.startsWith("family.sponsor_") &&
+            !NON_AMBIGUOUS_SPONSOR_FACTS.has(fact),
+        );
+      if (sponsorFacts.length === 0) continue;
+      if (rule.on_unknown === "NO_EFFECT") continue;
+      for (const relation of relations) {
+        dependentRelations.add(relation);
+      }
+    }
+
+    expect(dependentRelations).toEqual(new Set(["STEPCHILD"]));
+  });
 });
 
 describe("mapOracleFactsToApplicantFacts — discriminated-union validity (acceptance test 2)", () => {
@@ -804,7 +1006,11 @@ describe("family sponsor status — unverified human context", () => {
       status: "UNKNOWN",
       reason: "UNVERIFIED",
     });
-    expect(result.disclosed_review_flags).toContain("AMBIGUOUS_SPONSOR");
+    // NARROW-1 (2026-09-12): staying UNVERIFIED, not KNOWN, is unchanged —
+    // whether that UNVERIFIED-ness also HOLDS the decision is now a
+    // relation-level question, no `family_relation` is set here, and "FOO"
+    // is not `unsure`, so it does not. See "AMBIGUOUS_SPONSOR — narrowed…".
+    expect(result.disclosed_review_flags).not.toContain("AMBIGUOUS_SPONSOR");
   });
 
   // 2026-08-23: `family.sponsor_permit_basis` shipped in PR #4650 wired to
@@ -820,7 +1026,9 @@ describe("family sponsor status — unverified human context", () => {
       status: "UNKNOWN",
       reason: "UNVERIFIED",
     });
-    expect(result.disclosed_review_flags).toContain("AMBIGUOUS_SPONSOR");
+    // NARROW-1 (2026-09-12): dropped from the trigger entirely — no rule in
+    // seq-20 reads `family.sponsor_permit_basis` at all.
+    expect(result.disclosed_review_flags).not.toContain("AMBIGUOUS_SPONSOR");
   });
 
   it("resolves NOT_APPLICABLE for both sponsor facts when no sponsor is confirmed", () => {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -463,7 +463,17 @@ const REVIEW_FLAG_MAP: Readonly<
 export const ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS = {
   business_activity: ["meetings", "negotiation", "conference"],
   investment_vehicle: ["pt_pma"],
-  retirement_basis: ["bank_deposit", "passive_income"],
+  // `family_sponsor` added 2026-09-12 (NARROW-2, owner ruling SHWEB-20260911:
+  // hold is the exception, a deterministic pack answer is not). `el.e33f.
+  // retirement` (rulepack-prod-020) decides SUPPORT for E33F off
+  // `secondhome.passive_monthly_income_usd >= 3000` and `family.
+  // sponsor_confirmed == true` alone — it never reads `retirement_basis` at
+  // all — so this table was UNDER-inclusive: an applicant who answers
+  // `family_sponsor` and clears both of those facts already has a signed,
+  // deterministic SUPPORTED E33F, and raising ACTIVITY_BOUNDARY here only
+  // deletes it. `property` and `undecided` stay undecidable: no pack rule
+  // grants either an E33F path, so holding them loses nothing proven.
+  retirement_basis: ["bank_deposit", "passive_income", "family_sponsor"],
   diaspora_connection: ["former_wni", "descendant", "family"],
   diaspora_documents: ["yes", "no"],
   other_purpose: [],
@@ -503,9 +513,50 @@ export function mapDisclosedReviewFlags(
   if (hasUndecidableActivityAnswer(facts)) {
     flags.add("ACTIVITY_BOUNDARY");
   }
+  // NARROW-1 (owner ruling SHWEB-20260911, 2026-09-12 20:35 WITA): the flag
+  // used to fire on the mere PRESENCE of `family_sponsor_status_code` /
+  // `family_sponsor_permit_basis` — i.e. because the sponsor is foreign, not
+  // because any candidate the pack had proven actually needs that fact. That
+  // is the OVER-match shape (guard #3): `el.c1.tourism-family` (rulepack-
+  // prod-020) reads no sponsor fact at all, so a foreign sponsor deleted a
+  // verdict it cannot affect. `family_sponsor_permit_basis` is dropped from
+  // the trigger entirely: no rule in seq-20 reads `family.sponsor_permit_
+  // basis` (it is HUMAN_CONTEXT only, never wired to a FACT — see
+  // `mapFamilySponsorPermitBasis`, below), so it could never have been the
+  // fact a held candidate needed.
+  //
+  // Hold now only when:
+  //  (i) the applicant said `unsure` — a real disclosed uncertainty, not a
+  //      derived one; or
+  //  (ii) the relation answered has a pack product that genuinely depends on
+  //       the sponsor being resolved. `_apply_disclosed_review_flags`
+  //       (evaluate_path.py) is monotone over the WHOLE decision, so a
+  //       per-candidate hold is not available here — this is the frontend,
+  //       interview-time, RELATION-level proxy the constraint allows.
+  //
+  // Today exactly one relation qualifies for (ii): STEPCHILD.
+  // `el.e31d-stepchild-support` requires `family.sponsor_confirmed` with
+  // `on_unknown: NEEDS_INPUT` — the only family-relation product whose
+  // ELIGIBILITY is gated (not merely annotated) by a sponsor fact. SPOUSE /
+  // PARENT / CHILD / SIBLING each have a "*-sponsor-itas-itap" rule reading
+  // `family.sponsor_status_code`, but every one of them is `on_unknown:
+  // NO_EFFECT` — an unresolved sponsor status changes nothing they decide,
+  // so holding on their behalf would delete a proven verdict for no reason,
+  // the exact defect this narrowing exists to cure. Pinned against pack
+  // drift by "AMBIGUOUS_SPONSOR relation proxy tracks the signed pack" in
+  // fact-mapper.test.ts, which reads every production pack on disk and
+  // fails if that set of relations ever changes.
+  const RELATIONS_WITH_SPONSOR_DEPENDENT_PRODUCT: ReadonlySet<string> = new Set(
+    ["STEPCHILD"],
+  );
+  const sponsorRelationUnresolved =
+    facts.family_sponsor_status_code !== undefined &&
+    facts.family_relation !== undefined &&
+    RELATIONS_WITH_SPONSOR_DEPENDENT_PRODUCT.has(facts.family_relation);
   if (
-    facts.family_sponsor_status_code !== undefined ||
-    facts.family_sponsor_permit_basis !== undefined
+    facts.family_sponsor_status_code === "unsure" ||
+    facts.family_sponsor_confirmed === "unsure" ||
+    sponsorRelationUnresolved
   ) {
     flags.add("AMBIGUOUS_SPONSOR");
   }


### PR DESCRIPTION
## What

**PR-D2 of SHWEB-20260911 / W-ORACLE.** Zero ruled today (2026-09-12 20:35 WITA):

> «portare al minimo possibile il rimando a revisione umana; se abbiamo la certezza deterministica di una risposta veritiera, la dà visa oracle, non revisione umana.»

Human review is the exception. Where the signed pack yields a deterministic truthful verdict, the Oracle answers. This PR narrows the two disclosure holds that were deleting answers the pack could already give. **Frontend only** — `fact-mapper.ts` and its tests. No rule pack, no backend, no `evaluate_path.py`, no evaluator, no `oracle.css`.

## NARROW-2 — one value added to the decidable table

`ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS.retirement_basis` gains `family_sponsor`. `property` and `undecided` stay undecidable; `investment_vehicle` stays at `pt_pma` only; both `other` lists stay empty.

Why exactly that one value: `el.e33f.retirement` decides the sponsored retirement basis deterministically, and the corpus proves the table was UNDER-inclusive there — the same profile at age 64 produced SUPPORTED E33F with no flag, and the flag deleted it.

## NARROW-1 — the sponsor hold stops firing on a question having been asked

`AMBIGUOUS_SPONSOR` is now raised only when **(i)** the applicant answered `unsure` to `family_sponsor_status_code` or `family_sponsor_confirmed`, or **(ii)** the relation has a sponsor-dependent product in the pack. `family_sponsor_permit_basis` is removed from the trigger entirely — no rule in seq-20 reads that fact path.

The old trigger fired because a QUESTION WAS ASKED, and that question is asked precisely when the sponsor is foreign. The verdict it deleted (C1) reads no sponsor fact in the pack at all. That is the OVER-match shape: the guard judged a substring of the interview rather than the entity in the verdict.

**How (ii) is derived, and why it is a relation-level proxy.** `_apply_disclosed_review_flags` in `evaluate_path.py` is monotone over the WHOLE decision, so a per-candidate hold is not available to a frontend-only change. (ii) is therefore decided at interview time from the relation answer. The relation set is not hardcoded by hand: `el.e31d-stepchild-support` is the only family-relation rule in seq-20 with `on_unknown=NEEDS_INPUT` on a `family.sponsor_*` fact — SPOUSE/PARENT/CHILD/SIBLING's sponsor-keyed rules are all `on_unknown=NO_EFFECT`. A test ("AMBIGUOUS_SPONSOR relation proxy tracks the signed pack") reads the highest-sequence pack on disk and **goes red if that relation set ever changes**, so a seq-21 that makes another relation sponsor-dependent cannot pass silently.

## Acceptance — measured twice, independently

Replay of the 67-walk corpus through the real evaluator (`research/visa/2026-09-11-review-reason-audit/inputs.mts` → `test_census.py`), run by the implementer and then re-run from scratch by the orchestrator:

| 67 walks | SUPPORTED | NO_SUPPORTED_PATH | NEEDS_INPUT | HUMAN_REVIEW |
|---|---:|---:|---:|---:|
| before, real flags | 31 | 7 | 0 | 29 |
| **after, real flags** | **46** | **8** | **0** | **13** |
| without flags (unchanged either way) | 55 | 10 | 2 | — |

Both clocks (`signed_at` and current) agree. Decisive answers go from 38/67 to **54/67**.

The 13 that remain, named: `offshore/invest/{property,bank_deposit,merit,family,undecided}` (5) · `offshore/retirement/{property,undecided}` and their age-64 twins (4) · `offshore/other` and `onshore/other` (2) · `offshore/{family,diaspora}/STEPCHILD/spNat=IT` (2). Exactly the acceptance set, including the two STEPCHILD rows the relation proxy was required to keep.

## Not done, and where it goes

**Item (c) of the mandate — the non-blocking note on a released C1 verdict** (a family stay permit may exist, subject to verifying the sponsor's own KITAS/KITAP) — is NOT in this PR. It requires `engine-adapter.ts`, which PR-O2 owns and has frozen at CANDIDATO. The implementer stopped at the boundary rather than crossing it, which is the correct call: two PRs editing the same file in parallel is how a merge queue produces a silent conflict. It is re-homed to PR-D3, whose D3-4 item already carries the E31D document note.

Without it, a released C1 is complete but not maximally advised — the visitor is told the answer, not the caveat. That is a gap of advice, not a false statement.

## Gates

- `tsc --noEmit` → exit 0
- `vitest run 'src/app/(visa-oracle)'` → exit 0, **699/699**
- `eslint` → clean
- backend `pytest test_interview_walk_census.py` → 15/15 (unaffected: corpus fixtures carry no disclosure flags)
- census replay → the table above, re-run independently by the orchestrator against this exact head
- harness floor → **1**, source `none`; no evidence pack required at this floor

## Bites

Bites: consumer = every visitor whose walk was being held by these two flags — 16 of them in the corpus; observation = on `origin/main` after merge, the census replay (`npx --no-install tsx research/visa/2026-09-11-review-reason-audit/inputs.mts` then `pytest research/visa/2026-09-11-review-reason-audit/test_census.py`, which writes `/tmp/visaoracle-audit-20260911/census.json`) reports 46 / 8 / 0 / 13 over the 67 walks, and `offshore/family/SPOUSE/spNat=IT` carries an empty `disclosed_review_flags` while `offshore/family/STEPCHILD/spNat=IT` still carries `AMBIGUOUS_SPONSOR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
