### PR TITLE
fix(visaoracle): retirement dead-ends and the STEPCHILD sponsor-permit question (PR-D3 half-2)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67798,6 +67798,98 @@
         "line_number": 34,
         "is_secret": false
       }
+    ],
+    "apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID.json",
+        "hashed_secret": "a8463d954c0f5c1231855e9266779b4d4df12470",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      }
+    ],
+    "apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID_sponsor_permit_no.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID_sponsor_permit_no.json",
+        "hashed_secret": "c1573a51ac31f77c37a8f86be1f504f88c0b1c47",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      }
+    ],
+    "apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID_sponsor_permit_unsure.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID_sponsor_permit_unsure.json",
+        "hashed_secret": "3ca231ccb0a03f0a4362709e393b3b631be8e09c",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      }
+    ],
+    "apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_IT.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_IT.json",
+        "hashed_secret": "d3b557d579ce6ae4188191b77a4fb6609863a319",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      }
+    ],
+    "apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py",
+        "hashed_secret": "a8463d954c0f5c1231855e9266779b4d4df12470",
+        "is_verified": false,
+        "line_number": 364,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py",
+        "hashed_secret": "d3b557d579ce6ae4188191b77a4fb6609863a319",
+        "is_verified": false,
+        "line_number": 365,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py",
+        "hashed_secret": "c1573a51ac31f77c37a8f86be1f504f88c0b1c47",
+        "is_verified": false,
+        "line_number": 373,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py",
+        "hashed_secret": "3ca231ccb0a03f0a4362709e393b3b631be8e09c",
+        "is_verified": false,
+        "line_number": 377,
+        "is_secret": false
+      }
+    ],
+    "apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts",
+        "hashed_secret": "c1573a51ac31f77c37a8f86be1f504f88c0b1c47",
+        "is_verified": false,
+        "line_number": 439,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts",
+        "hashed_secret": "3ca231ccb0a03f0a4362709e393b3b631be8e09c",
+        "is_verified": false,
+        "line_number": 449,
+        "is_secret": false
+      }
     ]
   },
   "version": "1.5.0"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_diaspora_STEPCHILD_spNat_ID.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_diaspora_STEPCHILD_spNat_ID.json
@@ -16,6 +16,7 @@
     "family_sponsor_nationalities",
     "family_stepchild_marriage_certificate_confirmed",
     "family_stepchild_birth_certificate_confirmed",
+    "family_stepchild_sponsor_permit_confirmed",
     "family_sponsor_confirmed",
     "stay_days",
     "review_gate"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_diaspora_STEPCHILD_spNat_IT.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_diaspora_STEPCHILD_spNat_IT.json
@@ -18,6 +18,7 @@
     "family_sponsor_permit_basis",
     "family_stepchild_marriage_certificate_confirmed",
     "family_stepchild_birth_certificate_confirmed",
+    "family_stepchild_sponsor_permit_confirmed",
     "family_sponsor_confirmed",
     "stay_days",
     "review_gate"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID.json
@@ -14,6 +14,7 @@
     "family_sponsor_nationalities",
     "family_stepchild_marriage_certificate_confirmed",
     "family_stepchild_birth_certificate_confirmed",
+    "family_stepchild_sponsor_permit_confirmed",
     "family_sponsor_confirmed",
     "stay_days",
     "review_gate"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID_sponsor_permit_no.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID_sponsor_permit_no.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/family/STEPCHILD/spNat=ID/sponsor_permit_no",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -9,12 +9,12 @@
     "category",
     "trip_scope",
     "sponsor_category",
-    "retirement_basis",
-    "retirement_undecided_basis",
-    "secondhome_deposit_usd",
-    "secondhome_state_bank",
-    "secondhome_own_name",
-    "secondhome_passive_income_usd",
+    "family_relation",
+    "marital_status",
+    "family_sponsor_nationalities",
+    "family_stepchild_marriage_certificate_confirmed",
+    "family_stepchild_birth_certificate_confirmed",
+    "family_stepchild_sponsor_permit_confirmed",
     "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
@@ -22,7 +22,7 @@
   "overrides": {
     "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
-    "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "person.marital_status": { "status": "KNOWN", "value": "SINGLE" },
     "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
     "immigration.current_status_code": {
       "status": "KNOWN",
@@ -39,7 +39,7 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["FAMILY"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -80,14 +80,8 @@
       "reason": "NOT_ASKED"
     },
     "investment.proposed_role": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "family.relation_to_sponsor": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
-    "family.sponsor_nationalities": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "family.relation_to_sponsor": { "status": "KNOWN", "value": "STEPCHILD" },
+    "family.sponsor_nationalities": { "status": "KNOWN", "value": ["ID"] },
     "family.sponsor_status_code": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -97,12 +91,12 @@
       "reason": "NOT_ASKED"
     },
     "family.stepchild_marriage_certificate_confirmed": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": true
     },
     "family.stepchild_birth_certificate_confirmed": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": true
     },
     "family.sponsor_permit_basis": {
       "status": "UNKNOWN",
@@ -113,19 +107,25 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
-    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "KNOWN",
-      "value": 1000000000
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID_sponsor_permit_unsure.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_ID_sponsor_permit_unsure.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/family/STEPCHILD/spNat=ID/sponsor_permit_unsure",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -9,12 +9,12 @@
     "category",
     "trip_scope",
     "sponsor_category",
-    "retirement_basis",
-    "retirement_undecided_basis",
-    "secondhome_deposit_usd",
-    "secondhome_state_bank",
-    "secondhome_own_name",
-    "secondhome_passive_income_usd",
+    "family_relation",
+    "marital_status",
+    "family_sponsor_nationalities",
+    "family_stepchild_marriage_certificate_confirmed",
+    "family_stepchild_birth_certificate_confirmed",
+    "family_stepchild_sponsor_permit_confirmed",
     "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
@@ -22,7 +22,7 @@
   "overrides": {
     "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
-    "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "person.marital_status": { "status": "KNOWN", "value": "SINGLE" },
     "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
     "immigration.current_status_code": {
       "status": "KNOWN",
@@ -39,7 +39,7 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["FAMILY"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -80,14 +80,8 @@
       "reason": "NOT_ASKED"
     },
     "investment.proposed_role": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "family.relation_to_sponsor": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
-    "family.sponsor_nationalities": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "family.relation_to_sponsor": { "status": "KNOWN", "value": "STEPCHILD" },
+    "family.sponsor_nationalities": { "status": "KNOWN", "value": ["ID"] },
     "family.sponsor_status_code": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -97,12 +91,12 @@
       "reason": "NOT_ASKED"
     },
     "family.stepchild_marriage_certificate_confirmed": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": true
     },
     "family.stepchild_birth_certificate_confirmed": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": true
     },
     "family.sponsor_permit_basis": {
       "status": "UNKNOWN",
@@ -113,19 +107,25 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
-    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "KNOWN",
-      "value": 1000000000
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_IT.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_family_STEPCHILD_spNat_IT.json
@@ -16,6 +16,7 @@
     "family_sponsor_permit_basis",
     "family_stepchild_marriage_certificate_confirmed",
     "family_stepchild_birth_certificate_confirmed",
+    "family_stepchild_sponsor_permit_confirmed",
     "family_sponsor_confirmed",
     "stay_days",
     "review_gate"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_bank_deposit.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_bank_deposit.json
@@ -117,8 +117,8 @@
     },
     "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
     "secondhome.qualifying_property_value_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 0
     },
     "secondhome.passive_monthly_income_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_bank_deposit_below_threshold.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_bank_deposit_below_threshold.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/invest/bank_deposit/below_threshold",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -9,13 +9,10 @@
     "category",
     "trip_scope",
     "sponsor_category",
-    "retirement_basis",
-    "retirement_undecided_basis",
+    "investment_vehicle",
     "secondhome_deposit_usd",
     "secondhome_state_bank",
     "secondhome_own_name",
-    "secondhome_passive_income_usd",
-    "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
@@ -39,7 +36,7 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["SECOND_HOME"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -108,12 +105,12 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 50000 },
     "secondhome.bank_deposit_at_state_bank": {
       "status": "KNOWN",
       "value": true
@@ -124,8 +121,8 @@
       "reason": "NOT_ASKED"
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "KNOWN",
-      "value": 1000000000
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_bank_deposit_below_threshold.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_bank_deposit_below_threshold.json
@@ -17,7 +17,7 @@
     "review_gate"
   ],
   "overrides": {
-    "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
@@ -117,8 +117,8 @@
     },
     "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
     "secondhome.qualifying_property_value_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 0
     },
     "secondhome.passive_monthly_income_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_property.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_property.json
@@ -108,17 +108,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "KNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_property_below_threshold.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_property_below_threshold.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/invest/property/below_threshold",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -9,13 +9,8 @@
     "category",
     "trip_scope",
     "sponsor_category",
-    "retirement_basis",
-    "retirement_undecided_basis",
-    "secondhome_deposit_usd",
-    "secondhome_state_bank",
-    "secondhome_own_name",
-    "secondhome_passive_income_usd",
-    "family_sponsor_confirmed",
+    "investment_vehicle",
+    "secondhome_property_value_usd",
     "stay_days",
     "review_gate"
   ],
@@ -39,7 +34,7 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["SECOND_HOME"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -108,24 +103,30 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
-    },
-    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
-    "secondhome.qualifying_property_value_usd": {
+    "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "secondhome.passive_monthly_income_usd": {
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
       "status": "KNOWN",
-      "value": 1000000000
+      "value": 500000
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_property_below_threshold.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_property_below_threshold.json
@@ -15,7 +15,7 @@
     "review_gate"
   ],
   "overrides": {
-    "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
@@ -108,17 +108,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "KNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_no_paid_activity.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_no_paid_activity.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/other/no_paid_activity",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -8,15 +8,11 @@
     "birth_date",
     "category",
     "trip_scope",
-    "sponsor_category",
-    "retirement_basis",
-    "retirement_undecided_basis",
-    "secondhome_deposit_usd",
-    "secondhome_state_bank",
-    "secondhome_own_name",
-    "secondhome_passive_income_usd",
+    "other_purpose",
+    "other_paid_activity",
     "family_sponsor_confirmed",
     "stay_days",
+    "entry_pattern",
     "review_gate"
   ],
   "overrides": {
@@ -39,10 +35,10 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["OTHER"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
     "intent.requested_product_code": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -112,20 +108,26 @@
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
+    "sponsor.type": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
-    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "KNOWN",
-      "value": 1000000000
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_employer_no.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_employer_no.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/other/paid/employer_no",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -8,15 +8,12 @@
     "birth_date",
     "category",
     "trip_scope",
-    "sponsor_category",
-    "retirement_basis",
-    "retirement_undecided_basis",
-    "secondhome_deposit_usd",
-    "secondhome_state_bank",
-    "secondhome_own_name",
-    "secondhome_passive_income_usd",
-    "family_sponsor_confirmed",
+    "other_purpose",
+    "other_paid_activity",
+    "work_payer",
+    "work_sponsor_confirmed",
     "stay_days",
+    "entry_pattern",
     "review_gate"
   ],
   "overrides": {
@@ -39,10 +36,10 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["EMPLOYMENT"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
     "intent.requested_product_code": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -51,10 +48,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "work.employer_is_indonesian_entity": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "work.employer_is_indonesian_entity": { "status": "KNOWN", "value": false },
     "work.serves_indonesian_clients": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -64,8 +58,8 @@
       "reason": "NOT_ASKED"
     },
     "work.indonesian_work_sponsor_confirmed": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": true
     },
     "investment.pt_pma_committed": {
       "status": "UNKNOWN",
@@ -108,24 +102,30 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
+    "sponsor.type": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
-    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "KNOWN",
-      "value": 1000000000
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_sponsor_unsure.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_sponsor_unsure.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/other/paid/sponsor_unsure",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -8,15 +8,12 @@
     "birth_date",
     "category",
     "trip_scope",
-    "sponsor_category",
-    "retirement_basis",
-    "retirement_undecided_basis",
-    "secondhome_deposit_usd",
-    "secondhome_state_bank",
-    "secondhome_own_name",
-    "secondhome_passive_income_usd",
-    "family_sponsor_confirmed",
+    "other_purpose",
+    "other_paid_activity",
+    "work_payer",
+    "work_sponsor_confirmed",
     "stay_days",
+    "entry_pattern",
     "review_gate"
   ],
   "overrides": {
@@ -39,10 +36,10 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["RETIREMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["EMPLOYMENT"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
     "intent.requested_product_code": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -51,10 +48,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "work.employer_is_indonesian_entity": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "work.employer_is_indonesian_entity": { "status": "KNOWN", "value": true },
     "work.serves_indonesian_clients": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -65,7 +59,7 @@
     },
     "work.indonesian_work_sponsor_confirmed": {
       "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "reason": "UNVERIFIED"
     },
     "investment.pt_pma_committed": {
       "status": "UNKNOWN",
@@ -108,24 +102,30 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
+    "sponsor.type": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
-    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "KNOWN",
-      "value": 1000000000
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_bank_deposit.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_bank_deposit.json
@@ -14,6 +14,7 @@
     "secondhome_state_bank",
     "secondhome_own_name",
     "secondhome_passive_income_usd",
+    "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
@@ -106,7 +107,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_bank_deposit_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_bank_deposit_age64.json
@@ -14,6 +14,7 @@
     "secondhome_state_bank",
     "secondhome_own_name",
     "secondhome_passive_income_usd",
+    "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
@@ -106,7 +107,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_bank_deposit_age64_below_threshold.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_bank_deposit_age64_below_threshold.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/retirement/bank_deposit/age64/below_threshold",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -10,7 +10,6 @@
     "trip_scope",
     "sponsor_category",
     "retirement_basis",
-    "retirement_undecided_basis",
     "secondhome_deposit_usd",
     "secondhome_state_bank",
     "secondhome_own_name",
@@ -20,7 +19,7 @@
     "review_gate"
   ],
   "overrides": {
-    "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
@@ -113,7 +112,7 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000 },
     "secondhome.bank_deposit_at_state_bank": {
       "status": "KNOWN",
       "value": true
@@ -125,7 +124,7 @@
     },
     "secondhome.passive_monthly_income_usd": {
       "status": "KNOWN",
-      "value": 1000000000
+      "value": 5000
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_family_sponsor.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_family_sponsor.json
@@ -109,17 +109,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_family_sponsor_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_family_sponsor_age64.json
@@ -109,17 +109,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_passive_income.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_passive_income.json
@@ -109,17 +109,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_passive_income_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_passive_income_age64.json
@@ -109,17 +109,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property.json
@@ -11,6 +11,8 @@
     "sponsor_category",
     "retirement_basis",
     "secondhome_property_value_usd",
+    "secondhome_passive_income_usd",
+    "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
@@ -103,7 +105,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -125,8 +127,8 @@
       "value": 1000000000
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 1000000000
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property.json
@@ -110,17 +110,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "KNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64.json
@@ -11,6 +11,8 @@
     "sponsor_category",
     "retirement_basis",
     "secondhome_property_value_usd",
+    "secondhome_passive_income_usd",
+    "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
@@ -103,7 +105,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
@@ -125,8 +127,8 @@
       "value": 1000000000
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 1000000000
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64.json
@@ -110,17 +110,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "KNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64_sponsor_no.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64_sponsor_no.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/retirement/property/age64/sponsor_no",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -10,17 +10,14 @@
     "trip_scope",
     "sponsor_category",
     "retirement_basis",
-    "retirement_undecided_basis",
-    "secondhome_deposit_usd",
-    "secondhome_state_bank",
-    "secondhome_own_name",
+    "secondhome_property_value_usd",
     "secondhome_passive_income_usd",
     "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
   "overrides": {
-    "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
@@ -90,7 +87,7 @@
     },
     "family.sponsor_status_code": {
       "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "reason": "NOT_APPLICABLE"
     },
     "family.marriage_registered": {
       "status": "UNKNOWN",
@@ -106,22 +103,28 @@
     },
     "family.sponsor_permit_basis": {
       "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "reason": "NOT_APPLICABLE"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": false },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
-    },
-    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
-    "secondhome.qualifying_property_value_usd": {
+    "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "KNOWN",
+      "value": 1000000000
     },
     "secondhome.passive_monthly_income_usd": {
       "status": "KNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64_sponsor_no.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_property_age64_sponsor_no.json
@@ -110,17 +110,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "KNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64.json
@@ -10,6 +10,12 @@
     "trip_scope",
     "sponsor_category",
     "retirement_basis",
+    "retirement_undecided_basis",
+    "secondhome_deposit_usd",
+    "secondhome_state_bank",
+    "secondhome_own_name",
+    "secondhome_passive_income_usd",
+    "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
@@ -102,30 +108,24 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": true
     },
-    "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 1000000000
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64_family_sponsor.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64_family_sponsor.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/retirement/undecided/age64/family_sponsor",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -11,16 +11,13 @@
     "sponsor_category",
     "retirement_basis",
     "retirement_undecided_basis",
-    "secondhome_deposit_usd",
-    "secondhome_state_bank",
-    "secondhome_own_name",
     "secondhome_passive_income_usd",
     "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
   "overrides": {
-    "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
@@ -113,12 +110,18 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
-    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64_family_sponsor.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64_family_sponsor.json
@@ -110,17 +110,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64_still_unsure.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_retirement_undecided_age64_still_unsure.json
@@ -1,5 +1,5 @@
 {
-  "label": "offshore/retirement/undecided",
+  "label": "offshore/retirement/undecided/age64/still_unsure",
   "asked": [
     "in_indonesia",
     "holds_stay_permit",
@@ -11,16 +11,11 @@
     "sponsor_category",
     "retirement_basis",
     "retirement_undecided_basis",
-    "secondhome_deposit_usd",
-    "secondhome_state_bank",
-    "secondhome_own_name",
-    "secondhome_passive_income_usd",
-    "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
   "overrides": {
-    "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
+    "person.birth_date": { "status": "KNOWN", "value": "1961-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
@@ -108,24 +103,30 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
+    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "KNOWN", "value": "NONE" },
-    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 1000000000 },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
-    "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "KNOWN",
-      "value": 1000000000
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "process.application_channel": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_second_home_bank_deposit.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_second_home_bank_deposit.json
@@ -116,8 +116,8 @@
     },
     "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
     "secondhome.qualifying_property_value_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 0
     },
     "secondhome.passive_monthly_income_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_second_home_property.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_second_home_property.json
@@ -107,17 +107,14 @@
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "sponsor.type": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "secondhome.bank_deposit_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "secondhome.bank_deposit_usd": { "status": "KNOWN", "value": 0 },
     "secondhome.bank_deposit_at_state_bank": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": false
     },
     "secondhome.qualifying_property_value_usd": {
       "status": "KNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_retirement.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_retirement.json
@@ -18,6 +18,7 @@
     "secondhome_state_bank",
     "secondhome_own_name",
     "secondhome_passive_income_usd",
+    "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
@@ -107,7 +108,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_retirement_age64.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_retirement_age64.json
@@ -18,6 +18,7 @@
     "secondhome_state_bank",
     "secondhome_own_name",
     "secondhome_passive_income_usd",
+    "family_sponsor_confirmed",
     "stay_days",
     "review_gate"
   ],
@@ -107,7 +108,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_second_home.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/onshore_second_home.json
@@ -117,8 +117,8 @@
     },
     "secondhome.bank_deposit_in_own_name": { "status": "KNOWN", "value": true },
     "secondhome.qualifying_property_value_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 0
     },
     "secondhome.passive_monthly_income_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
