### PR TITLE
feat(mouth): obligations reviewer shows rule names, client names, counters and month groups (U1)

### DIFF
--- a/apps/mouth/src/app/(workspace)/obligations/components/ObligationsTable.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/components/ObligationsTable.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import { Fragment, useState } from "react";
+
+import {
+  CARD,
+  INPUT_STYLE,
+  type CatalogRuleOut,
+  type ObligationOut,
+} from "./types";
+
+const COLUMNS = [
+  "ID",
+  "Client",
+  "Rule",
+  "Authority",
+  "Period",
+  "Due date",
+  "Needs review",
+  "Status",
+  "Reviewer",
+  "Actions",
+] as const;
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+/**
+ * "2026-10-10" -> "October 2026". Parsed from the ISO string, never through
+ * `new Date(...)`: the backend sends a plain date and a Date parse would shift
+ * it by the viewer's UTC offset, moving a due date into the previous month for
+ * anyone west of Greenwich.
+ */
+export function dueMonthLabel(dueDate: string): string {
+  const match = /^(\d{4})-(\d{2})/.exec(dueDate ?? "");
+  if (!match) return "Unscheduled";
+  const month = MONTH_NAMES[Number(match[2]) - 1];
+  return month ? `${month} ${match[1]}` : "Unscheduled";
+}
+
+interface Props {
+  items: ObligationOut[];
+  /** rule_id -> catalog rule, from `GET /obligations/catalog`. */
+  catalog: Map<string, CatalogRuleOut>;
+  /** client_id -> display name; an absent id renders as the id. */
+  clientNames: Record<number, string>;
+  /** True when a client filter is set: rows are grouped by due month. */
+  groupByMonth: boolean;
+  notes: Record<number, string>;
+  rowError: Record<number, string>;
+  busyId: number | null;
+  onNoteChange: (id: number, value: string) => void;
+  onApprove: (row: ObligationOut) => void;
+  onReject: (row: ObligationOut) => void;
+}
+
+export function ObligationsTable({
+  items,
+  catalog,
+  clientNames,
+  groupByMonth,
+  notes,
+  rowError,
+  busyId,
+  onNoteChange,
+  onApprove,
+  onReject,
+}: Props) {
+  const [openDetail, setOpenDetail] = useState<number | null>(null);
+
+  // Groups in the order the server returned the rows (due_date ascending), so
+  // the flat and grouped views never disagree about sequence.
+  const groups: Array<{ label: string; rows: ObligationOut[] }> = [];
+  if (groupByMonth) {
+    for (const row of items) {
+      const label = dueMonthLabel(row.due_date);
+      const last = groups[groups.length - 1];
+      if (last && last.label === label) last.rows.push(row);
+      else groups.push({ label, rows: [row] });
+    }
+  } else {
+    groups.push({ label: "", rows: items });
+  }
+
+  const renderRow = (row: ObligationOut) => {
+    const rule = catalog.get(row.rule_id);
+    const isOpen = openDetail === row.id;
+    const clientName = clientNames[row.client_id];
+
+    return (
+      <>
+        <tr
+          className="border-b last:border-b-0"
+          style={{ borderColor: "var(--bz-border)" }}
+        >
+          <td className="px-3 py-2" style={{ color: "var(--bz-text-1)" }}>
+            {row.id}
+          </td>
+          <td className="px-3 py-2" style={{ color: "var(--bz-text-1)" }}>
+            {clientName ? (
+              <>
+                <span className="block">{clientName}</span>
+                <span
+                  className="block text-xs"
+                  style={{ color: "var(--bz-text-3)" }}
+                >
+                  #{row.client_id}
+                </span>
+              </>
+            ) : (
+              <span>{row.client_id}</span>
+            )}
+          </td>
+          <td className="px-3 py-2" style={{ color: "var(--bz-text-1)" }}>
+            <button
+              type="button"
+              onClick={() => setOpenDetail(isOpen ? null : row.id)}
+              aria-expanded={isOpen}
+              aria-label={`Rule detail for obligation ${row.id}`}
+              className="text-left underline-offset-2 hover:underline"
+              style={{ color: "var(--bz-text-1)" }}
+            >
+              {rule?.name ?? row.rule_id}
+            </button>
+            <span
+              className="ml-2 rounded px-1.5 py-0.5 text-xs"
+              style={{
+                border: `1px solid ${
+                  rule?.verified
+                    ? "var(--state-success)"
+                    : "var(--state-warning)"
+                }`,
+                color: "var(--bz-text-2)",
+              }}
+            >
+              {rule?.verified ? "verified" : "unverified"}
+            </span>
+            {rule?.name && (
+              <span
+                className="block text-xs"
+                style={{ color: "var(--bz-text-3)" }}
+              >
+                {row.rule_id}
+              </span>
+            )}
+          </td>
+          <td
+            className="px-3 py-2 text-xs"
+            style={{ color: "var(--bz-text-2)" }}
+          >
+            {rule?.authority ?? "—"}
+          </td>
+          <td className="px-3 py-2" style={{ color: "var(--bz-text-1)" }}>
+            {row.period_key}
+          </td>
+          <td className="px-3 py-2" style={{ color: "var(--bz-text-1)" }}>
+            {row.due_date}
+          </td>
+          <td
+            className="px-3 py-2 text-xs"
+            style={{ color: "var(--bz-text-3)" }}
+          >
+            {row.needs_review_reason ?? "—"}
+          </td>
+          <td className="px-3 py-2" style={{ color: "var(--bz-text-1)" }}>
+            {row.status}
+          </td>
+          <td
+            className="px-3 py-2 text-xs"
+            style={{ color: "var(--bz-text-3)" }}
+          >
+            {row.reviewer_email ? (
+              <>
+                {row.reviewer_email}
+                {row.reviewed_at
+                  ? ` · ${new Date(row.reviewed_at).toLocaleString()}`
+                  : ""}
+              </>
+            ) : (
+              "—"
+            )}
+          </td>
+          <td className="px-3 py-2">
+            {row.status === "proposed" ? (
+              <div className="flex flex-col gap-1">
+                <input
+                  aria-label={`Note for obligation ${row.id}`}
+                  className="w-40 rounded border px-2 py-1 text-xs"
+                  style={INPUT_STYLE}
+                  placeholder="note (required to reject)"
+                  value={notes[row.id] ?? ""}
+                  onChange={(e) => onNoteChange(row.id, e.target.value)}
+                />
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    disabled={busyId === row.id}
+                    onClick={() => onApprove(row)}
+                    className="rounded-md px-3 py-1 text-xs font-medium text-white"
+                    style={{
+                      background: "var(--state-success)",
+                      opacity: busyId === row.id ? 0.6 : 1,
+                    }}
+                  >
+                    {busyId === row.id ? "…" : "Approve"}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={busyId === row.id}
+                    onClick={() => onReject(row)}
+                    className="rounded-md px-3 py-1 text-xs font-medium text-white"
+                    style={{
+                      background: "var(--state-danger)",
+                      opacity: busyId === row.id ? 0.6 : 1,
+                    }}
+                  >
+                    {busyId === row.id ? "…" : "Reject"}
+                  </button>
+                </div>
+                {rowError[row.id] && (
+                  <p
+                    role="alert"
+                    className="text-xs"
+                    style={{ color: "var(--state-danger)" }}
+                  >
+                    {rowError[row.id]}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <span className="text-xs" style={{ color: "var(--bz-text-3)" }}>
+                {row.alert_id ? `alert ${row.alert_id}` : "—"}
+              </span>
+            )}
+          </td>
+        </tr>
+        {isOpen && (
+          <tr
+            className="border-b last:border-b-0"
+            style={{ borderColor: "var(--bz-border)" }}
+          >
+            <td colSpan={COLUMNS.length} className="px-3 py-3">
+              {rule ? (
+                <dl
+                  className="grid gap-x-6 gap-y-1 text-xs sm:grid-cols-2"
+                  style={{ color: "var(--bz-text-2)" }}
+                >
+                  <div className="sm:col-span-2">
+                    <dt
+                      className="font-medium"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      Legal source
+                    </dt>
+                    <dd>{rule.legal_source}</dd>
+                  </div>
+                  <div>
+                    <dt
+                      className="font-medium"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      Schedule
+                    </dt>
+                    <dd>
+                      {rule.frequency}, roll {rule.roll}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt
+                      className="font-medium"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
+                      Trigger
+                    </dt>
+                    <dd>{rule.trigger ?? "—"}</dd>
+                  </div>
+                  {rule.needs_review_reason && (
+                    <div className="sm:col-span-2">
+                      <dt
+                        className="font-medium"
+                        style={{ color: "var(--bz-text-1)" }}
+                      >
+                        Catalog review note
+                      </dt>
+                      <dd>{rule.needs_review_reason}</dd>
+                    </div>
+                  )}
+                  {rule.notes && (
+                    <div className="sm:col-span-2">
+                      <dt
+                        className="font-medium"
+                        style={{ color: "var(--bz-text-1)" }}
+                      >
+                        Notes
+                      </dt>
+                      <dd>{rule.notes}</dd>
+                    </div>
+                  )}
+                </dl>
+              ) : (
+                <p className="text-xs" style={{ color: "var(--bz-text-3)" }}>
+                  Rule {row.rule_id} is not in the catalog.
+                </p>
+              )}
+            </td>
+          </tr>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <div className="overflow-auto rounded-xl border" style={CARD}>
+      <table className="w-full text-sm">
+        <thead>
+          <tr
+            className="border-b text-left"
+            style={{ borderColor: "var(--bz-border)" }}
+          >
+            {COLUMNS.map((h) => (
+              <th
+                key={h}
+                className="px-3 py-2 text-xs font-medium"
+                style={{ color: "var(--bz-text-3)" }}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        {groups.map((group) => (
+          <tbody key={group.label || "all"}>
+            {group.label && (
+              <tr style={{ background: "var(--bz-surface)" }}>
+                <th
+                  colSpan={COLUMNS.length}
+                  scope="colgroup"
+                  className="px-3 py-2 text-left text-xs font-semibold"
+                  style={{ color: "var(--bz-text-2)" }}
+                >
+                  {group.label}
+                  <span
+                    className="ml-2 font-normal"
+                    style={{ color: "var(--bz-text-3)" }}
+                  >
+                    {group.rows.length} due
+                  </span>
+                </th>
+              </tr>
+            )}
+            {group.rows.map((row) => (
+              <Fragment key={row.id}>{renderRow(row)}</Fragment>
+            ))}
+          </tbody>
+        ))}
+      </table>
+    </div>
+  );
+}

--- a/apps/mouth/src/app/(workspace)/obligations/components/StatusCounters.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/components/StatusCounters.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { CARD, COUNTER_STATUSES, type StatusFilter } from "./types";
+import type { StatusCounts } from "./useStatusCounters";
+
+const SWATCH: Record<string, string> = {
+  proposed: "var(--bz-accent)",
+  approved: "var(--state-success)",
+  rejected: "var(--state-danger)",
+  alerted: "var(--state-warning)",
+};
+
+interface Props {
+  counts: StatusCounts;
+  loading: boolean;
+  /** "" = every client; shown so the reviewer knows what the numbers cover. */
+  clientId: string;
+  /** Clicking a tile moves the status filter to it. */
+  onSelect: (status: StatusFilter) => void;
+  activeStatus: StatusFilter;
+}
+
+/** Row counts per status for the current client filter (four parallel reads). */
+export function StatusCounters({
+  counts,
+  loading,
+  clientId,
+  onSelect,
+  activeStatus,
+}: Props) {
+  return (
+    <section className="mb-4" aria-label="Status counters">
+      <p className="mb-2 text-xs" style={{ color: "var(--bz-text-3)" }}>
+        {clientId ? `Client ${clientId}` : "All clients"}
+      </p>
+      <div className="flex flex-wrap gap-3">
+        {COUNTER_STATUSES.map((status) => {
+          const value = counts[status];
+          return (
+            <button
+              key={status}
+              type="button"
+              onClick={() => onSelect(status)}
+              aria-label={`Filter by ${status}`}
+              aria-pressed={activeStatus === status}
+              className="min-w-28 rounded-xl border px-4 py-2 text-left"
+              style={{
+                ...CARD,
+                borderColor:
+                  activeStatus === status ? SWATCH[status] : "var(--bz-border)",
+              }}
+            >
+              <span
+                className="block text-xs capitalize"
+                style={{ color: "var(--bz-text-3)" }}
+              >
+                {status}
+              </span>
+              <span
+                className="block text-xl font-semibold"
+                style={{ color: "var(--bz-text-1)" }}
+                data-testid={`counter-${status}`}
+              >
+                {loading && value === undefined
+                  ? "…"
+                  : value === undefined
+                    ? "—"
+                    : value}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/mouth/src/app/(workspace)/obligations/components/describe-error.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/describe-error.ts
@@ -1,0 +1,14 @@
+import { ApiError } from "@/lib/api/error-handler";
+
+/** Turn a thrown api error into the exact text a reviewer should see. */
+export function describeError(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) {
+    if (e.statusCode === 401 || e.statusCode === 403) return "Admin only.";
+    if (e.statusCode === 404) return e.message || "Not found.";
+    if (e.statusCode === 409)
+      return e.message || "Conflict — this row was already decided.";
+    return e.message || fallback;
+  }
+  if (e instanceof Error) return e.message || fallback;
+  return fallback;
+}

--- a/apps/mouth/src/app/(workspace)/obligations/components/types.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared contract types for the obligations reviewer screen.
+ *
+ * Backend: apps/backend-rag/backend/app/routers/compliance_obligations.py
+ * (`ObligationOut`, `ObligationListOut`, `GenerateOut`, `ApproveOut`,
+ * `CatalogRuleOut`). Local interfaces rather than the generated
+ * `schema.d.ts` typed paths, matching the convention the rest of this screen
+ * and `(workspace)/review/page.tsx` already follow.
+ */
+
+export type ObligationStatus =
+  "proposed" | "approved" | "rejected" | "alerted" | "done";
+
+export const STATUS_FILTER_OPTIONS = [
+  "proposed",
+  "approved",
+  "rejected",
+  "alerted",
+  "done",
+  "all",
+] as const;
+export type StatusFilter = (typeof STATUS_FILTER_OPTIONS)[number];
+
+/** The statuses the counter strip reports, in display order. */
+export const COUNTER_STATUSES = [
+  "proposed",
+  "approved",
+  "rejected",
+  "alerted",
+] as const;
+export type CounterStatus = (typeof COUNTER_STATUSES)[number];
+
+export interface ObligationOut {
+  id: number;
+  client_id: number;
+  rule_id: string;
+  period_key: string;
+  due_date: string;
+  status: ObligationStatus;
+  needs_review_reason: string | null;
+  reviewer_email: string | null;
+  reviewed_at: string | null;
+  review_note: string | null;
+  alert_id: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface ObligationListOut {
+  total: number;
+  limit: number;
+  offset: number;
+  items: ObligationOut[];
+}
+
+export interface GenerateOut {
+  client_id: number;
+  inserted_count: number;
+  company_type: string;
+  needs_manual_classification: boolean;
+  warning: string | null;
+  rows: ObligationOut[];
+}
+
+export interface ApproveOut {
+  obligation: ObligationOut;
+  alert_id: string;
+}
+
+/**
+ * One row of `GET /api/compliance/obligations/catalog` (M3).
+ *
+ * Rule metadata only, no client data. This screen reads the catalog from the
+ * API and never keeps a copy of it: a rule renamed or verified in
+ * `backend/data/obligations_catalog.yaml` changes the table without a
+ * frontend deploy.
+ */
+export interface CatalogRuleOut {
+  id: string;
+  name: string;
+  authority: string;
+  legal_source: string;
+  verified: boolean;
+  frequency: string;
+  roll: string;
+  needs_review_reason: string | null;
+  trigger: string | null;
+  notes: string | null;
+}
+
+export const CARD = {
+  borderColor: "var(--bz-border)",
+  background: "var(--bz-card, var(--bz-surface))",
+} as const;
+
+export const INPUT_STYLE = {
+  borderColor: "var(--bz-border)",
+  background: "var(--bz-surface)",
+  color: "var(--bz-text-1)",
+} as const;

--- a/apps/mouth/src/app/(workspace)/obligations/components/useClientNames.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/useClientNames.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+
+/** The one field this screen needs from the CRM client read. */
+interface ClientNameRead {
+  id: number;
+  full_name?: string | null;
+}
+
+/**
+ * Resolve `client_id` -> display name for the ids currently on screen.
+ *
+ * Read: `GET /api/crm/clients/{client_id}` (`crm_clients.py`, one row plus a
+ * lateral last-interaction join) — the lightest per-client read that returns
+ * `full_name`. Its gate is `verify_client_access(..., allow_assigned=True)`,
+ * and `is_crm_admin` short-circuits it to allowed, so any session that already
+ * passed this screen's own admin gate can resolve every id it sees.
+ *
+ * PII boundary: a resolved name lives in this hook's state for the life of the
+ * browser tab and nowhere else. It is never logged (failures log the id only),
+ * never sent anywhere, and never persisted. An id that fails to resolve is
+ * remembered as attempted so the screen does not retry it on every render; the
+ * caller falls back to the id, which is what the table showed before.
+ */
+export function useClientNames(clientIds: number[]): Record<number, string> {
+  const [names, setNames] = useState<Record<number, string>>({});
+  // Ids already fetched (resolved OR failed). Cache key = client id.
+  const attempted = useRef<Set<number>>(new Set());
+
+  // Stable dependency: the sorted unique id list as a string, so an unchanged
+  // page of rows does not re-run the effect on every parent render.
+  const key = Array.from(new Set(clientIds))
+    .sort((a, b) => a - b)
+    .join(",");
+
+  useEffect(() => {
+    const ids = key
+      .split(",")
+      .filter(Boolean)
+      .map(Number)
+      .filter((id) => Number.isInteger(id) && id > 0)
+      .filter((id) => !attempted.current.has(id));
+    if (ids.length === 0) return;
+    ids.forEach((id) => attempted.current.add(id));
+
+    let cancelled = false;
+    void (async () => {
+      const resolved = await Promise.all(
+        ids.map(async (id) => {
+          try {
+            const client = await api.get<ClientNameRead>(
+              `/api/crm/clients/${id}`,
+            );
+            const name = (client?.full_name ?? "").trim();
+            return name ? ([id, name] as const) : null;
+          } catch {
+            // Deliberately NOT passing the thrown error: its message comes from
+            // a client-record read and must not reach the log sink.
+            logger.warn(
+              "client name resolution failed; falling back to the id",
+              {
+                component: "ObligationsPage",
+                action: "resolveClientName",
+                metadata: { client_id: id },
+              },
+            );
+            return null;
+          }
+        }),
+      );
+      if (cancelled) return;
+      const found = resolved.filter((pair): pair is readonly [number, string] =>
+        Boolean(pair),
+      );
+      if (found.length === 0) return;
+      setNames((prev) => {
+        const next = { ...prev };
+        for (const [id, name] of found) next[id] = name;
+        return next;
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+
+  return names;
+}

--- a/apps/mouth/src/app/(workspace)/obligations/components/useClientNames.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/useClientNames.ts
@@ -47,7 +47,12 @@ export function useClientNames(clientIds: number[]): Record<number, string> {
     if (ids.length === 0) return;
     ids.forEach((id) => attempted.current.add(id));
 
-    let cancelled = false;
+    // No `cancelled` guard, deliberately. The merge below is per id and
+    // idempotent, so a late response can never be stale: there is no ordering
+    // hazard to protect against. A guard would be actively harmful — the rows
+    // change (a page turn, a filter) while a read is in flight, React runs the
+    // cleanup, the result gets dropped, and the id stays in `attempted`, so
+    // those names would never load again for the life of the tab.
     void (async () => {
       const resolved = await Promise.all(
         ids.map(async (id) => {
@@ -72,7 +77,6 @@ export function useClientNames(clientIds: number[]): Record<number, string> {
           }
         }),
       );
-      if (cancelled) return;
       const found = resolved.filter((pair): pair is readonly [number, string] =>
         Boolean(pair),
       );
@@ -83,10 +87,6 @@ export function useClientNames(clientIds: number[]): Record<number, string> {
         return next;
       });
     })();
-
-    return () => {
-      cancelled = true;
-    };
   }, [key]);
 
   return names;

--- a/apps/mouth/src/app/(workspace)/obligations/components/useObligationsCatalog.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/useObligationsCatalog.ts
@@ -29,19 +29,27 @@ export function useObligationsCatalog(): CatalogState {
   );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // StrictMode mounts effects twice in dev; the catalog must still be read once.
-  const started = useRef(false);
+  // The request itself, not an "already started" boolean. `reactStrictMode` is on
+  // (apps/mouth/next.config.ts), so in dev React runs setup -> cleanup -> setup:
+  // a boolean guard would let the first run start the read, the cleanup discard
+  // its result, and the second run bail out — leaving the catalog empty forever
+  // with no second request to recover it. Holding the PROMISE means the second
+  // setup re-attaches to the same in-flight read: still exactly one request,
+  // and its result lands.
+  const inflight = useRef<Promise<CatalogRuleOut[]> | null>(null);
 
   useEffect(() => {
-    if (started.current) return;
-    started.current = true;
     let cancelled = false;
+    if (!inflight.current) {
+      inflight.current = api.get<CatalogRuleOut[]>(
+        "/api/compliance/obligations/catalog",
+      );
+    }
+    const request = inflight.current;
 
     void (async () => {
       try {
-        const rules = await api.get<CatalogRuleOut[]>(
-          "/api/compliance/obligations/catalog",
-        );
+        const rules = await request;
         if (cancelled) return;
         // A non-array body (an older backend, or a proxy error page) must not
         // throw inside render — degrade to ids instead.

--- a/apps/mouth/src/app/(workspace)/obligations/components/useObligationsCatalog.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/useObligationsCatalog.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+
+import type { CatalogRuleOut } from "./types";
+
+export interface CatalogState {
+  /** rule_id -> rule. Empty until the catalog read resolves. */
+  byId: Map<string, CatalogRuleOut>;
+  loading: boolean;
+  /** Non-null when the catalog read failed; the table then falls back to ids. */
+  error: string | null;
+}
+
+/**
+ * Load `GET /api/compliance/obligations/catalog` ONCE per mount.
+ *
+ * The catalog is process-cached server-side (`_cached_rules()`) and carries no
+ * client data, so one read per screen is enough and the result is safe to hold
+ * in component state. A failure is not fatal: the caller renders `rule_id`
+ * unchanged, which is what the screen did before this hook existed.
+ */
+export function useObligationsCatalog(): CatalogState {
+  const [byId, setById] = useState<Map<string, CatalogRuleOut>>(
+    () => new Map(),
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // StrictMode mounts effects twice in dev; the catalog must still be read once.
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const rules = await api.get<CatalogRuleOut[]>(
+          "/api/compliance/obligations/catalog",
+        );
+        if (cancelled) return;
+        // A non-array body (an older backend, or a proxy error page) must not
+        // throw inside render — degrade to ids instead.
+        const list = Array.isArray(rules) ? rules : [];
+        setById(new Map(list.map((rule) => [rule.id, rule])));
+        setError(list.length === 0 ? "Rule catalog is empty." : null);
+      } catch (e) {
+        if (cancelled) return;
+        logger.error(
+          "obligations catalog load failed",
+          { component: "ObligationsPage", action: "loadCatalog" },
+          e instanceof Error ? e : new Error(String(e)),
+        );
+        setError("Could not load the rule catalog — showing rule ids.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { byId, loading, error };
+}

--- a/apps/mouth/src/app/(workspace)/obligations/components/useStatusCounters.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/useStatusCounters.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+
+import {
+  COUNTER_STATUSES,
+  type CounterStatus,
+  type ObligationListOut,
+} from "./types";
+
+export type StatusCounts = Partial<Record<CounterStatus, number>>;
+
+/**
+ * Per-status row counts for the current client filter.
+ *
+ * The list endpoint already returns `total` for whatever filter it is given,
+ * so one `limit=1` read per status is the whole implementation — no new
+ * backend route, and the four reads go out in parallel. `clientId` is the
+ * trimmed client filter ("" = all clients); `refreshTick` is bumped by the
+ * page after a generate / approve / reject so the strip follows the register.
+ */
+export function useStatusCounters(
+  clientId: string,
+  refreshTick: number,
+): { counts: StatusCounts; loading: boolean } {
+  const [counts, setCounts] = useState<StatusCounts>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    void (async () => {
+      const results = await Promise.all(
+        COUNTER_STATUSES.map(async (status) => {
+          const params = new URLSearchParams();
+          if (clientId) params.set("client_id", clientId);
+          params.set("status", status);
+          params.set("limit", "1");
+          params.set("offset", "0");
+          try {
+            const res = await api.get<ObligationListOut>(
+              `/api/compliance/obligations?${params.toString()}`,
+            );
+            return [status, res?.total ?? 0] as const;
+          } catch (e) {
+            logger.error(
+              "obligations status counter failed",
+              {
+                component: "ObligationsPage",
+                action: "statusCounter",
+                metadata: { status },
+              },
+              e instanceof Error ? e : new Error(String(e)),
+            );
+            return null;
+          }
+        }),
+      );
+      if (cancelled) return;
+      const next: StatusCounts = {};
+      for (const pair of results) {
+        if (pair) next[pair[0]] = pair[1];
+      }
+      setCounts(next);
+      setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [clientId, refreshTick]);
+
+  return { counts, loading };
+}

--- a/apps/mouth/src/app/(workspace)/obligations/components/useStatusCounters.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/useStatusCounters.ts
@@ -32,6 +32,10 @@ export function useStatusCounters(
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    // Clear, do not keep. Holding the previous filter's numbers while the new
+    // reads are in flight shows one client's counts under another client's
+    // label — a wrong number the reviewer has no way to spot.
+    setCounts({});
 
     void (async () => {
       const results = await Promise.all(

--- a/apps/mouth/src/app/(workspace)/obligations/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "@/lib/api/error-handler";
@@ -86,7 +87,11 @@ const CATALOG = [
   },
 ];
 
-const CLIENT_42 = { id: 42, full_name: "Fixture Client Alpha" };
+/** Synthetic names — no real client appears in this fixture. */
+const CLIENT_NAMES: Record<string, string> = {
+  "42": "Fixture Client Alpha",
+  "43": "Fixture Client Beta",
+};
 
 interface Deferred {
   status: string;
@@ -106,6 +111,8 @@ function installApiGet(
     clientFails?: boolean;
     counterTotals?: Record<string, number>;
     deferCounters?: Deferred[];
+    /** Collects one resolver per CRM client read instead of answering at once. */
+    deferClients?: Array<{ id: string; resolve: () => void }>;
   } = {},
 ) {
   const listCalls: string[] = [];
@@ -151,7 +158,20 @@ function installApiGet(
           new ApiError("Client not found", 404, { detail: "Client not found" }),
         );
       }
-      return Promise.resolve(CLIENT_42);
+      const id = url.slice("/api/crm/clients/".length);
+      if (opts.deferClients) {
+        return new Promise((resolve) => {
+          opts.deferClients?.push({
+            id,
+            resolve: () =>
+              resolve({ id: Number(id), full_name: CLIENT_NAMES[id] ?? null }),
+          });
+        });
+      }
+      return Promise.resolve({
+        id: Number(id),
+        full_name: CLIENT_NAMES[id] ?? null,
+      });
     }
     return Promise.reject(new Error(`unexpected GET ${url}`));
   });
@@ -256,6 +276,46 @@ describe("ObligationsPage", () => {
     expect(screen.getByText("42")).toBeVisible();
   });
 
+  it("keeps a name resolution that lands after the rows changed", async () => {
+    // Regression: ids are marked attempted when the read STARTS, so a cleanup
+    // that discarded in-flight results (rows changed while the read was open)
+    // left those ids permanently stuck on the id fallback.
+    const deferClients: Array<{ id: string; resolve: () => void }> = [];
+    installApiGet({
+      deferClients,
+      listForClient: {
+        total: 1,
+        limit: 50,
+        offset: 0,
+        items: [{ ...PROPOSED_ROW, id: 103, client_id: 43 }],
+      },
+    });
+
+    render(<ObligationsPage />);
+    await waitFor(() => expect(deferClients.length).toBe(1));
+    expect(deferClients[0].id).toBe("42");
+
+    // Rows change while client 42's read is still open: the effect re-runs for
+    // the new id set and React cleans up the previous run.
+    fireEvent.change(screen.getByPlaceholderText("all clients"), {
+      target: { value: "43" },
+    });
+    await waitFor(() => expect(deferClients.length).toBe(2));
+
+    // Back to the first id set. 42 is already attempted, so no second read.
+    fireEvent.change(screen.getByPlaceholderText("all clients"), {
+      target: { value: "" },
+    });
+    deferClients.forEach((d) => d.resolve());
+
+    expect(await screen.findByText("Fixture Client Alpha")).toBeVisible();
+    expect(
+      apiMock.get.mock.calls.filter(
+        (call: unknown[]) => call[0] === "/api/crm/clients/42",
+      ).length,
+    ).toBe(1);
+  });
+
   it("reads one counter per status with limit=1, all four in parallel", async () => {
     const deferred: Deferred[] = [];
     const { counterCalls } = installApiGet({ deferCounters: deferred });
@@ -280,12 +340,60 @@ describe("ObligationsPage", () => {
     };
     deferred.forEach((d) => d.resolve(totals[d.status] ?? 0));
 
-    expect(await screen.findByTestId("counter-proposed")).toHaveTextContent(
-      "7",
+    // waitFor, not findByTestId: the tiles already exist (showing the loading
+    // placeholder), so findBy* would resolve before the totals land and assert
+    // against the placeholder.
+    await waitFor(() => {
+      expect(screen.getByTestId("counter-proposed")).toHaveTextContent("7");
+      expect(screen.getByTestId("counter-approved")).toHaveTextContent("3");
+      expect(screen.getByTestId("counter-rejected")).toHaveTextContent("1");
+      expect(screen.getByTestId("counter-alerted")).toHaveTextContent("2");
+    });
+  });
+
+  it("clears the counters when the client filter changes", async () => {
+    // Regression: holding the previous filter's totals while the new reads are
+    // in flight showed one client's counts under another client's label.
+    const deferred: Deferred[] = [];
+    installApiGet({ deferCounters: deferred, listForClient: LIST_RESPONSE });
+
+    render(<ObligationsPage />);
+    await waitFor(() => expect(deferred.length).toBe(4));
+    deferred.forEach((d) => d.resolve(9));
+    await waitFor(() =>
+      expect(screen.getByTestId("counter-proposed")).toHaveTextContent("9"),
     );
-    expect(screen.getByTestId("counter-approved")).toHaveTextContent("3");
-    expect(screen.getByTestId("counter-rejected")).toHaveTextContent("1");
-    expect(screen.getByTestId("counter-alerted")).toHaveTextContent("2");
+
+    deferred.length = 0;
+    fireEvent.change(screen.getByPlaceholderText("all clients"), {
+      target: { value: "42" },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("counter-proposed")).not.toHaveTextContent("9"),
+    );
+    expect(screen.getByText("Client 42")).toBeVisible();
+  });
+
+  it("reads the catalog once and renders it under StrictMode", async () => {
+    // Regression: `reactStrictMode` is on, so React runs setup -> cleanup ->
+    // setup in dev. A boolean "already started" guard let the first run fetch,
+    // the cleanup discard the result, and the second run bail out — an empty
+    // catalog with no request left to recover it.
+    render(
+      <StrictMode>
+        <ObligationsPage />
+      </StrictMode>,
+    );
+
+    expect(
+      await screen.findByText("PPh 21 — employee withholding deposit"),
+    ).toBeVisible();
+    expect(
+      apiMock.get.mock.calls.filter(
+        (call: unknown[]) => call[0] === "/api/compliance/obligations/catalog",
+      ).length,
+    ).toBe(1);
   });
 
   it("groups rows by due month only when a client filter is set", async () => {

--- a/apps/mouth/src/app/(workspace)/obligations/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/page.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/lib/logger", () => ({
 const PROPOSED_ROW = {
   id: 101,
   client_id: 42,
-  rule_id: "PPH21_MONTHLY",
+  rule_id: "pph21_monthly",
   period_key: "2026-09",
   due_date: "2026-10-10",
   status: "proposed",
@@ -42,6 +42,14 @@ const PROPOSED_ROW = {
   updated_at: "2026-09-01T00:00:00Z",
 };
 
+const NOVEMBER_ROW = {
+  ...PROPOSED_ROW,
+  id: 102,
+  rule_id: "ppn_monthly",
+  period_key: "2026-10",
+  due_date: "2026-11-30",
+};
+
 const LIST_RESPONSE = {
   total: 1,
   limit: 50,
@@ -49,26 +57,131 @@ const LIST_RESPONSE = {
   items: [PROPOSED_ROW],
 };
 
+/** Two rows from the catalog M3 serves; the page must never hardcode these. */
+const CATALOG = [
+  {
+    id: "pph21_monthly",
+    name: "PPh 21 — employee withholding deposit",
+    authority: "DJP",
+    legal_source: "PMK 81/2024 art. 94 (pajak.go.id)",
+    verified: true,
+    frequency: "monthly",
+    roll: "next_business_day",
+    needs_review_reason: null,
+    trigger: null,
+    notes: "Deposit by the 15th of the following month.",
+  },
+  {
+    id: "ppn_monthly",
+    name: "PPN — monthly VAT return",
+    authority: "DJP",
+    legal_source: "UU PPN (verify)",
+    verified: false,
+    frequency: "monthly",
+    roll: "next_business_day",
+    needs_review_reason:
+      "Filing deadline not confirmed against a primary source",
+    trigger: null,
+    notes: null,
+  },
+];
+
+const CLIENT_42 = { id: 42, full_name: "Fixture Client Alpha" };
+
+interface Deferred {
+  status: string;
+  resolve: (total: number) => void;
+}
+
+/**
+ * URL-dispatching `api.get`: the screen now issues four different reads (list,
+ * catalog, the four `limit=1` counters, and one CRM client read per id), so a
+ * single blanket mockResolvedValue cannot serve them.
+ */
+function installApiGet(
+  opts: {
+    list?: unknown;
+    listForClient?: unknown;
+    catalog?: unknown;
+    clientFails?: boolean;
+    counterTotals?: Record<string, number>;
+    deferCounters?: Deferred[];
+  } = {},
+) {
+  const listCalls: string[] = [];
+  const counterCalls: string[] = [];
+  const clientCalls: string[] = [];
+
+  apiMock.get.mockImplementation((url: string) => {
+    if (url.startsWith("/api/compliance/obligations/catalog")) {
+      return Promise.resolve(opts.catalog ?? CATALOG);
+    }
+    if (url.startsWith("/api/compliance/obligations?")) {
+      const params = new URLSearchParams(url.split("?")[1] ?? "");
+      if (params.get("limit") === "1") {
+        const status = params.get("status") ?? "";
+        counterCalls.push(url);
+        if (opts.deferCounters) {
+          return new Promise((resolve) => {
+            opts.deferCounters?.push({
+              status,
+              resolve: (total: number) =>
+                resolve({ total, limit: 1, offset: 0, items: [] }),
+            });
+          });
+        }
+        return Promise.resolve({
+          total: opts.counterTotals?.[status] ?? 0,
+          limit: 1,
+          offset: 0,
+          items: [],
+        });
+      }
+      listCalls.push(url);
+      const body =
+        params.get("client_id") && opts.listForClient
+          ? opts.listForClient
+          : (opts.list ?? LIST_RESPONSE);
+      return Promise.resolve(body);
+    }
+    if (url.startsWith("/api/crm/clients/")) {
+      clientCalls.push(url);
+      if (opts.clientFails) {
+        return Promise.reject(
+          new ApiError("Client not found", 404, { detail: "Client not found" }),
+        );
+      }
+      return Promise.resolve(CLIENT_42);
+    }
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+
+  return { listCalls, counterCalls, clientCalls };
+}
+
 describe("ObligationsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    apiMock.get.mockResolvedValue(LIST_RESPONSE);
+    installApiGet();
     apiMock.post.mockResolvedValue({});
   });
 
   it("renders proposed rows from the list response", async () => {
     render(<ObligationsPage />);
 
-    expect(await screen.findByText("PPH21_MONTHLY")).toBeVisible();
+    expect(
+      await screen.findByText("PPh 21 — employee withholding deposit"),
+    ).toBeVisible();
     expect(screen.getByText("2026-09")).toBeVisible();
     expect(screen.getByText("2026-10-10")).toBeVisible();
     expect(screen.getByText("New rule matched")).toBeVisible();
-    // "proposed" also appears as the status-filter default option, so assert
-    // presence (>=1) rather than uniqueness.
+    // "proposed" also appears as the status-filter default option and as a
+    // counter label, so assert presence (>=1) rather than uniqueness.
     expect(screen.getAllByText("proposed").length).toBeGreaterThan(0);
-    // client_id and id are rendered as bare numbers, ids-only (no PII join).
-    expect(screen.getByText("42")).toBeVisible();
     expect(screen.getByText("101")).toBeVisible();
+    // The rule id stays visible under the name: the reviewer still needs it to
+    // talk to the engine.
+    expect(screen.getByText("pph21_monthly")).toBeVisible();
 
     expect(apiMock.get).toHaveBeenCalledWith(
       expect.stringContaining("/api/compliance/obligations?"),
@@ -78,20 +191,142 @@ describe("ObligationsPage", () => {
     );
   });
 
+  it("labels each rule with its catalog name, authority and verified badge", async () => {
+    installApiGet({
+      list: {
+        total: 2,
+        limit: 50,
+        offset: 0,
+        items: [PROPOSED_ROW, NOVEMBER_ROW],
+      },
+    });
+    render(<ObligationsPage />);
+
+    await screen.findByText("PPh 21 — employee withholding deposit");
+    expect(screen.getByText("PPN — monthly VAT return")).toBeVisible();
+    expect(screen.getByText("verified")).toBeVisible();
+    expect(screen.getByText("unverified")).toBeVisible();
+    expect(screen.getAllByText("DJP").length).toBe(2);
+
+    expect(apiMock.get).toHaveBeenCalledWith(
+      "/api/compliance/obligations/catalog",
+    );
+    // Catalog read is once per mount, not once per row.
+    expect(
+      apiMock.get.mock.calls.filter(
+        (call: unknown[]) => call[0] === "/api/compliance/obligations/catalog",
+      ).length,
+    ).toBe(1);
+  });
+
+  it("shows legal_source in the row detail", async () => {
+    render(<ObligationsPage />);
+    await screen.findByText("PPh 21 — employee withholding deposit");
+
+    expect(
+      screen.queryByText("PMK 81/2024 art. 94 (pajak.go.id)"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Rule detail for obligation 101"));
+
+    expect(
+      await screen.findByText("PMK 81/2024 art. 94 (pajak.go.id)"),
+    ).toBeVisible();
+    expect(screen.getByText("Legal source")).toBeVisible();
+  });
+
+  it("resolves the client id to a display name through the CRM read", async () => {
+    render(<ObligationsPage />);
+
+    expect(await screen.findByText("Fixture Client Alpha")).toBeVisible();
+    expect(screen.getByText("#42")).toBeVisible();
+    expect(apiMock.get).toHaveBeenCalledWith("/api/crm/clients/42");
+  });
+
+  it("falls back to the client id when the CRM read fails", async () => {
+    installApiGet({ clientFails: true });
+    render(<ObligationsPage />);
+
+    await screen.findByText("PPh 21 — employee withholding deposit");
+    await waitFor(() =>
+      expect(apiMock.get).toHaveBeenCalledWith("/api/crm/clients/42"),
+    );
+
+    expect(screen.queryByText("Fixture Client Alpha")).not.toBeInTheDocument();
+    expect(screen.getByText("42")).toBeVisible();
+  });
+
+  it("reads one counter per status with limit=1, all four in parallel", async () => {
+    const deferred: Deferred[] = [];
+    const { counterCalls } = installApiGet({ deferCounters: deferred });
+
+    render(<ObligationsPage />);
+
+    // All four reads are dispatched before any of them resolves.
+    await waitFor(() => expect(deferred.length).toBe(4));
+    expect(counterCalls.every((url) => url.includes("limit=1"))).toBe(true);
+    expect(deferred.map((d) => d.status).sort()).toEqual([
+      "alerted",
+      "approved",
+      "proposed",
+      "rejected",
+    ]);
+
+    const totals: Record<string, number> = {
+      proposed: 7,
+      approved: 3,
+      rejected: 1,
+      alerted: 2,
+    };
+    deferred.forEach((d) => d.resolve(totals[d.status] ?? 0));
+
+    expect(await screen.findByTestId("counter-proposed")).toHaveTextContent(
+      "7",
+    );
+    expect(screen.getByTestId("counter-approved")).toHaveTextContent("3");
+    expect(screen.getByTestId("counter-rejected")).toHaveTextContent("1");
+    expect(screen.getByTestId("counter-alerted")).toHaveTextContent("2");
+  });
+
+  it("groups rows by due month only when a client filter is set", async () => {
+    installApiGet({
+      listForClient: {
+        total: 2,
+        limit: 50,
+        offset: 0,
+        items: [PROPOSED_ROW, NOVEMBER_ROW],
+      },
+    });
+    render(<ObligationsPage />);
+
+    await screen.findByText("PPh 21 — employee withholding deposit");
+    expect(screen.queryByText("October 2026")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("all clients"), {
+      target: { value: "42" },
+    });
+
+    expect(await screen.findByText("October 2026")).toBeVisible();
+    expect(screen.getByText("November 2026")).toBeVisible();
+    expect(apiMock.get).toHaveBeenCalledWith(
+      expect.stringContaining("client_id=42"),
+    );
+  });
+
   it("approve sends the note and refetches the list", async () => {
+    const { listCalls } = installApiGet();
     apiMock.post.mockResolvedValueOnce({
       obligation: { ...PROPOSED_ROW, status: "alerted" },
       alert_id: "alert_obligation_42_abcd1234",
     });
 
     render(<ObligationsPage />);
-    await screen.findByText("PPH21_MONTHLY");
+    await screen.findByText("PPh 21 — employee withholding deposit");
 
     const noteInput = screen.getByLabelText("Note for obligation 101");
     fireEvent.change(noteInput, { target: { value: "looks correct" } });
 
-    const approveBtn = screen.getByRole("button", { name: "Approve" });
-    fireEvent.click(approveBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
 
     await waitFor(() => {
       expect(apiMock.post).toHaveBeenCalledWith(
@@ -101,7 +336,7 @@ describe("ObligationsPage", () => {
     });
 
     // Refetch: the initial load + the post-approve reload.
-    await waitFor(() => expect(apiMock.get).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(listCalls.length).toBe(2));
 
     expect(
       await screen.findByText(
@@ -112,7 +347,7 @@ describe("ObligationsPage", () => {
 
   it("reject requires a reason and is disabled without one", async () => {
     render(<ObligationsPage />);
-    await screen.findByText("PPH21_MONTHLY");
+    await screen.findByText("PPh 21 — employee withholding deposit");
 
     const rejectBtn = screen.getByRole("button", { name: "Reject" });
     fireEvent.click(rejectBtn);
@@ -146,7 +381,7 @@ describe("ObligationsPage", () => {
     });
 
     render(<ObligationsPage />);
-    await screen.findByText("PPH21_MONTHLY");
+    await screen.findByText("PPh 21 — employee withholding deposit");
 
     fireEvent.change(screen.getByPlaceholderText("e.g. 42"), {
       target: { value: "42" },
@@ -175,5 +410,8 @@ describe("ObligationsPage", () => {
     render(<ObligationsPage />);
 
     expect(await screen.findByText("Admin only.")).toBeVisible();
+    expect(
+      screen.getByText("Could not load the rule catalog — showing rule ids."),
+    ).toBeVisible();
   });
 });

--- a/apps/mouth/src/app/(workspace)/obligations/page.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/page.tsx
@@ -21,97 +21,41 @@
  * stale row (already decided by someone else, or re-clicked) comes back 409
  * with the current status in the message; that message is shown verbatim.
  *
+ * Reviewer usability (U1): the table labels each row through the catalog read
+ * `GET /obligations/catalog` (M3) — rule name, authority, verified badge, and
+ * `legal_source` in the row detail — and resolves `client_id` to a display
+ * name through `GET /api/crm/clients/{id}`. The catalog is never copied into
+ * the frontend and a resolved client name never leaves the browser tab: no
+ * log, no storage, no other request carries it (see `useClientNames`).
+ *
  * Auth + transport reuse the shared `api` client (httpOnly cookie + bearer),
- * same as `(workspace)/review/page.tsx`. No client join / no PII beyond what
- * the API already returns (ids only — this page never fetches client names).
+ * same as `(workspace)/review/page.tsx`.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { api } from "@/lib/api";
-import { ApiError } from "@/lib/api/error-handler";
 import { logger } from "@/lib/logger";
 
-// ── API contract (local types — review/page.tsx also calls `api.get`/`api.post`
-//    with plain interfaces rather than the generated `schema.d.ts` typed paths,
-//    so this page follows the same convention; see PR notes for why no
-//    `npm run generate:openapi` regen was needed). ─────────────────────────
-type ObligationStatus =
-  "proposed" | "approved" | "rejected" | "alerted" | "done";
-
-const STATUS_FILTER_OPTIONS = [
-  "proposed",
-  "approved",
-  "rejected",
-  "alerted",
-  "done",
-  "all",
-] as const;
-type StatusFilter = (typeof STATUS_FILTER_OPTIONS)[number];
-
-interface ObligationOut {
-  id: number;
-  client_id: number;
-  rule_id: string;
-  period_key: string;
-  due_date: string;
-  status: ObligationStatus;
-  needs_review_reason: string | null;
-  reviewer_email: string | null;
-  reviewed_at: string | null;
-  review_note: string | null;
-  alert_id: string | null;
-  created_at: string | null;
-  updated_at: string | null;
-}
-
-interface ObligationListOut {
-  total: number;
-  limit: number;
-  offset: number;
-  items: ObligationOut[];
-}
-
-interface GenerateOut {
-  client_id: number;
-  inserted_count: number;
-  company_type: string;
-  needs_manual_classification: boolean;
-  warning: string | null;
-  rows: ObligationOut[];
-}
-
-interface ApproveOut {
-  obligation: ObligationOut;
-  alert_id: string;
-}
+import { ObligationsTable } from "./components/ObligationsTable";
+import { StatusCounters } from "./components/StatusCounters";
+import { describeError } from "./components/describe-error";
+import {
+  CARD,
+  INPUT_STYLE,
+  STATUS_FILTER_OPTIONS,
+  type ApproveOut,
+  type GenerateOut,
+  type ObligationListOut,
+  type ObligationOut,
+  type StatusFilter,
+} from "./components/types";
+import { useClientNames } from "./components/useClientNames";
+import { useObligationsCatalog } from "./components/useObligationsCatalog";
+import { useStatusCounters } from "./components/useStatusCounters";
 
 const LIMIT = 50;
-
-const CARD = {
-  borderColor: "var(--bz-border)",
-  background: "var(--bz-card, var(--bz-surface))",
-} as const;
-
-const INPUT_STYLE = {
-  borderColor: "var(--bz-border)",
-  background: "var(--bz-surface)",
-  color: "var(--bz-text-1)",
-} as const;
-
-/** Turn a thrown api error into the exact text a reviewer should see. */
-function describeError(e: unknown, fallback: string): string {
-  if (e instanceof ApiError) {
-    if (e.statusCode === 401 || e.statusCode === 403) return "Admin only.";
-    if (e.statusCode === 404) return e.message || "Not found.";
-    if (e.statusCode === 409)
-      return e.message || "Conflict — this row was already decided.";
-    return e.message || fallback;
-  }
-  if (e instanceof Error) return e.message || fallback;
-  return fallback;
-}
 
 export default function ObligationsPage() {
   const router = useRouter();
@@ -123,6 +67,8 @@ export default function ObligationsPage() {
   const [loading, setLoading] = useState(true);
   const [listError, setListError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  // Bumped after every write so the counter strip follows the register.
+  const [refreshTick, setRefreshTick] = useState(0);
 
   // ── filters ─────────────────────────────────────────────────────────────
   const [filterClientId, setFilterClientId] = useState("");
@@ -141,6 +87,19 @@ export default function ObligationsPage() {
   const [busyId, setBusyId] = useState<number | null>(null);
   const [notes, setNotes] = useState<Record<number, string>>({});
   const [rowError, setRowError] = useState<Record<number, string>>({});
+
+  // ── catalog, client names, counters ────────────────────────────────────
+  const catalog = useObligationsCatalog();
+  const clientIds = useMemo(() => items.map((row) => row.client_id), [items]);
+  const clientNames = useClientNames(clientIds);
+  const trimmedClientFilter = filterClientId.trim();
+  const { counts, loading: countsLoading } = useStatusCounters(
+    trimmedClientFilter,
+    refreshTick,
+  );
+  // Grouping by due month only makes sense for one client's calendar; across
+  // clients the flat, server-ordered table is what the reviewer works through.
+  const groupByMonth = trimmedClientFilter !== "";
 
   const loadList = useCallback(async () => {
     setLoading(true);
@@ -203,6 +162,7 @@ export default function ObligationsPage() {
         { client_id: cid, horizon_days: horizon },
       );
       setGenerateResult(res);
+      setRefreshTick((t) => t + 1);
       await loadList();
     } catch (e) {
       logger.error(
@@ -230,6 +190,7 @@ export default function ObligationsPage() {
           body,
         );
         setNotice(`✓ Obligation #${row.id} approved → alert ${res.alert_id}.`);
+        setRefreshTick((t) => t + 1);
         await loadList();
       } catch (e) {
         logger.error(
@@ -273,6 +234,7 @@ export default function ObligationsPage() {
           reason,
         });
         setNotice(`Obligation #${row.id} rejected.`);
+        setRefreshTick((t) => t + 1);
         await loadList();
       } catch (e) {
         logger.error(
@@ -294,6 +256,10 @@ export default function ObligationsPage() {
     },
     [notes, loadList],
   );
+
+  const handleNoteChange = useCallback((id: number, value: string) => {
+    setNotes((prev) => ({ ...prev, [id]: value }));
+  }, []);
 
   const pageStart = total === 0 ? 0 : offset + 1;
   const pageEnd = Math.min(offset + LIMIT, total);
@@ -417,6 +383,15 @@ export default function ObligationsPage() {
         )}
       </section>
 
+      {/* ── Status counters ──────────────────────────────────────────── */}
+      <StatusCounters
+        counts={counts}
+        loading={countsLoading}
+        clientId={trimmedClientFilter}
+        activeStatus={filterStatus}
+        onSelect={setFilterStatus}
+      />
+
       {/* ── Filters ──────────────────────────────────────────────────── */}
       <section className="mb-4 flex flex-wrap items-end gap-3">
         <label className="text-xs" style={{ color: "var(--bz-text-3)" }}>
@@ -448,7 +423,10 @@ export default function ObligationsPage() {
         </label>
         <button
           type="button"
-          onClick={() => void loadList()}
+          onClick={() => {
+            setRefreshTick((t) => t + 1);
+            void loadList();
+          }}
           disabled={loading}
           className="rounded-md border px-3 py-1.5 text-sm"
           style={{ borderColor: "var(--bz-border)", color: "var(--bz-text-2)" }}
@@ -456,6 +434,12 @@ export default function ObligationsPage() {
           {loading ? "Refreshing…" : "Refresh"}
         </button>
       </section>
+
+      {catalog.error && (
+        <p className="mb-3 text-xs" style={{ color: "var(--state-warning)" }}>
+          {catalog.error}
+        </p>
+      )}
 
       {listError && (
         <div
@@ -477,164 +461,18 @@ export default function ObligationsPage() {
         <p style={{ color: "var(--bz-text-3)" }}>No obligations found.</p>
       ) : (
         !listError && (
-          <div className="overflow-auto rounded-xl border" style={CARD}>
-            <table className="w-full text-sm">
-              <thead>
-                <tr
-                  className="border-b text-left"
-                  style={{ borderColor: "var(--bz-border)" }}
-                >
-                  {[
-                    "ID",
-                    "Client",
-                    "Rule",
-                    "Period",
-                    "Due date",
-                    "Needs review",
-                    "Status",
-                    "Reviewer",
-                    "Actions",
-                  ].map((h) => (
-                    <th
-                      key={h}
-                      className="px-3 py-2 text-xs font-medium"
-                      style={{ color: "var(--bz-text-3)" }}
-                    >
-                      {h}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((row) => (
-                  <tr
-                    key={row.id}
-                    className="border-b last:border-b-0"
-                    style={{ borderColor: "var(--bz-border)" }}
-                  >
-                    <td
-                      className="px-3 py-2"
-                      style={{ color: "var(--bz-text-1)" }}
-                    >
-                      {row.id}
-                    </td>
-                    <td
-                      className="px-3 py-2"
-                      style={{ color: "var(--bz-text-1)" }}
-                    >
-                      {row.client_id}
-                    </td>
-                    <td
-                      className="px-3 py-2"
-                      style={{ color: "var(--bz-text-1)" }}
-                    >
-                      {row.rule_id}
-                    </td>
-                    <td
-                      className="px-3 py-2"
-                      style={{ color: "var(--bz-text-1)" }}
-                    >
-                      {row.period_key}
-                    </td>
-                    <td
-                      className="px-3 py-2"
-                      style={{ color: "var(--bz-text-1)" }}
-                    >
-                      {row.due_date}
-                    </td>
-                    <td
-                      className="px-3 py-2 text-xs"
-                      style={{ color: "var(--bz-text-3)" }}
-                    >
-                      {row.needs_review_reason ?? "—"}
-                    </td>
-                    <td
-                      className="px-3 py-2"
-                      style={{ color: "var(--bz-text-1)" }}
-                    >
-                      {row.status}
-                    </td>
-                    <td
-                      className="px-3 py-2 text-xs"
-                      style={{ color: "var(--bz-text-3)" }}
-                    >
-                      {row.reviewer_email ? (
-                        <>
-                          {row.reviewer_email}
-                          {row.reviewed_at
-                            ? ` · ${new Date(row.reviewed_at).toLocaleString()}`
-                            : ""}
-                        </>
-                      ) : (
-                        "—"
-                      )}
-                    </td>
-                    <td className="px-3 py-2">
-                      {row.status === "proposed" ? (
-                        <div className="flex flex-col gap-1">
-                          <input
-                            aria-label={`Note for obligation ${row.id}`}
-                            className="w-40 rounded border px-2 py-1 text-xs"
-                            style={INPUT_STYLE}
-                            placeholder="note (required to reject)"
-                            value={notes[row.id] ?? ""}
-                            onChange={(e) =>
-                              setNotes((prev) => ({
-                                ...prev,
-                                [row.id]: e.target.value,
-                              }))
-                            }
-                          />
-                          <div className="flex gap-2">
-                            <button
-                              type="button"
-                              disabled={busyId === row.id}
-                              onClick={() => void handleApprove(row)}
-                              className="rounded-md px-3 py-1 text-xs font-medium text-white"
-                              style={{
-                                background: "var(--state-success)",
-                                opacity: busyId === row.id ? 0.6 : 1,
-                              }}
-                            >
-                              {busyId === row.id ? "…" : "Approve"}
-                            </button>
-                            <button
-                              type="button"
-                              disabled={busyId === row.id}
-                              onClick={() => void handleReject(row)}
-                              className="rounded-md px-3 py-1 text-xs font-medium text-white"
-                              style={{
-                                background: "var(--state-danger)",
-                                opacity: busyId === row.id ? 0.6 : 1,
-                              }}
-                            >
-                              {busyId === row.id ? "…" : "Reject"}
-                            </button>
-                          </div>
-                          {rowError[row.id] && (
-                            <p
-                              role="alert"
-                              className="text-xs"
-                              style={{ color: "var(--state-danger)" }}
-                            >
-                              {rowError[row.id]}
-                            </p>
-                          )}
-                        </div>
-                      ) : (
-                        <span
-                          className="text-xs"
-                          style={{ color: "var(--bz-text-3)" }}
-                        >
-                          {row.alert_id ? `alert ${row.alert_id}` : "—"}
-                        </span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <ObligationsTable
+            items={items}
+            catalog={catalog.byId}
+            clientNames={clientNames}
+            groupByMonth={groupByMonth}
+            notes={notes}
+            rowError={rowError}
+            busyId={busyId}
+            onNoteChange={handleNoteChange}
+            onApprove={(row) => void handleApprove(row)}
+            onReject={(row) => void handleReject(row)}
+          />
         )
       )}
 

--- a/evidence/2026-09/agent-air-m5-mouth-obligations-reviewer-usabilit-6c392bf9/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-obligations-reviewer-usabilit-6c392bf9/brief.yml
@@ -12,7 +12,8 @@ objective: >-
   `total` with limit=1, and groups rows by due month when a client filter is set. The table,
   counters, hooks and shared types move under components/ so page.tsx stays under 800 lines
   (680 -> 518). Gear 2 is the computed floor: evidence_pack_lint --print-floor on
-  `git diff --name-only/--numstat origin/main...HEAD` returns 2 (9 files, +1131/-253). The
+  `git diff --name-only/--numstat origin/main...HEAD` returns 2 (10 files, +1368/-253,
+  brief included). The
   imperator may raise it; this brief does not lower anything.
 constraints:
   - >-
@@ -71,7 +72,16 @@ acceptance:
       header before the filter, "October 2026" and "November 2026" after it.
   - text: The screen SHALL keep its existing behaviour — generate, approve, reject, 403 handling.
     probe: >-
-      same vitest run — the four pre-existing tests still pass (11 total, was 5), exit 0.
+      same vitest run — the four pre-existing tests still pass (14 total, was 5), exit 0.
+  - text: >-
+      The three MAJOR defects the Codex spalla found SHALL be fixed, each with a test that fails
+      against the pre-fix code: the StrictMode catalog read, the client-name cache losing an
+      in-flight result, and the counters shown under the wrong client label.
+    probe: >-
+      same vitest run — "reads the catalog once and renders it under StrictMode", "keeps a name
+      resolution that lands after the rows changed", "clears the counters when the client filter
+      changes". Each was run against the reverted hook and observed RED (2 failed / 11 passed, then
+      1 failed / 13 passed) before the fix was restored.
   - text: Lint, types and the production build SHALL be clean.
     probe: >-
       from apps/mouth — npm run lint (exit 0, 0 errors / 150 pre-existing warnings, none in
@@ -101,7 +111,7 @@ risks:
   - "Month grouping assumes the server returns rows in due_date order (it does; the groups are built
     in arrival order, so an unsorted response would produce repeated month headers rather than wrong
     rows)."
-  - "+1131/-253 is above the ~400 net-line guidance, but ~370 of the additions are the table markup
+  - "+1368/-253 is above the ~400 net-line guidance, but ~370 of the additions are the table markup
     MOVED out of page.tsx, which shrank by 162 lines; the new logic is the three hooks and the
     counter strip (~240 lines) plus 238 net lines of tests."
   - "No live observation of a populated table is possible yet: client_obligations has 0 rows on prod

--- a/evidence/2026-09/agent-air-m5-mouth-obligations-reviewer-usabilit-6c392bf9/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-obligations-reviewer-usabilit-6c392bf9/brief.yml
@@ -1,0 +1,117 @@
+task_id: obligations-reviewer-usability
+gear: 2
+l_level: L2
+gate_class: opus
+objective: >-
+  Make the obligations reviewer screen readable without the catalog and the client book in the
+  reviewer's head. The screen at apps/mouth/src/app/(workspace)/obligations showed rule_id and
+  client_id only. It now labels every row through GET /api/compliance/obligations/catalog (M3,
+  #6330) — rule name, authority, verified/unverified badge, legal_source in the row detail —
+  resolves client_id to a display name through GET /api/crm/clients/{id}, reports
+  proposed/approved/rejected/alerted counts for the current client filter from the list endpoint's
+  `total` with limit=1, and groups rows by due month when a client filter is set. The table,
+  counters, hooks and shared types move under components/ so page.tsx stays under 800 lines
+  (680 -> 518). Gear 2 is the computed floor: evidence_pack_lint --print-floor on
+  `git diff --name-only/--numstat origin/main...HEAD` returns 2 (9 files, +1131/-253). The
+  imperator may raise it; this brief does not lower anything.
+constraints:
+  - >-
+    No new backend route and no backend change at all. The counters are four parallel limit=1 reads
+    of the list endpoint that already returns `total` for whatever filter it is given.
+  - >-
+    The catalog is never duplicated in the frontend. No rule id, name, authority or legal source is
+    typed into src/; the only rule literals in the diff are two fixtures inside page.test.tsx.
+  - >-
+    PII is an OUTPUT boundary. A resolved client name lives in useClientNames state for the life of
+    the browser tab and nowhere else: not logged (the failure path logs client_id and deliberately
+    drops the thrown error, whose message comes from a client-record read), not persisted, not sent
+    anywhere. The PR body and this pack carry ids and fixtures only.
+  - >-
+    The CRM read chosen is the lightest per-client read that returns a display name:
+    GET /api/crm/clients/{client_id} in crm_clients.py, one clients row plus a lateral
+    last-interaction join. Its gate is verify_client_access(..., allow_assigned=True), which
+    short-circuits to allowed for is_crm_admin — the gate this screen already requires on every
+    obligations route — so no session that can see the queue is denied a name.
+  - >-
+    Month labels are parsed from the ISO date string, never through new Date(...): the backend
+    sends a plain date and a Date parse shifts it by the viewer's UTC offset.
+  - >-
+    No lockfile touched (node_modules in the worktree is a symlink to the main checkout's, so no
+    npm ci was needed). No fly.toml, no .env, no zantara_core.py, no paid endpoint.
+  - >-
+    npm run build regenerates apps/mouth/public/llms*.txt from published content. Those three
+    regenerations were reverted, not committed: they belong to the editorial lane (#6322), not to
+    this concern.
+acceptance:
+  - text: >-
+      WHEN the catalog read succeeds the table SHALL render each row's rule NAME, its authority and
+      a verified or unverified badge, and the row detail SHALL show legal_source; the catalog SHALL
+      be read once per mount, not once per row.
+    probe: >-
+      npx vitest run 'src/app/(workspace)/obligations' — tests "labels each rule with its catalog
+      name, authority and verified badge" (asserts both badges, two DJP cells, exactly one catalog
+      call) and "shows legal_source in the row detail" (absent before the toggle, present after).
+  - text: >-
+      WHEN the CRM client read succeeds the client column SHALL show the display name with the id
+      beneath it, and WHEN it fails the column SHALL fall back to the bare id.
+    probe: >-
+      same vitest run — "resolves the client id to a display name through the CRM read" and "falls
+      back to the client id when the CRM read fails" (ApiError 404, name absent, id visible).
+  - text: >-
+      The four status counters SHALL come from the list endpoint's total with limit=1, one read per
+      status, all four dispatched before any resolves.
+    probe: >-
+      same vitest run — "reads one counter per status with limit=1, all four in parallel" holds all
+      four responses pending, asserts the four statuses were requested, then releases them and
+      asserts the rendered 7/3/1/2.
+  - text: >-
+      Rows SHALL be grouped by due month WHEN a client filter is set and SHALL stay flat otherwise.
+    probe: >-
+      same vitest run — "groups rows by due month only when a client filter is set": no month
+      header before the filter, "October 2026" and "November 2026" after it.
+  - text: The screen SHALL keep its existing behaviour — generate, approve, reject, 403 handling.
+    probe: >-
+      same vitest run — the four pre-existing tests still pass (11 total, was 5), exit 0.
+  - text: Lint, types and the production build SHALL be clean.
+    probe: >-
+      from apps/mouth — npm run lint (exit 0, 0 errors / 150 pre-existing warnings, none in
+      obligations); npx tsc --noEmit (exit 0); npm run build (exit 0).
+  - text: UI copy SHALL carry no forbidden phrase and no "AI" wording.
+    probe: >-
+      python3 scan of the 9 changed files against every backticked phrase in
+      skills/bali-zero-brand/voice/forbidden-phrases.md plus a \bAI\b regex — zero hits.
+consumer_map:
+  - "The tax team on kita.balizero.com/obligations: the screen they work the queue in."
+  - "GET /api/compliance/obligations/catalog (M3, #6330) gains its first caller — until now the
+    endpoint was live with no consumer."
+  - "GET /api/crm/clients/{client_id} (crm_clients.py) gains a caller from the obligations lane."
+  - "U2 (client compliance profile form) mounts its panel on this page and reuses
+    components/types.ts, components/describe-error.ts and the client-filter state added here."
+  - "Not a consumer, checked: nothing else imports from the obligations directory (grep), so the
+    components/ split breaks no other screen."
+risks:
+  - "The client column issues one CRM read per distinct client_id on the page — up to 50 parallel
+    requests on a cross-client page of proposals. Each is a single-row read and ids are attempted
+    once per tab, but a very wide page is a visible burst. Mitigation if it bites: batch through the
+    clients list endpoint instead of per id."
+  - "A failed CRM read is remembered as attempted for the life of the tab, so a transient failure
+    pins that row to its id until the reviewer reloads. Chosen over retrying on every render."
+  - "The four counter reads are four extra list queries per filter change. They are limit=1, but
+    they share the same count_filtered path as the table's own total."
+  - "Month grouping assumes the server returns rows in due_date order (it does; the groups are built
+    in arrival order, so an unsorted response would produce repeated month headers rather than wrong
+    rows)."
+  - "+1131/-253 is above the ~400 net-line guidance, but ~370 of the additions are the table markup
+    MOVED out of page.tsx, which shrank by 162 lines; the new logic is the three hooks and the
+    counter strip (~240 lines) plus 238 net lines of tests."
+  - "No live observation of a populated table is possible yet: client_obligations has 0 rows on prod
+    because the first /generate has never run (owner input: pilot client_id). The live proof is
+    therefore the screen rendering with its counters at zero plus the catalog read succeeding."
+grader: >-
+  The final on-disk gate is a fresh Opus 5 session commissioned by the imperator; this Dux does not
+  post harness/fable-gate. Codex (read-only, reasoning effort high) reviewed the diff as spalla; its
+  verdict is in the PR body under "## Adversarial review".
+budget: Existing subscription only; no paid API calls.
+pii: >-
+  none. Client ids and a synthetic fixture name ("Fixture Client Alpha") only. No real client name
+  appears in the diff, this pack or the PR body.


### PR DESCRIPTION
## What

The obligations reviewer at `kita.balizero.com/obligations` showed `rule_id` and `client_id` and nothing else, so the tax team had to keep the rule catalog and the client book in their head to work the queue. This wires the screen to the two reads M3 shipped (#6330) plus the CRM client read.

1. **Rule identity from the catalog.** One `GET /api/compliance/obligations/catalog` per mount. The table renders the rule NAME, its authority and a `verified` / `unverified` badge; the row detail (click the rule name) shows `legal_source`, the schedule, the trigger and the catalog's own review note. The catalog is **never** duplicated in the frontend: no rule id, name, authority or legal source is typed into `src/` — a rule renamed or verified in the YAML changes this screen with no frontend deploy. A failed catalog read degrades to rule ids with a one-line warning.
2. **Client display names.** `client_id` resolves through `GET /api/crm/clients/{id}` (`crm_clients.py`), the lightest per-client read that returns `full_name`. Its gate is `verify_client_access(..., allow_assigned=True)`, which short-circuits to allowed for `is_crm_admin` — the gate this screen already requires on every obligations route — so no session that can see the queue is denied a name. Cached per id, attempted once per tab, bare id on failure.
3. **Status counters.** proposed / approved / rejected / alerted for the current client filter, from the list endpoint's `total` with `limit=1`, four reads in parallel. No new backend route. Clicking a tile moves the status filter.
4. **Month grouping** when a client filter is set (one client's calendar); the flat server-ordered table stays for the cross-client view. The month label is parsed from the ISO string, not through `new Date`, so a due date cannot slide into the previous month west of Greenwich.

`page.tsx` 680 → 518 lines; the table, the counter strip, the three hooks and the shared types live under `components/`.

**PII boundary.** A resolved client name lives in `useClientNames` state for the life of the browser tab and nowhere else: not logged (the failure path logs `client_id` and deliberately drops the thrown error, whose message comes from a client-record read), not persisted, not forwarded. This PR body and the evidence pack carry ids and synthetic fixtures only.

**Not included:** the client compliance profile form (U2, next PR). `npm run build` regenerates `apps/mouth/public/llms*.txt` from published content; those three regenerations were reverted rather than committed — they belong to the editorial lane (#6322), not to this concern.

## Checks

From `apps/mouth` in the worktree, all exit 0:

```
npm run lint                                    # 0 errors, 150 pre-existing warnings, none in obligations
npx tsc --noEmit
npx vitest run 'src/app/(workspace)/obligations' # 14 passed (was 5)
npm run build                                    # /obligations builds static
```

Evidence: `evidence/2026-09/agent-air-m5-mouth-obligations-reviewer-usabilit-6c392bf9/brief.yml`, gear 2 as computed by `scripts/evidence_pack_lint.py --print-floor` (10 files, +1368/-253).

`+1368/-253` is above the ~400 net-line guidance: ~370 of the additions are the table markup MOVED out of `page.tsx`, which shrank by 162 lines. The new logic is the three hooks plus the counter strip.

## Adversarial review

Codex CLI, `--sandbox read-only -c model_reasoning_effort=high`, on `git diff origin/main...HEAD`. Verdict: **BLOCK**, three MAJOR and one MINOR. All four accepted and fixed in `97bae1cc07`, each with a regression test verified RED against the pre-fix code.

1. **MAJOR, `useObligationsCatalog`** — the single-read guard was an "already started" boolean. `reactStrictMode: true` (`apps/mouth/next.config.ts`), so in dev React runs setup → cleanup → setup: the first run started the read, the cleanup discarded its result, the second run bailed out. Catalog empty forever, no request left to recover it. **Fixed:** the ref holds the PROMISE, so the second setup re-attaches to the same in-flight read — still exactly one request. Test: *reads the catalog once and renders it under StrictMode*.
2. **MAJOR, `useClientNames`** — ids were marked attempted when the read STARTED while a cleanup dropped in-flight results, so rows changing mid-read pinned those ids to the id fallback for the life of the tab. **Fixed:** the cleanup guard is gone — the merge is per id and idempotent, so there is no staleness hazard for it to protect against. Test: *keeps a name resolution that lands after the rows changed*.
3. **MAJOR, `useStatusCounters`** — the previous filter's totals stayed on screen while the new reads were in flight, rendered under the NEW client's label: one client's counts attributed to another. **Fixed:** counts are cleared when the inputs change, so the tiles show the loading placeholder. Test: *clears the counters when the client filter changes*.
4. **MINOR, `page.test.tsx`** — the parallel-counters test used `findByTestId`, which resolves on an element that already exists, so the content assertions could run before the totals landed. **Fixed:** they are inside `waitFor`.

Verification of the RED: the three hooks were reverted to their pre-fix shape and the suite re-run — 2 failed / 11 passed, then 1 failed / 13 passed — before the fixes were restored.

Bites: consumer = the tax team on `kita.balizero.com/obligations`, plus `GET /api/compliance/obligations/catalog` which gains its first caller; observation = the live page after Vercel deploys, showing a rule name with its verified badge and the four counters (empty state acceptable — `client_obligations` has 0 rows on prod because the first `/generate` has never run, pending the owner's pilot `client_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151rdiec2WR4Lf2BG4UUYqP
