### PR TITLE
chore(mouth): /clients and /clients/analytics — drop duplicated stats and controls that send nothing

### DIFF
--- a/apps/mouth/src/app/(workspace)/clients/analytics/page.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/analytics/page.tsx
@@ -36,11 +36,6 @@ import {
   Target,
   Clock,
   Award,
-  ArrowUpRight,
-  ArrowDownRight,
-  Smartphone,
-  Tablet,
-  Monitor,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
@@ -58,8 +53,6 @@ interface ClientOverview {
   new_this_week: number;
   by_status: Record<string, number>;
   by_nationality: Record<string, number>;
-  growth_rate: number;
-  churn_rate: number;
 }
 
 interface TeamPerformance {
@@ -115,35 +108,14 @@ interface FunnelStage {
   drop_off: number;
 }
 
-type DateRange = "7d" | "30d" | "90d" | "6m" | "1y" | "all";
 type ViewMode = "desktop" | "tablet" | "mobile";
 
-// ================================================
-// UTILITY COMPONENTS
-// ================================================
-
-const TrendIndicator = ({
-  value,
-  suffix = "%",
-}: {
-  value: number;
-  suffix?: string;
-}) => {
-  const isPositive = value >= 0;
-  return (
-    <span
-      className={`flex items-center gap-1 text-xs font-medium ${isPositive ? "text-[var(--state-success)]" : "text-[var(--state-danger)]"}`}
-    >
-      {isPositive ? (
-        <ArrowUpRight className="w-3 h-3" />
-      ) : (
-        <ArrowDownRight className="w-3 h-3" />
-      )}
-      {Math.abs(value).toFixed(1)}
-      {suffix}
-    </span>
-  );
-};
+// The trend endpoint's lookback window. A user-facing range picker used to
+// sit in front of this (7d/30d/90d/6m/1y/all) but only the "1y" option ever
+// changed anything (6 vs 12 months on this one query) and no other section
+// on this page reads a selected range at all — see PR body for the audit
+// trail. Fixed at the picker's own former default.
+const TREND_LOOKBACK_MONTHS = 6;
 
 // ================================================
 // STAT CARD COMPONENT
@@ -153,7 +125,6 @@ interface StatCardProps {
   title: string;
   value: string | number;
   subtitle?: string;
-  trend?: number;
   icon: React.ElementType;
   color: "blue" | "green" | "amber" | "purple" | "red" | "cyan";
   loading?: boolean;
@@ -164,7 +135,6 @@ const StatCard = ({
   title,
   value,
   subtitle,
-  trend,
   icon: Icon,
   color,
   loading,
@@ -201,11 +171,6 @@ const StatCard = ({
               </p>
               {subtitle && (
                 <p className="text-xs mt-1 opacity-70 truncate">{subtitle}</p>
-              )}
-              {trend !== undefined && (
-                <div className="mt-1">
-                  <TrendIndicator value={trend} />
-                </div>
               )}
             </>
           )}
@@ -339,45 +304,6 @@ const ProgressBar = ({
 };
 
 // ================================================
-// DATE RANGE SELECTOR
-// ================================================
-
-const DateRangeSelector = ({
-  value,
-  onChange,
-}: {
-  value: DateRange;
-  onChange: (v: DateRange) => void;
-}) => {
-  const ranges: { value: DateRange; label: string }[] = [
-    { value: "7d", label: "7 Days" },
-    { value: "30d", label: "30 Days" },
-    { value: "90d", label: "90 Days" },
-    { value: "6m", label: "6 Months" },
-    { value: "1y", label: "1 Year" },
-    { value: "all", label: "All Time" },
-  ];
-
-  return (
-    <div className="flex flex-wrap gap-1 bg-muted p-1 rounded-lg">
-      {ranges.map((r) => (
-        <button
-          key={r.value}
-          onClick={() => onChange(r.value)}
-          className={`px-2 sm:px-3 py-1 text-xs rounded-md transition-all ${
-            value === r.value
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          {r.label}
-        </button>
-      ))}
-    </div>
-  );
-};
-
-// ================================================
 // EXPORT BUTTON
 // ================================================
 
@@ -423,7 +349,6 @@ export default function ClientAnalyticsPage() {
   const router = useRouter();
   const { error: showError } = useToast();
   const [isLoading, setIsLoading] = useState(true);
-  const [dateRange, setDateRange] = useState<DateRange>("6m");
   const [viewMode, setViewMode] = useState<ViewMode>("desktop");
   const [activeTab, setActiveTab] = useState<
     "overview" | "team" | "revenue" | "processes"
@@ -463,7 +388,7 @@ export default function ClientAnalyticsPage() {
           api.get<RevenueSummary>("/api/crm/analytics/revenue/summary"),
           api.get<ProcessTypeMetric[]>("/api/crm/analytics/processes/by-type"),
           api.get<TrendPoint[]>(
-            `/api/crm/analytics/clients/trend?months=${dateRange === "6m" ? 6 : dateRange === "1y" ? 12 : 6}`,
+            `/api/crm/analytics/clients/trend?months=${TREND_LOOKBACK_MONTHS}`,
           ),
         ]);
 
@@ -520,7 +445,7 @@ export default function ClientAnalyticsPage() {
     } finally {
       setIsLoading(false);
     }
-  }, [dateRange, showError]);
+  }, [showError]);
 
   useEffect(() => {
     fetchData();
@@ -609,23 +534,6 @@ export default function ClientAnalyticsPage() {
             </Button>
           </div>
         </div>
-
-        {/* Controls Row */}
-        <div className="flex flex-col sm:flex-row gap-3 justify-between items-start sm:items-center">
-          <DateRangeSelector value={dateRange} onChange={setDateRange} />
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <span className="hidden sm:inline">View:</span>
-            <Monitor
-              className={`w-4 h4 ${viewMode === "desktop" ? "text-foreground" : ""}`}
-            />
-            <Tablet
-              className={`w-4 h-4 ${viewMode === "tablet" ? "text-foreground" : ""}`}
-            />
-            <Smartphone
-              className={`w-4 h-4 ${viewMode === "mobile" ? "text-foreground" : ""}`}
-            />
-          </div>
-        </div>
       </div>
 
       {/* Mobile Tabs */}
@@ -646,9 +554,6 @@ export default function ClientAnalyticsPage() {
               <Users className="w-4 h-4 sm:w-5 sm:h-5" />
               Client Overview
             </h2>
-            {overview?.growth_rate !== undefined && (
-              <TrendIndicator value={overview.growth_rate} />
-            )}
           </div>
 
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
@@ -659,7 +564,6 @@ export default function ClientAnalyticsPage() {
                 isLoading ? "-" : formatCompact(overview?.total_clients || 0)
               }
               subtitle={`+${overview?.new_this_month || 0} this month`}
-              trend={overview?.growth_rate}
               icon={Users}
               color="blue"
               loading={isLoading}

--- a/apps/mouth/src/app/(workspace)/clients/page.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/page.tsx
@@ -561,9 +561,6 @@ function ClientsListContent() {
             {hasMore && " (scroll for more)"}
             {activeFiltersCount > 0 &&
               ` • filtered from ${isMounted ? visibleClients.length.toLocaleString("en-US") : visibleClients.length}`}
-            {stats && (
-              <span className="ml-2 text-xs">• {stats.totalClients} total</span>
-            )}
             {statsError && (
               <span
                 className="ml-2 text-xs"
@@ -720,9 +717,7 @@ function ClientsListContent() {
       {/* Health Awareness Bar — global counts from backend stats */}
       {isMounted &&
         stats &&
-        (stats.passportExpired > 0 ||
-          stats.passportExpiringSoon > 0 ||
-          stats.silent30d > 0) && (
+        (stats.passportExpired > 0 || stats.passportExpiringSoon > 0) && (
           <div className="flex flex-wrap gap-2 text-xs">
             {stats.passportExpired > 0 && (
               <button
@@ -759,22 +754,6 @@ function ClientsListContent() {
               >
                 <AlertCircle className="w-3 h-3" />
                 {stats.passportExpiringSoon} expiring in 90d
-              </button>
-            )}
-            {stats.silent30d > 0 && (
-              <button
-                onClick={() => setSilentFilter(silentFilter === 30 ? null : 30)}
-                className="flex items-center gap-1 px-2.5 py-1 rounded-full transition-colors"
-                style={{
-                  background:
-                    "color-mix(in srgb, var(--bz-neon-purple) 15%, transparent)",
-                  color: "var(--bz-neon-purple)",
-                  border:
-                    "1px solid color-mix(in srgb, var(--bz-neon-purple) 25%, transparent)",
-                }}
-              >
-                <AlertCircle className="w-3 h-3" />
-                {stats.silent30d} silent 30d+
               </button>
             )}
           </div>
@@ -921,34 +900,6 @@ function ClientsListContent() {
             </FilterSelect>
             <FilterSelect
               label="Assigned To"
-              labelExtra={
-                currentUserEmail ? (
-                  <button
-                    onClick={() =>
-                      setFilters({
-                        ...filters,
-                        assigned_to:
-                          filters.assigned_to === currentUserEmail
-                            ? ""
-                            : currentUserEmail,
-                      })
-                    }
-                    className="text-xs px-2 py-0.5 rounded-full transition-colors"
-                    style={{
-                      background:
-                        filters.assigned_to === currentUserEmail
-                          ? "var(--bz-accent)"
-                          : "var(--bz-surface)",
-                      color:
-                        filters.assigned_to === currentUserEmail
-                          ? "var(--bz-text-pure)"
-                          : "var(--bz-text-2)",
-                    }}
-                  >
-                    My Clients
-                  </button>
-                ) : undefined
-              }
               value={filters.assigned_to}
               onChange={(v) => setFilters({ ...filters, assigned_to: v })}
               selectClassName="transition-all duration-300"
@@ -1336,9 +1287,7 @@ function ClientsListContent() {
                   className="p-4 text-center text-xs"
                   style={{ color: "var(--bz-text-2)" }}
                 >
-                  {isLoadingMore
-                    ? "Loading more..."
-                    : `${clients.length} of ${clients.length} loaded`}
+                  {isLoadingMore && "Loading more..."}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## What
- `/clients`: removed the duplicate "My Clients" toggle (kept the always-visible toolbar button, dropped the identical one hidden inside the collapsed "Assigned To" filter's `labelExtra`).
- `/clients`: removed the "Silent 30d+" health-bar segment (kept the dedicated "Silent 30d" filter button, which pairs with "Silent 7d" and is always present regardless of stats).
- `/clients`: removed the "• N total" subtitle chip (kept the "Total Clients" StatChip below it — same `stats.totalClients` value).
- `/clients`: table-view footer no longer prints `${clients.length} of ${clients.length} loaded` (both sides of that ratio were always the same array length — it could never show a real partial-load state). It now only shows "Loading more…" while a page fetch is in flight.
- `/clients/analytics`: removed `DateRangeSelector` (7d/30d/90d/6m/1y/all) and its `dateRange` state. Traced every consumer: only the `clients/trend` call (feeding the Revenue Trend sparkline) read it, and only distinguished `1y` (12 months) from every other option (6 months). No other section (overview cards, Conversion Funnel, Revenue Analysis, Team Performance, Cases by Type, Top Nationalities) reads `dateRange` at all. The trend call now fetches a fixed 6-month lookback (the picker's own former default) so the one real effect it had keeps working.
- `/clients/analytics`: removed the decorative Monitor/Tablet/Smartphone "View:" icon row — no `onClick`, no data prop, it only mirrored the page's own auto-detected `window.innerWidth`, which the responsive layout (mobile tabs, column counts) already makes visible.
- `/clients/analytics`: removed `overview.growth_rate` / `overview.churn_rate` and their two call sites (header `TrendIndicator`, "Total Clients" StatCard `trend` arrow). Verified against `apps/backend-rag/backend/app/routers/crm_analytics.py::get_client_overview` — the endpoint never returns either field, so both were permanently dead (`!== undefined` never passed). Also removed the now-fully-unused `trend` prop on `StatCard` and the `TrendIndicator` component itself, plus the now-unused `ArrowUpRight`/`ArrowDownRight` icon imports.

## Kept on purpose
- Map view (`PrimeNexusLayout`, `/clients?view=map`) — untouched, per scope; verified none of the dedupe changes touch the map branch.
- "Conversion Funnel" section on `/clients/analytics` — NOT removed. It's computed client-side from `overview.by_status`, which is real data the same (alive) `/api/crm/analytics/clients/overview` endpoint returns. This is legitimate, not a phantom-endpoint section — reporting rather than deleting.
- "Revenue Trend" sparkline — kept; it consumes real `trend` data from `/api/crm/analytics/clients/trend`, just with a fixed 6-month window now instead of a picker.
- `PieChart`, `Calendar`, `Filter`, `ChevronDown` icon imports on the analytics page — confirmed unused, but pre-existing (unrelated to this diff) and outside this PR's named scope; left alone to keep the diff to the audit's named items.

## Verification
- `npx tsc --noEmit` — exit 0
- `npx vitest --run --root . --config vitest.config.ts` — exit 0 (477 files / 5110 tests passed)
- `npm run build` — exit 0, printed `PUBLIC_LOGIN_BUNDLE_OK` (`apps/mouth/public/llms*.txt` build churn reverted before commit, not part of the diff)

## Skipped / out of scope
- `/revenue/analytics` and `/team/analytics` consolidation into `/clients/analytics` — explicitly out of scope for this PR (belongs to a different lot per the audit).
- `clients/[id]/` and `clients/new/` — other agents' lanes in this same pruning effort, not touched.
- Team Performance's unused `avg_response_time_hours`/`satisfaction_score` fields and Process/Trend interface fields the backend never returns (`avg_completion_days`, `success_rate`, trend's `active_cases`/`completed_cases`) — not named in this PR's brief; left as-is to keep this diff to the specifically audited items (DateRangeSelector, device icons, growth/churn trend, Conversion Funnel verification).

## Bites
Consumer: kita.balizero.com CRM operators viewing `/clients` and `/clients/analytics`. Observable post-deploy: the `/clients` table's load-more footer no longer shows a static "N of N loaded" string while more clients remain unloaded; `/clients/analytics` no longer shows a 6-option date-range picker that only ever changed one sparkline's lookback, nor the non-interactive Monitor/Tablet/Smartphone icon row, nor a "Total Clients" trend arrow that could never render (backend never sends `growth_rate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
