### PR TITLE
feat(compliance): holiday-aware roll for obligation due dates (M1)

### DIFF
--- a/apps/backend-rag/backend/data/id_holidays.py
+++ b/apps/backend-rag/backend/data/id_holidays.py
@@ -1,0 +1,110 @@
+"""Decreed Indonesian non-working days — the ONE place such a date may live.
+
+Two unrelated organs need the same fact and must never disagree about it:
+
+- ``services.garuda_flow.operating_calendar`` — is Bali Zero's office open that day?
+- ``services.compliance.business_days`` — does a statutory tax deadline move off that day?
+
+They answer different questions with different boundaries — the VOA gate publishes only the part
+of the year its pilot materialized, a tax deadline cares about the whole year — so they keep
+their own logic. What they share is the DATA, and a date is typed here once or not at all.
+
+DECREED ONLY. Bali Zero's own non-working days are not decreed days and may never be added here:
+a day the office chooses to close does not move a statutory deadline, and putting one in this
+table would move it. 24-25 December 2026 are in the table because the decree puts them there,
+not because anyone is on holiday.
+
+Provenance — every date below comes from one decree, whose number this module does not invent:
+
+    KEPUTUSAN BERSAMA MENTERI AGAMA / MENTERI KETENAGAKERJAAN / MENTERI PANRB RI —
+    NOMOR 1497 TAHUN 2025, NOMOR 2 TAHUN 2025, NOMOR 5 TAHUN 2025, tentang Hari Libur
+    Nasional dan Cuti Bersama Tahun 2026. Ditetapkan di Jakarta, 19 September 2025.
+    Full year 2026 = 17 hari libur nasional + 8 cuti bersama (``test_id_holidays`` pins
+    both counts, so a hand-edit that drops or invents a day fails loudly).
+
+    Retrieved 2026-09-12 from Sekretariat Negara RI, which publishes the decree's own tables:
+    https://setneg.go.id/baca/index/inilah_skb_3_menteri_libur_nasional_dan_cuti_bersama_2026
+    Decree PDF: https://www.kemenkopmk.go.id/sites/default/files/pengumuman/2025-09/
+    SKB%20Libur%20Nasional%20dan%20Cuti%20Bersama%20Tahun%202026.pdf
+    The four dates from 2026-07-28 onward were independently sourced in the 2026-07-27
+    GARUDA session (decree + press route, zero divergence) and agree with this table.
+
+``DECREED_YEARS`` is the honest coverage statement and the reason this module is not just a
+tuple: a year is listed ONLY when the whole calendar year is materialized from a real decree.
+This decree class is issued around September of the PRECEDING year, so the 2027 SKB does not
+exist yet (expected ~September 2026). Any "2027 Indonesian holiday calendar" circulating before
+that is a third-party estimate, not a decreed fact. Callers that cannot silently under-answer
+for an undecreed year read ``DECREED_YEARS`` and say so — see
+``business_days.holiday_years_loaded`` and the ``needs_review_reason`` the obligations register
+attaches. NOTHING here may carry a date outside ``DECREED_YEARS``.
+
+PURE data — no I/O, no ``date.today()``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+
+__all__ = ["DECREED_YEARS", "HOLIDAYS", "HOLIDAY_DATES", "Holiday", "HolidayKind"]
+
+
+class HolidayKind(str, Enum):
+    """The decree names two distinct kinds of non-working day.
+
+    Both are "hari libur" for a tax deadline (PMK 81/2024 Pasal 100 ayat (2) names cuti bersama
+    explicitly) and both close Bali Zero's own systems, but the tag stays on the data so either
+    reading can be revisited later without re-sourcing a single date.
+    """
+
+    LIBUR_NASIONAL = "libur_nasional"
+    CUTI_BERSAMA = "cuti_bersama"
+
+
+@dataclass(frozen=True)
+class Holiday:
+    """One decreed non-working day."""
+
+    at: date
+    kind: HolidayKind
+    name: str
+
+
+_LN = HolidayKind.LIBUR_NASIONAL
+_CB = HolidayKind.CUTI_BERSAMA
+
+# SKB 3 Menteri 2026 — in decree order within each kind, merged chronologically.
+HOLIDAYS: tuple[Holiday, ...] = (
+    Holiday(date(2026, 1, 1), _LN, "Tahun Baru 2026 Masehi"),
+    Holiday(date(2026, 1, 16), _LN, "Isra Mikraj Nabi Muhammad S.A.W."),
+    Holiday(date(2026, 2, 16), _CB, "Cuti Bersama Tahun Baru Imlek 2577 Kongzili"),
+    Holiday(date(2026, 2, 17), _LN, "Tahun Baru Imlek 2577 Kongzili"),
+    Holiday(date(2026, 3, 18), _CB, "Cuti Bersama Hari Suci Nyepi"),
+    Holiday(date(2026, 3, 19), _LN, "Hari Suci Nyepi (Tahun Baru Saka 1948)"),
+    Holiday(date(2026, 3, 20), _CB, "Cuti Bersama Idulfitri 1447 Hijriah"),
+    Holiday(date(2026, 3, 21), _LN, "Idulfitri 1447 Hijriah"),
+    Holiday(date(2026, 3, 22), _LN, "Idulfitri 1447 Hijriah"),
+    Holiday(date(2026, 3, 23), _CB, "Cuti Bersama Idulfitri 1447 Hijriah"),
+    Holiday(date(2026, 3, 24), _CB, "Cuti Bersama Idulfitri 1447 Hijriah"),
+    Holiday(date(2026, 4, 3), _LN, "Wafat Yesus Kristus"),
+    Holiday(date(2026, 4, 5), _LN, "Kebangkitan Yesus Kristus (Paskah)"),
+    Holiday(date(2026, 5, 1), _LN, "Hari Buruh Internasional"),
+    Holiday(date(2026, 5, 14), _LN, "Kenaikan Yesus Kristus"),
+    Holiday(date(2026, 5, 15), _CB, "Cuti Bersama Kenaikan Yesus Kristus"),
+    Holiday(date(2026, 5, 27), _LN, "Iduladha 1447 Hijriah"),
+    Holiday(date(2026, 5, 28), _CB, "Cuti Bersama Iduladha 1447 Hijriah"),
+    Holiday(date(2026, 5, 31), _LN, "Hari Raya Waisak 2570 BE"),
+    Holiday(date(2026, 6, 1), _LN, "Hari Lahir Pancasila"),
+    Holiday(date(2026, 6, 16), _LN, "1 Muharam Tahun Baru Islam 1448 Hijriah"),
+    Holiday(date(2026, 8, 17), _LN, "Proklamasi Kemerdekaan"),
+    Holiday(date(2026, 8, 25), _LN, "Maulid Nabi Muhammad S.A.W."),
+    Holiday(date(2026, 12, 24), _CB, "Cuti Bersama Kelahiran Yesus Kristus"),
+    Holiday(date(2026, 12, 25), _LN, "Kelahiran Yesus Kristus (Hari Raya Natal)"),
+)
+
+# Years materialized IN FULL from a decree. Not "years that appear in HOLIDAYS" — a partially
+# typed year must never be advertised as covered, which is why this is written, not derived.
+DECREED_YEARS: frozenset[int] = frozenset({2026})
+
+HOLIDAY_DATES: frozenset[date] = frozenset(h.at for h in HOLIDAYS)

--- a/apps/backend-rag/backend/services/compliance/business_days.py
+++ b/apps/backend-rag/backend/services/compliance/business_days.py
@@ -13,11 +13,19 @@ https://peraturan.bpk.go.id/Download/366884/2024pmkeuangan081.pdf):
           libur nasional, hari yang diliburkan untuk penyelenggaraan pemilihan umum, atau hari
           yang ditetapkan sebagai cuti bersama secara nasional."
 
-    Pasal 173 — SPT reporting: a SEPARATE provision, keyed to Pasal 171/172 and not to Pasal
+    Pasal 173 — SPT Masa reporting: a SEPARATE provision, keyed to Pasal 171/172 and not to Pasal
     94/100, carrying the identical hari-libur definition in its own ayat (2). Payment rules and
-    reporting rules therefore roll for the same reason under two different articles; this module
-    is the one implementation of both, and a caller does not have to know which article it is
-    under. Pasal 264 ayat (2)-(3) repeats the same template for oil-and-gas reporting.
+    monthly reporting rules therefore roll for the same reason under two different articles, and
+    this module is the one implementation of both. Pasal 264 ayat (2)-(3) repeats the template for
+    oil-and-gas reporting.
+
+WHAT THIS MODULE DOES NOT DECIDE: which obligations are entitled to the roll. That is the `roll`
+field of each catalog rule, and the articles above cover the monthly payment and SPT Masa rules —
+NOT every deadline in the catalog. The annual corporate return is a known open case: it sits under
+UU KUP art. 3, its catalog `legal_source` still ends in "(verify)", and Pasal 173 does not name it.
+Rolling it is therefore an unverified catalog entitlement, not something this module asserts; the
+catalog-source verification pass owns that question. An over-broad `roll` still only ever moves a
+date onto an open day, so it cannot produce a deadline nobody can meet.
 
 Two deliberate gaps, both of which under-roll (they can only leave a date earlier than the law
 allows, never later, so they never invent a deadline that has already passed):

--- a/apps/backend-rag/backend/services/compliance/business_days.py
+++ b/apps/backend-rag/backend/services/compliance/business_days.py
@@ -1,0 +1,92 @@
+"""Indonesian business days for statutory deadlines (pure, no I/O).
+
+A tax deadline that falls on a hari libur does not stay there, and the regulation defines the
+holiday set in the same breath as the roll. Verified 2026-09-12 against the text of
+PMK-81/PMK.03/2024 (the jdih.kemenkeu.go.id page-stamped PDF, read on the BPK mirror
+https://peraturan.bpk.go.id/Download/366884/2024pmkeuangan081.pdf):
+
+    Pasal 100 — payment and deposit:
+      (1) "Dalam hal tanggal jatuh tempo pembayaran atau penyetoran pajak sebagaimana dimaksud
+          dalam Pasal 94 bertepatan dengan hari libur, pembayaran atau penyetoran pajak dapat
+          dilakukan paling lambat pada hari kerja berikutnya."
+      (2) "Hari libur sebagaimana dimaksud pada ayat (1) yaitu hari Sabtu, hari Minggu, hari
+          libur nasional, hari yang diliburkan untuk penyelenggaraan pemilihan umum, atau hari
+          yang ditetapkan sebagai cuti bersama secara nasional."
+
+    Pasal 173 — SPT reporting: a SEPARATE provision, keyed to Pasal 171/172 and not to Pasal
+    94/100, carrying the identical hari-libur definition in its own ayat (2). Payment rules and
+    reporting rules therefore roll for the same reason under two different articles; this module
+    is the one implementation of both, and a caller does not have to know which article it is
+    under. Pasal 264 ayat (2)-(3) repeats the same template for oil-and-gas reporting.
+
+Two deliberate gaps, both of which under-roll (they can only leave a date earlier than the law
+allows, never later, so they never invent a deadline that has already passed):
+
+- Election days ("hari yang diliburkan untuk penyelenggaraan pemilihan umum") are NOT modelled.
+  They are decreed per election, are not part of the SKB this data comes from, and 2026 has no
+  national election day. A deadline falling on a future one will not move here.
+- A year whose SKB is not decreed yet rolls off WEEKENDS ONLY. `holiday_years_loaded` exists so
+  a caller can say that out loud instead of shipping a silently incomplete date; the obligations
+  register turns it into a `needs_review_reason` on the proposal.
+
+Bali Zero's own closures are not statutory and cannot reach this module: it reads nothing but the
+decreed national set in `backend.data.id_holidays`, whose docstring forbids an undecreed date and
+whose test pins the decree's own 17 + 8 counts. A day the office chooses to take off does not
+move a DJP deadline, and the office being open on a decreed holiday does not unmove one.
+`garuda_flow.operating_calendar` answers the different question "is our office open" from the
+same table; neither module is the other's source.
+
+PURE functions — no I/O, no ``date.today()``. The caller always injects the day.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from backend.data.id_holidays import DECREED_YEARS, HOLIDAY_DATES
+
+__all__ = ["holiday_years_loaded", "is_business_day", "next_business_day"]
+
+# The longest real closed run in the 2026 decree is 2026-03-18..2026-03-24 (7 days: Nyepi plus
+# the Idulfitri block plus a weekend). This bound only exists so a future data error fails loudly
+# instead of looping forever; it is never reached with decreed data.
+_MAX_ROLL_DAYS: int = 30
+
+
+def holiday_years_loaded() -> frozenset[int]:
+    """Calendar years whose national holiday table is materialized IN FULL from a decree.
+
+    A year absent from this set is not holiday-free: it is unknown. `is_business_day` then judges
+    that year on weekends alone, so a caller that must not publish an under-rolled date checks
+    membership and flags the result for review.
+    """
+    return DECREED_YEARS
+
+
+def is_business_day(day: date) -> bool:
+    """True unless ``day`` is a Saturday, a Sunday, or a decreed libur nasional / cuti bersama.
+
+    Both kinds of decreed day count: PMK 81/2024 Pasal 100 ayat (2) names cuti bersama
+    explicitly. For a year outside `holiday_years_loaded` only the weekend test can fire.
+    """
+    if day.weekday() >= 5:  # Monday=0 ... Saturday=5, Sunday=6
+        return False
+    return day not in HOLIDAY_DATES
+
+
+def next_business_day(day: date) -> date:
+    """The first business day at or AFTER ``day`` — ``day`` itself when it already is one.
+
+    This is the "hari kerja berikutnya" of Pasal 100 / Pasal 173 applied to a statutory date: a
+    deadline already on a working day does not move, and one on a closed day moves forward until
+    the office and the tax system are both open. Never moves a date backwards.
+    """
+    candidate = day
+    for _ in range(_MAX_ROLL_DAYS + 1):
+        if is_business_day(candidate):
+            return candidate
+        candidate += timedelta(days=1)
+    raise ValueError(
+        f"no business day within {_MAX_ROLL_DAYS} days of {day.isoformat()} — "
+        "the holiday data is almost certainly wrong"
+    )

--- a/apps/backend-rag/backend/services/compliance/obligations_register.py
+++ b/apps/backend-rag/backend/services/compliance/obligations_register.py
@@ -16,8 +16,12 @@ A `day` past the end of a month means that month's last day. Fiscal years are mo
 the MM of fiscal_year_end is the closing month. Period keys: "YYYY-MM" (monthly), "YYYY-Qn"
 (calendar quarter), "FYyyyy-Qn" (fiscal quarter), "FYyyyy" (annual), where yyyy is the calendar
 year in which the fiscal year ends.
-roll=next_business_day moves a Saturday or Sunday to the following Monday. Indonesian national
-holidays and cuti bersama are NOT modelled in v1: a due date on a holiday does not move.
+roll=next_business_day moves a date that is not an Indonesian business day to the first one after
+it: Saturday, Sunday, libur nasional and cuti bersama all push it (`business_days.py`, PMK
+81/2024 Pasal 100 for payment and Pasal 173 for reporting). When the due date's year has no
+decreed holiday table the roll degrades to weekends only, and `propose` attaches
+"holiday calendar for <year> not loaded" to that proposal's needs_review_reason so the reviewer
+sees a date the engine could not finish computing. roll=none never moves, holiday or not.
 The horizon window is [start, start + horizon_days): start inclusive, end exclusive, after rolling.
 """
 
@@ -33,6 +37,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+from backend.services.compliance.business_days import holiday_years_loaded, next_business_day
 
 DEFAULT_CATALOG_PATH = Path(__file__).resolve().parents[2] / "data" / "obligations_catalog.yaml"
 
@@ -345,17 +351,29 @@ def due_dates(
     out = []
     for key, due in _periods(rule, profile, range(start.year - span, end.year + 2)):
         if rule.due.roll == "next_business_day":
-            due += timedelta(days=max(0, 7 - due.weekday()) if due.weekday() >= 5 else 0)
+            due = next_business_day(due)
         if start <= due < end:
             out.append((key, due))
     return sorted(out, key=lambda kd: (kd[1], kd[0]))
+
+
+def _review_reason(rule: ObligationRule, due: date) -> str | None:
+    """The rule's own reason, plus the holiday gap when this date's year has no decreed table.
+
+    Only a rolling rule can be wrong for that reason: a roll=none date never moved in the first
+    place, so an undecreed year tells the reviewer nothing about it.
+    """
+    if rule.due.roll != "next_business_day" or due.year in holiday_years_loaded():
+        return rule.needs_review_reason
+    gap = f"holiday calendar for {due.year} not loaded"
+    return f"{rule.needs_review_reason}; {gap}" if rule.needs_review_reason else gap
 
 
 def propose(
     rules: Iterable[ObligationRule], profile: ClientProfile, start: date, horizon_days: int
 ) -> list[ProposedObligation]:
     out = [
-        ProposedObligation(rule.id, key, due, rule.needs_review_reason)
+        ProposedObligation(rule.id, key, due, _review_reason(rule, due))
         for rule in rules
         if applies(rule, profile)
         for key, due in due_dates(rule, profile, start, horizon_days)

--- a/apps/backend-rag/backend/services/garuda_flow/operating_calendar.py
+++ b/apps/backend-rag/backend/services/garuda_flow/operating_calendar.py
@@ -11,25 +11,23 @@ has. It does NOT touch the extension path — extensions require an in-person
 photo/interview (since 29 May 2025) and carry their own published D-7
 Ngurah Rai filing deadline (`safe_clock.py`), untouched by this ruling.
 
-Provenance — every date below is traceable to ONE decree, cross-checked by
-a second, independent sourcing route in the same session with zero
-divergence on any date:
+Provenance — NO date is typed in this module. The decreed dates live in
+`backend.data.id_holidays` (SKB 3 Menteri No. 1497/2025, 2/2025, 5/2025 —
+see that module for the decree text, URLs and the 2026-07-27 corroboration
+route), because a second organ now needs the same dates: the compliance
+obligations register rolls a statutory tax deadline off a hari libur
+(`services.compliance.business_days`, PMK 81/2024). Two readers, one table,
+no hand-copied date.
 
-    KEPUTUSAN BERSAMA MENTERI AGAMA / MENTERI KETENAGAKERJAAN / MENTERI
-    PANRB RI — NOMOR 1497 TAHUN 2025, NOMOR 2 TAHUN 2025, NOMOR 5 TAHUN
-    2025, tentang Hari Libur Nasional dan Cuti Bersama Tahun 2026.
-    Ditetapkan di Jakarta, 19 September 2025.
-    Primary source (PDF): https://www.kemenkopmk.go.id/sites/default/files/
-    pengumuman/2025-09/SKB%20Libur%20Nasional%20dan%20Cuti%20Bersama%20
-    Tahun%202026.pdf
-    Corroborated (2026-07-27 session) by an independent route through
-    Indonesian press — both agreed on every date, zero divergence.
-
-    Full year 2026 per the decree = 17 hari libur nasional + 8 cuti
-    bersama. This module materializes ONLY the closure set needed from
-    2026-07-28 onward. Earlier dates were deliberately omitted when the
-    pilot began, so this dataset cannot certify an open day before that
-    materialization boundary even though the source decree spans the year.
+    This module still publishes only the closure set from 2026-07-28
+    onward: `OPERATING_CALENDAR` is the shared table CLIPPED to
+    [COVERAGE_START, COVERAGE_END], which is byte-for-byte the four days it
+    carried before the table moved out (17 Aug, 25 Aug, 24 Dec, 25 Dec
+    2026). Clipping is not data loss — `is_open` already fails closed
+    outside coverage — it keeps this gate's promise that it cannot certify
+    an open day before its materialization boundary. Widening the VOA
+    pilot's coverage is a separate decision with its own evidence; it is
+    not a side effect of giving the dates a home.
 
 ⚠️ COVERAGE_END = 2026-12-31. The 2027 SKB does not exist yet — this decree
 class is issued around September of the PRECEDING year (this one was
@@ -47,9 +45,9 @@ makes the whole engine deterministic and unit-testable.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import date, timedelta
-from enum import Enum
+
+from backend.data.id_holidays import HOLIDAYS, Holiday, HolidayKind
 
 __all__ = [
     "COVERAGE_END",
@@ -62,50 +60,26 @@ __all__ = [
 ]
 
 
-class HolidayKind(str, Enum):
-    """The decree names two distinct kinds of non-working day. Both close
-    Bali Zero's systems for the purpose of this gate (the conservative
-    reading — see `is_open`'s docstring for why), but the tag is kept on
-    the data so a future retune can revisit that reading without having to
-    re-source a single date."""
+# This gate's historical name for one decreed closed day. The type moved to
+# `backend.data.id_holidays` with the dates it describes; the alias keeps the
+# name this module (and `garuda_flow/__init__`) has always exported, with the
+# same frozen `at` / `kind` / `name` fields. `HolidayKind` is re-exported from
+# the same place for the same reason: both kinds close this gate (the
+# conservative reading — see `is_open`), and the tag stays on the data so that
+# reading can be revisited without re-sourcing a single date.
+OperatingCalendarDate = Holiday
 
-    LIBUR_NASIONAL = "libur_nasional"
-    CUTI_BERSAMA = "cuti_bersama"
-
-
-@dataclass(frozen=True)
-class OperatingCalendarDate:
-    """One decreed non-working day."""
-
-    at: date
-    kind: HolidayKind
-    name: str
-
-
-# The one and only place a 2026 non-working day may be added — see the
-# module docstring for provenance and the COVERAGE_END boundary.
-OPERATING_CALENDAR: tuple[OperatingCalendarDate, ...] = (
-    OperatingCalendarDate(date(2026, 8, 17), HolidayKind.LIBUR_NASIONAL, "Proklamasi Kemerdekaan"),
-    OperatingCalendarDate(
-        date(2026, 8, 25), HolidayKind.LIBUR_NASIONAL, "Maulid Nabi Muhammad S.A.W."
-    ),
-    OperatingCalendarDate(
-        date(2026, 12, 24),
-        HolidayKind.CUTI_BERSAMA,
-        "Cuti Bersama Kelahiran Yesus Kristus",
-    ),
-    OperatingCalendarDate(
-        date(2026, 12, 25),
-        HolidayKind.LIBUR_NASIONAL,
-        "Kelahiran Yesus Kristus (Hari Raya Natal)",
-    ),
-)
-
-# The source decree spans 2026, but the checked-in closure subset begins at
-# the pilot's materialization boundary. Coverage describes what THIS dataset
-# can actually certify, not what exists in the omitted part of the decree.
+# The source decree spans 2026, but the closure subset this gate publishes
+# begins at the pilot's materialization boundary. Coverage describes what THIS
+# dataset can actually certify, not what exists in the clipped part.
 COVERAGE_START: date = date(2026, 7, 28)
 COVERAGE_END: date = date(2026, 12, 31)
+
+# Derived, never typed: a new non-working day is added to the shared decree
+# table, and shows up here only if it falls inside the coverage window.
+OPERATING_CALENDAR: tuple[OperatingCalendarDate, ...] = tuple(
+    holiday for holiday in HOLIDAYS if COVERAGE_START <= holiday.at <= COVERAGE_END
+)
 
 _CLOSED_DATES: frozenset[date] = frozenset(d.at for d in OPERATING_CALENDAR)
 

--- a/apps/backend-rag/backend/tests/services/compliance/test_business_days.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_business_days.py
@@ -1,0 +1,140 @@
+"""Indonesian business days and the decreed holiday table behind them (pure, no I/O).
+
+Calendar facts used below, all 2026: 15 Feb is a Sunday; 16 Feb (cuti bersama Imlek) and 17 Feb
+(Imlek) are decreed; 18 Feb is a Wednesday. 20 Mar (cuti bersama Idulfitri) is a Friday, 21-22 Mar
+are Idulfitri AND the weekend, 23-24 Mar are cuti bersama, 25 Mar is a Wednesday — the longest
+closed run in the decree. 17 Aug (Proklamasi Kemerdekaan) is a Monday. 9 Sep is a Wednesday.
+
+The 18 February 2026 case is not invented: DJP published exactly it (SPT Masa PPh Unifikasi for
+Masa Pajak Januari 2026 moves to 18 February 2026 because 15 Feb is a Sunday and 16-17 Feb are
+non-working days), so this file pins the engine against the authority's own worked example.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from backend.data.id_holidays import DECREED_YEARS, HOLIDAY_DATES, HOLIDAYS, HolidayKind
+from backend.services.compliance.business_days import (
+    holiday_years_loaded,
+    is_business_day,
+    next_business_day,
+)
+from backend.services.garuda_flow.operating_calendar import (
+    COVERAGE_END,
+    COVERAGE_START,
+    OPERATING_CALENDAR,
+)
+
+
+class TestIsBusinessDay:
+    def test_ordinary_weekday_is_a_business_day(self) -> None:
+        assert is_business_day(date(2026, 9, 9)) is True
+
+    @pytest.mark.parametrize("day", [date(2026, 9, 12), date(2026, 9, 13)])
+    def test_weekend_is_not_a_business_day(self, day: date) -> None:
+        assert is_business_day(day) is False
+
+    def test_libur_nasional_is_not_a_business_day(self) -> None:
+        assert is_business_day(date(2026, 8, 17)) is False  # Proklamasi Kemerdekaan, a Monday
+
+    def test_cuti_bersama_is_not_a_business_day(self) -> None:
+        # PMK 81/2024 Pasal 100 ayat (2) names cuti bersama in the hari-libur definition, so a
+        # deadline moves off it exactly like a libur nasional.
+        assert is_business_day(date(2026, 3, 20)) is False  # Friday, cuti bersama Idulfitri
+
+    def test_every_decreed_date_is_closed(self) -> None:
+        assert not [day for day in HOLIDAY_DATES if is_business_day(day)]
+
+
+class TestNextBusinessDay:
+    def test_a_business_day_does_not_move(self) -> None:
+        assert next_business_day(date(2026, 9, 9)) == date(2026, 9, 9)
+
+    def test_weekend_moves_to_monday(self) -> None:
+        assert next_business_day(date(2026, 9, 12)) == date(2026, 9, 14)
+        assert next_business_day(date(2026, 9, 13)) == date(2026, 9, 14)
+
+    def test_sunday_before_two_decreed_days_lands_on_wednesday(self) -> None:
+        # DJP's own published example: Sun 15 Feb -> Mon 16 (cuti bersama) -> Tue 17 (Imlek) -> Wed.
+        assert next_business_day(date(2026, 2, 15)) == date(2026, 2, 18)
+
+    def test_friday_before_the_idulfitri_block_crosses_the_longest_closed_run(self) -> None:
+        # Fri 20 Mar cuti bersama, Sat/Sun 21-22 Idulfitri, Mon/Tue 23-24 cuti bersama -> Wed 25.
+        assert next_business_day(date(2026, 3, 20)) == date(2026, 3, 25)
+
+    def test_monday_holiday_pushes_a_weekend_date_past_it(self) -> None:
+        # Sat 15 Aug -> Sun 16 -> Mon 17 is Independence Day -> Tue 18.
+        assert next_business_day(date(2026, 8, 15)) == date(2026, 8, 18)
+
+    def test_never_moves_a_date_backwards_and_is_idempotent(self) -> None:
+        day = date(2026, 1, 1)
+        while day < date(2027, 1, 1):
+            rolled = next_business_day(day)
+            assert rolled >= day
+            assert next_business_day(rolled) == rolled
+            assert is_business_day(rolled)
+            day += timedelta(days=1)
+
+
+class TestUndecreedYears:
+    def test_only_fully_decreed_years_are_reported_loaded(self) -> None:
+        assert holiday_years_loaded() == frozenset({2026})
+        assert 2027 not in holiday_years_loaded()
+
+    def test_an_undecreed_year_rolls_weekends_only(self) -> None:
+        # 1 January is a national holiday every year, but 2027's SKB does not exist, so this
+        # module must not pretend to know. It under-rolls and `holiday_years_loaded` is how a
+        # caller learns to say so — see the obligations register's needs_review_reason.
+        assert is_business_day(date(2027, 1, 1)) is True
+        assert next_business_day(date(2027, 1, 1)) == date(2027, 1, 1)
+        assert next_business_day(date(2027, 1, 2)) == date(2027, 1, 4)  # Sat -> Mon
+
+
+class TestDecreedTableIntegrity:
+    """The data, not the arithmetic: a hand-edit that invents or drops a day fails here."""
+
+    def test_the_decree_counts_are_17_libur_nasional_and_8_cuti_bersama(self) -> None:
+        kinds = [h.kind for h in HOLIDAYS]
+        assert kinds.count(HolidayKind.LIBUR_NASIONAL) == 17
+        assert kinds.count(HolidayKind.CUTI_BERSAMA) == 8
+        assert len(HOLIDAYS) == 25
+
+    def test_no_date_outside_a_decreed_year_and_no_duplicate(self) -> None:
+        assert {h.at.year for h in HOLIDAYS} <= DECREED_YEARS
+        assert len(HOLIDAY_DATES) == len(HOLIDAYS)
+
+    def test_table_is_sorted_so_a_pasted_date_is_visible_in_review(self) -> None:
+        assert [h.at for h in HOLIDAYS] == sorted(h.at for h in HOLIDAYS)
+
+    def test_only_decreed_days_can_close_a_deadline(self) -> None:
+        # The enforceable half of "Bali Zero's own closures are not statutory": the set this
+        # module consults IS the decree's set, so an office closure cannot move a due date
+        # without first being added to a table whose counts are pinned above.
+        assert HOLIDAY_DATES == frozenset(h.at for h in HOLIDAYS)
+
+
+class TestGarudaReadsTheSameTable:
+    """Both readers, one table — and the VOA gate's published dataset did not change when the
+    dates moved out of it (family #9: a shared-data refactor that silently mutates a consumer)."""
+
+    def test_operating_calendar_is_the_shared_table_clipped_to_its_coverage(self) -> None:
+        assert OPERATING_CALENDAR == tuple(
+            h for h in HOLIDAYS if COVERAGE_START <= h.at <= COVERAGE_END
+        )
+
+    def test_the_voa_gate_still_carries_exactly_its_four_days(self) -> None:
+        assert [h.at for h in OPERATING_CALENDAR] == [
+            date(2026, 8, 17),
+            date(2026, 8, 25),
+            date(2026, 12, 24),
+            date(2026, 12, 25),
+        ]
+
+    def test_clipping_hides_the_earlier_decreed_dates_from_the_voa_gate_only(self) -> None:
+        # They exist in the shared table (so a deadline moves off them) and are outside the VOA
+        # gate's materialized window (so it still cannot certify an open day back there).
+        assert date(2026, 3, 19) in HOLIDAY_DATES
+        assert date(2026, 3, 19) not in {h.at for h in OPERATING_CALENDAR}

--- a/apps/backend-rag/backend/tests/services/compliance/test_business_days.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_business_days.py
@@ -5,9 +5,10 @@ Calendar facts used below, all 2026: 15 Feb is a Sunday; 16 Feb (cuti bersama Im
 are Idulfitri AND the weekend, 23-24 Mar are cuti bersama, 25 Mar is a Wednesday — the longest
 closed run in the decree. 17 Aug (Proklamasi Kemerdekaan) is a Monday. 9 Sep is a Wednesday.
 
-The 18 February 2026 case is not invented: DJP published exactly it (SPT Masa PPh Unifikasi for
-Masa Pajak Januari 2026 moves to 18 February 2026 because 15 Feb is a Sunday and 16-17 Feb are
-non-working days), so this file pins the engine against the authority's own worked example.
+The 18 February 2026 case is the PAYMENT/deposit deadline of Pasal 94 (the 15th of the following
+month), not a reporting deadline: Sun 15 Feb, then cuti bersama and Imlek, land it on Wed 18 Feb.
+The same month's SPT Masa is a different deadline (Pasal 171, the 20th) and does not move at all.
+The arithmetic below rests on the decreed dates, not on anyone's worked example.
 """
 
 from __future__ import annotations
@@ -58,7 +59,8 @@ class TestNextBusinessDay:
         assert next_business_day(date(2026, 9, 13)) == date(2026, 9, 14)
 
     def test_sunday_before_two_decreed_days_lands_on_wednesday(self) -> None:
-        # DJP's own published example: Sun 15 Feb -> Mon 16 (cuti bersama) -> Tue 17 (Imlek) -> Wed.
+        # Sun 15 Feb -> Mon 16 (cuti bersama Imlek) -> Tue 17 (Imlek) -> Wed 18. The old
+        # weekend-only roll stopped on the 16th, a day the tax system is closed.
         assert next_business_day(date(2026, 2, 15)) == date(2026, 2, 18)
 
     def test_friday_before_the_idulfitri_block_crosses_the_longest_closed_run(self) -> None:

--- a/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
@@ -262,12 +262,15 @@ def test_horizon_start_is_inclusive_and_end_exclusive(catalog):
         due_dates(rule, PMA, date(2026, 11, 16), -1)
 
 
-def test_due_on_a_libur_nasional_moves_to_the_next_business_day(catalog):
-    # 2026-05 PPN is statutorily due Tue 30 Jun; the 2026-06 period is due Fri 31 Jul. Neither is
-    # decreed, so pick the one that is: pph21 for 2026-07 is due Mon 17 Aug, Independence Day.
-    assert due_dates(catalog["pph21_payment"], PMA, date(2026, 8, 1), 30) == [
-        ("2026-07", date(2026, 8, 18))
-    ]
+def test_due_on_a_libur_nasional_moves_to_the_next_business_day():
+    # No 2026 catalog date lands on a decreed WEEKDAY, so this case needs a synthetic rule: due on
+    # the 17th means Mon 2026-08-17, Proklamasi Kemerdekaan, a holiday that is not also a weekend.
+    rule = ObligationRule(
+        "synthetic_17", "n", "a", "s", False, (), DueRule("monthly", 17, None, 0, "none", "fiscal")
+    )
+    rolling = replace(rule, due=replace(rule.due, roll="next_business_day"))
+    assert due_dates(rule, PMA, date(2026, 8, 1), 30) == [("2026-08", date(2026, 8, 17))]
+    assert due_dates(rolling, PMA, date(2026, 8, 1), 30) == [("2026-08", date(2026, 8, 18))]
 
 
 def test_due_on_a_cuti_bersama_moves_to_the_next_business_day(catalog):
@@ -278,24 +281,22 @@ def test_due_on_a_cuti_bersama_moves_to_the_next_business_day(catalog):
 
 
 def test_due_on_a_weekend_skips_the_monday_holiday_too(catalog):
-    # Sun 2026-02-15 used to roll to Mon 16 Feb (cuti bersama Imlek) and stop there; 17 Feb is
-    # Imlek itself. This is DJP's own published example: the deadline lands on Wed 18 Feb 2026.
+    # The PPh 21 DEPOSIT deadline (Pasal 94: the 15th) for Masa Pajak 2026-01 is Sun 15 Feb. The
+    # old weekend-only roll stopped on Mon 16 Feb, which is cuti bersama Imlek; Tue 17 Feb is Imlek
+    # itself. Wed 18 Feb is the first day the deposit can actually be made.
     assert due_dates(catalog["pph21_payment"], PMA, date(2026, 2, 1), 28) == [
         ("2026-01", date(2026, 2, 18))
     ]
+    # The RETURN for the same month is a different deadline (Pasal 171: the 20th) and does not
+    # move: Fri 20 Feb 2026 is a business day. Conflating the two is the easy mistake here.
+    assert due_dates(catalog["spt_masa_pph21"], PMA, date(2026, 2, 1), 28) == [
+        ("2026-01", date(2026, 2, 20))
+    ]
 
 
-def test_roll_none_never_moves_even_on_a_holiday(catalog):
-    # Same statutory date, Mon 2026-08-17 (Proklamasi Kemerdekaan), under both rolls: the only
-    # difference is the roll field, so this isolates it from the calendar.
-    due = DueRule("monthly", 17, None, 0, "none", "fiscal")
-    stays = ObligationRule("stays", "n", "a", "s", False, (), due)
-    moves = ObligationRule(
-        "moves", "n", "a", "s", False, (), replace(due, roll="next_business_day")
-    )
-    assert due_dates(stays, PMA, date(2026, 8, 1), 30) == [("2026-08", date(2026, 8, 17))]
-    assert due_dates(moves, PMA, date(2026, 8, 1), 30) == [("2026-08", date(2026, 8, 18))]
-    # And in the catalog: BPJS Ketenagakerjaan is roll: none, so Sat 15 Aug stays Sat 15 Aug.
+def test_a_catalog_roll_none_rule_ignores_the_holiday_block_after_it(catalog):
+    # BPJS Ketenagakerjaan for 2026-07 is due Sat 15 Aug with roll: none. The next business day is
+    # Tue 18 Aug (Sun 16, then Independence Day on Mon 17), and none of that reaches this rule.
     assert due_dates(catalog["bpjs_ketenagakerjaan_monthly"], PMA, date(2026, 8, 1), 30) == [
         ("2026-07", date(2026, 8, 15))
     ]
@@ -312,14 +313,15 @@ def test_a_year_without_a_holiday_table_rolls_weekends_only_and_says_so(catalog)
 
 
 def test_the_holiday_gap_is_flagged_per_proposal_not_per_run(catalog):
-    # One horizon can straddle a decreed year and an undecreed one; each date answers for itself.
+    # One horizon straddles the decreed year and the undecreed one, so the flag cannot be a
+    # property of the run: 2026-11 is due inside 2026 and says nothing, 2026-12 lands in 2027.
     reasons = {
         (p.period_key, p.due_date): p.needs_review_reason
-        for p in propose([catalog["spt_masa_ppn"]], PMA, date(2027, 12, 1), 75)
+        for p in propose([catalog["spt_masa_ppn"]], PMA, date(2026, 12, 1), 75)
     }
     assert reasons == {
-        ("2027-11", date(2027, 12, 31)): "holiday calendar for 2027 not loaded",
-        ("2027-12", date(2028, 1, 31)): "holiday calendar for 2028 not loaded",
+        ("2026-11", date(2026, 12, 31)): None,
+        ("2026-12", date(2027, 2, 1)): "holiday calendar for 2027 not loaded",
     }
 
 

--- a/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import fields as dataclass_fields
+from dataclasses import replace
 from datetime import date
 from pathlib import Path
 
@@ -259,6 +260,84 @@ def test_horizon_start_is_inclusive_and_end_exclusive(catalog):
     assert due_dates(rule, PMA, date(2026, 11, 16), 0) == []
     with pytest.raises(ValueError):
         due_dates(rule, PMA, date(2026, 11, 16), -1)
+
+
+def test_due_on_a_libur_nasional_moves_to_the_next_business_day(catalog):
+    # 2026-05 PPN is statutorily due Tue 30 Jun; the 2026-06 period is due Fri 31 Jul. Neither is
+    # decreed, so pick the one that is: pph21 for 2026-07 is due Mon 17 Aug, Independence Day.
+    assert due_dates(catalog["pph21_payment"], PMA, date(2026, 8, 1), 30) == [
+        ("2026-07", date(2026, 8, 18))
+    ]
+
+
+def test_due_on_a_cuti_bersama_moves_to_the_next_business_day(catalog):
+    # Fri 2026-03-20 is cuti bersama Idulfitri and the block runs to Tue 24 Mar -> Wed 25 Mar.
+    assert due_dates(catalog["spt_masa_pph21"], PMA, date(2026, 3, 1), 31) == [
+        ("2026-02", date(2026, 3, 25))
+    ]
+
+
+def test_due_on_a_weekend_skips_the_monday_holiday_too(catalog):
+    # Sun 2026-02-15 used to roll to Mon 16 Feb (cuti bersama Imlek) and stop there; 17 Feb is
+    # Imlek itself. This is DJP's own published example: the deadline lands on Wed 18 Feb 2026.
+    assert due_dates(catalog["pph21_payment"], PMA, date(2026, 2, 1), 28) == [
+        ("2026-01", date(2026, 2, 18))
+    ]
+
+
+def test_roll_none_never_moves_even_on_a_holiday(catalog):
+    # Same statutory date, Mon 2026-08-17 (Proklamasi Kemerdekaan), under both rolls: the only
+    # difference is the roll field, so this isolates it from the calendar.
+    due = DueRule("monthly", 17, None, 0, "none", "fiscal")
+    stays = ObligationRule("stays", "n", "a", "s", False, (), due)
+    moves = ObligationRule(
+        "moves", "n", "a", "s", False, (), replace(due, roll="next_business_day")
+    )
+    assert due_dates(stays, PMA, date(2026, 8, 1), 30) == [("2026-08", date(2026, 8, 17))]
+    assert due_dates(moves, PMA, date(2026, 8, 1), 30) == [("2026-08", date(2026, 8, 18))]
+    # And in the catalog: BPJS Ketenagakerjaan is roll: none, so Sat 15 Aug stays Sat 15 Aug.
+    assert due_dates(catalog["bpjs_ketenagakerjaan_monthly"], PMA, date(2026, 8, 1), 30) == [
+        ("2026-07", date(2026, 8, 15))
+    ]
+
+
+def test_a_year_without_a_holiday_table_rolls_weekends_only_and_says_so(catalog):
+    # 2028 has no decree yet (they are issued ~September of the preceding year). Sat 2028-01-15
+    # therefore rolls on the weekend alone, to Mon 17 Jan, and the proposal says the date is
+    # unfinished instead of presenting it as computed.
+    rule = catalog["pph21_payment"]
+    assert due_dates(rule, PMA, date(2028, 1, 1), 31) == [("2027-12", date(2028, 1, 17))]
+    [proposed] = propose([rule], PMA, date(2028, 1, 1), 31)
+    assert proposed.needs_review_reason == "holiday calendar for 2028 not loaded"
+
+
+def test_the_holiday_gap_is_flagged_per_proposal_not_per_run(catalog):
+    # One horizon can straddle a decreed year and an undecreed one; each date answers for itself.
+    reasons = {
+        (p.period_key, p.due_date): p.needs_review_reason
+        for p in propose([catalog["spt_masa_ppn"]], PMA, date(2027, 12, 1), 75)
+    }
+    assert reasons == {
+        ("2027-11", date(2027, 12, 31)): "holiday calendar for 2027 not loaded",
+        ("2027-12", date(2028, 1, 31)): "holiday calendar for 2028 not loaded",
+    }
+
+
+def test_the_holiday_gap_reason_appends_to_the_rules_own_reason(catalog):
+    rule = catalog["pph25_installment"]
+    assert rule.needs_review_reason  # the rule already has one; the gap must not replace it
+    [proposed] = propose([rule], PMA, date(2027, 1, 10), 10)
+    assert proposed.needs_review_reason == (
+        f"{rule.needs_review_reason}; holiday calendar for 2027 not loaded"
+    )
+
+
+def test_a_roll_none_rule_is_not_flagged_for_an_undecreed_year(catalog):
+    # Nothing about an unknown holiday table can change a date that never moves.
+    rule = catalog["bpjs_kesehatan_monthly"]
+    [proposed] = propose([rule], PMA, date(2027, 1, 1), 15)
+    assert proposed.due_date == date(2027, 1, 10)
+    assert proposed.needs_review_reason == rule.needs_review_reason
 
 
 def test_one_time_and_event_rules_produce_nothing(catalog):

--- a/evidence/2026-09/agent-air-m5-backend-rag-obligations-holiday-rol-f93dd73a/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-obligations-holiday-rol-f93dd73a/brief.yml
@@ -1,0 +1,39 @@
+mandate: >
+  M1 of the compliance-stack second wave (spec docs/plans/2026-09-12-compliance-stack-engine-ui-windows.md):
+  make the obligations register roll a statutory due date off Indonesian national holidays and cuti
+  bersama, not just off Saturday and Sunday. Adds backend/data/id_holidays.py (the full 2026 SKB 3
+  Menteri table, 17 libur nasional + 8 cuti bersama, the single place such a date may be typed) and
+  backend/services/compliance/business_days.py (is_business_day, next_business_day,
+  holiday_years_loaded); routes roll=next_business_day through it; attaches
+  "holiday calendar for <year> not loaded" to a proposal whose year has no decreed table; rewires
+  garuda_flow/operating_calendar.py to read the same table instead of carrying four hand-typed dates.
+gear: 2
+gear_reason: >
+  Deterministic floor 2 as printed by scripts/evidence_pack_lint.py --print-floor on
+  git diff --name-only/--numstat origin/main...HEAD. Churn is about 520 lines across six files in
+  apps/backend-rag, of which roughly 280 are the decree table and new tests. Pure functions only:
+  no migration, no router, no schema, no workflow, no guard, no lockfile, no secret, no CODEOWNERS
+  path. One shared module (garuda_flow/operating_calendar.py) changes hands, which is the reason the
+  adversarial round was pointed at behaviour parity for the VOA gate rather than at the arithmetic.
+origin: >
+  Measured gap, not a report: due_dates() rolled weekends only, so the register proposed dates on
+  decreed closed days (for a PT PMA with employees and PKP, five of 39 proposals in the first 120
+  days of 2026, including 2026-02-16, cuti bersama Imlek). PMK 81/2024 moves them: Pasal 100 for
+  payment (referencing Pasal 94) and Pasal 173 for SPT Masa reporting (referencing Pasal 171/172),
+  each defining hari libur as Saturday, Sunday, libur nasional, election days and cuti bersama in
+  its own ayat (2). Both articles read verbatim off the regulation PDF on peraturan.bpk.go.id; the
+  25 dates come from Sekretariat Negara's publication of the decree's own tables.
+instruction_to_the_grader: >
+  Three things deserve attack. (1) Parity: OPERATING_CALENDAR is now derived and clipped to
+  [COVERAGE_START, COVERAGE_END] — prove the VOA gate's answers did not move, ideally by comparing
+  is_open and last_open_day_before against origin/main over the whole covered range rather than by
+  reading the clip expression. (2) Honesty of coverage: DECREED_YEARS is written, not derived, and
+  the claim it makes is that 2026 is materialized IN FULL — check the 25 dates against the decree,
+  and check that an undecreed year under-rolls and says so rather than silently passing as clean.
+  (3) Scope of the entitlement: the annual corporate return rolls because the CATALOG says roll:
+  next_business_day, and Pasal 173 does not name it. That is recorded as an open finding for the
+  catalog-source pass, not fixed here; verify the PR does not quietly claim the annual roll is
+  grounded, and that no catalog file was touched. Election days are deliberately unmodelled.
+appetite:
+  wall_clock_hours: 2
+  adversarial_rounds: 1


### PR DESCRIPTION
`due_dates()` rolled Saturday and Sunday only, so a statutory deadline landing on libur nasional or cuti bersama stayed there: the register proposed a date the office cannot act on and DJP does not require. For a PT PMA with employees and PKP, that was 5 of the first 39 proposals of 2026.

PMK 81/2024 says otherwise, in two places, read verbatim off the regulation PDF on `peraturan.bpk.go.id` (the `jdih.kemenkeu.go.id` page-stamped file):

- **Pasal 100** ayat (1)-(2) — payment and deposit, referencing Pasal 94.
- **Pasal 173** ayat (1)-(2) — SPT Masa reporting, referencing Pasal 171/172, a separate provision with the identical hari-libur definition.

Both define hari libur as Saturday, Sunday, libur nasional, election days and cuti bersama, and move the deadline to `hari kerja berikutnya`. Both are quoted in `business_days.py`'s docstring.

## What changed

| File | Net | What |
| --- | --- | --- |
| `backend/data/id_holidays.py` | +110 | The full 2026 SKB 3 Menteri table (17 libur nasional + 8 cuti bersama, No. 1497/2025, 2/2025, 5/2025), the one place such a date may be typed. `DECREED_YEARS` states coverage honestly. |
| `backend/services/compliance/business_days.py` | +99 | `is_business_day`, `next_business_day` (at-or-after, never backwards), `holiday_years_loaded`. |
| `backend/services/compliance/obligations_register.py` | +18 | `roll=next_business_day` goes through `next_business_day()`; a due date in an undecreed year rolls weekends only and the proposal says so. |
| `backend/services/garuda_flow/operating_calendar.py` | -26 | Reads the same table instead of carrying four hand-typed dates, clipped to its own coverage window. |
| `backend/tests/.../test_business_days.py` | +140 | 21 cases: the two kinds of decreed day, the longest closed run, a year-long never-backwards sweep, coverage honesty, decree-count integrity, VOA parity. |
| `backend/tests/.../test_obligations_register.py` | +91/-31 | The additions the spec lists, plus the per-proposal flag and the payment-vs-return distinction. |

The dates were never retyped. `OPERATING_CALENDAR` is now the shared table clipped to `[COVERAGE_START, COVERAGE_END]`, which is byte-for-byte the four days it carried before, so the VOA gate's fail-closed boundary is untouched. Widening that pilot's coverage is a separate decision and is not taken here.

Two deliberate gaps, both of which under-roll and so cannot invent a deadline that has already passed: **election days** are not modelled (decreed per election, absent from the SKB, none national in 2026), and an **undecreed year** rolls weekends only while flagging the proposal.

## Probe — synthetic PT PMA, 120 days from 2026-01-01

`has_employees=True, pkp=True`, window `[2026-01-01, 2026-05-01)`. `OLD` is the weekend-only roll this PR removes, computed with the removed line itself.

```
rule_id                      period   statutory   OLD wknd    NEW due_date reason
pph21_payment                2026-01  2026-02-15  2026-02-16  2026-02-18   -            <== MOVED (cuti bersama Imlek)
pph23_26_payment             2026-01  2026-02-15  2026-02-16  2026-02-18   third-party payments not modelled...  <== MOVED
pph25_installment            2026-01  2026-02-15  2026-02-16  2026-02-18   final-tax regime PP 55/2022...        <== MOVED
spt_masa_pph21               2026-02  2026-03-20  2026-03-20  2026-03-25   -            <== MOVED (cuti bersama Idulfitri)
spt_masa_pph23_26            2026-02  2026-03-20  2026-03-20  2026-03-25   third-party payments not modelled...  <== MOVED
marketplace_withholding_pmk37 2026-01 2026-02-28  2026-03-02  2026-03-02   (weekend only, unchanged)
spt_tahunan_badan            FY2025   2026-04-30  2026-04-30  2026-04-30   -

39 proposals, 5 dates moved by a holiday that the old weekend-only roll left on a closed day
```

The old 2026-02-16 is cuti bersama Imlek and 2026-02-17 is Imlek itself, so the deposit lands on Wed 2026-02-18. The Friday case is sharper: 2026-03-20 is cuti bersama, 21-22 March are Idulfitri and the weekend, 23-24 March are cuti bersama, so the return lands on Wed 2026-03-25.

Undecreed year, same profile from 2027-01-01, rolling rules only:

```
pph21_payment      2027-01  2027-02-15  holiday calendar for 2027 not loaded
spt_masa_pph21     2027-01  2027-02-22  holiday calendar for 2027 not loaded
pph25_installment  2027-01  2027-02-15  final-tax regime PP 55/2022 ... ; holiday calendar for 2027 not loaded
```

## Tests

From `apps/backend-rag`, `source .venv/bin/activate && PYTHONPATH=.:../crm-cell pytest <path>`:

| Command | Result |
| --- | --- |
| `pytest backend/tests/services/compliance` | 391 passed, exit 0 |
| `pytest backend/tests/services/garuda_flow backend/tests/app/routers/test_garuda_voa_no_internal_leak.py backend/tests/unit/app/routers/test_compliance_obligations.py` | 265 passed, 3 errors |
| `python -c "from backend.app.main_cloud import app"` | import OK, 175 routes |
| `ruff check` on the six changed files | All checks passed |

The 3 errors are `test_check_store_purge.py` needing a Postgres relation that does not exist locally (`asyncpg.UndefinedTableError: relation "garuda_voa_check_idempotency"`). Reproduced identically on a branch with zero `apps/backend-rag` changes, so they are environmental and pre-existing.

## Adversarial review

Codex (`codex exec --sandbox read-only -c model_reasoning_effort=high`) on the full diff. It **confirmed no GARUDA regression by measurement**, comparing `is_open` and `last_open_day_before` against the parent commit over 1,461 dates with identical results, and confirmed all 25 dates against the Sekretariat Negara table, no off-by-one in the roll or the horizon window, and correct per-year flag attribution. Three findings, all disposed:

1. **HIGH, not fixed here, escalated.** The annual corporate return carries `roll: next_business_day` in the catalog, but Pasal 173 names only Pasal 171/172; the annual return sits under UU KUP art. 3 and its `legal_source` still ends in `(verify)`. Reproduced: `fiscal_year_end="01-31"` gives 2026-06-02 where the old code gave 2026-06-01. **Which rules are entitled to roll is catalog data, not engine behaviour**, and it is M4's mandate (`obligations-catalog-sources`) to verify each rule's basis against a primary source. No catalog file is touched here. `business_days.py` now states the limit instead of implying every rolling rule is grounded. Worth noting the new date is still strictly better: the old 2026-06-01 is Hari Lahir Pancasila, also a closed day.
2. **LOW, fixed.** The per-proposal flag test straddled 2027 and 2028, both undecreed, so it could not show the flag being *absent* for a covered year. Now 2026-12-01 + 75 days: 2026-11 is due 2026-12-31 unflagged, 2026-12 lands on 2027-02-01 flagged.
3. **LOW, fixed.** Two test explanations were wrong. The libur-nasional test asserted a statutory Saturday and called it Independence Day, so it was a second weekend case; it now uses a synthetic rule due on Mon 2026-08-17. And 18 February 2026 is the Pasal 94 *deposit* deadline, not an SPT Masa reporting deadline; the register test now pins both deadlines for that month, since the return on the 20th does not move.

`Bites:` consumer = `POST /api/compliance/obligations/generate`, which calls `propose()` for every generation. Observation = the probe above, run on this head: the same PT PMA profile that was proposed 2026-02-16 (cuti bersama Imlek) by the weekend-only roll is now proposed 2026-02-18, and 4 further dates move, with the undecreed-year proposals carrying `holiday calendar for 2027 not loaded`.

Evidence: `evidence/2026-09/agent-air-m5-backend-rag-obligations-holiday-rol-f93dd73a/brief.yml`, gear 2 as printed by `evidence_pack_lint.py --print-floor`. Note for the gate: `evidence_pack_lint.py` fails on `evidence_root_deprecated` for the legacy tracked `evidence/pack.yml`, identically on a branch that changes nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151rdiec2WR4Lf2BG4UUYqP
