### PR TITLE
chore(mouth): kita pruning lot 5 — command-palette keys and dead chrome props

### DIFF
--- a/apps/mouth/src/app/(workspace)/layout.tsx
+++ b/apps/mouth/src/app/(workspace)/layout.tsx
@@ -58,8 +58,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     role: "",
     team: "",
     avatar: undefined as string | undefined,
-    isOnline: false,
-    hoursToday: undefined as string | undefined,
   });
 
   // INTAKE login gate (spec §3/§5). `gateChecked` stays false until the first
@@ -113,8 +111,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
           role: storedProfile.role || "Member",
           team: storedProfile.team || "Team",
           avatar: storedProfile.avatar,
-          isOnline: true,
-          hoursToday: undefined,
         });
         return;
       }
@@ -128,8 +124,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
         role: profile.role || "Member",
         team: profile.team || "Team",
         avatar: profile.avatar,
-        isOnline: true,
-        hoursToday: undefined,
       });
     } catch (error) {
       // A 401 here is NOT a fault — it is this gate working. An anonymous
@@ -253,8 +247,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
               role: "admin",
               team: "Management",
               avatar: undefined,
-              isOnline: true,
-              hoursToday: undefined,
             });
             // No backend in local dev — treat the gate as cleared so the
             // workspace is inspectable.
@@ -289,8 +281,6 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
               role: "Member",
               team: "Team",
               avatar: undefined,
-              isOnline: true,
-              hoursToday: undefined,
             });
             await refetchGate();
             return;

--- a/apps/mouth/src/app/(workspace)/process/new/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/new/page.tsx
@@ -141,6 +141,26 @@ export default function NewPracticePage() {
     loadCatalog();
   }, []);
 
