### PR TITLE
feat(compliance): one_time obligations reach the queue, with an optional fixed statutory date (M2)

### DIFF
--- a/apps/backend-rag/backend/data/obligations_catalog.yaml
+++ b/apps/backend-rag/backend/data/obligations_catalog.yaml
@@ -232,8 +232,8 @@ rules:
     verified: true
     applies_if:
       - {attr: company_type, op: in, value: [PT_PMA, PT_PMDN, CV, OTHER]}
-    needs_review_reason: "sector (food and beverage, cosmetics, supplements) is not a profile attribute: applies to every operating company until reviewed"
-    due: {frequency: one_time, month: null, months_after_period_end: 0, roll: none}
+    needs_review_reason: "neither sector (food and beverage, cosmetics, supplements) nor business size is a profile attribute: the 17 October 2026 due date is the MICRO-AND-SMALL phase of art. 160(2), while medium and large have been in force since 17 October 2024 (art. 160(1)) and are already late. Confirm sector and size before acting on the date"
+    due: {frequency: one_time, month: null, months_after_period_end: 0, roll: none, fixed_date: 2026-10-17}
     trigger: "sector in food_beverage, cosmetics, supplements: certified by 17 October 2026 for micro and small businesses (art. 160(2)); medium and large have been in force since 17 October 2024 (art. 160(1)). Cosmetics and health supplements run on the separate art. 161 schedule, whose letters a and d also end on 17 October 2026"
     notes: "17 October 2026, not 18: the PP states the 17th. It falls on a Saturday, which may be why the 18th circulates, but no source was found saying so. Assist only, never certify. The free SEHATI self-declare route for UMK is a BPJPH programme under art. 98; the IDR 500 million turnover figure is a programme threshold, not PP text."
 

--- a/apps/backend-rag/backend/services/compliance/obligations_register.py
+++ b/apps/backend-rag/backend/services/compliance/obligations_register.py
@@ -11,7 +11,14 @@ Due-date semantics (v1):
   last month.
 - annual: the period is the fiscal year; due on `day` of the month `months_after_period_end`
   after its last month, or on the first `month`/`day` after the fiscal year end when `month` is set.
-- one_time / event: nothing is scheduled in v1; the rule names its `trigger` instead.
+- one_time: ONE proposal per client, period_key "once". The due date is the generation date
+  (`start`) unless the rule states `due.fixed_date`, the one statutory deadline an unscheduled
+  rule can carry: a fixed_date at or after `start` becomes the due date, a fixed_date already
+  past leaves the generation date and says so in needs_review_reason. The reviewer sets the real
+  deadline. UNIQUE (client_id, rule_id, "once") makes the row appear once and stay, so a later
+  run never duplicates it and never moves it either.
+- event: nothing is scheduled; the dates are per person or per event (each expat's KITAS, each
+  data change), so the rule names its `trigger` instead.
 A `day` past the end of a month means that month's last day. Fiscal years are month-granular:
 the MM of fiscal_year_end is the closing month. Period keys: "YYYY-MM" (monthly), "YYYY-Qn"
 (calendar quarter), "FYyyyy-Qn" (fiscal quarter), "FYyyyy" (annual), where yyyy is the calendar
@@ -43,6 +50,10 @@ from backend.services.compliance.business_days import holiday_years_loaded, next
 DEFAULT_CATALOG_PATH = Path(__file__).resolve().parents[2] / "data" / "obligations_catalog.yaml"
 
 COMPANY_TYPES = frozenset({"PT_PMA", "PT_PMDN", "CV", "KP3A", "KPPA", "FOREIGN_PLATFORM", "OTHER"})