@@ -273,24 +273,35 @@ class DeadEnd:
 #: ask `family_sponsor_confirmed` too (flow.ts) — measured 2026-09-13,
 #: `offshore/retirement/property/age64` now answers `SUPPORTED_CANDIDATES
 #: [E33F]` and `offshore/retirement/undecided/age64` answers
-#: `SUPPORTED_CANDIDATES [E33E, E33F]`. Five NEW dead ends replace them,
-#: none a re-hash of the old shape:
+#: `SUPPORTED_CANDIDATES [E33E, E33F]`.
 #:
-#: - `offshore/invest/property/below_threshold` and `offshore/retirement/
-#:   property/age64/sponsor_no`: once the CHOSEN basis fails (below
-#:   threshold, or the sponsor fallback denied) with no decisive candidate,
-#:   the evaluator surfaces the DEPOSIT trio as still-missing even though
-#:   this walk's own branch never asks it (D3-1/D3-3 deliberately narrow
-#:   each vehicle/basis to its own evidence) — a genuine `QUESTION_NOT_IN_
-#:   THIS_WALK` dead end, and `engine-adapter.ts`'s `questionForFact` cannot
-#:   offer it as a follow-up either (no OTHER category reaches it without
-#:   ALSO setting the sibling vehicle/basis fact), so the applicant sees the
-#:   generic fallback message, not a named one. Reported as a finding, not
-#:   cured here (see the PR body / implementer report): asking the sibling
-#:   evidence unconditionally would defeat the whole point of narrowing to
-#:   the declared basis.
-#: - `offshore/invest/bank_deposit/below_threshold`: the mirror image —
-#:   `secondhome.qualifying_property_value_usd` missing, same reasoning.
+#: A first pass of D3-3 landed with 5 rows: `family_sponsor_confirmed`'s
+#: cure exposed a TWIN pattern on `offshore/invest/property/below_threshold`,
+#: `offshore/invest/bank_deposit/below_threshold` and `offshore/retirement/
+#: property/age64/sponsor_no` — once the CHOSEN basis fails, `el.e33.
+#: property-basis` / `el.e33.deposit-basis` / `el.e33e.retirement`
+#: (`on_unknown: NEEDS_INPUT`, verified against rulepack-prod-020.
+#: source.json) surface the TWIN, unasked basis's facts as still-missing,
+#: because "unknown AND known" does not short-circuit the way "known-false
+#: AND known" does. Owner ruling 2026-09-13: closed, not allowlisted — a
+#: below-threshold answer on a Second Home base is a definitive negative
+#: ("I did not claim a deposit/property via this route"), not an unresolved
+#: one, so `mapOracleFactsToApplicantFacts` (fact-mapper.ts,
+#: `depositBasisDecisivelyNotChosen` / `propertyBasisDecisivelyNotChosen`)
+#: now emits the twin basis's facts as KNOWN(0)/KNOWN(false) whenever the
+#: interview has decisively routed to the OTHER basis — turning the rule's
+#: own AND definitively false instead of leaving it unknown. Measured
+#: 2026-09-13: all three now answer `NO_SUPPORTED_PATH` with `missing_facts
+#: == []`. The two `invest` walks reach `OPERATIONAL_NO_PRODUCT_MATCHES_
+#: DECLARED_PURPOSES` (the pack has no EXCLUDE-type reason naming this
+#: threshold — a SUPPORT rule that fails to fire emits no reason_code of its
+#: own), which `engine-adapter.ts`'s `secondHomeBelowThresholdReason` now
+#: renders naming the applicant's declared value and the exact USD
+#: threshold instead of the generic catalogue sentence. The retirement walk
+#: reaches the pre-existing, now-reachable-for-the-first-time
+#: `SPONSOR_REQUIRED` (`hf.e33f.sponsor-required`), given real copy in the
+#: same PR. Two rows remain, neither this pattern:
+#:
 #: - `offshore/other/paid/sponsor_unsure`: `work_sponsor_confirmed` IS asked
 #:   on this walk (D3-2's employment route) and the mapper refuses to
 #:   certify "unsure" — `ANSWER_NEVER_CERTIFIED`, correctly nameable as a