+  // Preselect the service from `?type=` (the command palette's "New KITAS" /
+  // "New PT Setup" shortcuts) once the catalog is loaded — matches either a
+  // category code (e.g. "kitas") or a specific service code within one.
+  useEffect(() => {
+    const typeParam = searchParams?.get("type");
+    if (!typeParam || catalog.length === 0) return;
+    const cat = catalog.find((c) => c.code === typeParam);
+    if (cat) {
+      setSelectedCategory(cat.code);
+      return;
+    }
+    const svcCat = catalog.find((c) =>
+      c.services.some((s) => s.code === typeParam),
+    );
+    if (svcCat) {
+      setSelectedCategory(svcCat.code);
+      setSelectedServiceCode(typeParam);
+    }
+  }, [catalog, searchParams]);
+
   // Map API team options to the format used by the form
   const allTeamMembers = useMemo(
     () => allTeamOptions.map((o) => ({ email: o.value, name: o.label })),

--- a/apps/mouth/src/app/portal/(authenticated)/layout.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/layout.tsx
@@ -301,7 +301,6 @@ export default function PortalLayout({
               ...user,
               role: isPartnerPortal ? "partner" : "client",
               team: isPartnerPortal ? "Partner Portal" : "Client Portal",
-              isOnline: true,
             }}
             navigationConfig={
               isPartnerPortal ? partnerPortalNavigation : portalNavigation
@@ -333,7 +332,6 @@ export default function PortalLayout({
                   ...user,
                   role: isPartnerPortal ? "partner" : "client",
                   team: isPartnerPortal ? "Partner Portal" : "Client Portal",
-                  isOnline: true,
                 }}
                 navigationConfig={
                   isPartnerPortal ? partnerPortalNavigation : portalNavigation

--- a/apps/mouth/src/components/workspace/AppSidebar.tsx
+++ b/apps/mouth/src/components/workspace/AppSidebar.tsx
@@ -74,8 +74,6 @@ interface AppSidebarProps {
     role?: string;
     team?: string;
     avatar?: string;
-    isOnline?: boolean;
-    hoursToday?: string;
   };
   unreadWhatsApp?: number;
   reviewCount?: number;
@@ -314,17 +312,6 @@ export function AppSidebar({
               {isPortal ? "Client Portal" : user.role || user.team || "Team"}
             </div>
           </div>
-          <div
-            className="w-[7px] h-[7px] rounded-full flex-shrink-0"
-            style={{
-              background: user.isOnline
-                ? "var(--bz-green)"
-                : "var(--bz-text-3)",
-              boxShadow: user.isOnline
-                ? "0 0 6px color-mix(in srgb, var(--bz-green) 45%, transparent)"
-                : "none",
-            }}
-          />
         </div>
         <button
           onClick={onLogout}

--- a/apps/mouth/src/components/workspace/Header.tsx
+++ b/apps/mouth/src/components/workspace/Header.tsx
@@ -116,12 +116,6 @@ export function Header({
           >
             {userName ? `${userName}, ayo!` : getPageTitle()}
           </span>
-          <span
-            className="hidden lg:inline text-[11px] truncate"
-            style={{ color: "var(--bz-text-1)" }}
-          >
-            We are writing the history!
-          </span>
         </div>
 
         <div className="flex-1" />

--- a/apps/mouth/src/i18n/locales/en.json
+++ b/apps/mouth/src/i18n/locales/en.json
@@ -1,4 +1,22 @@
 {
+  "commandPalette": {
+    "actions": {
+      "goInbox": "Inbox",
+      "goClients": "Clients",
+      "goProcess": "Process",
+      "goPrime": "Prime (external)",
+      "createKitas": "New KITAS Process",
+      "createPtSetup": "New PT Setup Process",
+      "exportLkpm": "LKPM",
+      "openAnalytics": "Analytics"
+    },
+    "groups": {
+      "navigation": "Navigation",
+      "cases": "Create Case",
+      "tax": "Tax",
+      "analytics": "Analytics"
+    }
+  },
   "common": {
     "nav": {
       "news": "News",

--- a/apps/mouth/src/i18n/locales/fr.json
+++ b/apps/mouth/src/i18n/locales/fr.json
@@ -1,4 +1,22 @@
 {
+  "commandPalette": {
+    "actions": {
+      "goInbox": "Inbox",
+      "goClients": "Clients",
+      "goProcess": "Process",
+      "goPrime": "Prime (external)",
+      "createKitas": "New KITAS Process",
+      "createPtSetup": "New PT Setup Process",
+      "exportLkpm": "LKPM",
+      "openAnalytics": "Analytics"
+    },
+    "groups": {
+      "navigation": "Navigation",
+      "cases": "Create Case",
+      "tax": "Tax",
+      "analytics": "Analytics"
+    }
+  },
   "common": {
     "nav": {
       "news": "Actualités",

--- a/apps/mouth/src/i18n/locales/id.json
+++ b/apps/mouth/src/i18n/locales/id.json
@@ -1,4 +1,22 @@
 {
+  "commandPalette": {
+    "actions": {
+      "goInbox": "Inbox",
+      "goClients": "Clients",
+      "goProcess": "Process",
+      "goPrime": "Prime (external)",
+      "createKitas": "New KITAS Process",
+      "createPtSetup": "New PT Setup Process",
+      "exportLkpm": "LKPM",
+      "openAnalytics": "Analytics"
+    },
+    "groups": {
+      "navigation": "Navigation",
+      "cases": "Create Case",
+      "tax": "Tax",
+      "analytics": "Analytics"
+    }
+  },
   "common": {
     "nav": {
       "news": "Berita",

--- a/apps/mouth/src/i18n/locales/it.json
+++ b/apps/mouth/src/i18n/locales/it.json
@@ -1,4 +1,22 @@
 {
+  "commandPalette": {
+    "actions": {
+      "goInbox": "Inbox",
+      "goClients": "Clients",
+      "goProcess": "Process",
+      "goPrime": "Prime (external)",
+      "createKitas": "New KITAS Process",
+      "createPtSetup": "New PT Setup Process",
+      "exportLkpm": "LKPM",
+      "openAnalytics": "Analytics"
+    },
+    "groups": {
+      "navigation": "Navigation",
+      "cases": "Create Case",
+      "tax": "Tax",
+      "analytics": "Analytics"
+    }
+  },
   "common": {
     "nav": {
       "news": "Notizie",

--- a/apps/mouth/src/i18n/locales/ru.json
+++ b/apps/mouth/src/i18n/locales/ru.json
@@ -1,4 +1,22 @@
 {
+  "commandPalette": {
+    "actions": {
+      "goInbox": "Inbox",
+      "goClients": "Clients",
+      "goProcess": "Process",
+      "goPrime": "Prime (external)",
+      "createKitas": "New KITAS Process",
+      "createPtSetup": "New PT Setup Process",
+      "exportLkpm": "LKPM",
+      "openAnalytics": "Analytics"
+    },
+    "groups": {
+      "navigation": "Navigation",
+      "cases": "Create Case",
+      "tax": "Tax",
+      "analytics": "Analytics"
+    }
+  },
   "common": {
     "nav": {
       "news": "Новости",

--- a/apps/mouth/src/types/navigation.ts
+++ b/apps/mouth/src/types/navigation.ts
@@ -23,8 +23,6 @@ export interface UserProfile {
   team: string;
   avatar?: string;
   isOnline: boolean;
-  clockedInAt?: string;
-  hoursToday?: string;
 }
 
 export interface BreadcrumbItem {


### PR DESCRIPTION
## What

- **KitaCommandPalette i18n (item 21)**: added the `commandPalette.actions.*` and
  `commandPalette.groups.*` keys the palette already calls via `t()` to all five
  locale files (`en`, `id`, `it`, `fr`, `ru` — not just en/id/it; `apps/mouth/src/i18n`
  ships five bundles and `locale-key-parity.test.ts` enforces zero gap across all of
  them). English copy across every locale (no invented translations), matching the
  "copy the English text" instruction. Before this change every palette label
  rendered as the raw key (`commandPalette.actions.goClients`); now it renders real
  text.
- **`/process/new?type=` preselect (item 21)**: the command palette's "New KITAS"
  and "New PT Setup" shortcuts navigate to `/process/new?type=kitas` /
  `?type=pt_setup`, which the page ignored. Added a small effect that matches
  `?type=` against the loaded practice-types catalog (`GET
  /api/crm/practices/types/catalog`) — first as a category code, then as a service
  code within a category — and preselects it. `?type=kitas` matches the real
  `kitas` category code and now preselects it. `?type=pt_setup` does not match any
  current category or service code (confirmed: no `pt_setup` anywhere in the
  backend), so it is a no-op, same as before — not a regression, and out of this
  PR's scope to invent a new practice-type code.
- **Dead chrome (item 22)**: removed `isOnline`/`hoursToday` from the workspace
  `user` state and from `AppSidebarProps` (the online dot in the sidebar was always
  green because `layout.tsx` hardcoded `isOnline: true` on every branch), and the
  "We are writing the history!" tagline from `Header`. Also removed the now-dead
  `UserProfile.clockedInAt`/`hoursToday` fields from `types/navigation.ts` (grepped:
  zero readers). `I18nProvider` stays — `KitaCommandPalette` is a live consumer via
  `useTranslation()`.
- **Fallout fix**: `apps/mouth/src/app/portal/(authenticated)/layout.tsx` passed
  `isOnline: true` into the same shared `AppSidebar` component (portal route, not
  kita workspace) — removed both call sites so the type-check stays green.

## Kept on purpose

- Header WhatsApp button and `/whatsapp`/`/inbox`/`/team-management` etc. — lot 4's
  scope, untouched.
- The three chat surfaces (item 23) — see "Owner decision pending" below, no
  deletion per the gate's decision.
- `routeTitles` ghosts, `portalNavigation` unused import, settings pages, dashboard
  widgets — already handled by PR #6296 (lots 1–2, merged) or other lots; verified
  on disk, not re-touched here.

## Owner decision pending — item 23 (three chat UIs on the same RAG endpoint)

`components/workspace/WorkspaceAssistant.tsx` (the third surface the audit named)
was already deleted by PR #6296 as zero-importer dead code, so two live surfaces
remain:

| Surface | File / route | Endpoint called |
|---|---|---|
| ZantaraWidget | `components/workspace/ZantaraWidget.tsx` (floating widget, mounted in every workspace page) | `sendChat()` in `lib/gateway.ts` → `POST /api/agentic-rag/workspace-stream` on the cloud backend (optional local-gateway `/v1/chat` fallback first, if a gateway token is configured) |
| Terminal | `app/(workspace)/terminal/page.tsx` via `components/terminal/useTerminal.ts` | same `sendChat()` → same `/api/agentic-rag/workspace-stream` |
| WorkspaceAssistant *(already deleted, PR #6296)* | was `components/workspace/WorkspaceAssistant.tsx`, zero importers | same endpoint (historical) |

No code change made here per the gate's standing decision ("DO NOT delete any chat
surface"). Choosing ZantaraWidget-only, Terminal-only, or keeping both is a product
call for Zero.

## Verification

- `cd apps/mouth && npx tsc --noEmit` — exit `0`, 2026-09-12 23:47 WITA (post-rebase)
- `cd apps/mouth && npx vitest --run --root . --config vitest.config.ts` — exit
  `0` (477 files, 5110 tests), 2026-09-12 23:53-23:59 WITA
- `cd apps/mouth && npm run build` — exit `0` (PUBLIC_LOGIN_BUNDLE_OK), 2026-09-13 00:00 WITA

Bites: consumer kita.balizero.com operators; observation: opening the Cmd+K command
palette shows real action labels ("Clients", "Process", "New KITAS Process", …)
instead of raw `commandPalette.actions.*` keys, the sidebar online dot and the
Header tagline are gone, and creating a process from the palette's "New KITAS"
shortcut preselects the KITAS category on `/process/new`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
