### PR TITLE
fix(visaoracle): route investor property/deposit and declared paid activity to deterministic products (PR-D3, routes)

### DIFF
--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_bank_deposit.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_bank_deposit.json
@@ -13,8 +13,6 @@
     "secondhome_deposit_usd",
     "secondhome_state_bank",
     "secondhome_own_name",
-    "family_sponsor_confirmed",
-    "wants_onshore_conversion",
     "stay_days",
     "review_gate"
   ],
@@ -38,7 +36,7 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["INVESTMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["SECOND_HOME"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -107,7 +105,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -130,7 +128,10 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "process.wants_onshore_conversion": { "status": "KNOWN", "value": true },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "commercial.service_fee_budget_idr": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_property.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_property.json
@@ -11,8 +11,6 @@
     "sponsor_category",
     "investment_vehicle",
     "secondhome_property_value_usd",
-    "family_sponsor_confirmed",
-    "wants_onshore_conversion",
     "stay_days",
     "review_gate"
   ],
@@ -36,7 +34,7 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["INVESTMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["SECOND_HOME"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -105,7 +103,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -134,7 +132,10 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "process.wants_onshore_conversion": { "status": "KNOWN", "value": true },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "commercial.service_fee_budget_idr": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other.json
@@ -10,7 +10,8 @@
     "trip_scope",
     "other_purpose",
     "other_paid_activity",
-    "family_sponsor_confirmed",
+    "work_payer",
+    "work_sponsor_confirmed",
     "stay_days",
     "entry_pattern",
     "review_gate"
@@ -35,7 +36,7 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["OTHER"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["EMPLOYMENT"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
@@ -47,10 +48,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "work.employer_is_indonesian_entity": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "work.employer_is_indonesian_entity": { "status": "KNOWN", "value": true },
     "work.serves_indonesian_clients": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -60,8 +58,8 @@
       "reason": "NOT_ASKED"
     },
     "work.indonesian_work_sponsor_confirmed": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": true
     },
     "investment.pt_pma_committed": {
       "status": "UNKNOWN",
@@ -104,7 +102,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_other.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_other.json
@@ -14,7 +14,8 @@
     "trip_scope",
     "other_purpose",
     "other_paid_activity",
-    "family_sponsor_confirmed",
+    "work_payer",
+    "work_sponsor_confirmed",
     "stay_days",
     "entry_pattern",
     "review_gate"
@@ -36,7 +37,7 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["OTHER"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["EMPLOYMENT"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
@@ -48,10 +49,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "work.employer_is_indonesian_entity": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "work.employer_is_indonesian_entity": { "status": "KNOWN", "value": true },
     "work.serves_indonesian_clients": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -61,8 +59,8 @@
       "reason": "NOT_ASKED"
     },
     "work.indonesian_work_sponsor_confirmed": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": true
     },
     "investment.pt_pma_committed": {
       "status": "UNKNOWN",
@@ -105,7 +103,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
@@ -321,13 +321,24 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "offshore/family/STEPCHILD/spNat=ID": ("SUPPORTED_CANDIDATES", ("C1", "E31D")),
     "offshore/family/STEPCHILD/spNat=IT": ("SUPPORTED_CANDIDATES", ("C1", "E31D")),
     "offshore/holdsPermit/current/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
-    "offshore/invest/bank_deposit": ("SUPPORTED_CANDIDATES", ("C2",)),
+    # D3-1 (PR-D3, owner ruling SHWEB-20260911): `property`/`bank_deposit`
+    # now route to Second Home — `mapPurposes` emits SECOND_HOME alone, never
+    # joined with INVESTMENT (owner ruling 3) — and the corpus's canned
+    # numeric answer (1_000_000_000, `generate-walk-corpus.ts::answerFor`)
+    # clears both E33 thresholds (USD 1,000,000 property / USD 130,000
+    # deposit), so both walks answer E33 instead of C2.
+    "offshore/invest/bank_deposit": ("SUPPORTED_CANDIDATES", ("E33",)),
     "offshore/invest/family": ("SUPPORTED_CANDIDATES", ("C2",)),
     "offshore/invest/merit": ("SUPPORTED_CANDIDATES", ("C2",)),
-    "offshore/invest/property": ("SUPPORTED_CANDIDATES", ("C2",)),
+    "offshore/invest/property": ("SUPPORTED_CANDIDATES", ("E33",)),
     "offshore/invest/pt_pma": ("SUPPORTED_CANDIDATES", ("C2",)),
     "offshore/invest/undecided": ("SUPPORTED_CANDIDATES", ("C2",)),
-    "offshore/other": ("SUPPORTED_CANDIDATES", ("C6",)),
+    # D3-2 (PR-D3): `other_paid_activity`'s first option is `yes`, so this
+    # walk now routes to the two employment facts `el.e23-employment-support`
+    # reads and `mapPurposes` emits EMPLOYMENT alone; both facts default to
+    # `yes`/true (`answerFor`'s first-option rule), so E23 answers instead of
+    # C6.
+    "offshore/other": ("SUPPORTED_CANDIDATES", ("E23",)),
     "offshore/remote": ("NO_SUPPORTED_PATH", ()),
     "offshore/retirement/bank_deposit": ("NO_SUPPORTED_PATH", ()),
     "offshore/retirement/bank_deposit/age64": ("SUPPORTED_CANDIDATES", ("E33E",)),
@@ -350,7 +361,8 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "onshore/holdsPermit/current/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
     "onshore/holdsPermit/expired/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
     "onshore/invest": ("SUPPORTED_CANDIDATES", ("C2",)),
-    "onshore/other": ("SUPPORTED_CANDIDATES", ("C6",)),
+    # D3-2 (PR-D3): same route change as `offshore/other` above.
+    "onshore/other": ("SUPPORTED_CANDIDATES", ("E23",)),
     "onshore/remote": ("NO_SUPPORTED_PATH", ()),
     "onshore/retirement": ("NO_SUPPORTED_PATH", ()),
     "onshore/retirement/age64": ("SUPPORTED_CANDIDATES", ("E33E",)),

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
@@ -141,20 +141,35 @@ const WALKS: readonly WalkCase[] = [
     flags: [],
   },
   {
-    name: "invest · property — HELD: a Second Home shape no purpose can be emitted for (§6 R3)",
+    // Released (PR-D3, D3-1): `investment_vehicle=property` now routes to
+    // Second Home and `mapPurposes` emits SECOND_HOME alone, so neither
+    // `family_sponsor_confirmed` nor `wants_onshore_conversion` is asked any
+    // more — no E33 rule reads either fact. Was "HELD" under §6 R3; see
+    // fact-mapper.ts's `ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS` comment.
+    name: "invest · property — FREED (D3-1): routes to Second Home, SECOND_HOME alone",
     category: "invest",
     tripScope: "single",
     branch: [
       ["sponsor_category", "INVESTMENT"],
       ["investment_vehicle", "property"],
       ["secondhome_property_value_usd", "1200000"],
-      // Both inserted into the invest branch by #5855 — they are the two
-      // facts that turned this walk's NEEDS_INPUT into an answer.
-      ["family_sponsor_confirmed", "yes"],
-      ["wants_onshore_conversion", "no"],
       ["stay_days", "730"],
     ],
-    flags: ["ACTIVITY_BOUNDARY"],
+    flags: [],
+  },
+  {
+    name: "invest · bank_deposit — FREED (D3-1): routes to Second Home, SECOND_HOME alone",
+    category: "invest",
+    tripScope: "single",
+    branch: [
+      ["sponsor_category", "INVESTMENT"],
+      ["investment_vehicle", "bank_deposit"],
+      ["secondhome_deposit_usd", "150000"],
+      ["secondhome_state_bank", "yes"],
+      ["secondhome_own_name", "yes"],
+      ["stay_days", "730"],
+    ],
+    flags: [],
   },
   {
     name: "retirement · property — HELD: §6 R3 measured the unflagged answer as a wrong NO_PATH",
@@ -302,6 +317,29 @@ const WALKS: readonly WalkCase[] = [
       ["other_paid_activity", "no"],
       // Inserted into the `other` branch by #5855.
       ["family_sponsor_confirmed", "yes"],
+      ["stay_days", "30"],
+      ["entry_pattern", "SINGLE"],
+    ],
+    flags: ["ACTIVITY_BOUNDARY"],
+  },
+  {
+    // D3-2 changes the ENGINE-level route (`other_paid_activity=yes` now
+    // asks the two employment facts `el.e23-employment-support` reads and
+    // `mapPurposes` emits EMPLOYMENT alone), but `other_purpose` ITSELF
+    // stays fully undecidable on purpose (spec: "holds on the
+    // `other_purpose` values stay until each value is mapped") — so this
+    // walk still holds, on the value `other_paid_activity` no longer
+    // contributes to. `disclosed_review_flags` is a boundary flag, not a
+    // per-cause list: removing one undecidable answer cannot un-hold a walk
+    // that another undecidable answer already holds.
+    name: "other · paid activity yes — engine reroutes to employment; other_purpose still holds",
+    category: "other",
+    tripScope: "single",
+    branch: [
+      ["other_purpose", "transit"],
+      ["other_paid_activity", "yes"],
+      ["work_payer", "yes"],
+      ["work_sponsor_confirmed", "yes"],
       ["stay_days", "30"],
       ["entry_pattern", "SINGLE"],
     ],

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
@@ -188,9 +188,21 @@ const WALKS: readonly WalkCase[] = [
     // retirement` (rulepack-prod-020) decides SUPPORT off
     // `secondhome.passive_monthly_income_usd >= 3000` and `family.
     // sponsor_confirmed == true` alone — it never reads `retirement_basis`
-    // at all — so the table was UNDER-inclusive: this exact profile (age 25
-    // here; age 64 is the same branch replayed, see the corpus) already had
-    // a deterministic SUPPORTED E33F, and the flag deleted it.
+    // at all — so the table was UNDER-inclusive: it deleted a real,
+    // deterministic engine answer regardless of which one it was.
+    // CORRECTED 2026-09-12 (D3-C/C2): this fixture is the YOUNG identity
+    // (age 25, `YOUNG_APPLICANT_BIRTH_DATE`), and at 25 the answer is
+    // NO_SUPPORTED_PATH — `hf.e33f.age-below-55` excludes E33F before
+    // `el.e33f.retirement` is ever reached. SUPPORTED E33F is reached only
+    // by the SAME branch replayed at age 64 in the backend corpus
+    // (`offshore/retirement/family_sponsor/age64`,
+    // `test_interview_walk_census.py`'s `EXPECTED_OUTCOME`); the walk at
+    // this age (`offshore/retirement/family_sponsor`) is pinned
+    // NO_SUPPORTED_PATH there. What NARROW-2 actually fixed is age-blind:
+    // `mapDisclosedReviewFlags` never sees `birth_date`, so the flag was
+    // deleting whichever real verdict the engine reached — a proven
+    // NO_SUPPORTED_PATH at 25, a proven SUPPORTED E33F at 64 — for a fact
+    // (`retirement_basis`) neither verdict depends on.
     name: "retirement · family_sponsor — FREED (NARROW-2): el.e33f.retirement never reads retirement_basis",
     category: "retirement",
     tripScope: "single",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -230,12 +230,10 @@ describe("question registry -> wire coverage", () => {
     ["trip_scope", "multiple", "MULTI_PURPOSE_TRIP"],
     ["business_activity", "training", "ACTIVITY_BOUNDARY"],
     ["business_activity", "other", "ACTIVITY_BOUNDARY"],
-    ["investment_vehicle", "property", "ACTIVITY_BOUNDARY"],
     ["retirement_basis", "property", "ACTIVITY_BOUNDARY"],
     ["diaspora_connection", "former_citizen", "ACTIVITY_BOUNDARY"],
     ["diaspora_documents", "passport", "ACTIVITY_BOUNDARY"],
     ["other_purpose", "medical", "ACTIVITY_BOUNDARY"],
-    ["other_paid_activity", "yes", "ACTIVITY_BOUNDARY"],
   ])(
     "maps an undecidable HUMAN_CONTEXT answer (%s=%s) to a conservative review flag",
     (id, value, flag) => {
@@ -258,6 +256,11 @@ describe("question registry -> wire coverage", () => {
     ["business_activity", "negotiation"],
     ["business_activity", "conference"],
     ["investment_vehicle", "pt_pma"],
+    // Released (PR-D3, D3-1) — `mapPurposes` routes both to SECOND_HOME
+    // alone and the Second Home facts the interview already collects for
+    // them decide E33 on the pack's own terms. See fact-mapper.ts.
+    ["investment_vehicle", "property"],
+    ["investment_vehicle", "bank_deposit"],
     ["retirement_basis", "bank_deposit"],
     ["retirement_basis", "passive_income"],
     // Released 2026-09-12 (NARROW-2) — el.e33f.retirement decides SUPPORT
@@ -281,6 +284,12 @@ describe("question registry -> wire coverage", () => {
     // seq-20 reads `family.sponsor_permit_basis` (HUMAN_CONTEXT only, never
     // wired to a FACT — see `mapFamilySponsorPermitBasis`).
     ["family_sponsor_permit_basis", "EXPERT"],
+    // Released (PR-D3, D3-2) — `mapPurposes` routes `yes` to EMPLOYMENT
+    // (only `el.e23-employment-support` covers it) and `no` stays OTHER
+    // (`el.c6.social` reachable); both are decisive on the pack's own
+    // terms. See fact-mapper.ts.
+    ["other_paid_activity", "yes"],
+    ["other_paid_activity", "no"],
   ])(
     "leaves a decidable answer (%s=%s) unflagged — it must not veto a proven candidate",
     (id, value) => {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -505,6 +505,27 @@ export const ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS = {
   retirement_basis: ["bank_deposit", "passive_income", "family_sponsor"],
   diaspora_connection: ["former_wni", "descendant", "family"],
   diaspora_documents: ["yes", "no"],
+  // D3-B (PR-D3, owner ruling SHWEB-20260911) investigated pack-outward,
+  // NARROW-2 style, whether any of the 8 options (transit/medical/
+  // volunteer/religious/arts_sport/journalism/crew/other) is decided by a
+  // seq-20 rule. RESULT: NONE is, and the list stays empty — not a
+  // judgement call, a structural fact. `other_purpose`'s own
+  // `decisionMapping` is `HUMAN_CONTEXT` (tree.ts) — it maps to NO
+  // FactPath at all, and `mapOracleFactsToApplicantFacts` never reads
+  // `facts.other_purpose` anywhere — so no rule in the signed pack can
+  // ever see which of the 8 values was chosen; the wire request is
+  // byte-identical regardless. Verified against rulepack-prod-020.
+  // signed.json: exactly 5 rules cover the OTHER purpose
+  // (`el.c6.social`, the one ELIGIBILITY rule that can grant a product,
+  // plus 4 advisory/BRIDGING-only rules), and `el.c6.social`'s
+  // `required_facts` is `family.sponsor_confirmed` /
+  // `intent.purposes` / `intent.stay_days` alone — nothing derived from
+  // this question. Releasing any value here would therefore not be
+  // "found decidable", it would be inventing a distinction the engine
+  // cannot draw, on a purpose where the wrong side hands a visitor a
+  // visit visa for a legally excluded activity. C6's actual release
+  // (D3-2) rests solely on the `other_paid_activity = no` branch, which
+  // this table already lists below.
   other_purpose: [],
   // `yes`/`no` added (PR-D3, D3-2): `mapPurposes` now routes `yes` to
   // EMPLOYMENT (only `el.e23-employment-support` covers it) and leaves `no`

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -335,6 +335,30 @@ export function mapPurposes(facts: OracleFacts): FactValue<Purpose[]> {
   if (facts.category === undefined) return unknownFact(NOT_ASKED);
   if (facts.category === "unsure") return unknownFact(UNVERIFIED);
   const category = facts.category as CategoryKey;
+  // D3-1 (owner ruling SHWEB-20260911, PR-D3): an `invest` applicant whose
+  // vehicle is a property purchase or a bank deposit is a Second Home
+  // applicant, not an investor — `getCategoryQuestionIds` already serves the
+  // Second Home question set for these two vehicles. SECOND_HOME ALONE,
+  // never joined with INVESTMENT: `hit_policy.eligibility =
+  // COVER_ALL_DECLARED_PURPOSES` drops E33 the moment a second purpose is
+  // declared (owner ruling 3, 2026-09-06 — same reasoning as the
+  // `second_home` tile's own entry above).
+  if (
+    category === "invest" &&
+    (facts.investment_vehicle === "property" ||
+      facts.investment_vehicle === "bank_deposit")
+  ) {
+    return known(["SECOND_HOME"]);
+  }
+  // D3-2 (owner ruling SHWEB-20260911, PR-D3): declared paid activity is
+  // employment, not a generic OTHER purpose — `el.c1/c2/c6` all exclude paid
+  // activity (UU 6/2011 Pasal 122) and only `el.e23-employment-support`
+  // covers it. `no` and `unsure` fall through to OTHER unchanged: `no` is
+  // the honest negative (C6 stays reachable) and `unsure` is a disclosed
+  // uncertainty the NOT_CERTAIN flag already holds on.
+  if (category === "other" && facts.other_paid_activity === "yes") {
+    return known(["EMPLOYMENT"]);
+  }
   const purpose = CATEGORY_TO_PURPOSE[category];
   return purpose === undefined ? unknownFact(NOT_APPLICABLE) : known([purpose]);
 }
@@ -462,7 +486,12 @@ const REVIEW_FLAG_MAP: Readonly<
  */
 export const ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS = {
   business_activity: ["meetings", "negotiation", "conference"],
-  investment_vehicle: ["pt_pma"],
+  // `property`/`bank_deposit` added (PR-D3, D3-1): `mapPurposes` now routes
+  // both to SECOND_HOME alone, and `el.e33.property-basis`/`el.e33.
+  // deposit-basis` decide E33 off the Second Home facts the interview
+  // already collects for these two vehicles — holding them discarded a
+  // deterministic answer the same way `family_sponsor` did above.
+  investment_vehicle: ["pt_pma", "property", "bank_deposit"],
   // `family_sponsor` added 2026-09-12 (NARROW-2, owner ruling SHWEB-20260911:
   // hold is the exception, a deterministic pack answer is not). `el.e33f.
   // retirement` (rulepack-prod-020) decides SUPPORT for E33F off
@@ -477,7 +506,14 @@ export const ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS = {
   diaspora_connection: ["former_wni", "descendant", "family"],
   diaspora_documents: ["yes", "no"],
   other_purpose: [],
-  other_paid_activity: [],
+  // `yes`/`no` added (PR-D3, D3-2): `mapPurposes` now routes `yes` to
+  // EMPLOYMENT (only `el.e23-employment-support` covers it) and leaves `no`
+  // on OTHER (`el.c6.social` stays reachable) — both are decisive on the
+  // pack's own terms, so holding either discarded a deterministic answer.
+  // `unsure` is not listed: it stays undecidable, and the generic
+  // `NOT_CERTAIN` flag (a disclosed uncertainty, not a derived one) already
+  // holds on it.
+  other_paid_activity: ["yes", "no"],
 } as const satisfies Readonly<Record<string, readonly string[]>>;
 
 /** Question ids the ACTIVITY_BOUNDARY table classifies. */

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -666,13 +666,13 @@ const FIXED_CATEGORY_QUESTIONS: Record<CategoryKey, readonly string[]> = {
     "stay_days",
   ],
   diaspora: [],
+  // `other`'s real sequence is computed dynamically in
+  // `getCategoryQuestionIds` (D3-2, PR-D3): a declared paid activity
+  // branches to the employment facts instead of this fixed list. Kept here,
+  // unreached, only so this Record stays total over `CategoryKey`.
   other: [
     "other_purpose",
     "other_paid_activity",
-    // `family_sponsor_confirmed` added 2026-09-06: `el.c6.social` is the
-    // one rule that covers the `OTHER` purpose and it requires
-    // `family.sponsor_confirmed == true`, so this branch could not reach a
-    // candidate without it.
     "family_sponsor_confirmed",
     "stay_days",
     "entry_pattern",
@@ -690,6 +690,14 @@ export function getCategoryQuestionIds(facts: OracleFacts): readonly string[] {
 
   if (category === "invest") {
     const branch = facts.investment_vehicle;
+    // D3-1 (owner ruling SHWEB-20260911): `property`/`bank_deposit` route to
+    // Second Home (`mapPurposes` emits SECOND_HOME alone), and no E33 rule
+    // reads `sponsor.type` or `family.sponsor_confirmed` — same reasoning as
+    // the `second_home` tile's own branch below. Asking either question here
+    // would only add review volume (an `unsure` answer trips `NOT_CERTAIN`)
+    // for a fact no rule this route reaches ever consults.
+    const isSecondHomeRoute =
+      branch === "property" || branch === "bank_deposit";
     const branchQuestions =
       branch === "pt_pma"
         ? [
@@ -711,30 +719,39 @@ export function getCategoryQuestionIds(facts: OracleFacts): readonly string[] {
       "sponsor_category",
       "investment_vehicle",
       ...branchQuestions,
-      // `family_sponsor_confirmed` added 2026-09-06: `el.c2.business` is
-      // the rule that covers a declared INVESTMENT purpose and it requires
-      // `family.sponsor_confirmed == true`. Already asked in the family
-      // and retirement branches — same question, same fact, new branch.
-      "family_sponsor_confirmed",
-      // `wants_onshore_conversion` added 2026-09-06, OFFSHORE ONLY. Onshore
-      // the spine already asks it (`computeNextNode`'s `overstay_days`
-      // case), so adding it here would ask it twice. Offshore it was
-      // structurally unaskable, which is exactly where
-      // `hf.d12-onshore-conversion-excluded`
-      // (`on_unknown: NEEDS_INPUT`, `safety_critical`) bites: D12's own
-      // target population is offshore. Measured 2026-09-06 on signed
-      // seq-19: with the answer supplied, offshore/invest/PT-PMA returns
-      // `SUPPORTED_CANDIDATES [D12]` on "no" and `NO_SUPPORTED_PATH` on
-      // "yes" — decisive both ways.
-      //
-      // ASKED, never derived. Deriving `false` from "offshore and holding
-      // no permit" was measured as a fail-open on this exact persona: the
-      // fact is forward-looking INTENT ("are you asking to change status
-      // without leaving Indonesia?"), so an investor planning "enter on
-      // D12, then alih status onshore" answers TRUE, and a derived `false`
-      // returns a confident D12 recommendation with zero review reasons
-      // for a visa that by regulation cannot be converted onshore.
-      ...(facts.in_indonesia === "no" ? ["wants_onshore_conversion"] : []),
+      ...(isSecondHomeRoute
+        ? []
+        : [
+            // `family_sponsor_confirmed` added 2026-09-06: `el.c2.business`
+            // is the rule that covers a declared INVESTMENT purpose and it
+            // requires `family.sponsor_confirmed == true`. Already asked in
+            // the family and retirement branches — same question, same
+            // fact, new branch.
+            "family_sponsor_confirmed",
+            // `wants_onshore_conversion` added 2026-09-06, OFFSHORE ONLY.
+            // Onshore the spine already asks it (`computeNextNode`'s
+            // `overstay_days` case), so adding it here would ask it twice.
+            // Offshore it was structurally unaskable, which is exactly
+            // where `hf.d12-onshore-conversion-excluded`
+            // (`on_unknown: NEEDS_INPUT`, `safety_critical`) bites: D12's
+            // own target population is offshore. Measured 2026-09-06 on
+            // signed seq-19: with the answer supplied,
+            // offshore/invest/PT-PMA returns `SUPPORTED_CANDIDATES [D12]`
+            // on "no" and `NO_SUPPORTED_PATH` on "yes" — decisive both
+            // ways.
+            //
+            // ASKED, never derived. Deriving `false` from "offshore and
+            // holding no permit" was measured as a fail-open on this exact
+            // persona: the fact is forward-looking INTENT ("are you asking
+            // to change status without leaving Indonesia?"), so an investor
+            // planning "enter on D12, then alih status onshore" answers
+            // TRUE, and a derived `false` returns a confident D12
+            // recommendation with zero review reasons for a visa that by
+            // regulation cannot be converted onshore.
+            ...(facts.in_indonesia === "no"
+              ? ["wants_onshore_conversion"]
+              : []),
+          ]),
       "stay_days",
     ];
   }
@@ -801,6 +818,26 @@ export function getCategoryQuestionIds(facts: OracleFacts): readonly string[] {
       "diaspora_connection",
       "diaspora_documents",
       ...familyQuestionIds(facts),
+    ];
+  }
+
+  // D3-2 (owner ruling SHWEB-20260911): a declared paid activity is
+  // employment, not a generic OTHER purpose — `mapPurposes` emits
+  // EMPLOYMENT for `yes`, so the interview asks the two facts
+  // `el.e23-employment-support` actually reads (`work.
+  // employer_is_indonesian_entity`, `work.indonesian_work_sponsor_confirmed`)
+  // instead of holding on a bare ACTIVITY_BOUNDARY flag. `no` and `unsure`
+  // keep today's `family_sponsor_confirmed` question: `el.c6.social` (the
+  // OTHER-purpose rule) still needs it, and neither branch changes purpose.
+  if (category === "other") {
+    return [
+      "other_purpose",
+      "other_paid_activity",
+      ...(facts.other_paid_activity === "yes"
+        ? ["work_payer", "work_sponsor_confirmed"]
+        : ["family_sponsor_confirmed"]),
+      "stay_days",
+      "entry_pattern",
     ];
   }
 


### PR DESCRIPTION
## What

**PR-D3, routes half (D3-1 + D3-2).** Two interview branches that were being held now route to the product the signed pack already decides. Frontend only: `fact-mapper.ts`, `flow.ts`, their tests, and the four walk fixtures the change moves. **The rule pack is untouched.**

Zero's principle (D2): human review is the exception; where the pack yields a deterministic truthful verdict, the Oracle answers.

- **D3-1** — an investor declaring `property` or `bank_deposit` now takes the Second Home question set and emits purpose `SECOND_HOME` alone (never joined with `INVESTMENT`). Those two walks stop being held.
- **D3-2** — a declared paid activity now asks the two work facts the pack reads and emits `EMPLOYMENT`.

> **CORRECTION (2026-09-13), from PR-D3 half-2's measurement.** This body originally said the `other_paid_activity = no` branch "is what makes C6 deliverable at all". **That claim is false in production.** Half-2 added the walk that tests it: `offshore/other/no_paid_activity` still comes back HUMAN_REVIEW with `ACTIVITY_BOUNDARY` / `DISCLOSED_ACTIVITY_BOUNDARY_REVIEW`. The whole `other` tile is held by `other_purpose`'s always-undecidable list, independently of `other_paid_activity` — and D3-B in this same PR proved no pack rule can ever see `other_purpose`, so no frontend change can release it. C6 is reachable at raw-engine level and suppressed in production. Releasing the tile needs a seq-21 rule that reads the disclosed purpose; it is on the D4b list, not curable here.

**Split, per the spec's own instruction**: D3-3, D3-4 and D3-5 are deferred to a second PR. Routes first. Production size, stated as the command rather than a digit — the digit was wrong here and the gate caught it:

```
git diff --numstat 986cc6d765 ac4d8f733f -- \
  'apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts' \
  'apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts'
```

→ `59/2` + `65/28` = **+124 / −30, net +94** on the two production files. The body previously said +73: that figure was measured after the first commit and went stale when the second one landed, which is the fourth time this mandate has paid for a typed count instead of a command.

## Census — measured on the same 67 walks, twice

Regenerated with `inputs.mts` and replayed through `test_census.py` by the implementer, then re-run independently by the orchestrator. Identical on both clocks:

| 67 walks, real flags | SUPPORTED | NO_SUPPORTED_PATH | NEEDS_INPUT | HUMAN_REVIEW |
|---|---:|---:|---:|---:|
| after D2 (this PR's base) | 46 | 8 | 0 | 13 |
| **after D3 routes** | **48** | **8** | **0** | **11** |

`offshore/invest/property` and `offshore/invest/bank_deposit` leave the review set. The 11 that remain: `offshore/invest/{merit,family,undecided}`, both `STEPCHILD/spNat=IT` walks, `offshore/retirement/{property,undecided}` at both ages, `offshore/other`, `onshore/other`.

## The two acceptance targets are NOT met, and that is stated, not buried

The spec asks for **HUMAN_REVIEW ≤ 4** and **≥ 15 distinct products** named. This PR reaches **11** and **13**. Those are the targets of the COMPLETE D3, and three of its five items are deferred here under the spec's own routes-first rule. What moves each number is named: `retirement/{property,undecided}` (4 walks) is D3-3, the two STEPCHILD walks are D3-4, `invest/{merit,family,undecided}` (3 walks) is D3-5. `offshore/other` and `onshore/other` are addressed below and do not move.

## D3-B — a negative result, with the evidence

The addendum asked to release the `other_purpose` values the pack decides. **No value is decidable, and the reason is structural**: `other_purpose`'s decision mapping is `HUMAN_CONTEXT` with no fact path, and `mapOracleFactsToApplicantFacts` never reads `facts.other_purpose` — the wire request is byte-identical whichever of the 8 values the visitor picks. Verified against the signed pack independently: exactly 5 rules cover purpose `OTHER`, and the only non-bridging ELIGIBILITY rule among them, `el.c6.social`, has `required_facts = [family.sponsor_confirmed, intent.purposes, intent.stay_days]` — nothing derived from the disclosed value. No rule can see it, so none can be released.

`ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS.other_purpose` therefore stays `[]`, now with that evidence recorded beside it, and **C6's release rests solely on the `other_paid_activity = no` branch** shipped in D3-2. Stretching a value into "decidable" here would hand a visitor a visit visa for an activity the law excludes, with a criminal penalty attached — the empty list is the safe side, not the lazy one.

## Conditions carried from the D2 post-merge gate

- **C1** — the two walks the D2 relation proxy still holds are `offshore/family/STEPCHILD/spNat=IT` and `offshore/diaspora/STEPCHILD/spNat=IT`. Both have all their facts KNOWN, so this is product prudence rather than a pack `NEEDS_INPUT`. The branch chosen to resolve them is **D3-4's sponsor-permit question**, deferred to the second half; their census row after that lands will be reported with it.
- **C2** — a comment in `activity-boundary.test.ts` claimed the age-25 `retirement/family_sponsor` fixture already had a deterministic SUPPORTED E33F. It does not: at 25 the walk is `NO_SUPPORTED_PATH` (`hf.e33f.age-below-55` excludes it), and only the age-64 replay reaches `SUPPORTED_CANDIDATES [E33F]`. Corrected against `EXPECTED_OUTCOME`. NARROW-2's actual fix is age-blind — the flag computation never sees `birth_date`.
- **C3** — declared: the narrowed trigger also fires on `family_sponsor_confirmed = "unsure"` on its own, without `family_sponsor_status_code` (`fact-mapper.ts:615`).

## What the reachability census changed about our confidence

The funnel-wide census (169 question sequences, 3554 distinct wire walks) found a dead end our corpus never touched: **30 retirement `bank_deposit` walks end NEEDS_INPUT on `family.sponsor_confirmed`** — the largest of the three retirement branches, while the corpus allowlisted only the two small ones. That is D3-3's scope and it is not in this PR. It is also the honest lesson: a first-option corpus of 67 measures what it touches, not what exists, and this PR's numbers should be read with that bound.

## seq-21 candidates (for Zero's pack governance, never into the pack here)

`hf.e31d.sponsor-permit-required` and a paid-activity hard filter for the C-family. No others surfaced.

## Gates

- `_lib` vitest → exit 0, **603/603** · `tsc --noEmit` → exit 0
- `test_interview_walk_census.py` → 15/15 · corpus regen → zero fixture drift
- census regen + `test_census.py` → exit 0, numbers above
- harness floor → **1**, source `none`
- pre-commit hooks (prettier, ruff, tsc, secrets, off-limits, import chain) all passed; no `--no-verify`

## Bites

Bites: consumer = an investor declaring property or a bank deposit, and anyone declaring paid activity — both previously held; observation = on `origin/main` after merge, regenerating the census (`npx --no-install tsx research/visa/2026-09-11-review-reason-audit/inputs.mts`, then `pytest research/visa/2026-09-11-review-reason-audit/test_census.py`, which writes `/tmp/visaoracle-audit-20260911/census.json`) reports 48 / 8 / 0 / 11 over the 67 walks, with `offshore/invest/property` and `offshore/invest/bank_deposit` absent from the HUMAN_REVIEW set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


