### PR TITLE
feat(compliance): catalog and client compliance-profile endpoints for the obligations reviewer (M3)

### DIFF
--- a/apps/backend-rag/backend/app/routers/compliance_obligations.py
+++ b/apps/backend-rag/backend/app/routers/compliance_obligations.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from dataclasses import asdict
 from datetime import date
 from functools import lru_cache
 from typing import Any
@@ -45,11 +46,21 @@ from pydantic import BaseModel, Field
 
 from backend.app.dependencies import get_current_user, get_database_pool
 from backend.app.utils.crm_utils import is_crm_admin
+from backend.app.utils.json_utils import to_jsonb
 from backend.services.compliance.alert_repository import AlertRepository, AlertRow
 from backend.services.compliance.obligations_register import (
+    ATTRIBUTES,
+    BOOL_ATTRS,
+    COMPANY_TYPES,
+    INT_ATTRS,
+    INVESTMENT_STAGES,
     ObligationRule,
+    _as_bool,
+    _as_int,
+    _valid_fye,
     load_catalog,
     profile_from_rows,
+    profile_inputs,
     propose,
 )
 from backend.services.compliance.obligations_repository import (
@@ -194,6 +205,215 @@ async def list_obligations(
 
 
 # --------------------------------------------------------------------------- #
+# GET /catalog, GET /profile/{client_id}, PATCH /profile/{client_id}
+#
+# These MUST stay registered BEFORE "/{obligation_id}" below: FastAPI matches
+# routes in registration order, so with the order reversed "/catalog" would hit
+# the int path converter of the detail route and answer 422 instead of 200.
+# --------------------------------------------------------------------------- #
+class CatalogRuleOut(BaseModel):
+    """One catalog rule, flattened for the reviewer screen. No client data."""
+
+    id: str
+    name: str
+    authority: str
+    legal_source: str
+    verified: bool
+    frequency: str
+    roll: str
+    needs_review_reason: str | None
+    trigger: str | None
+    notes: str | None
+
+
+class ProfileOut(BaseModel):
+    """The computed ClientProfile plus the provenance the reviewer UI needs."""
+
+    client_id: int
+    profile: dict[str, Any]
+    present_keys: list[str]
+    missing_keys: list[str]
+    company_type_raw: str | None
+    needs_manual_classification: bool
+
+
+@router.get("/catalog")
+async def get_catalog(
+    user: dict[str, Any] = Depends(get_current_user),
+) -> list[CatalogRuleOut]:
+    """The obligations catalog the reviewer screen labels proposals with.
+
+    Rule metadata only — no client data and no database read (``_cached_rules``
+    is the process-wide YAML load). The UI must render `rule_id` through THIS
+    endpoint instead of duplicating the catalog in the frontend.
+    """
+    _require_admin(user)
+    return [
+        CatalogRuleOut(
+            id=rule.id,
+            name=rule.name,
+            authority=rule.authority,
+            legal_source=rule.legal_source,
+            verified=rule.verified,
+            frequency=rule.due.frequency,
+            roll=rule.due.roll,
+            needs_review_reason=rule.needs_review_reason,
+            trigger=rule.trigger,
+            notes=rule.notes,
+        )
+        for rule in _cached_rules()
+    ]
+
+
+def _profile_out(
+    client_id: int, client_row: dict[str, Any] | None, company_row: dict[str, Any] | None
+) -> ProfileOut:
+    inputs = profile_inputs(client_row, company_row)
+    raw_type = (company_row or {}).get("company_type")
+    return ProfileOut(
+        client_id=client_id,
+        profile=asdict(inputs.profile),
+        present_keys=list(inputs.present_keys),
+        missing_keys=list(inputs.missing_attributes),
+        company_type_raw=None if raw_type is None else str(raw_type),
+        needs_manual_classification=inputs.profile.company_type == "OTHER",
+    )
+
+
+@router.get("/profile/{client_id}")
+async def get_client_profile(
+    client_id: int = Path(..., ge=1),
+    user: dict[str, Any] = Depends(get_current_user),
+    pool: asyncpg.Pool = Depends(get_database_pool),
+) -> ProfileOut:
+    """The profile ``POST /generate`` would compute for this client, with provenance.
+
+    ``present_keys`` are the custom_fields keys the engine recognised AND parsed;
+    ``missing_keys`` the engine ATTRIBUTES still sitting at their ClientProfile
+    default, which is what makes ``applies()`` propose the minimum. 404 when the
+    client does not exist. A client with no company row is NOT an error here (the
+    profile is simply all defaults); only PATCH needs a row to write to, and says
+    409 instead.
+    """
+    _require_admin(user)
+    async with pool.acquire() as conn:
+        client_row, company_row = await _load_client_and_company(conn, client_id)
+    if client_row is None:
+        raise HTTPException(status_code=404, detail="Client not found")
+    return _profile_out(client_id, client_row, company_row)
+
+
+# company_type is stored under its OWN custom_fields key so it never collides
+# with the companies.company_type column it overrides (see profile_inputs).
+_PATCH_CUSTOM_KEY = {"company_type": "compliance_company_type"}
+_PATCH_DOMAINS: dict[str, frozenset[str]] = {
+    "company_type": COMPANY_TYPES,
+    "investment_stage": INVESTMENT_STAGES,
+}
+
+
+def _validated_patch(body: dict[str, Any]) -> dict[str, Any]:
+    """Translate an ATTRIBUTES patch into custom_fields values, or raise 422.
+
+    Values are normalised through the engine's OWN parsers (``_as_bool`` /
+    ``_as_int`` / ``_valid_fye``), so what is stored is exactly what
+    ``profile_inputs`` will read back. Error details name the rejected KEY and
+    the allowed domain, never the submitted value.
+    """
+    if not body:
+        raise HTTPException(
+            status_code=422, detail=f"body must set at least one of {sorted(ATTRIBUTES)}"
+        )
+    unknown = sorted(set(body) - ATTRIBUTES)
+    if unknown:
+        raise HTTPException(
+            status_code=422,
+            detail=f"unknown attribute(s) {unknown}; allowed: {sorted(ATTRIBUTES)}",
+        )
+    out: dict[str, Any] = {}
+    for name, raw in body.items():
+        value: Any
+        if name in BOOL_ATTRS:
+            value = _as_bool(raw)
+        elif name in INT_ATTRS:
+            value = _as_int(raw)
+        elif name == "fiscal_year_end":
+            value = raw if _valid_fye(raw) else None
+        else:  # company_type / investment_stage: a closed domain
+            candidate = raw.strip().upper() if isinstance(raw, str) else None
+            if name == "investment_stage" and isinstance(raw, str):
+                candidate = raw.strip().lower()
+            value = candidate if candidate in _PATCH_DOMAINS[name] else None  # None: not a member
+        if value is None:
+            allowed = _PATCH_DOMAINS.get(name)
+            hint = f"; allowed: {sorted(allowed)}" if allowed else ""
+            raise HTTPException(status_code=422, detail=f"invalid value for {name!r}{hint}")
+        out[_PATCH_CUSTOM_KEY.get(name, name)] = value
+    return out
+
+
+@router.patch("/profile/{client_id}")
+async def patch_client_profile(
+    client_id: int = Path(..., ge=1),
+    body: dict[str, Any] = Body(...),
+    user: dict[str, Any] = Depends(get_current_user),
+    pool: asyncpg.Pool = Depends(get_database_pool),
+) -> ProfileOut:
+    """Merge engine ATTRIBUTES into the client's companies.custom_fields.
+
+    Body = any subset of ATTRIBUTES. ``company_type`` is accepted only as one of
+    COMPANY_TYPES and is stored under the custom_fields key
+    ``compliance_company_type``, which ``profile_inputs`` honours BEFORE the
+    companies.company_type string mapping — that precedence is what lets the
+    reviewer fix a company the string reads as OTHER, and it is documented at the
+    single place that implements it (``profile_inputs``'s docstring).
+
+    The write is the JSONB merge ``crm_enhanced.py`` already uses
+    (``COALESCE(custom_fields, '{}'::jsonb) || $1::text::jsonb``), so unrelated
+    keys survive untouched and no read-modify-write race can drop one. Nothing is
+    created: 409 when the client has no linked company row, 404 when the client
+    does not exist. A PATCH only ever SETS keys; it never removes one.
+
+    Logs the keys written, never their values (they are client data).
+    """
+    _require_admin(user)
+    patch = _validated_patch(body)
+
+    async with pool.acquire() as conn, conn.transaction():
+        client_row, company_row = await _load_client_and_company(conn, client_id)
+        if client_row is None:
+            raise HTTPException(status_code=404, detail="Client not found")
+        company_id = (company_row or {}).get("company_id")
+        if company_id is None:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Client has no company row to store the compliance profile on "
+                    "(no client_company_links entry). Link a company first; this endpoint "
+                    "creates nothing."
+                ),
+            )
+        await conn.execute(
+            """
+            UPDATE companies
+               SET custom_fields = COALESCE(custom_fields, '{}'::jsonb) || $1::text::jsonb,
+                   updated_at = NOW()
+             WHERE id = $2
+            """,
+            to_jsonb(patch),
+            company_id,
+        )
+        client_row, company_row = await _load_client_and_company(conn, client_id)
+
+    logger.info(
+        "compliance.obligations.profile.patch client_id=%s keys=%s",
+        client_id,
+        sorted(patch),
+    )
+    return _profile_out(client_id, client_row, company_row)
+
+
+# --------------------------------------------------------------------------- #
 # GET /{id} — detail
 # --------------------------------------------------------------------------- #
 @router.get("/{obligation_id}")
