### PR TITLE
feat(mouth): kita pruning lot 4b — owner-only "Da fare" section for the live pages without a link

### DIFF
--- a/apps/mouth/src/components/workspace/AppSidebar.test.tsx
+++ b/apps/mouth/src/components/workspace/AppSidebar.test.tsx
@@ -71,4 +71,102 @@ describe("AppSidebar", () => {
       screen.getByRole("link", { name: "Bali Zero — workspace home" }),
     ).toHaveAttribute("data-prefetch", "false");
   });
+
+  it("shows the owner-only 'Da fare' section to the owner", () => {
+    render(
+      <AppSidebar
+        user={{ name: "Zero", email: "zero@balizero.com" }}
+        onLogout={() => undefined}
+        navigationConfig={[
+          {
+            title: "Da fare",
+            note: "Pagine vive senza link — da rivedere",
+            ownerOnly: true,
+            items: [
+              { title: "Accounting", href: "/accounting", icon: "Banknote" },
+              {
+                title: "Funnel Analytics",
+                href: "/analytics/funnel",
+                icon: "BarChart3",
+              },
+              {
+                title: "GARUDA VOA",
+                href: "/garuda-voa",
+                icon: "ClipboardCheck",
+              },
+              {
+                title: "Team Activity",
+                href: "/admin/team-activity",
+                icon: "Activity",
+              },
+              { title: "Agents", href: "/agents", icon: "BotMessageSquare" },
+              {
+                title: "Intelligence Analytics",
+                href: "/intelligence/analytics",
+                icon: "BarChart3",
+              },
+              {
+                title: "Tax Pilot",
+                href: "/clients/tax-pilot",
+                icon: "Receipt",
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Da fare")).toBeInTheDocument();
+    expect(
+      screen.getByText("Pagine vive senza link — da rivedere"),
+    ).toBeInTheDocument();
+    for (const label of [
+      "Accounting",
+      "Funnel Analytics",
+      "GARUDA VOA",
+      "Team Activity",
+      "Agents",
+      "Intelligence Analytics",
+      "Tax Pilot",
+    ]) {
+      expect(screen.getByRole("link", { name: label })).toHaveAttribute(
+        "href",
+        expect.any(String),
+      );
+    }
+  });
+
+  it("hides the owner-only 'Da fare' section from a non-owner admin", () => {
+    render(
+      <AppSidebar
+        user={{ name: "Admin", email: "asya@balizero.com" }}
+        onLogout={() => undefined}
+        navigationConfig={[
+          {
+            title: "Da fare",
+            note: "Pagine vive senza link — da rivedere",
+            ownerOnly: true,
+            items: [
+              { title: "Accounting", href: "/accounting", icon: "Banknote" },
+            ],
+          },
+          {
+            title: "Work",
+            items: [{ title: "Clients", href: "/clients", icon: "Users" }],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("Da fare")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Pagine vive senza link — da rivedere"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Accounting" }),
+    ).not.toBeInTheDocument();
+    // Innocence: a sibling non-owner-only section on the same navigationConfig
+    // still renders — the filter drops only the flagged section, not everything.
+    expect(screen.getByRole("link", { name: "Clients" })).toBeInTheDocument();
+  });
 });

--- a/apps/mouth/src/components/workspace/AppSidebar.tsx
+++ b/apps/mouth/src/components/workspace/AppSidebar.tsx
@@ -36,6 +36,7 @@ import {
 import { BZLogo } from "@balizero/core/components/BZLogo";
 import { navigation, NavSection, NavItem } from "@/types/navigation";
 import { cn } from "@/lib/utils";
+import { isOwner } from "@/lib/auth/owner";
 
 // Icon mapping
 const iconMap: Record<string, React.ElementType> = {
@@ -96,7 +97,9 @@ export function AppSidebar({
   isZantaraOpen = false,
 }: AppSidebarProps) {
   const pathname = usePathname();
-  const nav = navigationConfig || navigation;
+  const nav = (navigationConfig || navigation).filter(
+    (section) => !section.ownerOnly || isOwner(user.email),
+  );
 
   const isActive = (href: string) => {
     if (!pathname) return false;
@@ -194,6 +197,14 @@ export function AppSidebar({
           style={{ color: "var(--bz-text-3)" }}
         >
           {section.title}
+        </div>
+      )}
+      {section.note && (
+        <div
+          className="text-[8px] px-2.5 pb-1.5 leading-snug"
+          style={{ color: "var(--bz-text-3)" }}
+        >
+          {section.note}
         </div>
       )}
       {section.items.map(renderNavItem)}

--- a/apps/mouth/src/types/navigation.ts
+++ b/apps/mouth/src/types/navigation.ts
@@ -12,6 +12,13 @@ export interface NavItem {
 
 export interface NavSection {
   title?: string;
+  // One-line note rendered under the section title (e.g. an explanatory
+  // subtitle). Currently only used by the owner-only "Da fare" section.
+  note?: string;
+  // When true, AppSidebar hides the whole section unless the signed-in
+  // user is the owner (lib/auth/owner.ts::isOwner). Undefined/false means
+  // visible to everyone, same as before this field existed.
+  ownerOnly?: boolean;
   items: NavItem[];
 }
 
@@ -78,6 +85,36 @@ export const navigation: NavSection[] = [
     title: "System",
     // Block 4: Admin
     items: [{ title: "Settings", href: "/settings", icon: "Settings" }],
+  },
+  {
+    title: "Da fare",
+    note: "Pagine vive senza link — da rivedere",
+    // Owner-only per Zero's 2026-09-12 ruling: these pages are live (real
+    // data, no dead endpoints) but had zero inbound links anywhere in the
+    // app before this section existed. Kept off the team sidebar until the
+    // owner decides which stay, get merged elsewhere, or get cut.
+    ownerOnly: true,
+    items: [
+      { title: "Accounting", href: "/accounting", icon: "Banknote" },
+      {
+        title: "Funnel Analytics",
+        href: "/analytics/funnel",
+        icon: "BarChart3",
+      },
+      { title: "GARUDA VOA", href: "/garuda-voa", icon: "ClipboardCheck" },
+      {
+        title: "Team Activity",
+        href: "/admin/team-activity",
+        icon: "Activity",
+      },
+      { title: "Agents", href: "/agents", icon: "BotMessageSquare" },
+      {
+        title: "Intelligence Analytics",
+        href: "/intelligence/analytics",
+        icon: "BarChart3",
+      },
+      { title: "Tax Pilot", href: "/clients/tax-pilot", icon: "Receipt" },
+    ],
   },
 ];
 
@@ -162,6 +199,12 @@ export const routeTitles: Record<string, string> = {
   "/hr/leave/request": "Request Leave",
   "/hr/settings": "HR Settings",
   "/analytics/funnel": "Funnel Analytics",
+  "/accounting": "Accounting",
+  "/garuda-voa": "GARUDA VOA",
+  "/admin/team-activity": "Team Activity",
+  "/agents": "Agents",
+  "/intelligence/analytics": "Intelligence Analytics",
+  "/clients/tax-pilot": "Tax Pilot",
   "/team/analytics": "Team Analytics",
   "/settings": "Settings",
   // Portal routes


### PR DESCRIPTION
## What
- Plan item 19 of the 2026-09-12 kita dead-surface audit: `/accounting`, `/analytics/funnel`, `/garuda-voa`, `/admin/team-activity`, `/agents`, `/intelligence/analytics` and `/clients/tax-pilot` are live pages (real data, no dead backend endpoints per the audit) that had zero inbound links anywhere in the app.
- Per the owner's ruling, these do NOT go on the team sidebar. Adds a new sidebar section, visible ONLY to the owner, titled `Da fare` with the note `Pagine vive senza link — da rivedere`, linking to all 7 (including `/clients/tax-pilot`, kept in per that ruling despite its two hardcoded company ids — owner will see it and decide).
- Reuses the existing owner predicate `lib/auth/owner.ts::isOwner` (the same SSOT `analytics/layout.tsx`'s founder gate and `hr/layout.tsx` already call) — no new email literal, no second gating mechanism.
- Adds `NavSection.ownerOnly?: boolean` and `NavSection.note?: string` (both optional, `undefined` on every existing section — zero behavior change for anyone else) and filters in `AppSidebar` before render: a non-owner never sees the section header, the note, or a gap where they'd be.
- All 7 items use icons already in `AppSidebar`'s `iconMap` (`Banknote`, `BarChart3` x2, `ClipboardCheck`, `Activity`, `BotMessageSquare`, `Receipt`) — no new icon imports.
- Adds the 6 `routeTitles` entries that were missing (the audit's own `/obligations` lesson: an unreachable page with no `routeTitles` entry silently falls back to "Workspace" in the page header).
- No i18n keys: `AppSidebar` renders `section.title`/`section.note`/`item.title` as literal strings today, same as every existing nav entry — no `t()` call added.

## Verification
- `cd apps/mouth && npx tsc --noEmit` — exit 0
- `cd apps/mouth && npx vitest --run --root . --config vitest.config.ts` — 473 files / 5073 tests passed, exit 0 (includes two new `AppSidebar.test.tsx` cases: owner sees "Da fare" + all 7 links; a non-owner admin sees neither the section nor its note, while a sibling non-owner-only section on the same config still renders — guilt and innocence)
- `cd apps/mouth && npm run build` — exit 0, `PUBLIC_LOGIN_BUNDLE_OK`

## Bites
Consumer: kita.balizero.com, signed in as the owner (`zero@balizero.com`/`antonellosiano@balizero.com`). Observation: the sidebar shows a `Da fare` section with 7 links (Accounting, Funnel Analytics, GARUDA VOA, Team Activity, Agents, Intelligence Analytics, Tax Pilot) and the note "Pagine vive senza link — da rivedere"; signed in as any other team member, the section is entirely absent (no header, no note, no gap).

## Kept on purpose
- `/clients/tax-pilot` left untouched otherwise (still hardcodes two company ids) — owner decision per the instruction, only its reachability changed.

## Out of scope
- Unifying the two owner-gating mechanisms in the codebase (`lib/auth/owner.ts::isOwner` vs. the pre-existing `KitaCommandPalette.tsx` hardcoded `zero@balizero.com` literal used elsewhere) — not touched, out of this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