+ONE_TIME_PERIOD_KEY = "once"
+ONE_TIME_REVIEW_NOTE = (
+    "one_time: due date is the generation date, set the statutory deadline on review"
+)
 BOOL_ATTRS = frozenset(
     {
         "has_employees",
@@ -65,9 +76,12 @@ _RULE_KEYS = frozenset(
     {"id", "name", "authority", "legal_source", "verified", "applies_if", "due"}
     | {"needs_review_reason", "trigger", "notes"}
 )
-_DUE_KEYS = frozenset({"frequency", "day", "month", "months_after_period_end", "roll", "basis"})
+_DUE_KEYS = frozenset(
+    {"frequency", "day", "month", "months_after_period_end", "roll", "basis", "fixed_date"}
+)
 _RULE_ID_RE = re.compile(r"^[a-z0-9_]{3,64}$")
 _FYE_RE = re.compile(r"^\d{2}-\d{2}$")
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _COMPANY_TYPE_MAP = {
     "PT PMA": "PT_PMA",
     "PT PMDN": "PT_PMDN",
@@ -146,6 +160,7 @@ class DueRule:
     months_after_period_end: int
     roll: str
     basis: str
+    fixed_date: date | None = None  # one_time only: the statutory deadline, when there is one
 
 
 @dataclass(frozen=True)
@@ -217,6 +232,26 @@ def _value_ok(attr: str, value: Any) -> bool:
     return isinstance(value, str) and value in domain
 
 
+def _parse_fixed_date(raw: Any, frequency: str, where: str) -> date | None:
+    """The optional statutory deadline of a one_time rule: YYYY-MM-DD, or a YAML date scalar.
+
+    Only one_time rules take it. A scheduled rule computes its dates from the period, and an
+    event rule's dates are per person or per event, so in both cases a fixed_date would be a
+    value nothing reads — the catalog fails to load instead of carrying a dead key.
+    """
+    if raw is None:
+        return None
+    _require(frequency == "one_time", where, "fixed_date is only for one_time rules")
+    if type(raw) is date:  # an unquoted 2026-10-17 in the YAML is already a date scalar
+        return raw
+    ok = isinstance(raw, str) and bool(_ISO_DATE_RE.match(raw))
+    _require(ok, where, f"fixed_date must be YYYY-MM-DD, got {raw!r}")
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        raise CatalogError(f"{where}: impossible fixed_date {raw!r}") from None
+
+
 def _parse_due(raw: Any, where: str) -> DueRule:
     _require(isinstance(raw, Mapping), where, "due must be a mapping")
     extra = set(raw) - _DUE_KEYS
@@ -234,7 +269,8 @@ def _parse_due(raw: Any, where: str) -> DueRule:
         _require(day is None, where, f"{freq} rules take no day")
     month_ok = month is None or (freq == "annual" and _is_int(month) and 1 <= month <= 12)
     _require(month_ok, where, "month must be null, or 1..12 on annual rules")
-    return DueRule(freq, day, month, after, roll, basis)
+    fixed_date = _parse_fixed_date(raw.get("fixed_date"), freq, where)
+    return DueRule(freq, day, month, after, roll, basis, fixed_date)
 
 
 def _parse_rule(raw: Any, index: int) -> ObligationRule:
@@ -357,6 +393,11 @@ def due_dates(
     return sorted(out, key=lambda kd: (kd[1], kd[0]))
 
 
+def _with_note(reason: str | None, note: str) -> str:
+    """Append a note to a rule's own needs_review_reason, keeping both."""
+    return f"{reason}; {note}" if reason else note
+
+
 def _review_reason(rule: ObligationRule, due: date) -> str | None:
     """The rule's own reason, plus the holiday gap when this date's year has no decreed table.
 
@@ -365,19 +406,53 @@ def _review_reason(rule: ObligationRule, due: date) -> str | None:
     """
     if rule.due.roll != "next_business_day" or due.year in holiday_years_loaded():
         return rule.needs_review_reason
-    gap = f"holiday calendar for {due.year} not loaded"
-    return f"{rule.needs_review_reason}; {gap}" if rule.needs_review_reason else gap
+    return _with_note(rule.needs_review_reason, f"holiday calendar for {due.year} not loaded")
+
+
+def _one_time_proposal(rule: ObligationRule, start: date) -> ProposedObligation:
+    """The single proposal a one_time rule makes, dated as well as the catalog can date it.
+
+    The horizon does not gate it: a one_time obligation is already live the moment the rule
+    applies — that is what `trigger` says — so withholding it until some window contains a date
+    the engine does not have is exactly the silence M2 exists to end. What the engine cannot do
+    is invent a deadline, so an undated one_time proposal carries the generation date and a
+    reason that tells the reviewer the date is a placeholder, not a computed deadline.
+    """
+    fixed = rule.due.fixed_date
+    if fixed is None:
+        reason = _with_note(rule.needs_review_reason, ONE_TIME_REVIEW_NOTE)
+        return ProposedObligation(rule.id, ONE_TIME_PERIOD_KEY, start, reason)
+    if fixed >= start:  # a statutory date the catalog knows: no placeholder note, it IS the date
+        return ProposedObligation(rule.id, ONE_TIME_PERIOD_KEY, fixed, rule.needs_review_reason)
+    passed = f"fixed statutory date {fixed.isoformat()} already passed"
+    return ProposedObligation(
+        rule.id, ONE_TIME_PERIOD_KEY, start, _with_note(rule.needs_review_reason, passed)
+    )
 
 
 def propose(
     rules: Iterable[ObligationRule], profile: ClientProfile, start: date, horizon_days: int
 ) -> list[ProposedObligation]:
-    out = [
-        ProposedObligation(rule.id, key, due, _review_reason(rule, due))
-        for rule in rules
-        if applies(rule, profile)
-        for key, due in due_dates(rule, profile, start, horizon_days)
-    ]
+    """Every obligation an applicable rule puts on this client in [start, start + horizon_days).
+
+    Scheduled rules contribute one proposal per period whose due date falls in the window;
+    one_time rules contribute exactly one "once" proposal (see `_one_time_proposal`); event
+    rules contribute nothing, because their dates live per person or per event and not in any
+    profile attribute.
+    """
+    if horizon_days < 0:
+        raise ValueError("horizon_days must be >= 0")
+    out: list[ProposedObligation] = []
+    for rule in rules:
+        if not applies(rule, profile):
+            continue
+        if rule.due.frequency == "one_time":
+            out.append(_one_time_proposal(rule, start))
+            continue
+        out.extend(
+            ProposedObligation(rule.id, key, due, _review_reason(rule, due))
+            for key, due in due_dates(rule, profile, start, horizon_days)
+        )
     return sorted(out, key=lambda p: (p.due_date, p.rule_id, p.period_key))
 
 
@@ -516,6 +591,8 @@ __all__ = [
     "ATTRIBUTES",
     "COMPANY_TYPES",
     "DEFAULT_CATALOG_PATH",
+    "ONE_TIME_PERIOD_KEY",
+    "ONE_TIME_REVIEW_NOTE",
     "CatalogError",
     "ClientProfile",
     "DueRule",

--- a/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_obligations_register.py
@@ -18,6 +18,7 @@ import pytest
 from backend.db.migration_base import split_migration_sql
 from backend.services.compliance.obligations_register import (
     ATTRIBUTES,
+    ONE_TIME_REVIEW_NOTE,
     CatalogError,
     ClientProfile,
     DueRule,
@@ -50,6 +51,25 @@ def catalog() -> dict[str, ObligationRule]:
 def _synthetic(frequency: str, day: int = 10, after: int = 1, basis: str = "fiscal", month=None):
     due = DueRule(frequency, day, month, after, "none", basis)
     return ObligationRule("synthetic", "n", "a", "s", False, (), due)
+
+
+def _one_time(fixed_date: date | None = None, reason: str | None = None) -> ObligationRule:
+    """A one_time rule with nothing in applies_if, so it applies to every profile."""
+    due = DueRule("one_time", None, None, 0, "none", "fiscal", fixed_date)
+    return ObligationRule(
+        "synthetic_one_time", "n", "a", "s", False, (), due, reason, trigger="when it triggers"
+    )
+
+
+def _rule_file(tmp_path: Path, due: str, trigger: bool) -> Path:
+    """A one-rule catalog whose `due` mapping is given verbatim (trigger iff unscheduled)."""
+    path = tmp_path / "rule.yaml"
+    path.write_text(
+        "rules:\n  - id: some_rule\n    name: n\n    authority: a\n    legal_source: s\n"
+        + ("    trigger: t\n" if trigger else "")
+        + f"    due: {due}\n"
+    )
+    return path
 
 
 def _catalog_file(tmp_path: Path, predicate: str, extra: str = "") -> Path:
@@ -329,12 +349,19 @@ def test_due_on_a_weekend_skips_the_monday_holiday_too(catalog):
     ]
 
 
-def test_a_catalog_roll_none_rule_ignores_the_holiday_block_after_it(catalog):
-    # BPJS Ketenagakerjaan for 2026-07 is due Sat 15 Aug with roll: none. The next business day is
-    # Tue 18 Aug (Sun 16, then Independence Day on Mon 17), and none of that reaches this rule.
-    assert due_dates(catalog["bpjs_ketenagakerjaan_monthly"], PMA, date(2026, 8, 1), 30) == [
-        ("2026-07", date(2026, 8, 15))
-    ]
+def test_a_roll_none_rule_ignores_the_holiday_block_after_it():
+    # Sat 2026-08-15 is followed by Sun 16 and Independence Day on Mon 17, so the next business day
+    # is Tue 18 Aug -- and none of that reaches a rule with roll: none. This was pinned on
+    # bpjs_ketenagakerjaan_monthly until M4 (#6336) read PP 44/2015 art. 21(3) and PP 46/2015
+    # art. 19(3) and flipped BOTH BPJS rules to next_business_day, which left the assertion
+    # failing on main. The subject is the engine's roll semantics, not which rule the catalog
+    # happens to exempt, so it is pinned on a synthetic rule the catalog cannot invalidate.
+    rule = ObligationRule(
+        "synthetic_15", "n", "a", "s", False, (), DueRule("monthly", 15, None, 1, "none", "fiscal")
+    )
+    rolling = replace(rule, due=replace(rule.due, roll="next_business_day"))
+    assert due_dates(rule, PMA, date(2026, 8, 1), 30) == [("2026-07", date(2026, 8, 15))]
+    assert due_dates(rolling, PMA, date(2026, 8, 1), 30) == [("2026-07", date(2026, 8, 18))]
 
 
 def test_a_year_without_a_holiday_table_rolls_weekends_only_and_says_so(catalog):
@@ -369,20 +396,152 @@ def test_the_holiday_gap_reason_appends_to_the_rules_own_reason(catalog):
     )
 
 
-def test_a_roll_none_rule_is_not_flagged_for_an_undecreed_year(catalog):
-    # Nothing about an unknown holiday table can change a date that never moves.
-    rule = catalog["bpjs_kesehatan_monthly"]
+def test_a_roll_none_rule_is_not_flagged_for_an_undecreed_year():
+    # Nothing about an unknown holiday table can change a date that never moves: Sun 2027-01-10
+    # stays, and the proposal carries the rule's own reason and nothing else. Also ex-catalog
+    # since M4 flipped bpjs_kesehatan_monthly to next_business_day (Perpres 82/2018 art. 39(4)).
+    rule = ObligationRule(
+        "synthetic_10",
+        "n", "a", "s", False, (),
+        DueRule("monthly", 10, None, 1, "none", "fiscal"),
+        needs_review_reason="the rule's own reason",
+    )  # fmt: skip
     [proposed] = propose([rule], PMA, date(2027, 1, 1), 15)
     assert proposed.due_date == date(2027, 1, 10)
-    assert proposed.needs_review_reason == rule.needs_review_reason
+    assert proposed.needs_review_reason == "the rule's own reason"
 
 
-def test_one_time_and_event_rules_produce_nothing(catalog):
-    platform = ClientProfile(company_type="FOREIGN_PLATFORM", serves_indonesian_users_online=True)
-    assert applies(catalog["pse_registration"], platform)
-    assert due_dates(catalog["pse_registration"], platform, date(2026, 9, 11), 365) == []
-    proposed = {p.rule_id for p in propose(catalog.values(), platform, date(2026, 9, 11), 365)}
-    assert not proposed & {"pse_registration", "pmse_vat_assessment", "wajib_lapor_ketenagakerjaan"}
+# -- one_time triggers and the optional fixed statutory date (PR M2) -------------------------
+# Before M2 these rules applied to a profile and produced nothing, so the three obligations the
+# compliance offer actually sells never reached the reviewer queue. One "once" proposal per
+# applicable rule now does, dated the generation date unless the catalog states a fixed_date.
+
+PLATFORM = ClientProfile(
+    company_type="FOREIGN_PLATFORM",
+    serves_indonesian_users_online=True,
+    pse_registered=False,
+    pmse_vat_appointed=False,
+)
+GEN = date(2026, 9, 11)
+
+
+def test_event_rules_still_schedule_nothing(catalog):
+    """Per-person and per-event dates are in no profile attribute; only the trigger is stated."""
+    expat = ClientProfile(
+        company_type="PT_PMA",
+        has_employees=True,
+        has_foreign_employees=True,
+        pse_registered=True,
+    )
+    event_ids = {"pse_data_update", "rptka_imta_expat", "wajib_lapor_ketenagakerjaan"}
+    for rule_id in event_ids:
+        rule = catalog[rule_id]
+        assert rule.due.frequency == "event"
+        assert applies(rule, expat), rule_id
+        assert due_dates(rule, expat, GEN, 365) == []
+    assert not {p.rule_id for p in propose(catalog.values(), expat, GEN, 365)} & event_ids
+
+
+def test_one_time_rules_reach_the_queue_once_with_the_generation_date(catalog):
+    """The M2 observation: the two PSE/PMSE obligations a foreign platform owes are proposed."""
+    once = [p for p in propose(catalog.values(), PLATFORM, GEN, 90) if p.period_key == "once"]
+    assert [(p.rule_id, p.due_date) for p in once] == [
+        ("pmse_vat_assessment", GEN),
+        ("pse_registration", GEN),
+    ]
+    for proposal in once:  # the rule's own reason (M4 gave pmse one), then the M2 note
+        rule = catalog[proposal.rule_id]
+        assert rule.due.fixed_date is None
+        expected = ONE_TIME_REVIEW_NOTE
+        if rule.needs_review_reason:
+            expected = f"{rule.needs_review_reason}; {ONE_TIME_REVIEW_NOTE}"
+        assert proposal.needs_review_reason == expected
+    registered = replace(PLATFORM, pse_registered=True, pmse_vat_appointed=True)
+    assert not [p for p in propose(catalog.values(), registered, GEN, 90) if p.period_key == "once"]
+
+
+def test_halal_certification_reaches_a_pt_pma_queue_on_its_statutory_date(catalog):
+    """The catalog states the UMK deadline PP 42/2024 art. 160(2) sets, so it is not a placeholder.
+
+    M4 (#6336) confirmed 17 October 2026 against the PP text, so this proposal is the one case
+    where a one_time due date is a real deadline: the generation-date note must NOT be added, and
+    the rule's own sector caveat must survive alone.
+    """
+    rule = catalog["halal_certification"]
+    assert rule.due.fixed_date == date(2026, 10, 17)
+    [once] = propose([rule], PMA, GEN, 30)
+    assert (once.rule_id, once.period_key) == ("halal_certification", "once")
+    assert once.due_date == date(2026, 10, 17)
+    assert once.needs_review_reason == rule.needs_review_reason
+    assert ONE_TIME_REVIEW_NOTE not in (once.needs_review_reason or "")
+
+
+def test_the_one_time_note_appends_to_the_rules_own_reason():
+    [once] = propose([_one_time(reason="sector is not a profile attribute")], PMA, GEN, 0)
+    assert (once.period_key, once.due_date) == ("once", GEN)
+    assert once.needs_review_reason == f"sector is not a profile attribute; {ONE_TIME_REVIEW_NOTE}"
+
+
+def test_a_one_time_proposal_is_identical_whatever_the_horizon(catalog):
+    """period_key "once" is the idempotence key: same tuple, so UNIQUE blocks the second row."""
+    short = [p for p in propose(catalog.values(), PLATFORM, GEN, 1) if p.period_key == "once"]
+    long = [p for p in propose(catalog.values(), PLATFORM, GEN, 400) if p.period_key == "once"]
+    assert short == long
+    assert len(short) == 2
+
+
+def test_a_fixed_date_at_or_after_the_generation_date_becomes_the_due_date():
+    rule = _one_time(fixed_date=date(2026, 10, 17), reason="sector not modelled")
+    [once] = propose([rule], PMA, GEN, 1)
+    assert (once.due_date, once.needs_review_reason) == (date(2026, 10, 17), "sector not modelled")
+    [same_day] = propose([_one_time(fixed_date=GEN)], PMA, GEN, 1)
+    assert (same_day.due_date, same_day.needs_review_reason) == (GEN, None)
+
+
+def test_a_fixed_date_already_past_keeps_the_obligation_and_says_it_passed():
+    """A missed statutory deadline is the one the reviewer most needs to see, not one to drop."""
+    [once] = propose([_one_time(fixed_date=date(2026, 8, 31), reason="sector")], PMA, GEN, 1)
+    assert once.due_date == GEN
+    assert once.needs_review_reason == "sector; fixed statutory date 2026-08-31 already passed"
+
+
+def test_load_catalog_accepts_a_fixed_date_on_a_one_time_rule(tmp_path):
+    bare = "{frequency: one_time, months_after_period_end: 0, roll: none}"
+    dated = bare[:-1] + ", fixed_date: 2026-10-17}"
+    quoted = bare[:-1] + ', fixed_date: "2026-10-17"}'
+    assert load_catalog(_rule_file(tmp_path, bare, True))[0].due.fixed_date is None
+    assert load_catalog(_rule_file(tmp_path, dated, True))[0].due.fixed_date == date(2026, 10, 17)
+    assert load_catalog(_rule_file(tmp_path, quoted, True))[0].due.fixed_date == date(2026, 10, 17)
+
+
+@pytest.mark.parametrize(
+    ("due", "trigger"),
+    [
+        ("{frequency: monthly, day: 10, months_after_period_end: 1, roll: none, fixed_date: 2026-10-17}", False),
+        ("{frequency: annual, day: 31, months_after_period_end: 4, roll: none, fixed_date: 2026-10-17}", False),
+        ("{frequency: event, months_after_period_end: 0, roll: none, fixed_date: 2026-10-17}", True),
+    ],
+)  # fmt: skip
+def test_load_catalog_rejects_a_fixed_date_on_a_rule_that_would_never_read_it(
+    tmp_path, due, trigger
+):
+    with pytest.raises(CatalogError, match="fixed_date is only for one_time rules"):
+        load_catalog(_rule_file(tmp_path, due, trigger))
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        ("17-10-2026", "fixed_date must be YYYY-MM-DD"),
+        ("20261017", "fixed_date must be YYYY-MM-DD"),
+        ("2026-10", "fixed_date must be YYYY-MM-DD"),
+        ("2026-02-30", "impossible fixed_date"),
+    ],
+)
+def test_load_catalog_rejects_a_malformed_fixed_date(tmp_path, raw, message):
+    due = f'{{frequency: one_time, months_after_period_end: 0, roll: none, fixed_date: "{raw}"}}'
+    with pytest.raises(CatalogError, match=message):
+        load_catalog(_rule_file(tmp_path, due, True))
 
 
 def test_propose_is_sorted_and_carries_review_reasons(catalog):
@@ -393,6 +552,8 @@ def test_propose_is_sorted_and_carries_review_reasons(catalog):
         (p.rule_id, p.period_key, p.due_date) for p in proposed
     }
     for p in proposed:
+        if catalog[p.rule_id].due.frequency == "one_time":
+            continue  # a "once" proposal carries the M2 note too; pinned by its own tests below
         assert p.needs_review_reason == catalog[p.rule_id].needs_review_reason
 
 
@@ -560,6 +721,32 @@ async def test_upsert_proposals_is_idempotent_and_never_resets_reviewed_rows(moc
     assert "ON CONFLICT (client_id, rule_id, period_key) DO NOTHING" in sql
     assert "DO UPDATE" not in sql
     assert (client_id, rule_ids) == (7, [p.rule_id for p in proposals])
+
+
+async def test_a_re_run_inserts_no_one_time_row_for_the_same_client(mock_db_pool, catalog):
+    """ON CONFLICT DO NOTHING plus the stable "once" key: the second run writes nothing."""
+    pool, conn = mock_db_pool
+    first = propose(catalog.values(), PLATFORM, GEN, 90)
+    # A day later the undated one_time proposals carry a DIFFERENT due_date (the new generation
+    # date) and the same "once" key, which is the half of idempotence the engine owns: the key the
+    # UNIQUE constraint matches on cannot drift with the clock. The constraint itself is pinned by
+    # test_migration_309_shape_and_rollback (the DDL) and exercised end to end by the router's
+    # test_generate_persists_and_is_idempotent; no live database is reachable from this suite.
+    later = propose(catalog.values(), PLATFORM, date(2026, 9, 12), 90)
+    assert [p.period_key for p in later] == [p.period_key for p in first]
+    assert [p.due_date for p in later] != [p.due_date for p in first]
+    conn.fetch.side_effect = [[{"id": n} for n in range(len(first))], []]
+    repo = ObligationsRepository(pool)
+    assert await repo.upsert_proposals(7, first) == len(first)
+    assert await repo.upsert_proposals(7, later) == 0
+    sql, client_id, rule_ids, period_keys, due_dates_arg, _reasons = conn.fetch.call_args.args
+    assert "ON CONFLICT (client_id, rule_id, period_key) DO NOTHING" in sql
+    assert (client_id, period_keys.count("once")) == (7, 2)
+    assert {r for r, k in zip(rule_ids, period_keys, strict=True) if k == "once"} == {
+        "pse_registration",
+        "pmse_vat_assessment",
+    }
+    assert all(d >= GEN for d in due_dates_arg)
 
 
 async def test_upsert_with_no_proposals_skips_the_database(mock_db_pool):

--- a/evidence/2026-09/agent-air-m5-backend-rag-obligations-one-time-tr-67d7841e/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-obligations-one-time-tr-67d7841e/brief.yml
@@ -1,0 +1,46 @@
+mandate: >
+  M2 of the compliance-stack second wave (spec docs/plans/2026-09-12-compliance-stack-engine-ui-windows.md):
+  make the three one_time obligations the compliance offer sells reach the reviewer queue. propose()
+  now emits ONE proposal per applicable one_time rule with period_key "once", dated the generation
+  date and flagged as such in needs_review_reason; _parse_due accepts an optional one_time-only
+  due.fixed_date (rejected on every other frequency) which becomes the due date when it is not
+  already past, and otherwise adds "fixed statutory date <date> already passed";
+  halal_certification gets fixed_date 2026-10-17, the date M4 (#6336) read off PP 42/2024
+  art. 160(2). event rules still schedule nothing.
+gear: 1
+gear_reason: >
+  Deterministic floor 1 as printed by scripts/evidence_pack_lint.py --print-floor on
+  git diff --name-only/--numstat of this PR's own commit range: 3 files, +293/-29 (264 net), all
+  under apps/backend-rag. Pure functions and one catalog data line: no migration, no router, no
+  schema, no workflow, no guard, no lockfile, no secret, no CODEOWNERS path, no client data. An
+  adversarial round ran anyway (Codex, read-only sandbox, reasoning effort high) because the change
+  puts a DATE in front of a reviewer, which is the part of this engine that can be confidently
+  wrong; both findings are disposed in the PR body.
+origin: >
+  Measured gap, not a report: pse_registration, pmse_vat_assessment and halal_certification pass
+  applies() and produced zero rows, because _periods() yields nothing for one_time and propose()
+  only ever read due_dates(). Probed on disk: a FOREIGN_PLATFORM profile
+  (serves_indonesian_users_online true, pse_registered false, pmse_vat_appointed false) proposed 0
+  obligations over 90 days from 2026-09-11 and now proposes 2; a PT_PMA with employees and PKP
+  proposed 27 and now proposes 28, the new rows being pse_registration/once,
+  pmse_vat_assessment/once (both dated the generation date) and halal_certification/once dated
+  2026-10-17.
+instruction_to_the_grader: >
+  Three things deserve attack. (1) The date the reviewer sees. An undated one_time proposal is
+  deliberately dated the generation date — check that needs_review_reason always says so, that the
+  rule's own caveat is never replaced, and that halal's proposal (the only one with a statutory
+  date) does NOT carry the placeholder note. The known weakness is disclosed, not fixed: PP 42/2024
+  art. 160(2) is the micro-and-small phase, the engine has neither sector nor size, and the cure
+  chosen was a sharper needs_review_reason rather than a silent date. Attack that choice if you
+  think a date no attribute conditions should not ship at all. (2) Idempotence. The claim is that
+  the "once" key cannot drift with the clock, so UNIQUE (client_id, rule_id, period_key) plus
+  ON CONFLICT DO NOTHING makes a re-run insert zero; no live database is reachable from this suite,
+  so the proof is three-layered (engine key stability under a later start date, the migration DDL
+  test, the router's fake store) and a real-DB test is absent on purpose. (3) The two repaired
+  tests. They were red on origin/main after #6336 flipped both BPJS rules to next_business_day on
+  primary sources; verify the repair moved the TESTS and not the catalog, and that the calendar
+  facts (Sat 2026-08-15 before Independence Day, Sun 2027-01-10 in an undecreed year) still carry
+  the same meaning.
+appetite:
+  wall_clock_hours: 1
+  adversarial_rounds: 1


### PR DESCRIPTION
## What

`propose()` emitted nothing for `due.frequency == one_time`, so the three obligations the
compliance offer actually sells — PSE registration, PMSE VAT assessment, halal certification —
passed `applies()` and produced no row. Each applicable one_time rule now emits **one** proposal
with `period_key "once"`:

- **Undated**: `due_date` is the generation date and `needs_review_reason` says so
  (`one_time: due date is the generation date, set the statutory deadline on review`), appended to
  the rule's own reason with `; ` and never replacing it.
- **`due.fixed_date`** (new key, accepted on one_time rules only — a scheduled or `event` rule
  carrying it fails to load, because nothing would read it): at or after the generation date it IS
  the due date and no placeholder note is added; already past, the generation date stays and the
  reason adds `fixed statutory date <date> already passed`, because a missed deadline is the one
  the reviewer most needs to see.
- **`event` rules still schedule nothing** — their dates are per person or per event.
- The `"once"` key never drifts with the clock, so `UNIQUE (client_id, rule_id, period_key)` with
  `ON CONFLICT DO NOTHING` makes a re-run insert zero rows even when the generation date has moved.

`halal_certification` carries `fixed_date: 2026-10-17` — PP 42/2024 art. 160(2), verified by #6336
(merged as af41675695).

## Bites

**Consumer**: `POST /api/compliance/obligations/generate` (`backend/app/routers/compliance_obligations.py`,
which calls `propose(_cached_rules(), profile, date.today(), horizon_days)` unchanged).
**Observation**: the probe below, run on disk at this head. A FOREIGN_PLATFORM profile proposed
**0** obligations over 90 days before this change and proposes **2** after; a PT PMA with employees
and PKP went from 27 to 28, the new row being the halal deadline.

```
--- FOREIGN_PLATFORM (serves_indonesian_users_online=True, pse_registered=False,
    pmse_vat_appointed=False), start=2026-09-11, horizon=90 -> 2 proposals ---
pmse_vat_assessment  once  2026-09-11 | NOT verified: the PMK 81/2024 PDF ... could not be read
                                        on a primary page ...; one_time: due date is the
                                        generation date, set the statutory deadline on review
pse_registration     once  2026-09-11 | one_time: due date is the generation date, set the
                                        statutory deadline on review

--- PT_PMA (has_employees, employee_count=5, pkp), start=2026-09-11, horizon=90 -> 28 proposals ---
halal_certification  once  2026-10-17 | neither sector ... nor business size is a profile
                                        attribute: the 17 October 2026 due date is the
                                        MICRO-AND-SMALL phase of art. 160(2) ...
```

## Tests

From `apps/backend-rag`, `source .venv/bin/activate`, `JWT_SECRET_KEY`/`API_KEYS` exported:

```
PYTHONPATH=.:../crm-cell python -m pytest backend/tests/services/compliance \
  backend/tests/unit/app/routers/test_compliance_obligations.py
468 passed — exit 0
```

New: one_time emitted once per profile with the generation date and the joined reason; the two
PSE/PMSE rules disappear once the client is registered/appointed; `event` rules still empty for a
profile all three apply to; the proposal is byte-identical at horizon 1 and 400; a future
`fixed_date` wins, a `fixed_date` on the generation date wins, a past one reports it passed; the
halal statutory date comes from the catalog and carries no placeholder note; a `fixed_date` on a
monthly, annual or `event` rule fails to load; four malformed `fixed_date` spellings fail to load;
and an upsert re-run at a LATER generation date inserts 0 because the `"once"` key did not move.

`PYTHONPATH=.:../crm-cell python -c "from backend.app.main_cloud import app"` imports (175 routes).
No migration, no router change, no schema change.

## Also in this PR: two tests #6336 left red on main

`Backend Shard 2` has been red on `origin/main` since 15:40Z. #6336 verified — correctly, on primary
sources — that **both** BPJS rules move a deadline off a non-working day (PP 44/2015 art. 21(3) and
PP 46/2015 art. 19(3); Perpres 82/2018 art. 39(4)) and flipped them from `roll: none` to
`roll: next_business_day`. That invalidated the two M1 tests that used those very rules as the
`roll: none` exemplars:

- `test_a_catalog_roll_none_rule_ignores_the_holiday_block_after_it` (expected 2026-08-15, got 18)
- `test_a_roll_none_rule_is_not_flagged_for_an_undecreed_year` (expected 2027-01-10, got 11)

**The catalog reading is right, so the tests moved** onto synthetic `roll: none` rules the catalog
cannot invalidate, keeping the same calendar facts (Sat 2026-08-15 ahead of Independence Day;
Sun 2027-01-10 in an undecreed year) and, in the first case, now asserting the rolling contrast in
the same test. No catalog date or `roll` was touched to make a test pass.

## Adversarial review

Codex (`codex exec --sandbox read-only -c model_reasoning_effort=high`, full diff, no tests run).
Verdict: *"Correggere l'applicazione indiscriminata della scadenza halal e verificare l'idempotenza
sul database prima di approvare."* Two findings, both disposed:

**P1 — the halal fixed date is conditional on a size the engine cannot see.** Correct and concrete:
art. 160(2)'s 17 October 2026 is the micro-and-small phase, while medium and large have been in
force since 17 October 2024 (art. 160(1)), so a medium F&B company is shown a future date when it
is already late. Disposed by **disclosure, not by silence**: `halal_certification`'s
`needs_review_reason` now names business size alongside sector and states both phases, so the
reviewer is told exactly what the engine could not decide. Dropping the date instead would replace a
verified statutory deadline with a generation-date placeholder, which is strictly less information;
conditioning it would need a `business_size` attribute, which is a catalog-and-profile change
outside M2. Flagged for the imperator as the natural U2/M5 follow-up.

**P2 — the mock-pool test does not exercise the UNIQUE constraint.** True, and no live database is
reachable from this suite. Partially addressed: the re-run now happens at a LATER generation date,
which proves the half the engine owns — the due date changes, the `"once"` key does not, so the
constraint has something stable to match on. The constraint itself stays pinned by
`test_migration_309_shape_and_rollback` (the DDL) and end to end by the router's
`test_generate_persists_and_is_idempotent`. A real-DB test is left out on purpose and named in
`instruction_to_the_grader`.

## Evidence

`evidence/2026-09/agent-air-m5-backend-rag-obligations-one-time-tr-67d7841e/brief.yml`, gear **1** —
the deterministic floor `scripts/evidence_pack_lint.py --print-floor` prints for this range
(3 files, +293/-29, no migration, router, workflow, guard or lockfile). No `pack.yml` at gear 1.

Merging this deploys `apps/backend-rag` to Fly. The fresh gate should run, from
`apps/backend-rag` with the venv active:
`PYTHONPATH=.:../crm-cell python -m pytest backend/tests/services/compliance backend/tests/unit/app/routers/test_compliance_obligations.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151rdiec2WR4Lf2BG4UUYqP