@@ -224,7 +444,7 @@ async def _load_client_and_company(
         return None, None
     company_row = await conn.fetchrow(
         """
-        SELECT c.company_type, c.custom_fields
+        SELECT c.id AS company_id, c.company_type, c.custom_fields
           FROM client_company_links ccl
           JOIN companies c ON c.id = ccl.company_id
          WHERE ccl.client_id = $1

--- a/apps/backend-rag/backend/services/compliance/obligations_register.py
+++ b/apps/backend-rag/backend/services/compliance/obligations_register.py
@@ -382,7 +382,10 @@ def _as_int(value: Any) -> int | None:
         return int(value)
     if isinstance(value, float) and value.is_integer() and value >= 0:
         return int(value)
-    if isinstance(value, str) and value.strip().isdigit():
+    # isdecimal(), NOT isdigit(): "\u00b2".isdigit() is True but int("\u00b2") raises, which turned a
+    # malformed custom_fields value into a 500 (Codex spalla, PR M3). Every isdecimal()
+    # string — including Arabic-Indic digits — int() parses.
+    if isinstance(value, str) and value.strip().isdecimal():
         return int(value.strip())
     return None
 

--- a/apps/backend-rag/backend/services/compliance/obligations_register.py
+++ b/apps/backend-rag/backend/services/compliance/obligations_register.py
@@ -397,41 +397,98 @@ def _custom_fields(row: Mapping[str, Any] | None) -> dict[str, Any]:
     return dict(raw) if isinstance(raw, Mapping) else {}
 
 
-def profile_from_rows(
-    client_row: Mapping[str, Any] | None, company_row: Mapping[str, Any] | None
-) -> ClientProfile:
-    """Build a profile from a clients row and a companies row.
+@dataclass(frozen=True)
+class ProfileInputs:
+    """A computed profile plus WHICH custom_fields keys produced it.
 
-    company_type comes from companies.company_type ("PT PMA" -> PT_PMA, "PT Perorangan"/"PT" ->
-    PT_PMDN, "CV" -> CV); anything else is OTHER, or FOREIGN_PLATFORM when custom_fields has
-    is_foreign_platform true. Every other attribute is read from custom_fields under its own name
-    (companies.custom_fields wins over clients.custom_fields); missing or malformed values fall
-    back to the ClientProfile defaults. has_employees is true if set or if employee_count > 0.
+    ``present_keys``: engine-recognised custom_fields keys that carried a value the engine could
+    parse, so they actually shaped the profile. ``missing_attributes``: engine ATTRIBUTES left at
+    their ClientProfile default because nothing valid was supplied (``company_type`` is listed
+    when it fell back to OTHER without an explicit ``compliance_company_type``).
+    """
+
+    profile: ClientProfile
+    present_keys: tuple[str, ...]
+    missing_attributes: tuple[str, ...]
+
+
+def profile_inputs(
+    client_row: Mapping[str, Any] | None, company_row: Mapping[str, Any] | None
+) -> ProfileInputs:
+    """Build a profile from a clients row and a companies row, with its provenance.
+
+    company_type precedence, highest first:
+    1. ``custom_fields["compliance_company_type"]`` when it is one of COMPANY_TYPES. This key is
+       written by PATCH /api/compliance/obligations/profile/{client_id} and WINS over the
+       companies.company_type string, so a reviewer can classify a company whose string spelling
+       the map below reads as OTHER.
+    2. the companies.company_type string mapped through _COMPANY_TYPE_MAP ("PT PMA" -> PT_PMA,
+       "PT Perorangan"/"PT" -> PT_PMDN, "CV" -> CV); anything unrecognised is OTHER.
+    3. FOREIGN_PLATFORM, when 2. yielded OTHER and custom_fields has is_foreign_platform true.
+
+    Every other attribute is read from custom_fields under its own name (companies.custom_fields
+    wins over clients.custom_fields); missing or malformed values fall back to the ClientProfile
+    defaults. has_employees is true if set or if employee_count > 0.
     """
     custom = {**_custom_fields(client_row), **_custom_fields(company_row)}
-    raw_type = str((company_row or {}).get("company_type") or "").upper()
-    raw_type = " ".join(re.sub(r"\(.*?\)|\.", " ", raw_type).split())  # "PT. PMA (Persero)"
-    company_type = _COMPANY_TYPE_MAP.get(raw_type, "OTHER")
-    if company_type == "OTHER" and _as_bool(custom.get("is_foreign_platform")):
-        company_type = "FOREIGN_PLATFORM"
+    present: list[str] = []
+    supplied: set[str] = set()
+
+    explicit = custom.get("compliance_company_type")
+    company_type = explicit.strip().upper() if isinstance(explicit, str) else ""
+    if company_type in COMPANY_TYPES:
+        present.append("compliance_company_type")
+        supplied.add("company_type")
+    else:
+        raw_type = str((company_row or {}).get("company_type") or "").upper()
+        raw_type = " ".join(re.sub(r"\(.*?\)|\.", " ", raw_type).split())  # "PT. PMA (Persero)"
+        company_type = _COMPANY_TYPE_MAP.get(raw_type, "OTHER")
+        if company_type != "OTHER":
+            supplied.add("company_type")
+        elif _as_bool(custom.get("is_foreign_platform")):
+            company_type = "FOREIGN_PLATFORM"
+            present.append("is_foreign_platform")
+            supplied.add("company_type")
+
     kwargs: dict[str, Any] = {"company_type": company_type}
     for name in BOOL_ATTRS:
         flag = _as_bool(custom.get(name))
         if flag is not None:
             kwargs[name] = flag
+            present.append(name)
+            supplied.add(name)
     for name in INT_ATTRS:
         number = _as_int(custom.get(name))
         if number is not None:
             kwargs[name] = number
+            present.append(name)
+            supplied.add(name)
     stage = custom.get("investment_stage")
     if isinstance(stage, str) and stage in INVESTMENT_STAGES:
         kwargs["investment_stage"] = stage
+        present.append("investment_stage")
+        supplied.add("investment_stage")
     if _valid_fye(custom.get("fiscal_year_end")):
         kwargs["fiscal_year_end"] = custom["fiscal_year_end"]
+        present.append("fiscal_year_end")
+        supplied.add("fiscal_year_end")
     kwargs["has_employees"] = (
         bool(kwargs.get("has_employees")) or kwargs.get("employee_count", 0) > 0
     )
-    return ClientProfile(**kwargs)
+    if kwargs["has_employees"]:  # explicit, or derived from a positive employee_count
+        supplied.add("has_employees")
+    return ProfileInputs(
+        profile=ClientProfile(**kwargs),
+        present_keys=tuple(sorted(present)),
+        missing_attributes=tuple(sorted(ATTRIBUTES - supplied)),
+    )
+
+
+def profile_from_rows(
+    client_row: Mapping[str, Any] | None, company_row: Mapping[str, Any] | None
+) -> ClientProfile:
+    """The profile only. See ``profile_inputs`` for the company_type precedence it applies."""
+    return profile_inputs(client_row, company_row).profile
 
 
 __all__ = [
@@ -443,10 +500,12 @@ __all__ = [
     "DueRule",
     "ObligationRule",
     "Predicate",
+    "ProfileInputs",
     "ProposedObligation",
     "applies",
     "due_dates",
     "load_catalog",
     "profile_from_rows",
+    "profile_inputs",
     "propose",
 ]

--- a/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
@@ -16,6 +16,7 @@ import pytest
 
 from backend.db.migration_base import split_migration_sql
 from backend.services.compliance.obligations_register import (
+    ATTRIBUTES,
     CatalogError,
     ClientProfile,
     DueRule,
@@ -24,6 +25,7 @@ from backend.services.compliance.obligations_register import (
     due_dates,
     load_catalog,
     profile_from_rows,
+    profile_inputs,
     propose,
 )
 from backend.services.compliance.obligations_repository import (
@@ -347,6 +349,66 @@ def test_leap_day_fiscal_year_end_is_kept():
 def test_profile_from_rows_survives_unhashable_values():
     company = {"company_type": "PT PMA", "custom_fields": {"investment_stage": [], "pkp": {}}}
     assert profile_from_rows(None, company) == ClientProfile(company_type="PT_PMA")
+
+
+# --------------------------------------------------------------------------- #
+# company_type precedence and the provenance profile_inputs reports (PR M3):
+# compliance_company_type is written by PATCH /profile/{client_id} and must win
+# over the companies.company_type string, which is what lets a reviewer fix a
+# company the string mapping reads as OTHER.
+# --------------------------------------------------------------------------- #
+def test_compliance_company_type_wins_over_an_unrecognised_company_type_string():
+    company = {
+        "company_type": "Yayasan Something Unrecognised",
+        "custom_fields": {"compliance_company_type": "pt_pma"},
+    }
+    inputs = profile_inputs(None, company)
+    assert inputs.profile.company_type == "PT_PMA"
+    assert "compliance_company_type" in inputs.present_keys
+    assert "company_type" not in inputs.missing_attributes
+
+
+def test_compliance_company_type_wins_over_a_recognised_company_type_string_too():
+    company = {"company_type": "PT PMA", "custom_fields": {"compliance_company_type": "CV"}}
+    assert profile_from_rows(None, company).company_type == "CV"
+
+
+@pytest.mark.parametrize("bad", ["PT_XYZ", "", None, 7, ["PT_PMA"], {}])
+def test_invalid_compliance_company_type_falls_back_to_the_string_mapping(bad):
+    company = {"company_type": "PT PMA", "custom_fields": {"compliance_company_type": bad}}
+    assert profile_from_rows(None, company).company_type == "PT_PMA"
+
+
+def test_profile_inputs_reports_present_keys_and_missing_attributes():
+    company = {"company_type": "PT PMA", "custom_fields": {"pkp": "yes", "employee_count": 3}}
+    inputs = profile_inputs({"id": 1}, company)
+    assert set(inputs.present_keys) == {"pkp", "employee_count"}
+    assert "has_employees" not in inputs.missing_attributes  # derived from employee_count > 0
+    assert {"pse_registered", "annual_turnover_idr", "investment_stage"} <= set(
+        inputs.missing_attributes
+    )
+    assert "company_type" not in inputs.missing_attributes  # the string mapped to PT_PMA
+
+
+def test_profile_inputs_lists_company_type_as_missing_when_it_defaulted_to_other():
+    inputs = profile_inputs(None, {"company_type": "Koperasi"})
+    assert inputs.profile.company_type == "OTHER"
+    assert "company_type" in inputs.missing_attributes
+    assert inputs.present_keys == ()
+
+
+def test_profile_inputs_of_a_bare_client_has_every_attribute_missing():
+    inputs = profile_inputs(None, None)
+    assert set(inputs.missing_attributes) == set(ATTRIBUTES)
+    assert inputs.present_keys == ()
+
+
+def test_profile_inputs_counts_the_foreign_platform_flag_as_a_present_key():
+    company = {"company_type": "Foreign co", "custom_fields": {"is_foreign_platform": True}}
+    inputs = profile_inputs(None, company)
+    assert inputs.profile.company_type == "FOREIGN_PLATFORM"
+    assert inputs.present_keys == ("is_foreign_platform",)
+    assert "company_type" not in inputs.missing_attributes
 
 
 @pytest.mark.parametrize(

--- a/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
@@ -321,6 +321,13 @@ def test_profile_from_rows_missing_custom_fields_gives_defaults(company_type, ex
     assert profile == ClientProfile(company_type=expected)
 
 
+@pytest.mark.parametrize("raw", ["\u00b2", "\u00bd", "12x", " ", "-3"])
+def test_int_attributes_drop_a_non_decimal_string_instead_of_raising(raw):
+    """isdigit() accepts "\u00b2" but int("\u00b2") raises: that ValueError reached the API as a 500."""
+    company = {"company_type": "PT PMA", "custom_fields": {"employee_count": raw}}
+    assert profile_from_rows(None, company) == ClientProfile(company_type="PT_PMA")
+
+
 def test_profile_from_rows_reads_json_text_and_drops_malformed_values():
     company = {
         "company_type": "PT PMA",

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_compliance_obligations.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_compliance_obligations.py
@@ -9,6 +9,7 @@ the router's response-shaping code (``_to_out``) is exercised unchanged.
 
 from __future__ import annotations
 
+import json
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
@@ -37,9 +38,11 @@ class Store:
         self.obligations: list[dict[str, Any]] = []
         self.alerts: list[dict[str, Any]] = []
         self.op_log: list[tuple[str, Any, bool]] = []
+        self.acquire_count = 0
         self._next_id = 1
 
     def acquire(self) -> _AcquireCtx:
+        self.acquire_count += 1
         return _AcquireCtx(self)
 
     def next_id(self) -> int:
@@ -77,7 +80,7 @@ class _CountingTxn:
 
 
 class FakeConn:
-    """Answers the THREE raw SQL calls the router makes directly on a connection."""
+    """Answers the raw SQL the router makes directly on a connection."""
 
     def __init__(self, store: Store) -> None:
         self.store = store
@@ -102,6 +105,21 @@ class FakeConn:
                     return {"status": row["status"]}
             return None
         raise AssertionError(f"unexpected fetchrow query in test fake: {query!r}")
+
+    async def execute(self, query: str, *args: Any) -> str:
+        flat = " ".join(query.split())
+        if flat.startswith("UPDATE companies SET custom_fields"):
+            patch = json.loads(args[0])  # the router passes to_jsonb(...) text
+            for row in self.store.companies.values():
+                if row.get("company_id") == args[1]:
+                    existing = row.get("custom_fields") or {}
+                    if isinstance(existing, str):
+                        existing = json.loads(existing)
+                    # mirrors COALESCE(custom_fields,'{}'::jsonb) || $1::text::jsonb
+                    row["custom_fields"] = {**existing, **patch}
+                    return "UPDATE 1"
+            return "UPDATE 0"
+        raise AssertionError(f"unexpected execute query in test fake: {query!r}")
 
 
 # --------------------------------------------------------------------------- #
@@ -284,6 +302,24 @@ def _seed_proposed(store: Store, **overrides: Any) -> dict[str, Any]:
     row.update(overrides)
     store.obligations.append(row)
     return row
+
+
+def _seed_client(
+    store: Store,
+    client_id: int = 1,
+    *,
+    company: dict[str, Any] | None = None,
+    client_custom_fields: dict[str, Any] | None = None,
+) -> None:
+    """A clients row, optionally with the companies row client_company_links resolves to.
+
+    ``company`` carries ``company_id`` because the PATCH writes to that id — the
+    SELECT in ``_load_client_and_company`` is the single place that decides WHICH
+    company row a client maps to, for both /generate and the profile routes.
+    """
+    store.clients[client_id] = {"id": client_id, "custom_fields": client_custom_fields or {}}
+    if company is not None:
+        store.companies[client_id] = dict(company)
 
 
 # --------------------------------------------------------------------------- #
@@ -537,3 +573,256 @@ def test_reject_unknown_id_404(store: Store) -> None:
     client = TestClient(_app(store, ADMIN_USER))
     resp = client.post("/api/compliance/obligations/999/reject", json={"reason": "no"})
     assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# GET /catalog — rule metadata only: no client data, no database, and the path
+# segment must NOT be read as an obligation id (route ordering, PR M3).
+# --------------------------------------------------------------------------- #
+def test_catalog_403_for_non_admin(store: Store) -> None:
+    client = TestClient(_app(store, NON_ADMIN_USER))
+    assert client.get("/api/compliance/obligations/catalog").status_code == 403
+
+
+def test_catalog_returns_every_rule_with_reviewer_metadata(store: Store) -> None:
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.get("/api/compliance/obligations/catalog")
+
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == len(compliance_obligations._cached_rules()) == 21
+    by_id = {row["id"]: row for row in rows}
+    assert set(by_id["pph21_payment"]) == {
+        "id",
+        "name",
+        "authority",
+        "legal_source",
+        "verified",
+        "frequency",
+        "roll",
+        "needs_review_reason",
+        "trigger",
+        "notes",
+    }
+    assert by_id["pph21_payment"]["frequency"] == "monthly"
+    assert by_id["pph21_payment"]["roll"] == "next_business_day"
+    assert all(isinstance(row["verified"], bool) and row["name"] for row in rows)
+
+
+def test_catalog_reads_no_client_data(store: Store) -> None:
+    client = TestClient(_app(store, ADMIN_USER))
+
+    assert client.get("/api/compliance/obligations/catalog").status_code == 200
+
+    assert store.acquire_count == 0  # never opens a connection
+
+
+# --------------------------------------------------------------------------- #
+# GET /profile/{client_id}
+# --------------------------------------------------------------------------- #
+def test_profile_403_for_non_admin(store: Store) -> None:
+    _seed_client(store)
+    client = TestClient(_app(store, NON_ADMIN_USER))
+    assert client.get("/api/compliance/obligations/profile/1").status_code == 403
+
+
+def test_profile_404_unknown_client(store: Store) -> None:
+    client = TestClient(_app(store, ADMIN_USER))
+    assert client.get("/api/compliance/obligations/profile/999").status_code == 404
+
+
+def test_profile_reports_present_and_missing_keys(store: Store) -> None:
+    _seed_client(
+        store,
+        company={"company_id": 90, "company_type": "PT PMA", "custom_fields": {"pkp": True}},
+    )
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.get("/api/compliance/obligations/profile/1")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["client_id"] == 1
+    assert body["profile"]["company_type"] == "PT_PMA"
+    assert body["profile"]["pkp"] is True
+    assert body["present_keys"] == ["pkp"]
+    assert "pse_registered" in body["missing_keys"]
+    assert "pkp" not in body["missing_keys"]
+    assert body["company_type_raw"] == "PT PMA"
+    assert body["needs_manual_classification"] is False
+
+
+def test_profile_without_a_company_row_is_all_defaults(store: Store) -> None:
+    _seed_client(store)  # client exists, no client_company_links row
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.get("/api/compliance/obligations/profile/1")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["profile"]["company_type"] == "OTHER"
+    assert body["company_type_raw"] is None
+    assert body["present_keys"] == []
+    assert body["needs_manual_classification"] is True
+
+
+# --------------------------------------------------------------------------- #
+# PATCH /profile/{client_id} — JSONB merge into companies.custom_fields
+# --------------------------------------------------------------------------- #
+def test_patch_403_for_non_admin(store: Store) -> None:
+    _seed_client(store, company={"company_id": 90, "company_type": "PT PMA", "custom_fields": {}})
+    client = TestClient(_app(store, NON_ADMIN_USER))
+    resp = client.patch("/api/compliance/obligations/profile/1", json={"pkp": True})
+    assert resp.status_code == 403
+
+
+def test_patch_merges_without_wiping_unrelated_keys(store: Store) -> None:
+    _seed_client(
+        store,
+        company={
+            "company_id": 90,
+            "company_type": "PT PMA",
+            "custom_fields": {"risk_status": "rendah", "pkp": False},
+        },
+    )
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.patch(
+        "/api/compliance/obligations/profile/1", json={"pkp": True, "employee_count": 4}
+    )
+
+    assert resp.status_code == 200
+    stored = store.companies[1]["custom_fields"]
+    assert stored["risk_status"] == "rendah"  # untouched by the merge
+    assert stored["pkp"] is True
+    assert stored["employee_count"] == 4
+    body = resp.json()
+    assert body["profile"]["pkp"] is True
+    assert body["profile"]["employee_count"] == 4
+    assert body["profile"]["has_employees"] is True  # derived
+    assert set(body["present_keys"]) >= {"pkp", "employee_count"}
+
+
+def test_patch_company_type_is_stored_under_its_own_key_and_wins(store: Store) -> None:
+    _seed_client(
+        store,
+        company={"company_id": 90, "company_type": "Yayasan Unrecognised", "custom_fields": {}},
+    )
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.patch("/api/compliance/obligations/profile/1", json={"company_type": "pt_pma"})
+
+    assert resp.status_code == 200
+    stored = store.companies[1]
+    assert stored["custom_fields"] == {"compliance_company_type": "PT_PMA"}
+    assert stored["company_type"] == "Yayasan Unrecognised"  # the column is never rewritten
+    body = resp.json()
+    assert body["profile"]["company_type"] == "PT_PMA"
+    assert body["company_type_raw"] == "Yayasan Unrecognised"
+    assert body["needs_manual_classification"] is False
+
+
+def test_patch_normalises_values_before_storing(store: Store) -> None:
+    _seed_client(store, company={"company_id": 90, "company_type": "CV", "custom_fields": {}})
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.patch(
+        "/api/compliance/obligations/profile/1",
+        json={"employee_count": "12", "pkp": "yes", "fiscal_year_end": "03-31"},
+    )
+
+    assert resp.status_code == 200
+    # typed values, not the submitted strings: what profile_inputs reads back
+    assert store.companies[1]["custom_fields"] == {
+        "employee_count": 12,
+        "pkp": True,
+        "fiscal_year_end": "03-31",
+    }
+    assert resp.json()["profile"]["fiscal_year_end"] == "03-31"
+
+
+def test_patch_unknown_key_is_422_and_writes_nothing(store: Store) -> None:
+    _seed_client(store, company={"company_id": 90, "company_type": "PT PMA", "custom_fields": {}})
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.patch(
+        "/api/compliance/obligations/profile/1", json={"pkp": True, "is_rich": True}
+    )
+
+    assert resp.status_code == 422
+    assert "is_rich" in resp.json()["detail"]
+    assert store.companies[1]["custom_fields"] == {}
+
+
+def test_patch_invalid_company_type_is_422(store: Store) -> None:
+    _seed_client(store, company={"company_id": 90, "company_type": "PT PMA", "custom_fields": {}})
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.patch("/api/compliance/obligations/profile/1", json={"company_type": "PT_XYZ"})
+
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert "company_type" in detail
+    assert "PT_XYZ" not in detail  # the detail names the key and the domain, never the value
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},
+        {"fiscal_year_end": "31-03"},
+        {"employee_count": -2},
+        {"pkp": "maybe"},
+        {"investment_stage": "pre-seed"},
+    ],
+)
+def test_patch_rejects_an_invalid_value_with_422(store: Store, body: dict[str, Any]) -> None:
+    _seed_client(store, company={"company_id": 90, "company_type": "PT PMA", "custom_fields": {}})
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.patch("/api/compliance/obligations/profile/1", json=body)
+
+    assert resp.status_code == 422
+    assert store.companies[1]["custom_fields"] == {}
+
+
+def test_patch_404_unknown_client(store: Store) -> None:
+    client = TestClient(_app(store, ADMIN_USER))
+    resp = client.patch("/api/compliance/obligations/profile/999", json={"pkp": True})
+    assert resp.status_code == 404
+
+
+def test_patch_409_when_the_client_has_no_company_row(store: Store) -> None:
+    _seed_client(store)  # no client_company_links row
+    client = TestClient(_app(store, ADMIN_USER))
+
+    resp = client.patch("/api/compliance/obligations/profile/1", json={"pkp": True})
+
+    assert resp.status_code == 409
+    assert "no company row" in resp.json()["detail"]
+
+
+def test_patch_then_generate_proposes_rules_the_default_profile_did_not(store: Store) -> None:
+    """The consumer proof: attributes the reviewer PATCHes widen what propose() emits."""
+    _seed_client(store, company={"company_id": 90, "company_type": "PT PMA", "custom_fields": {}})
+    client = TestClient(_app(store, ADMIN_USER))
+
+    bare = client.post(
+        "/api/compliance/obligations/generate", json={"client_id": 1, "horizon_days": 400}
+    )
+    assert bare.status_code == 200
+    bare_rules = {row["rule_id"] for row in bare.json()["rows"]}
+
+    patched = client.patch(
+        "/api/compliance/obligations/profile/1",
+        json={"has_employees": True, "employee_count": 5, "pkp": True},
+    )
+    assert patched.status_code == 200
+
+    again = client.post(
+        "/api/compliance/obligations/generate", json={"client_id": 1, "horizon_days": 400}
+    )
+    assert again.status_code == 200
+    assert again.json()["inserted_count"] > 0
+    assert {row["rule_id"] for row in again.json()["rows"]} > bare_rules

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_compliance_obligations.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_compliance_obligations.py
@@ -773,6 +773,7 @@ def test_patch_invalid_company_type_is_422(store: Store) -> None:
         {},
         {"fiscal_year_end": "31-03"},
         {"employee_count": -2},
+        {"employee_count": "\u00b2"},  # isdigit() true, int() raises: used to be a 500
         {"pkp": "maybe"},
         {"investment_stage": "pre-seed"},
     ],

--- a/evidence/2026-09/agent-air-m5-backend-rag-obligations-profile-api-4abf97c4/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-obligations-profile-api-4abf97c4/brief.yml
@@ -1,0 +1,53 @@
+task_id: obligations-profile-api
+gear: 2
+objective: >-
+  M3 of the compliance-stack second wave (docs/plans/2026-09-12-compliance-stack-engine-ui-windows.md):
+  give the obligations reviewer the two things it cannot compute itself. Before this PR the queue
+  could only render a bare rule_id, and no client carried the companies.custom_fields keys the
+  engine reads — so profile_from_rows collapsed every client to the ClientProfile defaults and
+  applies() proposed the statutory minimum. Three admin-gated routes: GET /catalog (the 21 rules
+  with name, authority, legal_source and verified — no client data, no connection acquired),
+  GET /profile/{client_id} (the computed profile plus present_keys / missing_keys /
+  company_type_raw / needs_manual_classification) and PATCH /profile/{client_id} (any subset of
+  the engine ATTRIBUTES, merged into companies.custom_fields). No migration.
+
+  Gear 2 by SIZE, deterministically: scripts/evidence_pack_lint.py --print-floor reports 2 on a
+  net churn of 636 lines over four files, of which 357 are tests.
+constraints:
+  - >-
+    ONE parse path, not two. profile_inputs() now owns the custom_fields parsing and
+    profile_from_rows() delegates to it, so the present_keys/missing_keys report the API returns
+    cannot drift from what the engine actually reads. A router-side re-derivation of the same
+    rules would have been a guard-over-match waiting to happen (cicatrix family #3).
+  - >-
+    company_type precedence is documented at the single place that implements it
+    (profile_inputs' docstring): custom_fields.compliance_company_type wins over the
+    companies.company_type string, which is what lets a reviewer classify a company the string
+    mapping reads as OTHER.
+  - >-
+    The PATCH creates nothing. 409 when the client has no client_company_links row, 404 when the
+    client does not exist, and the write is the JSONB merge crm_enhanced.py already uses
+    (COALESCE(custom_fields,'{}'::jsonb) || $1::text::jsonb) so unrelated keys survive and no
+    read-modify-write can drop one.
+  - >-
+    Route ordering is load-bearing: /catalog and /profile/{client_id} are registered BEFORE
+    /{obligation_id}, which FastAPI matches in registration order and would answer 422 for both.
+  - >-
+    Logs name the patched KEYS and never the values; 422 details name the rejected key and its
+    allowed domain, never the submitted value. Client ids only.
+acceptance:
+  - text: >-
+      The three routes answer for an admin and 403 for a non-admin; the PATCH merges without
+      wiping unrelated custom_fields keys, rejects an unknown key and an invalid value with 422,
+      and answers 409 for a client with no company row. 42 router tests.
+    probe: PYTHONPATH=.:../crm-cell pytest backend/tests/unit/app/routers/test_compliance_obligations.py
+  - text: >-
+      compliance_company_type wins over the company_type string, an invalid value falls back to
+      the string mapping, and the existing engine behaviour is unchanged. 86 engine tests.
+    probe: PYTHONPATH=.:../crm-cell pytest backend/tests/services/compliance/test_obligations_register.py
+  - text: >-
+      The whole compliance surface stays green: 422 passed, against 383 on origin/main.
+    probe: PYTHONPATH=.:../crm-cell pytest backend/tests/unit/app/routers/test_compliance_obligations.py backend/tests/services/compliance
+  - text: The app still imports with the new routes registered.
+    probe: PYTHONPATH=.:../crm-cell python -c "from backend.app.main_cloud import app"
+pii_scan: clean


### PR DESCRIPTION
M3 of the compliance-stack second wave (`docs/plans/2026-09-12-compliance-stack-engine-ui-windows.md`).

The obligations reviewer could only render a bare `rule_id`, and no client carried the
`companies.custom_fields` keys the engine reads — so `profile_from_rows` collapsed every client to
the `ClientProfile` defaults and `applies()` proposed the statutory minimum. Three admin-gated
routes (`is_crm_admin` on each, like the rest of the router) close both gaps. No migration.

| Route | What it answers |
| --- | --- |
| `GET /api/compliance/obligations/catalog` | the 21 rules with `name`, `authority`, `legal_source`, `verified`, `frequency`, `roll`, `trigger`, `notes`. No client data, and no connection acquired (test-asserted). |
| `GET /api/compliance/obligations/profile/{client_id}` | the computed profile plus `present_keys`, `missing_keys`, `company_type_raw`, `needs_manual_classification`. 404 for an unknown client. |
| `PATCH /api/compliance/obligations/profile/{client_id}` | any subset of the engine `ATTRIBUTES`, merged into `companies.custom_fields`. Returns the recomputed profile. |

### Three things worth reading in the diff

**One parse path, not two.** The new `profile_inputs()` owns the `custom_fields` parsing and
`profile_from_rows()` delegates to it. A router-side re-derivation of the same rules would have
been a guard that judges by key name rather than by what the engine actually parses — the
`present_keys` / `missing_keys` report cannot drift from the engine because it IS the engine.

**`company_type` precedence.** `PATCH` stores `company_type` under the `compliance_company_type`
key, which `profile_inputs` honours BEFORE the `companies.company_type` string mapping. That is
what lets a reviewer classify a company whose string spelling the map reads as `OTHER`, without
rewriting the CRM column. The precedence is documented in the docstring of the one function that
implements it. An invalid value falls back to the string mapping rather than raising.

**The write creates nothing.** 409 when the client has no `client_company_links` row, 404 when the
client does not exist, and the write is the JSONB merge `crm_enhanced.py` already uses
(`COALESCE(custom_fields, '{}'::jsonb) || $1::text::jsonb`) so unrelated keys survive and no
read-modify-write can drop one. Values are normalised through the engine's own
`_as_bool`/`_as_int`/`_valid_fye` before storage, so what is written is exactly what is read back.

Route ordering is load-bearing: `/catalog` and `/profile/{client_id}` are registered BEFORE
`/{obligation_id}`, which FastAPI matches in registration order and would answer 422 for both.

Logs name the patched KEYS, never the values. 422 details name the rejected key and its allowed
domain, never the submitted value. Client ids only, no names anywhere.

### Tests

```
$ PYTHONPATH=.:../crm-cell pytest backend/tests/unit/app/routers/test_compliance_obligations.py backend/tests/services/compliance
422 passed                     # 383 on origin/main: +21 router, +18 engine
$ PYTHONPATH=.:../crm-cell pytest backend/tests/unit/app/routers/test_compliance_obligations.py
42 passed
$ PYTHONPATH=.:../crm-cell python -c "from backend.app.main_cloud import app"   # exit 0
```

Router tests cover catalog 200 with 21 rows / 403 non-admin / zero connections, profile 200 with
`missing_keys` / 404 / the no-company all-defaults case / 403, and PATCH merge-without-wiping /
`compliance_company_type` precedence / value normalisation / unknown key 422 / invalid
`company_type` 422 with the value absent from the detail / empty body 422 / 404 / 409 / and an
end-to-end `PATCH` then `generate` that proposes a strict superset of the default profile's rules.

### Adversarial review

Codex (`codex exec --sandbox read-only -c model_reasoning_effort=high`, gpt-5.6) on the full diff.
Verdict: **ship-with-fixes**. Two findings, both disposed:

1. **major, accepted and fixed** (`8379c99`) — `{"employee_count": "²"}` returned 500, not 422.
   Reproduced: `"²".isdigit()` is True but `int("²")` raises, so `_as_int` propagated a
   `ValueError`, and the global 500 handler echoed the submitted value in the response body. The
   same malformed `custom_fields` value crashed `POST /generate`, so this pre-existed the PR in the
   engine parser. Fixed there with `isdecimal()` (every string it accepts, Arabic-Indic digits
   included, `int()` parses), plus regression tests at both the engine and the route.
2. **major, rejected with reason** — a non-object body (`[{"pkp": "x"}]`) is rejected by FastAPI
   before the handler, and `exc.errors()` echoes the submitted value in `detail[].input`. Measured
   the handler (`backend/app/setup/exception_handlers.py:150`): it logs the error COUNT and a
   sanitized path only, so nothing is persisted. The echo goes to the authenticated admin who just
   submitted the value, which is not an output boundary crossing, and the behaviour is app-wide
   FastAPI, not introduced here. A route-local `RequestValidationError` override would diverge from
   every other route in the app for no gain in confidentiality.

Evidence pack: `evidence/2026-09/agent-air-m5-backend-rag-obligations-profile-api-4abf97c4/brief.yml`,
Gear 2 as `scripts/evidence_pack_lint.py --print-floor` computes it (636 net lines, of which 357
are tests — over the ~400 guidance because the spec enumerates the tests; the non-test code is 279).

Bites: consumer = the UI PRs U1 (rule names and `verified` badges) and U2 (the client-profile form),
which cannot be built without these two reads and this write; observation = `GET /api/compliance/obligations/catalog`
on prod returning 21 rows with an admin JWT, or failing a JWT the merge-group run on this head sha
plus `/health` `build_sha`. The one command the fresh gate should run to verify by content:
`cd apps/backend-rag && PYTHONPATH=.:../crm-cell pytest backend/tests/unit/app/routers/test_compliance_obligations.py backend/tests/services/compliance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151rdiec2WR4Lf2BG4UUYqP