@@ -302,52 +313,11 @@ class DeadEnd:
 #:   follow-up (asked unconditionally by the `family`/`diaspora`/`invest`/
 #:   `other` categories, which is what `followUpPrerequisitesMet` checks).
 WALK_DEAD_END_ALLOWLIST: dict[str, tuple[DeadEnd, ...]] = {
-    "offshore/invest/property/below_threshold": (
-        DeadEnd(
-            fact="secondhome.bank_deposit_usd",
-            source_question="secondhome_deposit_usd",
-            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
-        ),
-        DeadEnd(
-            fact="secondhome.bank_deposit_at_state_bank",
-            source_question="secondhome_state_bank",
-            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
-        ),
-        DeadEnd(
-            fact="secondhome.bank_deposit_in_own_name",
-            source_question="secondhome_own_name",
-            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
-        ),
-    ),
-    "offshore/invest/bank_deposit/below_threshold": (
-        DeadEnd(
-            fact="secondhome.qualifying_property_value_usd",
-            source_question="secondhome_property_value_usd",
-            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
-        ),
-    ),
     "offshore/other/paid/sponsor_unsure": (
         DeadEnd(
             fact="work.indonesian_work_sponsor_confirmed",
             source_question="work_sponsor_confirmed",
             why_unaskable=ANSWER_NEVER_CERTIFIED,
-        ),
-    ),
-    "offshore/retirement/property/age64/sponsor_no": (
-        DeadEnd(
-            fact="secondhome.bank_deposit_usd",
-            source_question="secondhome_deposit_usd",
-            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
-        ),
-        DeadEnd(
-            fact="secondhome.bank_deposit_at_state_bank",
-            source_question="secondhome_state_bank",
-            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
-        ),
-        DeadEnd(
-            fact="secondhome.bank_deposit_in_own_name",
-            source_question="secondhome_own_name",
-            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
         ),
     ),
     "offshore/retirement/undecided/age64/still_unsure": (
@@ -421,12 +391,15 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "offshore/invest/property": ("SUPPORTED_CANDIDATES", ("E33",)),
     "offshore/invest/pt_pma": ("SUPPORTED_CANDIDATES", ("C2",)),
     "offshore/invest/undecided": ("SUPPORTED_CANDIDATES", ("C2",)),
-    # C1 gate (PR-D3): below-threshold walks for D3-1's re-route. See
-    # WALK_DEAD_END_ALLOWLIST above for why these are NEEDS_INPUT rather than
-    # the NO_SUPPORTED_PATH the spec's walk list expected — measured, not
-    # bent to fit.
-    "offshore/invest/property/below_threshold": ("NEEDS_INPUT", ()),
-    "offshore/invest/bank_deposit/below_threshold": ("NEEDS_INPUT", ()),
+    # C1 gate (PR-D3): below-threshold walks for D3-1's re-route. Owner
+    # ruling 2026-09-13 CLOSED the twin-base dead end this pattern first
+    # produced (see WALK_DEAD_END_ALLOWLIST above) — `fact-mapper.ts` now
+    # emits the twin basis's facts as KNOWN(0)/KNOWN(false), which resolves
+    # `el.e33.property-basis`/`el.e33.deposit-basis` decisively instead of
+    # leaving them unknown. `birth_date` is overridden past 55 on both so the
+    # reason is the actual threshold story, not an unrelated AGE_BELOW_55.
+    "offshore/invest/property/below_threshold": ("NO_SUPPORTED_PATH", ()),
+    "offshore/invest/bank_deposit/below_threshold": ("NO_SUPPORTED_PATH", ()),
     # D3-2 (PR-D3): `other_paid_activity`'s first option is `yes`, so this
     # walk now routes to the two employment facts `el.e23-employment-support`
     # reads and `mapPurposes` emits EMPLOYMENT alone; both facts default to
@@ -464,9 +437,12 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     # D3-3 (PR-D3): CURED — `property` now asks `family_sponsor_confirmed`
     # (default "yes"), so this walk answers E33F instead of dead-ending.
     "offshore/retirement/property/age64": ("SUPPORTED_CANDIDATES", ("E33F",)),
-    # C1 gate (PR-D3): the negative sponsor sub-branch. See
-    # WALK_DEAD_END_ALLOWLIST above for why this stays NEEDS_INPUT.
-    "offshore/retirement/property/age64/sponsor_no": ("NEEDS_INPUT", ()),
+    # C1 gate (PR-D3): the negative sponsor sub-branch. Owner ruling
+    # 2026-09-13 CLOSED this (same twin-base fix as the invest walks above)
+    # — `SPONSOR_REQUIRED` (`hf.e33f.sponsor-required`) now decides it, given
+    # real copy in the same PR (previously unreachable, would have fallen
+    # through to a raw code dump).
+    "offshore/retirement/property/age64/sponsor_no": ("NO_SUPPORTED_PATH", ()),
     "offshore/retirement/undecided": ("NO_SUPPORTED_PATH", ()),
     # D3-3 (PR-D3): CURED — `undecided` now asks `retirement_undecided_basis`
     # first; its default "deposit_or_income" answer routes through the full
@@ -525,13 +501,11 @@ EXPECTED_STATE_CENSUS: dict[str, int] = dict(
 #: `retirement` branch just doesn't route these two bases to the question
 #: that supplies it.
 #: PR-D3: the old `family.sponsor_confirmed: 2` (property/undecided age64)
-#: is cured; the 5 new dead ends (WALK_DEAD_END_ALLOWLIST above) replace it —
-#: the deposit trio appears twice (once per walk that dead-ends on it).
+#: is cured. The twin-base dead ends (below-threshold invest × 2,
+#: retirement/property/sponsor_no) are CLOSED (owner ruling 2026-09-13, see
+#: WALK_DEAD_END_ALLOWLIST above) rather than allowlisted, so they never
+#: reach NEEDS_INPUT and never appear here. Two facts remain, one each.
 EXPECTED_DEAD_END_FACT_CENSUS: dict[str, int] = {
-    "secondhome.bank_deposit_usd": 2,
-    "secondhome.bank_deposit_at_state_bank": 2,
-    "secondhome.bank_deposit_in_own_name": 2,
-    "secondhome.qualifying_property_value_usd": 1,
     "work.indonesian_work_sponsor_confirmed": 1,
     "family.sponsor_confirmed": 1,
 }
@@ -738,7 +712,7 @@ def test_every_walk_ends_in_its_pinned_outcome(outcomes: dict[str, dict[str, Any
     assert not violations, "interview-walk outcomes moved:\n  " + "\n  ".join(violations)
 
 
-def test_walk_state_census_is_5_dead_ends_11_no_paths_and_62_answers(
+def test_walk_state_census_is_2_dead_ends_14_no_paths_and_62_answers(
     outcomes: dict[str, dict[str, Any]],
 ) -> None:
     """The headline number of the decisiveness wave. Every PR that changes it
@@ -747,28 +721,31 @@ def test_walk_state_census_is_5_dead_ends_11_no_paths_and_62_answers(
     36/0/7 on seq-19; 21/0/22 once the signed seq-20 bundle's stay-day
     widening landed; 11/10/22 with PR-2's reorder on top; 0/10/51 over a
     43 → 61 corpus with PR-3's interview; 2/10/55 over a 61 → 67 corpus with
-    PR-5's age dimension on top; 5/11/62 over a 67 → 78 corpus with PR-D3
+    PR-5's age dimension on top; 2/14/62 over a 67 → 78 corpus with PR-D3
     (module docstring). PR-D3 CURES the 2 PR-5 dead ends
     (`offshore/retirement/property/age64` and `.../undecided/age64` both now
-    answer) and adds 11 new walks: 5 NEED_INPUT (the WALK_DEAD_END_ALLOWLIST
-    rows above), 1 NO_SUPPORTED_PATH (`offshore/other/paid/employer_no`), 5
-    SUPPORTED_CANDIDATES. Net: NEEDS_INPUT 2→0→5, NO_SUPPORTED_PATH
-    10→10→11, SUPPORTED_CANDIDATES 55→57→62."""
+    answer) and adds 11 new walks. A first pass left 5 of those 11
+    NEEDS_INPUT; owner ruling 2026-09-13 CLOSED 3 of them (the below-
+    threshold twin-base pattern, WALK_DEAD_END_ALLOWLIST above) to
+    NO_SUPPORTED_PATH instead of allowlisting them. Final split of the 11:
+    2 NEEDS_INPUT, 4 NO_SUPPORTED_PATH (`offshore/other/paid/employer_no`
+    plus the 3 closed dead ends), 5 SUPPORTED_CANDIDATES. Net: NEEDS_INPUT
+    2→0→2, NO_SUPPORTED_PATH 10→10→14, SUPPORTED_CANDIDATES 55→57→62."""
 
     census = dict(Counter(outcome["state"] for outcome in outcomes.values()))
     assert census == EXPECTED_STATE_CENSUS == {
-        "NEEDS_INPUT": 5,
-        "NO_SUPPORTED_PATH": 11,
+        "NEEDS_INPUT": 2,
+        "NO_SUPPORTED_PATH": 14,
         "SUPPORTED_CANDIDATES": 62,
     }
-    assert census["NEEDS_INPUT"] == 5
+    assert census["NEEDS_INPUT"] == 2
     # NOT a claim about production. The corpus carries no disclosure flags, so
     # the review arm of `apply_public_policy_adapters` is unreachable from
     # here by construction: this line says the FIXTURES trigger no review, and
     # a regression that adds a disclosure flag passes it invisibly. Bound 1 of
     # the module docstring, with the measurement.
     assert census.get("HUMAN_REVIEW_REQUIRED", 0) == 0
-    assert census["NO_SUPPORTED_PATH"] == 11
+    assert census["NO_SUPPORTED_PATH"] == 14
 
 
 def test_dead_end_fact_census_matches_the_blocking_fact_table(
@@ -873,26 +850,25 @@ def test_no_walk_dead_ends_outside_the_allowlist(outcomes: dict[str, dict[str, A
     assert not violations, "walk-census invariant broken:\n  " + "\n  ".join(violations)
 
 
-def test_allowlist_has_exactly_the_five_pr_d3_rows() -> None:
+def test_allowlist_has_exactly_the_two_pr_d3_rows() -> None:
     """PR-3's deliverable — ``len(...) == 0`` — held for exactly one wave;
     PR-5 reopened it with 2 rows; THIS PR (PR-D3) CURES both of PR-5's rows
-    (both retirement age64 walks now answer) and opens it again with 5
-    DIFFERENT rows, none a re-hash of PR-5's shape — see
-    `WALK_DEAD_END_ALLOWLIST`'s module-level comment for each row's reason.
+    (both retirement age64 walks now answer). A first pass opened it again
+    with 5 new rows; owner ruling 2026-09-13 CLOSED 3 of them (the
+    below-threshold twin-base pattern) rather than allowlist them — see
+    `WALK_DEAD_END_ALLOWLIST`'s module-level comment. 2 rows remain, neither
+    a re-hash of PR-5's shape.
 
-    An equality against a named 5-row dict is still not a loosened count in
+    An equality against a named 2-row dict is still not a loosened count in
     the sense PR-3 warned about: it names every row explicitly, and any
     additional row — however well argued — still has to move this literal in
     the PR that adds it."""
 
     assert set(WALK_DEAD_END_ALLOWLIST) == {
-        "offshore/invest/property/below_threshold",
-        "offshore/invest/bank_deposit/below_threshold",
         "offshore/other/paid/sponsor_unsure",
-        "offshore/retirement/property/age64/sponsor_no",
         "offshore/retirement/undecided/age64/still_unsure",
     }
-    assert len(WALK_DEAD_END_ALLOWLIST) == 5
+    assert len(WALK_DEAD_END_ALLOWLIST) == 2
 
 
 def _unaskable_violations(

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
@@ -269,15 +269,88 @@ class DeadEnd:
 #: Never add a row without an anchor showing the fact is genuinely unaskable
 #: in that walk — and prefer curing it, which is what every row before THIS
 #: PR became.
+#: PR-D3 (D3-3) cures BOTH rows above by making `property` and `undecided`
+#: ask `family_sponsor_confirmed` too (flow.ts) — measured 2026-09-13,
+#: `offshore/retirement/property/age64` now answers `SUPPORTED_CANDIDATES
+#: [E33F]` and `offshore/retirement/undecided/age64` answers
+#: `SUPPORTED_CANDIDATES [E33E, E33F]`. Five NEW dead ends replace them,
+#: none a re-hash of the old shape:
+#:
+#: - `offshore/invest/property/below_threshold` and `offshore/retirement/
+#:   property/age64/sponsor_no`: once the CHOSEN basis fails (below
+#:   threshold, or the sponsor fallback denied) with no decisive candidate,
+#:   the evaluator surfaces the DEPOSIT trio as still-missing even though
+#:   this walk's own branch never asks it (D3-1/D3-3 deliberately narrow
+#:   each vehicle/basis to its own evidence) — a genuine `QUESTION_NOT_IN_
+#:   THIS_WALK` dead end, and `engine-adapter.ts`'s `questionForFact` cannot
+#:   offer it as a follow-up either (no OTHER category reaches it without
+#:   ALSO setting the sibling vehicle/basis fact), so the applicant sees the
+#:   generic fallback message, not a named one. Reported as a finding, not
+#:   cured here (see the PR body / implementer report): asking the sibling
+#:   evidence unconditionally would defeat the whole point of narrowing to
+#:   the declared basis.
+#: - `offshore/invest/bank_deposit/below_threshold`: the mirror image —
+#:   `secondhome.qualifying_property_value_usd` missing, same reasoning.
+#: - `offshore/other/paid/sponsor_unsure`: `work_sponsor_confirmed` IS asked
+#:   on this walk (D3-2's employment route) and the mapper refuses to
+#:   certify "unsure" — `ANSWER_NEVER_CERTIFIED`, correctly nameable as a
+#:   follow-up since the question is already in this walk's own history.
+#: - `offshore/retirement/undecided/age64/still_unsure`: the honest
+#:   non-answer D3-3 asks for — no evidence question follows a genuine "I
+#:   still can't say", so `family.sponsor_confirmed` stays unknown exactly
+#:   as it did pre-cure, but `family_sponsor_confirmed` IS nameable as a
+#:   follow-up (asked unconditionally by the `family`/`diaspora`/`invest`/
+#:   `other` categories, which is what `followUpPrerequisitesMet` checks).
 WALK_DEAD_END_ALLOWLIST: dict[str, tuple[DeadEnd, ...]] = {
-    "offshore/retirement/property/age64": (
+    "offshore/invest/property/below_threshold": (
         DeadEnd(
-            fact="family.sponsor_confirmed",
-            source_question="family_sponsor_confirmed",
+            fact="secondhome.bank_deposit_usd",
+            source_question="secondhome_deposit_usd",
+            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
+        ),
+        DeadEnd(
+            fact="secondhome.bank_deposit_at_state_bank",
+            source_question="secondhome_state_bank",
+            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
+        ),
+        DeadEnd(
+            fact="secondhome.bank_deposit_in_own_name",
+            source_question="secondhome_own_name",
             why_unaskable=QUESTION_NOT_IN_THIS_WALK,
         ),
     ),
-    "offshore/retirement/undecided/age64": (
+    "offshore/invest/bank_deposit/below_threshold": (
+        DeadEnd(
+            fact="secondhome.qualifying_property_value_usd",
+            source_question="secondhome_property_value_usd",
+            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
+        ),
+    ),
+    "offshore/other/paid/sponsor_unsure": (
+        DeadEnd(
+            fact="work.indonesian_work_sponsor_confirmed",
+            source_question="work_sponsor_confirmed",
+            why_unaskable=ANSWER_NEVER_CERTIFIED,
+        ),
+    ),
+    "offshore/retirement/property/age64/sponsor_no": (
+        DeadEnd(
+            fact="secondhome.bank_deposit_usd",
+            source_question="secondhome_deposit_usd",
+            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
+        ),
+        DeadEnd(
+            fact="secondhome.bank_deposit_at_state_bank",
+            source_question="secondhome_state_bank",
+            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
+        ),
+        DeadEnd(
+            fact="secondhome.bank_deposit_in_own_name",
+            source_question="secondhome_own_name",
+            why_unaskable=QUESTION_NOT_IN_THIS_WALK,
+        ),
+    ),
+    "offshore/retirement/undecided/age64/still_unsure": (
         DeadEnd(
             fact="family.sponsor_confirmed",
             source_question="family_sponsor_confirmed",
@@ -320,6 +393,21 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "offshore/family/SPOUSE/spNat=IT": ("SUPPORTED_CANDIDATES", ("C1",)),
     "offshore/family/STEPCHILD/spNat=ID": ("SUPPORTED_CANDIDATES", ("C1", "E31D")),
     "offshore/family/STEPCHILD/spNat=IT": ("SUPPORTED_CANDIDATES", ("C1", "E31D")),
+    # D3-4 (PR-D3): the sponsor-permit question is HUMAN_CONTEXT — no seq-20
+    # rule reads it, so these two walks carry the IDENTICAL wire facts as
+    # the "yes" walk above and answer identically at THIS (backend, no-flag)
+    # layer. The frontend-only AMBIGUOUS_SPONSOR hold this question raises
+    # for `no`/`unsure` is verified separately in fact-mapper.test.ts /
+    # activity-boundary.test.ts — this file cannot see disclosed flags at
+    # all (module docstring, bound 1).
+    "offshore/family/STEPCHILD/spNat=ID/sponsor_permit_no": (
+        "SUPPORTED_CANDIDATES",
+        ("C1", "E31D"),
+    ),
+    "offshore/family/STEPCHILD/spNat=ID/sponsor_permit_unsure": (
+        "SUPPORTED_CANDIDATES",
+        ("C1", "E31D"),
+    ),
     "offshore/holdsPermit/current/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
     # D3-1 (PR-D3, owner ruling SHWEB-20260911): `property`/`bank_deposit`
     # now route to Second Home — `mapPurposes` emits SECOND_HOME alone, never
@@ -333,23 +421,66 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "offshore/invest/property": ("SUPPORTED_CANDIDATES", ("E33",)),
     "offshore/invest/pt_pma": ("SUPPORTED_CANDIDATES", ("C2",)),
     "offshore/invest/undecided": ("SUPPORTED_CANDIDATES", ("C2",)),
+    # C1 gate (PR-D3): below-threshold walks for D3-1's re-route. See
+    # WALK_DEAD_END_ALLOWLIST above for why these are NEEDS_INPUT rather than
+    # the NO_SUPPORTED_PATH the spec's walk list expected — measured, not
+    # bent to fit.
+    "offshore/invest/property/below_threshold": ("NEEDS_INPUT", ()),
+    "offshore/invest/bank_deposit/below_threshold": ("NEEDS_INPUT", ()),
     # D3-2 (PR-D3): `other_paid_activity`'s first option is `yes`, so this
     # walk now routes to the two employment facts `el.e23-employment-support`
     # reads and `mapPurposes` emits EMPLOYMENT alone; both facts default to
     # `yes`/true (`answerFor`'s first-option rule), so E23 answers instead of
     # C6.
+    # C2 gate (PR-D3): the `paid = no` walk that must actually yield C6 —
+    # `offshore/other`'s own default now answers `yes` (D3-2, EMPLOYMENT/E23,
+    # comment above), so this is the walk that proves C6 is deliverable.
+    "offshore/other/no_paid_activity": ("SUPPORTED_CANDIDATES", ("C6",)),
+    # C1 gate (PR-D3): the two negative D3-2 facts.
     "offshore/other": ("SUPPORTED_CANDIDATES", ("E23",)),
+    "offshore/other/paid/employer_no": ("NO_SUPPORTED_PATH", ()),
+    "offshore/other/paid/sponsor_unsure": ("NEEDS_INPUT", ()),
     "offshore/remote": ("NO_SUPPORTED_PATH", ()),
     "offshore/retirement/bank_deposit": ("NO_SUPPORTED_PATH", ()),
-    "offshore/retirement/bank_deposit/age64": ("SUPPORTED_CANDIDATES", ("E33E",)),
+    # D3-3 (PR-D3): now ALSO asks `family_sponsor_confirmed` (default "yes"),
+    # and the corpus's canned passive-income default clears E33F's own
+    # USD 3,000 floor too, so both products answer together.
+    "offshore/retirement/bank_deposit/age64": (
+        "SUPPORTED_CANDIDATES",
+        ("E33E", "E33F"),
+    ),
+    # D3-3 (PR-D3): the funnel census's LARGEST dead end (30 production
+    # walks) — below both E33 thresholds, cured only by the family-sponsor
+    # fallback `property`/`bank_deposit`/`undecided` now all ask.
+    "offshore/retirement/bank_deposit/age64/below_threshold": (
+        "SUPPORTED_CANDIDATES",
+        ("E33F",),
+    ),
     "offshore/retirement/family_sponsor": ("NO_SUPPORTED_PATH", ()),
     "offshore/retirement/family_sponsor/age64": ("SUPPORTED_CANDIDATES", ("E33F",)),
     "offshore/retirement/passive_income": ("NO_SUPPORTED_PATH", ()),
     "offshore/retirement/passive_income/age64": ("SUPPORTED_CANDIDATES", ("E33F",)),
     "offshore/retirement/property": ("NO_SUPPORTED_PATH", ()),
-    "offshore/retirement/property/age64": ("NEEDS_INPUT", ()),
+    # D3-3 (PR-D3): CURED — `property` now asks `family_sponsor_confirmed`
+    # (default "yes"), so this walk answers E33F instead of dead-ending.
+    "offshore/retirement/property/age64": ("SUPPORTED_CANDIDATES", ("E33F",)),
+    # C1 gate (PR-D3): the negative sponsor sub-branch. See
+    # WALK_DEAD_END_ALLOWLIST above for why this stays NEEDS_INPUT.
+    "offshore/retirement/property/age64/sponsor_no": ("NEEDS_INPUT", ()),
     "offshore/retirement/undecided": ("NO_SUPPORTED_PATH", ()),
-    "offshore/retirement/undecided/age64": ("NEEDS_INPUT", ()),
+    # D3-3 (PR-D3): CURED — `undecided` now asks `retirement_undecided_basis`
+    # first; its default "deposit_or_income" answer routes through the full
+    # deposit-basis evidence set, clearing E33E, AND `family_sponsor_confirmed`
+    # (default "yes") clears E33F too — both answer.
+    "offshore/retirement/undecided/age64": (
+        "SUPPORTED_CANDIDATES",
+        ("E33E", "E33F"),
+    ),
+    "offshore/retirement/undecided/age64/family_sponsor": (
+        "SUPPORTED_CANDIDATES",
+        ("E33F",),
+    ),
+    "offshore/retirement/undecided/age64/still_unsure": ("NEEDS_INPUT", ()),
     "offshore/second_home/bank_deposit": ("SUPPORTED_CANDIDATES", ("E33",)),
     "offshore/second_home/property": ("SUPPORTED_CANDIDATES", ("E33",)),
     "offshore/study": ("SUPPORTED_CANDIDATES", ("E30", "E30A")),
@@ -365,7 +496,11 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "onshore/other": ("SUPPORTED_CANDIDATES", ("E23",)),
     "onshore/remote": ("NO_SUPPORTED_PATH", ()),
     "onshore/retirement": ("NO_SUPPORTED_PATH", ()),
-    "onshore/retirement/age64": ("SUPPORTED_CANDIDATES", ("E33E",)),
+    # D3-3 (PR-D3): this walk never overrides `retirement_basis`, so it
+    # answers via the tree's own first-option default ("bank_deposit") —
+    # same shape and same fix as `offshore/retirement/bank_deposit/age64`
+    # above.
+    "onshore/retirement/age64": ("SUPPORTED_CANDIDATES", ("E33E", "E33F")),
     "onshore/second_home": ("SUPPORTED_CANDIDATES", ("E33",)),
     "onshore/study": ("SUPPORTED_CANDIDATES", ("E30", "E30A")),
     "onshore/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
@@ -389,7 +524,17 @@ EXPECTED_STATE_CENSUS: dict[str, int] = dict(
 #: `WALK_DEAD_END_ALLOWLIST` above) — this pack's rules still ask for it, the
 #: `retirement` branch just doesn't route these two bases to the question
 #: that supplies it.
-EXPECTED_DEAD_END_FACT_CENSUS: dict[str, int] = {"family.sponsor_confirmed": 2}
+#: PR-D3: the old `family.sponsor_confirmed: 2` (property/undecided age64)
+#: is cured; the 5 new dead ends (WALK_DEAD_END_ALLOWLIST above) replace it —
+#: the deposit trio appears twice (once per walk that dead-ends on it).
+EXPECTED_DEAD_END_FACT_CENSUS: dict[str, int] = {
+    "secondhome.bank_deposit_usd": 2,
+    "secondhome.bank_deposit_at_state_bank": 2,
+    "secondhome.bank_deposit_in_own_name": 2,
+    "secondhome.qualifying_property_value_usd": 1,
+    "work.indonesian_work_sponsor_confirmed": 1,
+    "family.sponsor_confirmed": 1,
+}
 
 
 def _load_walks() -> dict[str, dict[str, Any]]:
@@ -565,19 +710,23 @@ def outcomes(walks: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return _evaluate_walks(walks)
 
 
-def test_corpus_is_the_67_real_interview_walks(walks: dict[str, dict[str, Any]]) -> None:
+def test_corpus_is_the_78_real_interview_walks(walks: dict[str, dict[str, Any]]) -> None:
     """An empty or shrunken corpus fails loudly: a census that passes because
     nobody fed it any walks is the green-but-dead shape (cicatrix #2).
 
-    43 before PR-3, 61 before THIS PR. PR-5's 6 new walks are the 5 offshore
-    `retirement` bases plus the onshore neutral `retirement` walk, each
-    replayed with `birth_date` overridden to `RETIREMENT_AGE_64_BIRTH_DATE`
-    (age 64 on `CORPUS_TODAY`) instead of the corpus-wide default 25 — the
-    generator's own age dimension, not a new tree branch. Every OTHER walk in
-    the corpus is unchanged, byte-for-byte, because `birth_date` is a spine
-    question no branch reads."""
+    43 before PR-3, 61 before PR-5, 67 before PR-D3. PR-5's 6 new walks are
+    the 5 offshore `retirement` bases plus the onshore neutral `retirement`
+    walk, each replayed with `birth_date` overridden to
+    `RETIREMENT_AGE_64_BIRTH_DATE` (age 64 on `CORPUS_TODAY`) instead of the
+    corpus-wide default 25 — the generator's own age dimension, not a new
+    tree branch. PR-D3's 11 new walks are real new branches: the two
+    invest-vehicle below-threshold routes, the three declared-paid-activity
+    branches, the retirement property/bank_deposit/undecided branches that
+    used to dead-end, and the two new STEPCHILD sponsor-permit answers — see
+    `generate-walk-corpus.ts`. Every OTHER walk in the corpus is unchanged,
+    byte-for-byte."""
 
-    assert len(walks) == 67, f"expected 67 interview walks, found {len(walks)}"
+    assert len(walks) == 78, f"expected 78 interview walks, found {len(walks)}"
     assert sorted(walks) == sorted(EXPECTED_OUTCOME), "corpus and EXPECTED_OUTCOME disagree"
     for label, spec in walks.items():
         assert spec["asked"], f"{label}: walk carries no asked-question history"
@@ -589,7 +738,7 @@ def test_every_walk_ends_in_its_pinned_outcome(outcomes: dict[str, dict[str, Any
     assert not violations, "interview-walk outcomes moved:\n  " + "\n  ".join(violations)
 
 
-def test_walk_state_census_is_2_dead_ends_10_no_paths_and_55_answers(
+def test_walk_state_census_is_5_dead_ends_11_no_paths_and_62_answers(
     outcomes: dict[str, dict[str, Any]],
 ) -> None:
     """The headline number of the decisiveness wave. Every PR that changes it
@@ -598,29 +747,28 @@ def test_walk_state_census_is_2_dead_ends_10_no_paths_and_55_answers(
     36/0/7 on seq-19; 21/0/22 once the signed seq-20 bundle's stay-day
     widening landed; 11/10/22 with PR-2's reorder on top; 0/10/51 over a
     43 → 61 corpus with PR-3's interview; 2/10/55 over a 61 → 67 corpus with
-    THIS PR's age dimension on top (module docstring). The 2 NEEDS_INPUT are
-    new walks, not moved ones: `offshore/retirement/property/age64` and
-    `offshore/retirement/undecided/age64`, both allowlisted above."""
+    PR-5's age dimension on top; 5/11/62 over a 67 → 78 corpus with PR-D3
+    (module docstring). PR-D3 CURES the 2 PR-5 dead ends
+    (`offshore/retirement/property/age64` and `.../undecided/age64` both now
+    answer) and adds 11 new walks: 5 NEED_INPUT (the WALK_DEAD_END_ALLOWLIST
+    rows above), 1 NO_SUPPORTED_PATH (`offshore/other/paid/employer_no`), 5
+    SUPPORTED_CANDIDATES. Net: NEEDS_INPUT 2→0→5, NO_SUPPORTED_PATH
+    10→10→11, SUPPORTED_CANDIDATES 55→57→62."""
 
     census = dict(Counter(outcome["state"] for outcome in outcomes.values()))
     assert census == EXPECTED_STATE_CENSUS == {
-        "NEEDS_INPUT": 2,
-        "NO_SUPPORTED_PATH": 10,
-        "SUPPORTED_CANDIDATES": 55,
+        "NEEDS_INPUT": 5,
+        "NO_SUPPORTED_PATH": 11,
+        "SUPPORTED_CANDIDATES": 62,
     }
-    # No longer stated as an absence: THIS PR is the one that puts NEEDS_INPUT
-    # back in the census, on exactly the 2 walks the allowlist above names.
-    assert census["NEEDS_INPUT"] == 2
+    assert census["NEEDS_INPUT"] == 5
     # NOT a claim about production. The corpus carries no disclosure flags, so
     # the review arm of `apply_public_policy_adapters` is unreachable from
     # here by construction: this line says the FIXTURES trigger no review, and
     # a regression that adds a disclosure flag passes it invisibly. Bound 1 of
     # the module docstring, with the measurement.
     assert census.get("HUMAN_REVIEW_REQUIRED", 0) == 0
-    # The 10 NO_SUPPORTED_PATH walks are PR-2's, unmoved: this PR only ever
-    # adds NEW walks that either answer or dead-end, and no existing walk's
-    # state changed.
-    assert census["NO_SUPPORTED_PATH"] == 10
+    assert census["NO_SUPPORTED_PATH"] == 11
 
 
 def test_dead_end_fact_census_matches_the_blocking_fact_table(
@@ -725,32 +873,26 @@ def test_no_walk_dead_ends_outside_the_allowlist(outcomes: dict[str, dict[str, A
     assert not violations, "walk-census invariant broken:\n  " + "\n  ".join(violations)
 
 
-def test_allowlist_has_exactly_the_two_age64_rows_so_the_invariant_is_conditional_again() -> None:
-    """PR-3's deliverable — ``len(...) == 0``, the strongest form this table
-    can take — held for exactly one wave. THIS PR is the one that reopens it.
+def test_allowlist_has_exactly_the_five_pr_d3_rows() -> None:
+    """PR-3's deliverable — ``len(...) == 0`` — held for exactly one wave;
+    PR-5 reopened it with 2 rows; THIS PR (PR-D3) CURES both of PR-5's rows
+    (both retirement age64 walks now answer) and opens it again with 5
+    DIFFERENT rows, none a re-hash of PR-5's shape — see
+    `WALK_DEAD_END_ALLOWLIST`'s module-level comment for each row's reason.
 
-    The invariant is no longer unconditional: it now reads "no walk may end
-    NEEDS_INPUT on a fact for which the interview has no reachable question
-    in that walk's own history, OR the walk is one of these 2 named rows,
-    each checked against its own `asked` history below." That is a WEAKER
-    claim than PR-3 shipped, on purpose — `offshore/retirement/property/age64`
-    and `offshore/retirement/undecided/age64` are the first walks able to
-    clear `hf.e33e.age-below-55` / `hf.e33f.age-below-55` and reach
-    `el.e33e.retirement` / `el.e33f.retirement` on the facts, and neither
-    retirement sub-branch asks `family_sponsor_confirmed`. Curing `flow.ts` so
-    they do would restore `len(...) == 0`, but it is a second concern (see
-    `WALK_DEAD_END_ALLOWLIST`'s module-level comment) and not this PR's.
-
-    An equality against a named 2-row dict is still not a loosened count in
-    the sense PR-3 warned about: it names both rows explicitly, and any
-    THIRD row — however well argued — still has to move this literal in the
-    PR that adds it."""
+    An equality against a named 5-row dict is still not a loosened count in
+    the sense PR-3 warned about: it names every row explicitly, and any
+    additional row — however well argued — still has to move this literal in
+    the PR that adds it."""
 
     assert set(WALK_DEAD_END_ALLOWLIST) == {
-        "offshore/retirement/property/age64",
-        "offshore/retirement/undecided/age64",
+        "offshore/invest/property/below_threshold",
+        "offshore/invest/bank_deposit/below_threshold",
+        "offshore/other/paid/sponsor_unsure",
+        "offshore/retirement/property/age64/sponsor_no",
+        "offshore/retirement/undecided/age64/still_unsure",
     }
-    assert len(WALK_DEAD_END_ALLOWLIST) == 2
+    assert len(WALK_DEAD_END_ALLOWLIST) == 5
 
 
 def _unaskable_violations(

--- a/apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts
+++ b/apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts
@@ -310,6 +310,143 @@ export function enumerateScenarios(): Scenario[] {
     },
   });
 
+  // D3-3/D3-4 (PR-D3, owner ruling SHWEB-20260911): a walk per new branch
+  // (spec §3), covering the gate conditions half-1 (D3-1/D3-2) owed and the
+  // two new questions this PR adds.
+  const base = { in_indonesia: "no", holds_stay_permit: "no" } as const;
+
+  // C1: half-1's `invest` re-route, below the E33 threshold (walks 2/4,
+  // 23-PR-D3-SPEC §walk-list). Above-threshold is already the corpus's
+  // existing default for `offshore/invest/property`/`bank_deposit`.
+  scenarios.push({
+    label: "offshore/invest/property/below_threshold",
+    overrides: {
+      ...base,
+      category: "invest",
+      investment_vehicle: "property",
+      secondhome_property_value_usd: "500000",
+    },
+  });
+  scenarios.push({
+    label: "offshore/invest/bank_deposit/below_threshold",
+    overrides: {
+      ...base,
+      category: "invest",
+      investment_vehicle: "bank_deposit",
+      secondhome_deposit_usd: "50000",
+    },
+  });
+
+  // C1: half-1's declared-paid-activity route (D3-2), the two negative facts
+  // and the negative branch C2 says should deliver C6.
+  scenarios.push({
+    label: "offshore/other/paid/employer_no",
+    overrides: {
+      ...base,
+      category: "other",
+      other_paid_activity: "yes",
+      work_payer: "no",
+    },
+  });
+  scenarios.push({
+    label: "offshore/other/paid/sponsor_unsure",
+    overrides: {
+      ...base,
+      category: "other",
+      other_paid_activity: "yes",
+      work_payer: "yes",
+      work_sponsor_confirmed: "unsure",
+    },
+  });
+  // C2: the `paid = no` walk that must actually yield C6 (13 → 14 distinct
+  // products) — `offshore/other`'s own default now answers `yes` (D3-2), so
+  // this is a NEW walk, not a rewording of the existing one.
+  scenarios.push({
+    label: "offshore/other/no_paid_activity",
+    overrides: { ...base, category: "other", other_paid_activity: "no" },
+  });
+
+  // D3-3: retirement branches that used to dead-end. `property`'s negative
+  // sponsor answer (the age64/sponsor=yes walk is already the corpus's
+  // regenerated default for `offshore/retirement/property/age64`).
+  scenarios.push({
+    label: "offshore/retirement/property/age64/sponsor_no",
+    overrides: {
+      ...base,
+      category: "retirement",
+      retirement_basis: "property",
+      birth_date: RETIREMENT_AGE_64_BIRTH_DATE,
+      family_sponsor_confirmed: "no",
+    },
+  });
+  // `bank_deposit` was the funnel census's LARGEST dead end (30 production
+  // walks) — below both the deposit and passive-income thresholds, cured
+  // only by the family-sponsor fallback this PR adds.
+  scenarios.push({
+    label: "offshore/retirement/bank_deposit/age64/below_threshold",
+    overrides: {
+      ...base,
+      category: "retirement",
+      retirement_basis: "bank_deposit",
+      birth_date: RETIREMENT_AGE_64_BIRTH_DATE,
+      secondhome_deposit_usd: "1000",
+      // Above el.e33f.retirement's own USD 3,000 floor (fact-mapper.ts
+      // comment on ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS.retirement_basis) —
+      // deliberately NOT below it, so this walk proves the E33F fallback
+      // cures the deposit-below-threshold dead end rather than merely
+      // failing both products.
+      secondhome_passive_income_usd: "5000",
+      family_sponsor_confirmed: "yes",
+    },
+  });
+  // `undecided` becomes a real question. `deposit_or_income` is already the
+  // corpus's regenerated default for `offshore/retirement/undecided/age64`
+  // (first option); these are its other two answers.
+  scenarios.push({
+    label: "offshore/retirement/undecided/age64/family_sponsor",
+    overrides: {
+      ...base,
+      category: "retirement",
+      retirement_basis: "undecided",
+      birth_date: RETIREMENT_AGE_64_BIRTH_DATE,
+      retirement_undecided_basis: "family_sponsor",
+    },
+  });
+  scenarios.push({
+    label: "offshore/retirement/undecided/age64/still_unsure",
+    overrides: {
+      ...base,
+      category: "retirement",
+      retirement_basis: "undecided",
+      birth_date: RETIREMENT_AGE_64_BIRTH_DATE,
+      retirement_undecided_basis: "still_unsure",
+    },
+  });
+
+  // D3-4: STEPCHILD sponsor-permit answers. `yes` is already the corpus's
+  // regenerated default for the existing STEPCHILD walks (first option);
+  // these are `no` and `unsure`.
+  scenarios.push({
+    label: "offshore/family/STEPCHILD/spNat=ID/sponsor_permit_no",
+    overrides: {
+      ...base,
+      category: "family",
+      family_relation: "STEPCHILD",
+      family_sponsor_nationalities: "ID",
+      family_stepchild_sponsor_permit_confirmed: "no",
+    },
+  });
+  scenarios.push({
+    label: "offshore/family/STEPCHILD/spNat=ID/sponsor_permit_unsure",
+    overrides: {
+      ...base,
+      category: "family",
+      family_relation: "STEPCHILD",
+      family_sponsor_nationalities: "ID",
+      family_stepchild_sponsor_permit_confirmed: "unsure",
+    },
+  });
+
   return scenarios;
 }
 

--- a/apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts
+++ b/apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts
@@ -318,6 +318,13 @@ export function enumerateScenarios(): Scenario[] {
   // C1: half-1's `invest` re-route, below the E33 threshold (walks 2/4,
   // 23-PR-D3-SPEC §walk-list). Above-threshold is already the corpus's
   // existing default for `offshore/invest/property`/`bank_deposit`.
+  // `birth_date` overridden past 55 on BOTH (owner escalation, 2026-09-13
+  // gate finding): at the corpus-wide default age 25, `hf.e33e.age-below-55`
+  // fires independently of the threshold this walk exists to prove, masking
+  // it behind an unrelated AGE_BELOW_55 reason — these two walks are the
+  // ONLY thing that tests the threshold path itself, so they must not be
+  // confounded by it. `RETIREMENT_AGE_64_BIRTH_DATE` is a spine question no
+  // branch reads, same reasoning as the retirement age-64 walks below.
   scenarios.push({
     label: "offshore/invest/property/below_threshold",
     overrides: {
@@ -325,6 +332,7 @@ export function enumerateScenarios(): Scenario[] {
       category: "invest",
       investment_vehicle: "property",
       secondhome_property_value_usd: "500000",
+      birth_date: RETIREMENT_AGE_64_BIRTH_DATE,
     },
   });
   scenarios.push({
@@ -334,6 +342,7 @@ export function enumerateScenarios(): Scenario[] {
       category: "invest",
       investment_vehicle: "bank_deposit",
       secondhome_deposit_usd: "50000",
+      birth_date: RETIREMENT_AGE_64_BIRTH_DATE,
     },
   });
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
@@ -172,16 +172,18 @@ const WALKS: readonly WalkCase[] = [
     flags: [],
   },
   {
-    name: "retirement · property — HELD: §6 R3 measured the unflagged answer as a wrong NO_PATH",
+    name: "retirement · property — FREED (PR-D3, D3-3): family_sponsor_confirmed is now asked as a fallback, curing the §6 R3 defect this HELD",
     category: "retirement",
     tripScope: "single",
     branch: [
       ["sponsor_category", "NONE"],
       ["retirement_basis", "property"],
       ["secondhome_property_value_usd", "1200000"],
+      ["secondhome_passive_income_usd", "5000"],
+      ["family_sponsor_confirmed", "yes"],
       ["stay_days", "365"],
     ],
-    flags: ["ACTIVITY_BOUNDARY"],
+    flags: [],
   },
   {
     // NARROW-2 (owner ruling SHWEB-20260911, 2026-09-12): `el.e33f.
@@ -303,7 +305,7 @@ const WALKS: readonly WalkCase[] = [
     // asked at all); the Indonesian-sponsor STEPCHILD walk stays FREED —
     // see "innocence: STEPCHILD with an Indonesian sponsor" in
     // fact-mapper.test.ts.
-    name: "family · STEPCHILD, foreign sponsor — HELD (NARROW-1 ii): el.e31d-stepchild-support is sponsor-dependent",
+    name: "family · STEPCHILD, sponsor permit unresolved — HELD (D3-4, replaces NARROW-1 ii's relation proxy): el.e31d-stepchild-support is sponsor-dependent and no rule reads the sponsor's own permit",
     category: "family",
     tripScope: "single",
     branch: [
@@ -315,6 +317,7 @@ const WALKS: readonly WalkCase[] = [
       ["family_sponsor_permit_basis", "EXPERT"],
       ["family_stepchild_marriage_certificate_confirmed", "yes"],
       ["family_stepchild_birth_certificate_confirmed", "yes"],
+      ["family_stepchild_sponsor_permit_confirmed", "no"],
       ["family_sponsor_confirmed", "yes"],
       ["stay_days", "121"],
     ],
@@ -414,6 +417,15 @@ describe("ACTIVITY_BOUNDARY — the decision table itself", () => {
       // property` returns SUPPORTED_CANDIDATES [E33] — classifying `property`
       // as undecidable would delete an E33 the signed pack had proven.
       secondhome_basis:
+        "engine-inert routing label; the evidence carries the fact",
+      // D3-4 (PR-D3): raises AMBIGUOUS_SPONSOR directly from its own answer
+      // (`mapDisclosedReviewFlags`'s `stepchildSponsorPermitUnresolved`),
+      // never through this table.
+      family_stepchild_sponsor_permit_confirmed: "raises AMBIGUOUS_SPONSOR",
+      // D3-3 (PR-D3): same shape as `secondhome_basis` above — this only
+      // selects which evidence questions follow (`getCategoryQuestionIds`,
+      // flow.ts); the engine reads that evidence, never this label.
+      retirement_undecided_basis:
         "engine-inert routing label; the evidence carries the fact",
     };
     for (const question of Object.values(QUESTIONS)) {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from "url";
 import { describe, expect, it } from "vitest";
 import {
   REVIEW_REASON_COPY,
+  SECOND_HOME_DEPOSIT_THRESHOLD_USD,
+  SECOND_HOME_PROPERTY_THRESHOLD_USD,
   SUPPORT_REASON_COPY,
   buildEngineOutcome,
 } from "./engine-adapter";
@@ -642,6 +644,72 @@ describe("support reasons are sentences, not machine codes", () => {
     }
     throw new Error(`${ruleId} is absent from the highest-sequence pack`);
   }
+
+  /**
+   * Walks a rule's `when` tree (the `all`/`args` structure, never regexed
+   * off the raw JSON text) looking for a `{ op: "gte", fact, value }` node
+   * on the named fact, at any nesting depth — `el.e33e.retirement` nests its
+   * deposit-trio conjuncts inside an inner `all`, so a top-level-only walk
+   * would miss it for that rule even though it happens not to be needed
+   * here.
+   */
+  function findGteValue(node: unknown, fact: string): number | undefined {
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const found = findGteValue(item, fact);
+        if (found !== undefined) return found;
+      }
+      return undefined;
+    }
+    if (node === null || typeof node !== "object") return undefined;
+    const record = node as Record<string, unknown>;
+    if (
+      record.op === "gte" &&
+      record.fact === fact &&
+      typeof record.value === "number"
+    ) {
+      return record.value;
+    }
+    if (Array.isArray(record.args)) {
+      return findGteValue(record.args, fact);
+    }
+    return undefined;
+  }
+
+  function gteThresholdInPack(ruleId: string, fact: string): number {
+    const rule = (highestSequencePack().rules ?? []).find(
+      (r) => r.rule_id === ruleId,
+    );
+    if (!rule) {
+      throw new Error(`${ruleId} is absent from the highest-sequence pack`);
+    }
+    const value = findGteValue(rule.when, fact);
+    if (value === undefined) {
+      throw new Error(
+        `no gte(${fact}) node found in ${ruleId}'s when-tree — the rule's shape changed`,
+      );
+    }
+    return value;
+  }
+
+  // D3-3 gate finding (owner escalation, 2026-09-13): `secondHomeBelow
+  // ThresholdReason` (engine-adapter.ts) quotes these two constants to a
+  // real applicant as a legal requirement, in both languages. They are a
+  // SECOND COPY of a number the signed pack owns, with nothing tying them
+  // together — and a seq-21 pack revision naming Second Home thresholds is
+  // already in preparation. A wrong VERDICT is caught elsewhere (the
+  // interview walks); a stale NUMBER INSIDE A SENTENCE is caught only here.
+  it("SECOND_HOME_PROPERTY_THRESHOLD_USD and SECOND_HOME_DEPOSIT_THRESHOLD_USD track the signed pack's el.e33.property-basis / el.e33.deposit-basis gte thresholds", () => {
+    expect(SECOND_HOME_PROPERTY_THRESHOLD_USD).toBe(
+      gteThresholdInPack(
+        "el.e33.property-basis",
+        "secondhome.qualifying_property_value_usd",
+      ),
+    );
+    expect(SECOND_HOME_DEPOSIT_THRESHOLD_USD).toBe(
+      gteThresholdInPack("el.e33.deposit-basis", "secondhome.bank_deposit_usd"),
+    );
+  });
 
   function firstNoPathReason(code: string, facts?: OracleFacts) {
     const response = makeVisaOracleResponse("NO_SUPPORTED_PATH");

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./engine-adapter";
 import { TEST_NOW, makeVisaOracleResponse } from "./visa-oracle-test-fixture";
 import { translate, type I18nKey } from "./i18n";
-import { QUESTIONS } from "./tree";
+import { QUESTIONS, type OracleFacts } from "./tree";
 
 describe("Visa Oracle authoritative outcome adapter", () => {
   it("shows each source's own dates, not the decision's evaluation clock", () => {
@@ -643,10 +643,10 @@ describe("support reasons are sentences, not machine codes", () => {
     throw new Error(`${ruleId} is absent from the highest-sequence pack`);
   }
 
-  function firstNoPathReason(code: string) {
+  function firstNoPathReason(code: string, facts?: OracleFacts) {
     const response = makeVisaOracleResponse("NO_SUPPORTED_PATH");
     response.decision.no_path_reasons[0].code = code;
-    const outcome = buildEngineOutcome(response);
+    const outcome = buildEngineOutcome(response, { facts });
     if (outcome.state !== "NO_SUPPORTED_PATH")
       throw new Error("unexpected state");
     return outcome.noPathReasons[0].message;
@@ -665,6 +665,109 @@ describe("support reasons are sentences, not machine codes", () => {
     expect(message.id).not.toContain(code);
     expect(message.id).toMatch(/sumber di Indonesia/i);
     expect(message.id).toMatch(/jalur kerja/i);
+  });
+
+  // D3-3 gate finding (owner escalation, 2026-09-13): `el.e33.property-basis`
+  // / `el.e33.deposit-basis` are SUPPORT rules — a below-threshold value
+  // makes them silently not fire, so the ENGINE'S only reason is the generic
+  // `OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES` (verified against
+  // rulepack-prod-020.source.json: no EXCLUDE rule names this threshold).
+  // The frontend names it instead, from facts it already has.
+  it("names the property threshold when the interview declared a below-threshold property (D3-1 invest route)", () => {
+    const message = firstNoPathReason(
+      "OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES",
+      {
+        category: "invest",
+        investment_vehicle: "property",
+        secondhome_property_value_usd: "500000",
+      },
+    );
+    expect(message.en).not.toMatch(/^Verified reason: /);
+    expect(message.en).toMatch(/500,000/);
+    expect(message.en).toMatch(/1,000,000/);
+    expect(message.id).toMatch(/500\.000/);
+    expect(message.id).toMatch(/1\.000\.000/);
+  });
+
+  it("names the deposit threshold when the interview declared a below-threshold deposit (D3-1 invest route)", () => {
+    const message = firstNoPathReason(
+      "OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES",
+      {
+        category: "invest",
+        investment_vehicle: "bank_deposit",
+        secondhome_deposit_usd: "50000",
+      },
+    );
+    expect(message.en).toMatch(/50,000/);
+    expect(message.en).toMatch(/130,000/);
+    expect(message.id).toMatch(/50\.000/);
+    expect(message.id).toMatch(/130\.000/);
+  });
+
+  it("names the same thresholds on the direct second_home tile", () => {
+    const property = firstNoPathReason(
+      "OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES",
+      {
+        category: "second_home",
+        secondhome_basis: "property",
+        secondhome_property_value_usd: "1",
+      },
+    );
+    expect(property.en).toMatch(/1,000,000/);
+    const deposit = firstNoPathReason(
+      "OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES",
+      {
+        category: "second_home",
+        secondhome_basis: "bank_deposit",
+        secondhome_deposit_usd: "1",
+      },
+    );
+    expect(deposit.en).toMatch(/130,000/);
+  });
+
+  it("innocence: falls back to the generic sentence when the facts do not show a below-threshold Second Home basis", () => {
+    const noFacts = firstNoPathReason(
+      "OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES",
+    );
+    expect(noFacts.en).toBe(
+      SUPPORT_REASON_COPY.OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES.en,
+    );
+    // A property/deposit ABOVE threshold must not be misreported as a hold.
+    const aboveThreshold = firstNoPathReason(
+      "OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES",
+      {
+        category: "invest",
+        investment_vehicle: "property",
+        secondhome_property_value_usd: "5000000",
+      },
+    );
+    expect(aboveThreshold.en).toBe(
+      SUPPORT_REASON_COPY.OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES.en,
+    );
+    // A DIFFERENT code must never be rewritten, even with matching facts.
+    const otherCode = firstNoPathReason(
+      "BUSINESS_LOCAL_COMPENSATION_NOT_ALLOWED",
+      {
+        category: "invest",
+        investment_vehicle: "property",
+        secondhome_property_value_usd: "500000",
+      },
+    );
+    expect(otherCode.en).toBe(
+      SUPPORT_REASON_COPY.BUSINESS_LOCAL_COMPENSATION_NOT_ALLOWED.en,
+    );
+  });
+
+  // D3-3 (PR-D3): `hf.e33f.sponsor-required` is now reachable — a retirement
+  // walk whose chosen basis fails AND whose sponsor is denied resolves
+  // decisively to NO_SUPPORTED_PATH with this code (previously unreachable
+  // from any corpus walk, so it fell through the raw-code fallback).
+  it("explains hf.e33f.sponsor-required in prose, not a raw code dump", () => {
+    expect("SPONSOR_REQUIRED" in SUPPORT_REASON_COPY).toBe(true);
+    const message = firstNoPathReason("SPONSOR_REQUIRED");
+    expect(message.en).not.toMatch(/^Verified reason: /);
+    expect(message.en).toMatch(/sponsor/i);
+    expect(message.id).toMatch(/sponsor/i);
   });
 });
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -710,14 +710,45 @@ const GENERIC_REVIEW_REASON: LocalizedText = text(
   "Beberapa jawaban Anda memerlukan penilaian dari seseorang sebelum kami dapat mengonfirmasi jalur.",
 );
 
+// D3-4 (PR-D3, owner ruling SHWEB-20260911): `DISCLOSED_AMBIGUOUS_SPONSOR_
+// REVIEW`'s generic copy ("has not been established here") is true for an
+// `unsure` answer but would be FALSE for a STEPCHILD applicant who told the
+// interview their sponsor holds NO KITAS/KITAP — that fact IS established,
+// just not one any seq-20 rule reads. D2-bis forbids reusing an
+// "unresolved" sentence for a resolved-negative answer, so this one trigger
+// gets its own two variants, selected in `reviewReason` below from the
+// interview facts already threaded through `BuildEngineOutcomeOptions`. Not
+// the general D3-6 mechanism (deferred, three OTHER parameter-less codes) —
+// scoped to this one code and this one question.
+const STEPCHILD_SPONSOR_PERMIT_NO_REVIEW: LocalizedText = text(
+  "You told us your sponsor does not hold a valid KITAS/KITAP of their own. A sponsor without a stay permit cannot sponsor the Family Reunification Visa — Stepchild (E31D); this does not affect the Multiple-Entry Visa (C1), which stays available on its own terms. A person needs to confirm the E31D sponsorship route separately before it can be resolved.",
+  "Anda menyatakan bahwa sponsor Anda tidak memiliki KITAS/KITAP yang sah. Sponsor tanpa izin tinggal sendiri tidak dapat mensponsori Visa Penyatuan Keluarga — Anak Tiri (E31D); hal ini tidak memengaruhi Visa Kunjungan Berkali-kali (C1), yang tetap tersedia dengan syaratnya sendiri. Diperlukan konfirmasi terpisah oleh seseorang atas jalur sponsor E31D sebelum dapat diselesaikan.",
+);
+const STEPCHILD_SPONSOR_PERMIT_UNSURE_REVIEW: LocalizedText = text(
+  "Whether your sponsor holds a valid KITAS/KITAP of their own has not been established — confirming your sponsor's own stay permit is what resolves it before the Family Reunification Visa — Stepchild (E31D) can be confirmed.",
+  "Belum dapat dipastikan apakah sponsor Anda memiliki KITAS/KITAP yang sah — konfirmasi izin tinggal sponsor Anda sendiri adalah yang akan menyelesaikannya sebelum Visa Penyatuan Keluarga — Anak Tiri (E31D) dapat dipastikan.",
+);
+
 function reviewReason(
   code: string,
   sourceIds: readonly string[],
   trustedIds: ReadonlySet<string>,
+  facts?: OracleFacts,
 ): OutcomeReason {
+  const stepchildSponsorPermitAnswer =
+    code === "DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW" &&
+    facts?.family_relation === "STEPCHILD"
+      ? facts.family_stepchild_sponsor_permit_confirmed
+      : undefined;
+  const message =
+    stepchildSponsorPermitAnswer === "no"
+      ? STEPCHILD_SPONSOR_PERMIT_NO_REVIEW
+      : stepchildSponsorPermitAnswer === "unsure"
+        ? STEPCHILD_SPONSOR_PERMIT_UNSURE_REVIEW
+        : (REVIEW_REASON_COPY[code] ?? GENERIC_REVIEW_REASON);
   return {
     code,
-    message: REVIEW_REASON_COPY[code] ?? GENERIC_REVIEW_REASON,
+    message,
     sourceIds: sourceIds.filter((id) => trustedIds.has(id)),
   };
 }
@@ -1136,7 +1167,12 @@ function buildValidatedOutcome(
         pathsRemaining: Math.max(1, options.interviewBranchesRemaining ?? 1),
         reviewReasons: response.decision.review_reasons.map((item) => {
           requireReviewHoldRefs(item.source_refs);
-          return reviewReason(item.code, item.source_refs, trustedIds);
+          return reviewReason(
+            item.code,
+            item.source_refs,
+            trustedIds,
+            options.facts,
+          );
         }) as [OutcomeReason, ...OutcomeReason[]],
       };
     case "NO_SUPPORTED_PATH":

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -412,8 +412,15 @@ function reasonMessage(code: string): LocalizedText {
 // the generic sentence) whenever the facts do not actually show a
 // below-threshold Second Home basis, so a future cause of this same code
 // is never mis-attributed to a threshold it did not fail.
-const SECOND_HOME_PROPERTY_THRESHOLD_USD = 1_000_000;
-const SECOND_HOME_DEPOSIT_THRESHOLD_USD = 130_000;
+// Exported so `engine-adapter.test.ts` can pin these against the signed
+// pack's own `el.e33.property-basis` / `el.e33.deposit-basis` `gte` values
+// (same technique as fact-mapper.test.ts's "AMBIGUOUS_SPONSOR relation
+// proxy tracks the signed pack") — a second copy of a number the pack owns
+// is a silent-drift risk with a seq-21 threshold revision already in
+// preparation, and a wrong VERDICT is caught by other tests while a stale
+// NUMBER INSIDE A SENTENCE is not.
+export const SECOND_HOME_PROPERTY_THRESHOLD_USD = 1_000_000;
+export const SECOND_HOME_DEPOSIT_THRESHOLD_USD = 130_000;
 
 function usd(value: number, locale: "en-US" | "id-ID"): string {
   return `USD ${value.toLocaleString(locale)}`;

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -122,6 +122,16 @@ export const SUPPORT_REASON_COPY: Record<string, LocalizedText> = {
     "Retirement with passive income of USD 3,000 per month or more and a confirmed sponsor.",
     "Pensiun dengan penghasilan pasif minimal USD 3.000 per bulan dan penjamin terkonfirmasi.",
   ),
+  // `hf.e33f.sponsor-required` (EXCLUDE, `family.sponsor_confirmed == false`)
+  // — reachable via `no_path_reasons` since D3-3's retirement-basis
+  // dead-end fix made a definitively-denied sponsor a decisive
+  // NO_SUPPORTED_PATH outcome instead of leaving it unresolved. Previously
+  // unreachable from any corpus walk, so it fell through `reasonMessage`'s
+  // raw-code fallback with no test to catch it.
+  SPONSOR_REQUIRED: text(
+    "The Second Home Retirement Visa (E33F) requires a confirmed family sponsor, and you told us your sponsor has not confirmed. Confirming the sponsor is what would open this route.",
+    "Visa Rumah Kedua Pensiun (E33F) mensyaratkan sponsor keluarga yang telah dikonfirmasi, dan Anda menyatakan sponsor Anda belum mengonfirmasi. Konfirmasi sponsor adalah yang akan membuka jalur ini.",
+  ),
   E33_DEPOSIT_BASIS_ELIGIBLE: text(
     "Second Home on the deposit basis: USD 130,000 or more held in your own name at a state bank.",
     "Rumah Kedua berbasis deposito: minimal USD 130.000 atas nama sendiri di bank BUMN.",
@@ -386,14 +396,77 @@ function reasonMessage(code: string): LocalizedText {
   );
 }
 
+// D3-3 gate finding, owner escalation 2026-09-13: `el.e33.property-basis` /
+// `el.e33.deposit-basis` are ELIGIBILITY/SUPPORT rules — when their own
+// condition is false (a below-threshold value), the rule simply does not
+// fire and emits NO reason_code of its own (verified against
+// rulepack-prod-020.source.json: only a HARD_FILTER EXCLUDE carries a
+// reason_code, and no such filter exists for this threshold). The engine's
+// only fallback is the generic `OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_
+// PURPOSES`, which cannot name a number the pack itself never labeled. The
+// interview's OWN facts already carry the declared basis and its exact
+// value, so this names the threshold in the applicant's own terms instead
+// of leaving the generic catalogue sentence to stand in for it — the same
+// D2-bis move as the STEPCHILD copy above, applied to a NO_SUPPORTED_PATH
+// reason instead of a HUMAN_REVIEW one. Returns `undefined` (falls back to
+// the generic sentence) whenever the facts do not actually show a
+// below-threshold Second Home basis, so a future cause of this same code
+// is never mis-attributed to a threshold it did not fail.
+const SECOND_HOME_PROPERTY_THRESHOLD_USD = 1_000_000;
+const SECOND_HOME_DEPOSIT_THRESHOLD_USD = 130_000;
+
+function usd(value: number, locale: "en-US" | "id-ID"): string {
+  return `USD ${value.toLocaleString(locale)}`;
+}
+
+function secondHomeBelowThresholdReason(
+  facts: OracleFacts,
+): LocalizedText | undefined {
+  const basis =
+    facts.category === "invest"
+      ? facts.investment_vehicle
+      : facts.category === "second_home"
+        ? facts.secondhome_basis
+        : undefined;
+  if (basis === "property") {
+    const value = Number(facts.secondhome_property_value_usd);
+    if (
+      !Number.isFinite(value) ||
+      value >= SECOND_HOME_PROPERTY_THRESHOLD_USD
+    ) {
+      return undefined;
+    }
+    return text(
+      `You declared a qualifying property worth ${usd(value, "en-US")}. The Second Home Golden Visa requires at least ${usd(SECOND_HOME_PROPERTY_THRESHOLD_USD, "en-US")}.`,
+      `Anda menyatakan properti yang memenuhi syarat senilai ${usd(value, "id-ID")}. Visa Rumah Kedua mensyaratkan setidaknya ${usd(SECOND_HOME_PROPERTY_THRESHOLD_USD, "id-ID")}.`,
+    );
+  }
+  if (basis === "bank_deposit") {
+    const value = Number(facts.secondhome_deposit_usd);
+    if (!Number.isFinite(value) || value >= SECOND_HOME_DEPOSIT_THRESHOLD_USD) {
+      return undefined;
+    }
+    return text(
+      `You declared a bank deposit of ${usd(value, "en-US")}. The Second Home Golden Visa requires at least ${usd(SECOND_HOME_DEPOSIT_THRESHOLD_USD, "en-US")}.`,
+      `Anda menyatakan deposito bank senilai ${usd(value, "id-ID")}. Visa Rumah Kedua mensyaratkan setidaknya ${usd(SECOND_HOME_DEPOSIT_THRESHOLD_USD, "id-ID")}.`,
+    );
+  }
+  return undefined;
+}
+
 function reason(
   code: string,
   sourceIds: readonly string[],
   trustedIds: ReadonlySet<string>,
+  facts?: OracleFacts,
 ): OutcomeReason {
+  const message =
+    code === "OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES"
+      ? (secondHomeBelowThresholdReason(facts ?? {}) ?? reasonMessage(code))
+      : reasonMessage(code);
   return {
     code,
-    message: reasonMessage(code),
+    message,
     sourceIds: sourceIds.filter((id) => trustedIds.has(id)),
   };
 }
@@ -1183,7 +1256,7 @@ function buildValidatedOutcome(
         pathsRemaining: 0,
         noPathReasons: response.decision.no_path_reasons.map((item) => {
           requireDecisiveRefs(item.source_refs);
-          return reason(item.code, item.source_refs, trustedIds);
+          return reason(item.code, item.source_refs, trustedIds, options.facts);
         }) as [OutcomeReason, ...OutcomeReason[]],
         alternatives: [],
       };

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -352,6 +352,22 @@ describe("AMBIGUOUS_SPONSOR — narrowed to unsure or a sponsor-dependent relati
     ).not.toContain("AMBIGUOUS_SPONSOR");
   });
 
+  // Kills the mutant that re-adds the OLD D2 relation proxy alongside the
+  // new question (e.g. as an extra `||` arm) instead of replacing it: a
+  // foreign, non-unsure `family_sponsor_status_code` on a STEPCHILD relation
+  // is EXACTLY what the old proxy held on regardless of any other answer.
+  // With the permit explicitly confirmed 'yes', this must release — a
+  // reintroduced proxy would hold it and fail this assertion.
+  it("innocence: STEPCHILD with a foreign family_sponsor_status_code releases once the sponsor's permit is confirmed 'yes' — kills the old relation-proxy mutant", () => {
+    expect(
+      mapFacts({
+        family_relation: "STEPCHILD",
+        family_sponsor_status_code: "E23",
+        family_stepchild_sponsor_permit_confirmed: "yes",
+      }).disclosed_review_flags,
+    ).not.toContain("AMBIGUOUS_SPONSOR");
+  });
+
   it("innocence: a non-STEPCHILD relation whose sponsor's permit is answered 'no' releases — the question is STEPCHILD-only", () => {
     for (const relation of [
       "SPOUSE",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -230,7 +230,6 @@ describe("question registry -> wire coverage", () => {
     ["trip_scope", "multiple", "MULTI_PURPOSE_TRIP"],
     ["business_activity", "training", "ACTIVITY_BOUNDARY"],
     ["business_activity", "other", "ACTIVITY_BOUNDARY"],
-    ["retirement_basis", "property", "ACTIVITY_BOUNDARY"],
     ["diaspora_connection", "former_citizen", "ACTIVITY_BOUNDARY"],
     ["diaspora_documents", "passport", "ACTIVITY_BOUNDARY"],
     ["other_purpose", "medical", "ACTIVITY_BOUNDARY"],
@@ -267,6 +266,11 @@ describe("question registry -> wire coverage", () => {
     // off `secondhome.passive_monthly_income_usd`/`family.sponsor_confirmed`
     // alone, never `retirement_basis` itself. See fact-mapper.ts.
     ["retirement_basis", "family_sponsor"],
+    // Released (PR-D3, D3-3) — `property` and `undecided` now ask
+    // `family_sponsor_confirmed` too (flow.ts), so both are exactly as
+    // decidable as `family_sponsor` above, for the identical reason.
+    ["retirement_basis", "property"],
+    ["retirement_basis", "undecided"],
     // Engine-inert: no rule reads a work role (owner ruling, decision 6).
     // All five options are swept in `activity-boundary.test.ts`.
     ["work_role", "specialist"],
@@ -317,16 +321,38 @@ describe("AMBIGUOUS_SPONSOR — narrowed to unsure or a sponsor-dependent relati
     ).toContain("AMBIGUOUS_SPONSOR");
   });
 
-  it("guilt: STEPCHILD with a foreign (non-unsure) sponsor status still holds — el.e31d-stepchild-support is the one relation with a sponsor-dependent product", () => {
+  // Replaced (PR-D3, D3-4): the old proxy fired on the mere PRESENCE of
+  // `family_sponsor_status_code` for a STEPCHILD relation. It is now the
+  // direct question `family_stepchild_sponsor_permit_confirmed` — see
+  // `mapDisclosedReviewFlags` (fact-mapper.ts).
+  it("guilt: STEPCHILD whose sponsor's permit is answered 'no' holds — the pack has no rule to deny E31D on this fact", () => {
     expect(
       mapFacts({
         family_relation: "STEPCHILD",
-        family_sponsor_status_code: "E23",
+        family_stepchild_sponsor_permit_confirmed: "no",
       }).disclosed_review_flags,
     ).toContain("AMBIGUOUS_SPONSOR");
   });
 
-  it("innocence: a non-STEPCHILD relation with a resolved (non-unsure) foreign sponsor status releases — C1 reads no sponsor fact", () => {
+  it("guilt: STEPCHILD whose sponsor's permit is answered 'unsure' holds", () => {
+    expect(
+      mapFacts({
+        family_relation: "STEPCHILD",
+        family_stepchild_sponsor_permit_confirmed: "unsure",
+      }).disclosed_review_flags,
+    ).toContain("AMBIGUOUS_SPONSOR");
+  });
+
+  it("innocence: STEPCHILD whose sponsor's permit is answered 'yes' releases", () => {
+    expect(
+      mapFacts({
+        family_relation: "STEPCHILD",
+        family_stepchild_sponsor_permit_confirmed: "yes",
+      }).disclosed_review_flags,
+    ).not.toContain("AMBIGUOUS_SPONSOR");
+  });
+
+  it("innocence: a non-STEPCHILD relation whose sponsor's permit is answered 'no' releases — the question is STEPCHILD-only", () => {
     for (const relation of [
       "SPOUSE",
       "CHILD",
@@ -998,10 +1024,13 @@ describe("mapDisclosedReviewFlags — monotone abstention metadata", () => {
     });
   });
 
-  it("holds unsupported retirement property context for human review", () => {
-    expect(mapDisclosedReviewFlags({ retirement_basis: "property" })).toEqual([
-      "ACTIVITY_BOUNDARY",
-    ]);
+  // Released (PR-D3, D3-3): `property` now asks `family_sponsor_confirmed`
+  // too (flow.ts), so the bare `retirement_basis` answer alone no longer
+  // holds — see the ACTIVITY_BOUNDARY guilt/innocence table above.
+  it("releases a bare retirement property context — the basis alone no longer holds", () => {
+    expect(mapDisclosedReviewFlags({ retirement_basis: "property" })).toEqual(
+      [],
+    );
   });
 });
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -500,9 +500,21 @@ export const ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS = {
   // all — so this table was UNDER-inclusive: an applicant who answers
   // `family_sponsor` and clears both of those facts already has a signed,
   // deterministic SUPPORTED E33F, and raising ACTIVITY_BOUNDARY here only
-  // deletes it. `property` and `undecided` stay undecidable: no pack rule
-  // grants either an E33F path, so holding them loses nothing proven.
-  retirement_basis: ["bank_deposit", "passive_income", "family_sponsor"],
+  // deletes it.
+  // `property`/`undecided` added (PR-D3, D3-3): both used to stay
+  // undecidable because "no pack rule grants either an E33F path" — that was
+  // only true because `getCategoryQuestionIds` (flow.ts) never asked
+  // `family_sponsor_confirmed` on these two branches. Now both do (`property`
+  // unconditionally as a fallback; `undecided` via `retirement_undecided_
+  // basis`), so both are exactly as decidable as `family_sponsor` was above,
+  // for the identical reason.
+  retirement_basis: [
+    "bank_deposit",
+    "passive_income",
+    "family_sponsor",
+    "property",
+    "undecided",
+  ],
   diaspora_connection: ["former_wni", "descendant", "family"],
   diaspora_documents: ["yes", "no"],
   // D3-B (PR-D3, owner ruling SHWEB-20260911) investigated pack-outward,
@@ -599,21 +611,32 @@ export function mapDisclosedReviewFlags(
   // `family.sponsor_status_code`, but every one of them is `on_unknown:
   // NO_EFFECT` — an unresolved sponsor status changes nothing they decide,
   // so holding on their behalf would delete a proven verdict for no reason,
-  // the exact defect this narrowing exists to cure. Pinned against pack
-  // drift by "AMBIGUOUS_SPONSOR relation proxy tracks the signed pack" in
-  // fact-mapper.test.ts, which reads every production pack on disk and
-  // fails if that set of relations ever changes.
-  const RELATIONS_WITH_SPONSOR_DEPENDENT_PRODUCT: ReadonlySet<string> = new Set(
-    ["STEPCHILD"],
-  );
-  const sponsorRelationUnresolved =
-    facts.family_sponsor_status_code !== undefined &&
-    facts.family_relation !== undefined &&
-    RELATIONS_WITH_SPONSOR_DEPENDENT_PRODUCT.has(facts.family_relation);
+  // the exact defect this narrowing exists to cure. The RELATION this
+  // applies to is pinned against pack drift by "AMBIGUOUS_SPONSOR relation
+  // proxy tracks the signed pack" in fact-mapper.test.ts, which reads every
+  // production pack on disk and fails if the STEPCHILD dependency ever
+  // changes.
+  //
+  // D3-4 (PR-D3, owner ruling SHWEB-20260911) REPLACES the proxy this
+  // comment used to describe (raising the flag on the mere PRESENCE of
+  // `family_sponsor_status_code` for a STEPCHILD relation, whatever its
+  // value) with the direct question `family_stepchild_sponsor_permit_
+  // confirmed` (tree.ts): "does your sponsor hold a valid KITAS/KITAP of
+  // their own?" `no` holds — no seq-20 rule reads the sponsor's permit, so
+  // the pack itself would still return E31D ELIGIBLE, and fabricating
+  // `family.sponsor_confirmed = false` to force a denial would be exactly
+  // the guessed fact this file exists to refuse (seq-21 candidate
+  // `hf.e31d.sponsor-permit-required` is the pack-side fix, not this).
+  // `unsure` holds for the same reason `family_sponsor_confirmed === "unsure"`
+  // does two lines below: a real disclosed uncertainty. `yes` releases.
+  const stepchildSponsorPermitUnresolved =
+    facts.family_relation === "STEPCHILD" &&
+    facts.family_stepchild_sponsor_permit_confirmed !== undefined &&
+    facts.family_stepchild_sponsor_permit_confirmed !== "yes";
   if (
     facts.family_sponsor_status_code === "unsure" ||
     facts.family_sponsor_confirmed === "unsure" ||
-    sponsorRelationUnresolved
+    stepchildSponsorPermitUnresolved
   ) {
     flags.add("AMBIGUOUS_SPONSOR");
   }

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -764,6 +764,67 @@ function mapMarriageRegistered(facts: OracleFacts): FactValue<boolean> {
   return booleanFact(facts.family_marriage_registered);
 }
 
+/**
+ * D3-3 gate finding (2026-09-13): `el.e33.deposit-basis` / `el.e33e.
+ * retirement` both read the deposit trio with `on_unknown: NEEDS_INPUT`
+ * (rulepack-prod-020.source.json, verified) — an "all" AND over
+ * `secondhome.bank_deposit_usd >= threshold`, `..._at_state_bank`,
+ * `..._in_own_name`. When the interview has routed to a basis OTHER than
+ * the deposit one for a purpose whose rules read this trio, the trio was
+ * never asked because the CHOSEN basis already answers the question "is
+ * this a deposit case?" — false. Leaving it UNKNOWN made the rule escalate
+ * to NEEDS_INPUT instead of resolving to NOT-SUPPORTED, which is why a
+ * below-threshold property/invest walk, or a retirement walk whose sponsor
+ * fallback also failed, dead-ended on facts belonging to a basis the
+ * applicant never claimed. Emitting KNOWN(0)/KNOWN(false) here is not a
+ * guess: it states exactly what the chosen basis already implies, and
+ * nothing this function does asks the applicant anything new.
+ *
+ * Scoped to the purposes whose signed rules actually read this trio:
+ * SECOND_HOME (the `second_home` tile, and D3-1's `invest` → property/
+ * bank_deposit route) and RETIREMENT (every basis except `bank_deposit`
+ * itself, and `undecided` only once it has resolved to `family_sponsor` —
+ * a genuine "I still can't say" leaves this UNKNOWN on purpose, see
+ * `retirement_undecided_basis`'s tree.ts comment).
+ */
+function depositBasisDecisivelyNotChosen(facts: OracleFacts): boolean {
+  if (facts.category === "second_home") {
+    return facts.secondhome_basis === "property";
+  }
+  if (facts.category === "invest") {
+    return facts.investment_vehicle === "property";
+  }
+  if (facts.category === "retirement") {
+    if (facts.retirement_basis === "undecided") {
+      return facts.retirement_undecided_basis === "family_sponsor";
+    }
+    return (
+      facts.retirement_basis === "property" ||
+      facts.retirement_basis === "passive_income" ||
+      facts.retirement_basis === "family_sponsor"
+    );
+  }
+  return false;
+}
+
+/**
+ * Mirror of `depositBasisDecisivelyNotChosen` for `secondhome.
+ * qualifying_property_value_usd` (`el.e33.property-basis`, same
+ * `on_unknown: NEEDS_INPUT` shape). RETIREMENT purpose has no rule that
+ * reads this fact at all (`el.e33e.retirement`/`el.e33f.retirement`
+ * verified: neither names it), so only the SECOND_HOME-reachable routes
+ * need it decided.
+ */
+function propertyBasisDecisivelyNotChosen(facts: OracleFacts): boolean {
+  if (facts.category === "second_home") {
+    return facts.secondhome_basis === "bank_deposit";
+  }
+  if (facts.category === "invest") {
+    return facts.investment_vehicle === "bank_deposit";
+  }
+  return false;
+}
+
 export interface MapFactsOptions {
   assessmentId: string;
   /** One frozen clock shared by evaluation, dedupe and presentation. */
@@ -847,22 +908,30 @@ export function mapOracleFactsToApplicantFacts(
     "study.admission_confirmed": booleanFact(facts.study_admission_confirmed),
     "study.sponsor_confirmed": booleanFact(facts.study_sponsor_confirmed),
     "sponsor.type": mapSponsorType(facts),
-    "secondhome.bank_deposit_usd": integerFact(
-      facts.secondhome_deposit_usd,
-      0,
-      Number.MAX_SAFE_INTEGER,
-    ),
-    "secondhome.bank_deposit_at_state_bank": booleanFact(
-      facts.secondhome_state_bank,
-    ),
-    "secondhome.bank_deposit_in_own_name": booleanFact(
-      facts.secondhome_own_name,
-    ),
-    "secondhome.qualifying_property_value_usd": integerFact(
-      facts.secondhome_property_value_usd,
-      0,
-      Number.MAX_SAFE_INTEGER,
-    ),
+    "secondhome.bank_deposit_usd":
+      facts.secondhome_deposit_usd === undefined &&
+      depositBasisDecisivelyNotChosen(facts)
+        ? known(0)
+        : integerFact(facts.secondhome_deposit_usd, 0, Number.MAX_SAFE_INTEGER),
+    "secondhome.bank_deposit_at_state_bank":
+      facts.secondhome_state_bank === undefined &&
+      depositBasisDecisivelyNotChosen(facts)
+        ? known(false)
+        : booleanFact(facts.secondhome_state_bank),
+    "secondhome.bank_deposit_in_own_name":
+      facts.secondhome_own_name === undefined &&
+      depositBasisDecisivelyNotChosen(facts)
+        ? known(false)
+        : booleanFact(facts.secondhome_own_name),
+    "secondhome.qualifying_property_value_usd":
+      facts.secondhome_property_value_usd === undefined &&
+      propertyBasisDecisivelyNotChosen(facts)
+        ? known(0)
+        : integerFact(
+            facts.secondhome_property_value_usd,
+            0,
+            Number.MAX_SAFE_INTEGER,
+          ),
     "secondhome.passive_monthly_income_usd": integerFact(
       facts.secondhome_passive_income_usd,
       0,

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -247,6 +247,7 @@ describe("retirement evidence branches", () => {
         "secondhome_state_bank",
         "secondhome_own_name",
         "secondhome_passive_income_usd",
+        "family_sponsor_confirmed",
         "stay_days",
       ],
     ],
@@ -290,6 +291,7 @@ describe("retirement evidence branches", () => {
         ["secondhome_state_bank", "yes"],
         ["secondhome_own_name", "yes"],
         ["secondhome_passive_income_usd", "3000"],
+        ["family_sponsor_confirmed", "yes"],
         ["stay_days", "365"],
       ],
     },
@@ -1430,6 +1432,10 @@ describe("PR-3 · the second_home branch (owner ruling 3)", () => {
       "sponsor_category",
       "retirement_basis",
       "secondhome_property_value_usd",
+      // Added (PR-D3, D3-3): `property` now asks the same E33F fallback
+      // pair every other retirement basis does — see flow.ts.
+      "secondhome_passive_income_usd",
+      "family_sponsor_confirmed",
       "stay_days",
     ]);
   });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -777,6 +777,16 @@ export function getCategoryQuestionIds(facts: OracleFacts): readonly string[] {
 
   if (category === "retirement") {
     const branch = facts.retirement_basis;
+    // D3-3 (PR-D3, owner ruling SHWEB-20260911): the funnel census found
+    // `bank_deposit` the LARGEST dead end (30 walks ending NEEDS_INPUT on
+    // `family.sponsor_confirmed` because it was never asked on this branch)
+    // and `property`/`undecided` were allowlisted for the same reason.
+    // `family.sponsor_confirmed` is `el.e33f.retirement`'s fact, independent
+    // of the financial basis chosen — a below-threshold deposit or property
+    // may still have a confirmed family sponsor — so every basis that can
+    // reach E33F now asks it as a fallback, not only the two bases whose
+    // NAME says "sponsor".
+    const undecidedChoice = facts.retirement_undecided_basis;
     const branchQuestions =
       branch === "bank_deposit"
         ? [
@@ -784,14 +794,53 @@ export function getCategoryQuestionIds(facts: OracleFacts): readonly string[] {
             "secondhome_state_bank",
             "secondhome_own_name",
             "secondhome_passive_income_usd",
+            "family_sponsor_confirmed",
           ]
         : branch === "property"
-          ? ["secondhome_property_value_usd"]
+          ? [
+              "secondhome_property_value_usd",
+              // `el.e33f.retirement` needs BOTH `secondhome.
+              // passive_monthly_income_usd >= 3000` AND `family.
+              // sponsor_confirmed == true` (fact-mapper.ts's
+              // ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS comment) — measured
+              // 2026-09-13: without asking passive income too, a `property`
+              // walk that answers `family_sponsor_confirmed = no` still
+              // dead-ends NEEDS_INPUT on the passive-income fact instead of
+              // resolving to NO_SUPPORTED_PATH, because the rule's AND does
+              // not short-circuit on the known-false sponsor conjunct.
+              "secondhome_passive_income_usd",
+              "family_sponsor_confirmed",
+            ]
           : branch === "passive_income"
             ? ["secondhome_passive_income_usd", "family_sponsor_confirmed"]
             : branch === "family_sponsor"
               ? ["secondhome_passive_income_usd", "family_sponsor_confirmed"]
-              : [];
+              : branch === "undecided"
+                ? [
+                    "retirement_undecided_basis",
+                    ...(undecidedChoice === "deposit_or_income"
+                      ? [
+                          "secondhome_deposit_usd",
+                          "secondhome_state_bank",
+                          "secondhome_own_name",
+                          "secondhome_passive_income_usd",
+                          "family_sponsor_confirmed",
+                        ]
+                      : undecidedChoice === "family_sponsor"
+                        ? [
+                            "secondhome_passive_income_usd",
+                            "family_sponsor_confirmed",
+                          ]
+                        : // `still_unsure` (or not yet answered): no evidence
+                          // question follows. `family.sponsor_confirmed`
+                          // stays genuinely UNKNOWN, and the applicant is
+                          // never asked for evidence supporting a basis they
+                          // just said they cannot name — that would be
+                          // exactly the dead end this PR cures, worn as a
+                          // false choice.
+                          []),
+                  ]
+                : [];
     return [
       "sponsor_category",
       "retirement_basis",
@@ -882,6 +931,10 @@ function familyQuestionIds(facts: OracleFacts): readonly string[] {
       ? [
           "family_stepchild_marriage_certificate_confirmed",
           "family_stepchild_birth_certificate_confirmed",
+          // D3-4 (PR-D3): the sponsor's own KITAS/KITAP becomes a fact the
+          // applicant answers, replacing the D2 relation-proxy hold — see
+          // tree.ts and `mapDisclosedReviewFlags` (fact-mapper.ts).
+          "family_stepchild_sponsor_permit_confirmed",
         ]
       : []),
     "family_sponsor_confirmed",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
@@ -389,6 +389,12 @@ const en = {
     "The birth certificate should show the biological parent who is part of the mixed marriage.",
   "why.family_stepchild_birth_certificate_confirmed":
     "Birth-certificate evidence is sent as its own boolean decision fact.",
+  "q.family_stepchild_sponsor_permit_confirmed":
+    "Does your sponsor hold a valid KITAS/KITAP of their own?",
+  "q.family_stepchild_sponsor_permit_confirmed.hint":
+    "This asks about the sponsor's own stay permit, separate from the marriage and birth certificates above.",
+  "why.family_stepchild_sponsor_permit_confirmed":
+    "The signed rules for this route do not check the sponsor's own permit; this establishes that fact directly instead of leaving it assumed.",
   "q.family_sponsor_confirmed":
     "Has the family sponsor confirmed they will support the process?",
   "q.family_sponsor_confirmed.hint":
@@ -406,6 +412,16 @@ const en = {
   "q.retirement_basis.opt.undecided": "I have not chosen a basis",
   "why.retirement_basis":
     "There is no matching engine fact for this label. It only routes the next exact inputs.",
+  "q.retirement_undecided_basis": "Which of these can you document today?",
+  "q.retirement_undecided_basis.hint":
+    "Pick whichever basis you can support with evidence. If neither applies, say so — a person is not needed to answer that.",
+  "q.retirement_undecided_basis.opt.deposit_or_income":
+    "A bank deposit or documented passive income",
+  "q.retirement_undecided_basis.opt.family_sponsor":
+    "A confirmed family sponsor",
+  "q.retirement_undecided_basis.opt.still_unsure": "I still can't say",
+  "why.retirement_undecided_basis":
+    "There is no matching engine fact for this label either. It only routes the next exact inputs, same as the basis question above.",
   "q.secondhome_basis": "Which Second Home basis can you document today?",
   "q.secondhome_basis.hint":
     "Pick the one you can evidence now. Use Not sure rather than guessing.",
@@ -1212,6 +1228,12 @@ const id: Record<Keys, string> = {
     "Akta lahir sebaiknya menunjukkan orang tua kandung yang merupakan bagian dari pernikahan campuran.",
   "why.family_stepchild_birth_certificate_confirmed":
     "Bukti akta lahir dikirim sebagai fakta keputusan boolean tersendiri.",
+  "q.family_stepchild_sponsor_permit_confirmed":
+    "Apakah sponsor Anda memiliki KITAS/KITAP yang sah atas nama sendiri?",
+  "q.family_stepchild_sponsor_permit_confirmed.hint":
+    "Ini menanyakan izin tinggal sponsor sendiri, terpisah dari akta nikah dan akta lahir di atas.",
+  "why.family_stepchild_sponsor_permit_confirmed":
+    "Aturan yang telah disahkan untuk jalur ini tidak memeriksa izin tinggal sponsor sendiri; pertanyaan ini memastikan fakta tersebut secara langsung, bukan diasumsikan.",
   "q.family_sponsor_confirmed":
     "Apakah sponsor keluarga sudah mengonfirmasi dukungan proses?",
   "q.family_sponsor_confirmed.hint":
@@ -1229,6 +1251,18 @@ const id: Record<Keys, string> = {
   "q.retirement_basis.opt.undecided": "Saya belum memilih dasar",
   "why.retirement_basis":
     "Tidak ada fakta mesin yang cocok untuk label ini. Label hanya mengarahkan input persis berikutnya.",
+  "q.retirement_undecided_basis":
+    "Yang mana dari berikut yang dapat Anda buktikan saat ini?",
+  "q.retirement_undecided_basis.hint":
+    "Pilih dasar yang dapat Anda dukung dengan bukti. Jika tidak ada yang berlaku, sampaikan saja — tidak diperlukan peninjauan orang untuk itu.",
+  "q.retirement_undecided_basis.opt.deposit_or_income":
+    "Deposito bank atau penghasilan pasif yang terdokumentasi",
+  "q.retirement_undecided_basis.opt.family_sponsor":
+    "Sponsor keluarga yang dikonfirmasi",
+  "q.retirement_undecided_basis.opt.still_unsure":
+    "Saya masih belum bisa memastikan",
+  "why.retirement_undecided_basis":
+    "Tidak ada fakta mesin yang cocok untuk label ini juga. Hanya mengarahkan input persis berikutnya, sama seperti pertanyaan dasar di atas.",
   "q.secondhome_basis":
     "Dasar Second Home mana yang dapat Anda buktikan saat ini?",
   "q.secondhome_basis.hint":

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.ts
@@ -915,6 +915,33 @@ export const QUESTIONS: Record<string, OracleQuestion> = {
     whyWeAsk: { i18nKey: "why.family_stepchild_birth_certificate_confirmed" },
     notSure: { mode: "human-review" },
   },
+  // D3-4 (PR-D3, owner ruling SHWEB-20260911): the sponsor's OWN KITAS/KITAP
+  // becomes a fact the applicant can answer, replacing the D2 relation-proxy
+  // hold (which fired on the mere presence of `family_sponsor_status_code`
+  // for a STEPCHILD relation). HUMAN_CONTEXT, not FACT: no seq-20 rule reads
+  // the sponsor's permit at all (`el.e31d-stepchild-support` reads relation +
+  // `family.sponsor_confirmed` + the two certificates above, never this), so
+  // there is no FactPath to wire it to — same posture as
+  // `family_sponsor_permit_basis` immediately below. `no` and `unsure` both
+  // hold (see `mapDisclosedReviewFlags`, fact-mapper.ts): `no` because a
+  // sponsor without a stay permit of their own cannot sponsor E31D and the
+  // pack has no rule that says so (seq-21 candidate
+  // `hf.e31d.sponsor-permit-required`), `unsure` because the fact is
+  // genuinely unresolved. `yes` releases — no hold.
+  family_stepchild_sponsor_permit_confirmed: {
+    id: "family_stepchild_sponsor_permit_confirmed",
+    i18nKey: "q.family_stepchild_sponsor_permit_confirmed",
+    kind: "branch",
+    group: "details",
+    decisionMapping: { kind: "HUMAN_CONTEXT" },
+    sensitive: true,
+    options: [
+      { key: "yes", labelI18nKey: "q.boolean.yes" },
+      { key: "no", labelI18nKey: "q.boolean.no" },
+    ],
+    whyWeAsk: { i18nKey: "why.family_stepchild_sponsor_permit_confirmed" },
+    notSure: { mode: "human-review" },
+  },
   // Sponsor permit basis (2026-08-23 owner ruling — Permenkumham 11/2024
   // Pasal 33 ayat (7) blocks family-reunification chaining for four
   // specific ayat (2) huruf h categories; `family.sponsor_status_code` is
@@ -1020,6 +1047,40 @@ export const QUESTIONS: Record<string, OracleQuestion> = {
     ],
     whyWeAsk: { i18nKey: "why.retirement_basis" },
     notSure: { mode: "human-review" },
+  },
+  // D3-3 (PR-D3, owner ruling SHWEB-20260911): `undecided` stopped being a
+  // dead end. Instead of holding on the bare label, this presents the two
+  // bases the pack can actually decide (`el.e33e.retirement`'s deposit/
+  // passive-income facts, `el.e33f.retirement`'s family-sponsor fact) and
+  // routes to whichever's evidence questions. `still_unsure` is a REAL third
+  // option, not the generic NotSure affordance (deliberately absent here):
+  // choosing it asks no further evidence question, so `family.
+  // sponsor_confirmed` stays genuinely UNKNOWN and the engine's own
+  // `on_unknown: NEEDS_INPUT` on `el.e33f.retirement` fires — NEEDS_INPUT,
+  // never HUMAN_REVIEW, and `engine-adapter.ts`'s `questionForFact` already
+  // names `family_sponsor_confirmed`'s own question in that message.
+  retirement_undecided_basis: {
+    id: "retirement_undecided_basis",
+    i18nKey: "q.retirement_undecided_basis",
+    kind: "choice",
+    group: "details",
+    decisionMapping: { kind: "HUMAN_CONTEXT" },
+    sensitive: false,
+    options: [
+      {
+        key: "deposit_or_income",
+        labelI18nKey: "q.retirement_undecided_basis.opt.deposit_or_income",
+      },
+      {
+        key: "family_sponsor",
+        labelI18nKey: "q.retirement_undecided_basis.opt.family_sponsor",
+      },
+      {
+        key: "still_unsure",
+        labelI18nKey: "q.retirement_undecided_basis.opt.still_unsure",
+      },
+    ],
+    whyWeAsk: { i18nKey: "why.retirement_undecided_basis" },
   },
   // Router for the `second_home` category (owner ruling 3, 2026-09-06).
   // HUMAN_CONTEXT on purpose, exactly like its `retirement_basis` sibling:

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/walk-corpus-determinism.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/walk-corpus-determinism.test.ts
@@ -38,8 +38,13 @@ import {
  * replacing one). 61 → 67 on PR-5 (2026-09-07): the 5 offshore `retirement`
  * bases plus the onshore neutral `retirement` walk, each replayed a second
  * time at `RETIREMENT_AGE_64_BIRTH_DATE` (age 64) instead of the corpus-wide
- * default 25 — no new tree branch, the same 6 walks answered twice. */
-const EXPECTED_WALK_COUNT = 67;
+ * default 25 — no new tree branch, the same 6 walks answered twice. 67 → 78
+ * on PR-D3 (2026-09-13): 11 new walks — the two invest-vehicle
+ * below-threshold routes, the three declared-paid-activity branches
+ * (employer=no / sponsor=unsure / paid=no), the retirement property/
+ * bank_deposit/undecided branches that used to dead-end, and the two new
+ * STEPCHILD sponsor-permit answers (no/unsure) — see generate-walk-corpus.ts. */
+const EXPECTED_WALK_COUNT = 78;
 
 function jsonFilesIn(dir: string): string[] {
   return readdirSync(dir)

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml
@@ -1,0 +1,96 @@
+gear: 2
+gear_reason: >-
+  Measured the way CI measures it — `--changed-files-file` AND `--numstat-file`, because taking it
+  without the numstat under-reports the floor and has been rejected twice in this mandate:
+  `scripts/evidence_pack_lint.py --print-floor --changed-files-file <f> --numstat-file <n>` returns
+  2 and `--print-floor-source` returns `size`. Re-run both to check; no digit is typed here, because
+  four PRs in this mandate have been corrected for a count that went stale the moment it was written.
+task_id: shweb-w-oracle-d3b-20260912
+mandate_id: SHWEB-20260911/W-ORACLE/PR-D3-half-2
+colour: BLUE
+l_level: L1
+gate_class: opus
+objective: >-
+  PR-D3 half-2: the interview questions half-1 owed. Retirement branches that dead-ended now ask
+  `family_sponsor_confirmed` — including `bank_deposit`, which the funnel-wide reachability census
+  found is the LARGEST dead end (30 walks) and which the 67-walk corpus never touched. STEPCHILD
+  gains the sponsor-permit question, which closes the condition the PR-D2 gate left open. Eleven new
+  walks with EXPECTED_OUTCOME rows close the gate's C1 and C2 on half-1. Frontend only; the rule
+  pack is untouched.
+scope:
+  - apps/mouth — the visa-oracle interview (questions, flow, fact mapping) and its tests
+  - apps/backend-rag/backend/tests/services/visa_engine — the walk corpus fixtures and their census
+  - this brief
+constraints:
+  - Frontend only. No rule-pack change, no evaluate_path.py, no evaluator, no per-candidate hold.
+  - >-
+    The STEPCHILD "sponsor holds no KITAS/KITAP" branch keeps its hold and does NOT fabricate
+    `sponsor_confirmed=false`: no seq-20 rule reads the sponsor's permit, so the pack still returns
+    E31D ELIGIBLE. Faking the fact would move the census number by lying to the engine. The missing
+    rule is reported as a seq-21 candidate instead.
+  - No client PII in any file added or edited.
+acceptance:
+  - text: >-
+      WHEN the visa-oracle frontend suite runs, THEN every test SHALL pass — the questions, the
+      fact mapping and the flow changes included.
+    status: verified
+    probe: "cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)' --maxWorkers=2"
+  - text: WHEN the project typechecks, THEN it SHALL succeed.
+    status: verified
+    probe: "cd apps/mouth && npx --no-install tsc --noEmit -p ."
+  - text: >-
+      WHEN the backend walk-census test runs, THEN every walk SHALL match its EXPECTED_OUTCOME —
+      the eleven new walks included.
+    status: verified
+    probe: "cd apps/backend-rag && PYTHONPATH=. /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/visa_engine/test_interview_walk_census.py -q -o addopts=''"
+  - text: >-
+      WHEN the corpus is counted, THEN it SHALL carry more walks than the 67 it had before this PR,
+      and the STEPCHILD sponsor-permit branches SHALL both be present — the walks are what turn a
+      new question into evidence.
+    status: verified
+    probe: |
+      n=$(ls apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/*.json | wc -l | tr -d ' ')
+      [ "$n" -gt 67 ] || { echo "FAIL: corpus is $n walks, not grown"; exit 1; }
+      for b in sponsor_permit_no sponsor_permit_unsure; do
+        ls apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/ | grep -q "$b" || { echo "FAIL: missing STEPCHILD branch $b"; exit 1; }
+      done
+      echo "OK: corpus is $n walks and both STEPCHILD sponsor-permit branches exist"
+pii: none
+census_measured:
+  method: >-
+    `npx --no-install tsx research/visa/2026-09-11-review-reason-audit/inputs.mts`, then from
+    apps/backend-rag `PYTHONPATH=. python -m pytest
+    ../../research/visa/2026-09-11-review-reason-audit/test_census.py`, which writes
+    /tmp/visaoracle-audit-20260911/census.json. Re-run independently by the orchestrator.
+  walks: 78
+  with_real_flags:
+    SUPPORTED_CANDIDATES: 54
+    NO_SUPPORTED_PATH: 10
+    NEEDS_INPUT: 4
+    HUMAN_REVIEW_REQUIRED: 10
+  target_not_met: >-
+    The spec asks HUMAN_REVIEW <= 4. It is 10, and the shortfall is NOT a defect of this PR: 3 are
+    `invest` merit/family/undecided (D3-5, deferred), 2 are the STEPCHILD holds this PR创 deliberately
+    keeps, and 5 are the entire `other` tile — which no frontend change can release, because
+    `other_purpose` is never read as a fact and no seq-20 rule can see it. That last group makes
+    <= 4 unreachable frontend-only; it needs a seq-21 rule.
+deferred:
+  - D3-5 (indeterminate `investment_vehicle` options) — complexity, not net lines.
+  - D3-6 (trigger-aware copy for the three parameter-less codes).
+  - item (c) inherited from PR-D2 (the non-blocking note on a released C1).
+  - C3 (the D3-1 re-route sentence).
+seq21_candidates:
+  - >-
+    `hf.e31d.sponsor-permit-required` — would make the STEPCHILD sponsor-permit answer decisive
+    instead of held.
+  - >-
+    `el.e33.property-basis` / `el.e33.deposit-basis` / `el.e33e`/`el.e33f` escalate to NEEDS_INPUT on
+    the SIBLING unasked basis rather than NO_SUPPORTED_PATH when the chosen basis fails; the frontend
+    cannot name a reachable follow-up for it. Allowlisted here, not cured.
+  - >-
+    A rule that reads the disclosed `other_purpose` value — without one the whole `other` tile stays
+    held no matter what the interview asks.
+self_report:
+  note: >-
+    `deferred`, `seq21_candidates` and this note are this session's record, not machine-verified
+    facts. The census block IS reproducible with the method above.


### PR DESCRIPTION
## What

**PR-D3 half-2** — the interview questions half-1 owed, the walks the gate asked for, and the two branches that were dead-ending. Frontend only; **the rule pack is untouched**.

- **D3-3** — retirement branches that dead-ended now ask `family_sponsor_confirmed`, including **`bank_deposit`**, which the funnel-wide reachability census found is the *largest* dead end (30 walks ending NEEDS_INPUT on `family.sponsor_confirmed`) and which our 67-walk corpus never touched.
- **D3-4** — STEPCHILD gains the sponsor-permit question (yes / no / unsure). This closes the condition the **PR-D2 gate** left open on the two STEPCHILD walks.
- **C1 / C2 from the half-1 gate** — eleven new walks with `EXPECTED_OUTCOME` rows; the corpus goes **67 → 78**.

**Deferred to a third PR**, declared not dropped: D3-5 (indeterminate `investment_vehicle` options), D3-6 (trigger-aware copy), item (c) inherited from PR-D2, and C3 (the D3-1 re-route sentence). The reason is complexity and time, not net lines — production is +363/−19 here, inside the contract.

## Gate rework (head `f6fae4e8f6`) — all three dead ends CLOSED

The gate found the dead-end allowlist had grown 2 → 5, three of them one pattern, and the owner ruled: fix, do not declare. All three are closed.

**The mechanism, read from the pack rather than guessed.** `el.e33.property-basis`, `el.e33.deposit-basis` and `el.e33e.retirement` carry `on_unknown: NEEDS_INPUT` over a flat AND `when`. When the chosen basis FAILS, the unknown on the *twin* basis does not short-circuit the way a known-false would, so the evaluator asks for the other basis's facts — which the interview only offers on the other branch. Dead end.

**The cure**: once the interview has decisively routed to one basis, `fact-mapper.ts` emits the twin basis's facts as KNOWN(0)/KNOWN(false). The trigger is **any routing to the other basis — above the threshold as well as below it**, not only a below-threshold answer: `depositBasisDecisivelyNotChosen` fires on `secondhome_basis === "property"` / `investment_vehicle === "property"` (and on `retirement_undecided_basis === "family_sponsor"`), with no reference to the declared value. Choosing the other basis is itself the known fact — "no deposit claimed here" — regardless of what the chosen one turned out to be worth. An earlier revision of this section said "a below-threshold answer", which described only the subset that motivated the fix rather than the condition in the code. All three walks now reach **NO_SUPPORTED_PATH with `missing_facts == []`**, and the allowlist is back to **2** — both survivors being an applicant who answered "unsure", which names a reachable question rather than dead-ending.

Two walks land on the pack's generic `OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES` (no EXCLUDE rule in seq-20 names the threshold), so the frontend now names the declared value and the requirement from facts it already holds; the retirement walk reaches `SPONSOR_REQUIRED`, previously unreachable and therefore never given copy.

**A defect the cure introduced, caught here and fixed in the same push.** Naming the threshold meant hardcoding it: `SECOND_HOME_PROPERTY_THRESHOLD_USD = 1_000_000`, `SECOND_HOME_DEPOSIT_THRESHOLD_USD = 130_000`. Both are correct today — `el.e33.property-basis` is `gte … 1000000`, `el.e33.deposit-basis` is `gte … 130000` — but they are a second copy of a number the signed pack owns, and nothing tied them together. A seq-21 revision is in preparation with these very thresholds on its list; the day one moves, the engine changes its verdict while this sentence keeps quoting the old figure to a real applicant, in two languages, as a legal requirement. A wrong verdict gets caught by tests; a stale number inside a sentence does not.

Pinned with the technique this mandate already uses for the D2 relation proxy: a test reads the highest-sequence signed pack, walks the `all`/`args` tree for the `gte` node (no regex over JSON) and asserts each constant matches. Proven by mutation — setting the deposit constant to 131_000 turns **three** tests red, the pin plus two copy assertions on the rendered sentence:

```
AssertionError: expected 131000 to be 130000
AssertionError: expected 'You declared a bank deposit of USD 50…' to match /130,000/
```

**Other gate conditions**: mutant M4 killed by an innocence test (STEPCHILD + foreign `family_sponsor_status_code` + permit `yes` → no hold, the exact case the old proxy wrongly held); the brief's probes no longer hardcode one machine's venv path; `engine-adapter.ts` is touched, +120/−4 measured with `git diff --numstat origin/main...HEAD`.

> **Note, 2026-09-13 — condition C4 is NOT discharged at this head, and my earlier report of it was wrong.** The gate asked that the brief's probes stop pointing at one machine's interpreter. At `f6fae4e8f6` the committed brief still carries `cd apps/backend-rag && PYTHONPATH=. /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -m pytest …` at probe 3, and `evidence/…/brief.yml` was not touched in the `de59c016fb..f6fae4e8f6` delta at all — the portability fix landed on the scratchpad copies, not on the committed brief. My statement that the probes were portable and 4/4 green was measured on the machine where that absolute path exists, which is precisely the measurement that cannot detect this defect: the condition is "does not depend on one machine", not "exits 0 here". The cure moves to half-3, where the brief's probe 3 becomes repo-relative and is checked by running it somewhere that path does not resolve.

## Census — measured, and it does not reach the target

Regenerated with `inputs.mts` and replayed through `test_census.py`, then re-run independently by the orchestrator:

| 78 walks, real flags | SUPPORTED | NO_SUPPORTED_PATH | NEEDS_INPUT | HUMAN_REVIEW |
|---|---:|---:|---:|---:|
| after half-2, before the gate rework | 54 | 10 | 4 | 10 |
| **after the rework (this head)** | **54** | **13** | **1** | **10** |

NEEDS_INPUT falls 4 → 1 and NO_SUPPORTED_PATH rises 10 → 13: the three closed dead ends, moving from "the engine is still asking" to "there is no path, and here is the threshold you missed". Re-measured on both clocks by the orchestrator at this head.

The spec asks **HUMAN_REVIEW ≤ 4**. It is 10. That breaks down into three groups, and only one of them is work left to do:

| group | count | status |
|---|---:|---|
| `invest` merit / family / undecided | 3 | D3-5, deferred to the third PR |
| STEPCHILD sponsor-permit `no` / `unsure` | 2 | **deliberate** — see below |
| the whole `other` tile | 5 | **not reachable frontend-only** — see below |

## Two findings that change what "≤ 4" means

**1. The `other` tile cannot be released by any frontend change.** Half-1 proved (D3-B) that `other_purpose` is never read as a fact — its decision mapping is `HUMAN_CONTEXT` with no fact path, and the wire request is byte-identical whichever of the 8 values the visitor picks. No seq-20 rule can see it, so no interview change can release the tile. Five of the ten remaining reviews are exactly that tile. **≤ 4 is therefore unreachable without a pack rule**, and the rule is listed below as a seq-21 candidate.

**2. A claim in half-1's body was false, and this PR is what disproved it.** Half-1 (#6332) stated that the `other_paid_activity = no` branch "is what makes C6 deliverable at all". The walk added here to test that claim — `offshore/other/no_paid_activity` — comes back **HUMAN_REVIEW with `ACTIVITY_BOUNDARY`**. C6 is reachable at raw-engine level and suppressed in production, independently of `other_paid_activity`. #6332's body has been corrected in place with a dated note; the correction is recorded rather than quietly dropped, because that body is merged and someone will read it.

**3. The STEPCHILD `no` branch keeps its hold on purpose.** When the applicant answers that the sponsor holds no KITAS/KITAP, the pack still returns E31D ELIGIBLE — no seq-20 rule reads the sponsor's permit. Fabricating `sponsor_confirmed=false` would have moved the census by lying to the engine. The hold stays, the copy says why, and the missing rule is a seq-21 candidate.

## seq-21 candidates (for Zero's pack governance — never into the pack here)

- `hf.e31d.sponsor-permit-required` — makes the STEPCHILD sponsor-permit answer decisive instead of held.
- A rule that reads the disclosed `other_purpose` value — without one the `other` tile stays held no matter what the interview asks.
- `el.e33.property-basis` / `el.e33.deposit-basis` / `el.e33e` / `el.e33f` escalate to NEEDS_INPUT on the *sibling* unasked basis rather than NO_SUPPORTED_PATH when the chosen basis fails; the frontend cannot name a reachable follow-up. Allowlisted, not cured.

## Detect Secrets — cause named, cured per-finding

The job was red, and it was neither baseline drift nor a file CI scans that local did not: `.secrets.baseline` here is byte-identical to main's, and the failure reproduces locally with CI's own changed-file list. The cause is that **this PR is the first to touch those files**. The scan is diff-scoped, so it only ever sees what a PR changes; the walk labels — `offshore/family/STEPCHILD/spNat=ID/sponsor_permit_no` — are made entirely of base64-alphabet characters (letters, digits, `/`, `=`, `_`), so the Base64 High Entropy String plugin flags them as they arrive. Main's baseline carries no entry for `gold_coverage/fixtures/walks/` or `test_interview_walk_census.py`, because nothing had touched them.

It is the same false positive PR-O0 cured at `census.json:313`/`:325`. Cured the same way: **per-finding `is_secret: false` audits**, never a whole-file exclude — O0's own gate made us convert exactly those, since a whole-file exclude covers today's harmless labels and would silently stop scanning the file the day a real secret landed in it. Verified both arms in CI's shape: with the audits the check exits 0 ("All findings audited"); with them stripped it exits 1 naming exactly those findings.

**Not ours, stated so it is not re-diagnosed**: `Backend Shard 2` / `Backend Tests` / `Test Summary` are red from the fleet-wide compliance failure on main (`bpjs_ketenagakerjaan_monthly`, #6333 + af41675695). Untouched here.

## A note on the frozen audit artifact

`research/visa/2026-09-11-review-reason-audit/test_census.py` asserts `len(rows) == 72`, the corpus size at audit time; it is now 83 rows. That file is a **frozen evidence artifact** pinned byte-identical by PR-O0's `contract-lock.json`, so this PR does **not** edit it — editing it would falsify a hash probe that is merged on main. CI does not collect it (`testpaths = backend/tests`), so nothing is red; the census is still written before the assert. The clean separation — a living runner for the growing corpus, the frozen one left as the historical record — is worth a follow-up, and is flagged here rather than silently patched.

## Gates

- `vitest run 'src/app/(visa-oracle)'` → exit 0, 39 files / **717 tests**
- `tsc --noEmit` → exit 0
- `test_interview_walk_census.py` → **15/15**, exit 0 (the eleven new walks included)
- all 4 brief probes, verbatim through `bash -c` → exit 0
- harness floor → **2**, source `size`; brief declares gear 2
- pre-commit (tsc, ruff, import-chain, secrets, off-limits) → exit 0; no `--no-verify`

## Bites

Bites: consumer = a retiree on the `bank_deposit` basis and a STEPCHILD applicant, both of whom previously hit a dead end or a hold with no question behind it; observation = on `origin/main` after merge, `ls apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/*.json | wc -l` returns 78, the two `sponsor_permit_*` walks are present, and `pytest backend/tests/services/visa_engine/test_interview_walk_census.py` passes 15/15 with their `EXPECTED_OUTCOME` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


