### PR TITLE
fix(backend-rag): update two obligations tests orphaned by the #6336 roll correction

### DIFF
--- a/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
@@ -329,11 +329,13 @@ def test_due_on_a_weekend_skips_the_monday_holiday_too(catalog):
     ]
 
 
-def test_a_catalog_roll_none_rule_ignores_the_holiday_block_after_it(catalog):
-    # BPJS Ketenagakerjaan for 2026-07 is due Sat 15 Aug with roll: none. The next business day is
-    # Tue 18 Aug (Sun 16, then Independence Day on Mon 17), and none of that reaches this rule.
+def test_a_catalog_next_business_day_rule_absorbs_the_holiday_block_after_it(catalog):
+    # BPJS Ketenagakerjaan for 2026-07 is due Sat 15 Aug. #6336 (M4 source sweep) confirmed PP
+    # 44/2015 art. 21(3) and PP 46/2015 art. 19(3) both move a 15th falling on a hari libur to the
+    # next hari kerja, so this rule is roll: next_business_day, not roll: none as it read before
+    # that sweep. The next business day is Tue 18 Aug (Sun 16, then Independence Day on Mon 17).
     assert due_dates(catalog["bpjs_ketenagakerjaan_monthly"], PMA, date(2026, 8, 1), 30) == [
-        ("2026-07", date(2026, 8, 15))
+        ("2026-07", date(2026, 8, 18))
     ]
 
 
@@ -369,12 +371,14 @@ def test_the_holiday_gap_reason_appends_to_the_rules_own_reason(catalog):
     )
 
 
-def test_a_roll_none_rule_is_not_flagged_for_an_undecreed_year(catalog):
-    # Nothing about an unknown holiday table can change a date that never moves.
+def test_a_next_business_day_rule_is_flagged_for_an_undecreed_year(catalog):
+    # bpjs_kesehatan_monthly is roll: next_business_day (#6336, M4 source sweep: Perpres 82/2018
+    # art. 39(4)). Sun 2027-01-10 rolls on the weekend alone to Mon 11 Jan, since 2027 has no
+    # decreed holiday table yet, and the proposal says so instead of presenting it as settled.
     rule = catalog["bpjs_kesehatan_monthly"]
     [proposed] = propose([rule], PMA, date(2027, 1, 1), 15)
-    assert proposed.due_date == date(2027, 1, 10)
-    assert proposed.needs_review_reason == rule.needs_review_reason
+    assert proposed.due_date == date(2027, 1, 11)
+    assert proposed.needs_review_reason == "holiday calendar for 2027 not loaded"
 
 
 def test_one_time_and_event_rules_produce_nothing(catalog):


### PR DESCRIPTION
## What was red

`Backend Shard 2` (required check) has been red on `origin/main`, and therefore on every open PR (e.g. #6347), since #6336 merged. `test_obligations_register.py::test_a_catalog_roll_none_rule_ignores_the_holiday_block_after_it` expected `bpjs_ketenagakerjaan_monthly`'s due date to stay at Sat 2026-08-15; it now computes Tue 2026-08-18.

## Root cause

Not a moving clock — `due_dates()`/`obligations_register.py` reads no `date.today()`, and the failure reproduces identically at any time. #6336 (the M4 source-sweep PR) legitimately flipped both `bpjs_ketenagakerjaan_monthly` and `bpjs_kesehatan_monthly` from `roll: none` to `roll: next_business_day`, citing PP 44/2015 art. 21(3), PP 46/2015 art. 19(3) and Perpres 82/2018 art. 39(4). That PR updated one test using `bpjs_kesehatan_monthly` (`test_roll_none_keeps_the_weekend_date` moved onto `expat_tax_residency_review`) but missed two other tests that still assumed the pre-#6336 `roll: none` behaviour for these same two rules:

- `test_a_catalog_roll_none_rule_ignores_the_holiday_block_after_it` — asserted `bpjs_ketenagakerjaan_monthly`'s Sat 2026-08-15 due date never moves.
- `test_a_roll_none_rule_is_not_flagged_for_an_undecreed_year` — asserted `bpjs_kesehatan_monthly`'s Sun 2027-01-10 due date never moves and carries no review flag.

## The fix

Test-only, no production change:
- Renamed and corrected the first test: `bpjs_ketenagakerjaan_monthly` now correctly rolls Sat 2026-08-15 across the weekend and Independence Day to Tue 2026-08-18.
- Renamed and corrected the second test: `bpjs_kesehatan_monthly`'s Sun 2027-01-10 rolls weekend-only (2027 has no decreed holiday table yet) to Mon 2027-01-11, carrying `needs_review_reason == "holiday calendar for 2027 not loaded"`.

Ran ruff check/format on the changed file — clean. Full file: 95 passed (was 1 failed before this PR).

**Bites:** consumer = the required `Backend Shard 2` CI check on every open PR; observation = this head runs the whole test file green (95 passed), unblocking #6347 and the merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)