### PR TITLE
feat(mouth): client compliance-profile panel on the obligations reviewer (U2)

### DIFF
--- a/apps/mouth/src/app/(workspace)/obligations/components/ClientProfilePanel.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/components/ClientProfilePanel.tsx
@@ -1,0 +1,494 @@
+"use client";
+
+/**
+ * Client compliance profile panel (U2).
+ *
+ * Backend: `GET`/`PATCH /api/compliance/obligations/profile/{client_id}` (M3,
+ * `compliance_obligations.py`). The engine proposes from the attributes it can
+ * read out of `companies.custom_fields`; no client carried them, so every
+ * profile collapsed to the defaults and `applies()` proposed the minimum. This
+ * panel is where the reviewer fills them in before asking for proposals.
+ *
+ * Two rules shape the implementation:
+ *
+ * 1. A save PATCHes ONLY the fields the reviewer touched. The endpoint merges
+ *    into the existing JSONB and never removes a key, so sending the whole
+ *    computed profile back would write every DEFAULT as if a human had asserted
+ *    it — `missing_keys` would come back empty and the "nothing is known about
+ *    this client" signal would be destroyed on the first save.
+ * 2. Values are validated here against the same domains the endpoint enforces,
+ *    so the common mistake costs no round-trip; the server stays the authority
+ *    and its 422 detail is shown verbatim when the two disagree.
+ *
+ * PII: the attributes are client data. They live in component state for the life
+ * of the tab, are never logged and are never sent anywhere but the PATCH.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+
+import { describeError } from "./describe-error";
+import {
+  CARD,
+  COMPANY_TYPE_OPTIONS,
+  INPUT_STYLE,
+  INVESTMENT_STAGE_OPTIONS,
+  PROFILE_BOOLEAN_FIELDS,
+  type ClientProfileAttributes,
+  type ProfileOut,
+  type ProfilePatch,
+} from "./types";
+import { useClientProfile } from "./useClientProfile";
+
+/** A 409 here is not the register's "already decided" conflict. */
+const SAVE_ERROR_OVERRIDES: Readonly<Record<number, string>> = {
+  409: "No company on file for this client. Link a company first — this panel creates nothing.",
+};
+
+const INTEGER_RE = /^\d+$/;
+const FYE_RE = /^\d{2}-\d{2}$/;
+
+type DraftValue = string | boolean;
+type Draft = Record<string, DraftValue>;
+
+function buildPatch(draft: Draft): { patch?: ProfilePatch; error?: string } {
+  const patch: Record<string, string | number | boolean> = {};
+  for (const [name, raw] of Object.entries(draft)) {
+    if (typeof raw === "boolean") {
+      patch[name] = raw;
+      continue;
+    }
+    const value = raw.trim();
+    if (name === "employee_count" || name === "annual_turnover_idr") {
+      if (!INTEGER_RE.test(value)) {
+        return { error: `${name} must be a whole number, zero or more.` };
+      }
+      // JSON carries a double: past 2^53 the number that reaches the endpoint is
+      // not the number that was typed, so refuse rather than store a silent
+      // rounding of a turnover figure.
+      if (!Number.isSafeInteger(Number(value))) {
+        return { error: `${name} is too large to store exactly.` };
+      }
+      patch[name] = Number(value);
+      continue;
+    }
+    if (name === "fiscal_year_end") {
+      if (!FYE_RE.test(value)) {
+        return { error: "Fiscal year end must be MM-DD, for example 12-31." };
+      }
+      patch[name] = value;
+      continue;
+    }
+    if (name === "company_type") {
+      if (!(COMPANY_TYPE_OPTIONS as readonly string[]).includes(value)) {
+        return { error: "Choose one of the listed company types." };
+      }
+      patch[name] = value;
+      continue;
+    }
+    if (name === "investment_stage") {
+      if (value === "") {
+        // PATCH only ever SETS a key, so there is no way to go back to "none"
+        // from this panel — saying so beats a 422 on an empty string.
+        return {
+          error:
+            "Investment stage cannot be cleared here. Choose construction or commercial.",
+        };
+      }
+      if (!(INVESTMENT_STAGE_OPTIONS as readonly string[]).includes(value)) {
+        return { error: "Choose one of the listed investment stages." };
+      }
+      patch[name] = value;
+      continue;
+    }
+    return { error: `${name} is not an attribute this panel can write.` };
+  }
+  return { patch };
+}
+
+function textValue(
+  name: keyof ClientProfileAttributes,
+  draft: Draft,
+  profile: ClientProfileAttributes,
+): string {
+  const touched = draft[name];
+  if (typeof touched === "string") return touched;
+  const current = profile[name];
+  return current === null || current === undefined ? "" : String(current);
+}
+
+function boolValue(
+  name: keyof ClientProfileAttributes,
+  draft: Draft,
+  profile: ClientProfileAttributes,
+): boolean {
+  const touched = draft[name];
+  return typeof touched === "boolean" ? touched : Boolean(profile[name]);
+}
+
+interface FieldProps {
+  name: string;
+  label: string;
+  missing: boolean;
+  children: React.ReactNode;
+}
+
+/** One attribute row, flagged when the engine read it as a default. */
+function Field({ name, label, missing, children }: FieldProps) {
+  return (
+    <div
+      role="group"
+      // The "not set" marker is visible text next to the control, which a
+      // screen reader moving between fields does not pick up. Naming the GROUP
+      // carries it without touching the control's own accessible name (which
+      // stays the bare label, so a query for it still resolves to one element).
+      aria-label={missing ? `${label}, not set` : `${label}, on file`}
+      className="rounded-lg border px-3 py-2"
+      data-testid={`profile-field-${name}`}
+      data-missing={missing ? "true" : "false"}
+      style={{
+        borderColor: missing ? "var(--state-warning)" : "var(--bz-border)",
+      }}
+    >
+      <div className="mb-1 flex items-baseline justify-between gap-2">
+        <span className="text-xs" style={{ color: "var(--bz-text-3)" }}>
+          {label}
+        </span>
+        {missing && (
+          <span className="text-xs" style={{ color: "var(--state-warning)" }}>
+            not set
+          </span>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+interface Props {
+  /** Trimmed client filter. The panel is only rendered when it is non-empty. */
+  clientId: string;
+  /** The page's generate path, offered again once a save lands. */
+  onGenerate: (clientId: string) => void;
+  generating: boolean;
+}
+
+export function ClientProfilePanel({
+  clientId,
+  onGenerate,
+  generating,
+}: Props) {
+  const { data, loading, error, reload } = useClientProfile(clientId);
+  const [draft, setDraft] = useState<Draft>({});
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const missing = useMemo(
+    () => new Set(data?.missing_keys ?? []),
+    [data?.missing_keys],
+  );
+  const touchedKeys = Object.keys(draft);
+
+  const set = useCallback((name: string, value: DraftValue) => {
+    setSaveError(null);
+    setSaved(false);
+    setDraft((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    // The snapshot this save is built from. The fields stay editable while the
+    // request is open, so on success only the keys that are still AT the value
+    // we sent are cleared — an attribute edited again mid-flight stays in the
+    // draft instead of vanishing under a "Profile saved" banner.
+    const sent = draft;
+    const { patch, error: invalid } = buildPatch(sent);
+    if (invalid || !patch) {
+      setSaveError(invalid ?? "Nothing to save.");
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await api.patch<ProfileOut>(
+        `/api/compliance/obligations/profile/${clientId}`,
+        patch,
+      );
+      // Keys only, never values: the values are client data.
+      logger.info("obligations client profile saved", {
+        component: "ObligationsPage",
+        action: "saveClientProfile",
+        metadata: { client_id: clientId, keys: Object.keys(patch).sort() },
+      });
+      setDraft((prev) => {
+        const next: Draft = {};
+        for (const [name, value] of Object.entries(prev)) {
+          if (!(name in sent) || !Object.is(sent[name], value))
+            next[name] = value;
+        }
+        return next;
+      });
+      setSaved(true);
+      await reload();
+    } catch (e) {
+      logger.warn("obligations client profile save failed", {
+        component: "ObligationsPage",
+        action: "saveClientProfile",
+        metadata: { client_id: clientId, keys: Object.keys(patch).sort() },
+      });
+      setSaveError(
+        describeError(
+          e,
+          "Could not save the client profile.",
+          SAVE_ERROR_OVERRIDES,
+        ),
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [clientId, draft, reload]);
+
+  const profile = data?.profile;
+
+  return (
+    <section
+      className="mb-6 rounded-xl border p-4"
+      style={CARD}
+      aria-label="Client profile"
+    >
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <h2
+          className="text-lg font-medium"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          Client profile — client {clientId}
+        </h2>
+        {data && (
+          <span className="text-xs" style={{ color: "var(--bz-text-3)" }}>
+            {data.missing_keys.length} of{" "}
+            {data.missing_keys.length + data.present_keys.length} attributes not
+            set
+          </span>
+        )}
+      </div>
+
+      <p className="mb-3 text-xs" style={{ color: "var(--bz-text-3)" }}>
+        These attributes decide which rules apply. An attribute marked “not set”
+        is sitting at its default, so the register proposes the minimum for it.
+      </p>
+
+      {loading && !profile && (
+        <p style={{ color: "var(--bz-text-3)" }}>Loading the profile…</p>
+      )}
+
+      {error && (
+        <p
+          className="text-sm"
+          role="alert"
+          style={{ color: "var(--state-danger)" }}
+        >
+          {error}
+        </p>
+      )}
+
+      {profile && data && (
+        <>
+          {data.company_type_raw && (
+            <p className="mb-2 text-xs" style={{ color: "var(--bz-text-3)" }}>
+              Company type on file: <strong>{data.company_type_raw}</strong>
+            </p>
+          )}
+          {data.needs_manual_classification && (
+            <div
+              className="mb-3 rounded-md border px-3 py-2 text-sm"
+              role="alert"
+              style={{
+                borderColor: "var(--state-warning)",
+                color: "var(--bz-text-1)",
+              }}
+            >
+              Company type reads as OTHER, so LKPM, PPh 25, SPT Tahunan Badan
+              and RUPS are skipped. Set the company type below before
+              generating.
+            </div>
+          )}
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field
+              name="company_type"
+              label="Company type"
+              missing={missing.has("company_type")}
+            >
+              <select
+                aria-label="Company type"
+                className="block w-full rounded border px-2 py-1.5 text-sm"
+                style={INPUT_STYLE}
+                value={textValue("company_type", draft, profile)}
+                onChange={(e) => set("company_type", e.target.value)}
+              >
+                {COMPANY_TYPE_OPTIONS.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </select>
+            </Field>
+
+            <Field
+              name="investment_stage"
+              label="Investment stage"
+              missing={missing.has("investment_stage")}
+            >
+              <select
+                aria-label="Investment stage"
+                className="block w-full rounded border px-2 py-1.5 text-sm"
+                style={INPUT_STYLE}
+                value={textValue("investment_stage", draft, profile)}
+                onChange={(e) => set("investment_stage", e.target.value)}
+              >
+                <option value="">none</option>
+                {INVESTMENT_STAGE_OPTIONS.map((stage) => (
+                  <option key={stage} value={stage}>
+                    {stage}
+                  </option>
+                ))}
+              </select>
+            </Field>
+
+            <Field
+              name="employee_count"
+              label="Employee count"
+              missing={missing.has("employee_count")}
+            >
+              <input
+                type="number"
+                min={0}
+                aria-label="Employee count"
+                className="block w-full rounded border px-2 py-1.5 text-sm"
+                style={INPUT_STYLE}
+                value={textValue("employee_count", draft, profile)}
+                onChange={(e) => set("employee_count", e.target.value)}
+              />
+            </Field>
+
+            <Field
+              name="annual_turnover_idr"
+              label="Annual turnover (IDR)"
+              missing={missing.has("annual_turnover_idr")}
+            >
+              <input
+                type="number"
+                min={0}
+                aria-label="Annual turnover (IDR)"
+                className="block w-full rounded border px-2 py-1.5 text-sm"
+                style={INPUT_STYLE}
+                value={textValue("annual_turnover_idr", draft, profile)}
+                onChange={(e) => set("annual_turnover_idr", e.target.value)}
+              />
+            </Field>
+
+            <Field
+              name="fiscal_year_end"
+              label="Fiscal year end (MM-DD)"
+              missing={missing.has("fiscal_year_end")}
+            >
+              <input
+                type="text"
+                aria-label="Fiscal year end (MM-DD)"
+                placeholder="12-31"
+                className="block w-full rounded border px-2 py-1.5 text-sm"
+                style={INPUT_STYLE}
+                value={textValue("fiscal_year_end", draft, profile)}
+                onChange={(e) => set("fiscal_year_end", e.target.value)}
+              />
+            </Field>
+          </div>
+
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {PROFILE_BOOLEAN_FIELDS.map(([name, label]) => (
+              <Field
+                key={name}
+                name={name}
+                label={label}
+                missing={missing.has(name)}
+              >
+                <label
+                  className="flex items-center gap-2 text-sm"
+                  style={{ color: "var(--bz-text-2)" }}
+                >
+                  <input
+                    type="checkbox"
+                    aria-label={label}
+                    checked={boolValue(name, draft, profile)}
+                    onChange={(e) => set(name, e.target.checked)}
+                  />
+                  {boolValue(name, draft, profile) ? "yes" : "no"}
+                </label>
+              </Field>
+            ))}
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              disabled={saving || touchedKeys.length === 0}
+              onClick={() => void handleSave()}
+              className="rounded-md px-4 py-2 text-sm font-medium text-white"
+              style={{
+                background: "var(--bz-accent)",
+                opacity: saving || touchedKeys.length === 0 ? 0.6 : 1,
+              }}
+            >
+              {saving ? "Saving…" : "Save profile"}
+            </button>
+            <span className="text-xs" style={{ color: "var(--bz-text-3)" }}>
+              {touchedKeys.length === 0
+                ? "No change to save."
+                : `Saving ${touchedKeys.length} changed attribute${
+                    touchedKeys.length === 1 ? "" : "s"
+                  }.`}
+            </span>
+          </div>
+
+          {saveError && (
+            <p
+              className="mt-2 text-sm"
+              role="alert"
+              style={{ color: "var(--state-danger)" }}
+            >
+              {saveError}
+            </p>
+          )}
+
+          {saved && (
+            <div className="mt-3 flex flex-wrap items-center gap-3">
+              <span
+                className="text-sm"
+                role="status"
+                style={{ color: "var(--bz-text-2)" }}
+              >
+                Profile saved. Generate proposals to apply it.
+              </span>
+              <button
+                type="button"
+                disabled={generating}
+                onClick={() => onGenerate(clientId)}
+                className="rounded-md border px-3 py-1.5 text-sm"
+                style={{
+                  borderColor: "var(--bz-border)",
+                  color: "var(--bz-text-2)",
+                }}
+              >
+                {generating
+                  ? "Generating…"
+                  : `Generate proposals for client ${clientId}`}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/mouth/src/app/(workspace)/obligations/components/describe-error.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/describe-error.ts
@@ -1,8 +1,21 @@
 import { ApiError } from "@/lib/api/error-handler";
 
-/** Turn a thrown api error into the exact text a reviewer should see. */
-export function describeError(e: unknown, fallback: string): string {
+/**
+ * Turn a thrown api error into the exact text a reviewer should see.
+ *
+ * `overrides` replaces the text for one status on one call site, so a surface
+ * with its own wording for a status (the profile panel's 409, which must read
+ * as "no company on file" rather than the register's "already decided") still
+ * goes through this single mapping instead of branching on `statusCode` again.
+ */
+export function describeError(
+  e: unknown,
+  fallback: string,
+  overrides?: Readonly<Record<number, string>>,
+): string {
   if (e instanceof ApiError) {
+    const override = overrides?.[e.statusCode];
+    if (override) return override;
     if (e.statusCode === 401 || e.statusCode === 403) return "Admin only.";
     if (e.statusCode === 404) return e.message || "Not found.";
     if (e.statusCode === 409)

--- a/apps/mouth/src/app/(workspace)/obligations/components/types.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/types.ts
@@ -98,3 +98,86 @@ export const INPUT_STYLE = {
   background: "var(--bz-surface)",
   color: "var(--bz-text-1)",
 } as const;
+
+/**
+ * `GET`/`PATCH /api/compliance/obligations/profile/{client_id}` (M3).
+ *
+ * `profile` is the computed `ClientProfile` dataclass
+ * (`backend/services/compliance/obligations_register.py`) as a dict.
+ * `present_keys` are the `companies.custom_fields` keys the engine parsed;
+ * `missing_keys` the engine ATTRIBUTES still at their default, which is what
+ * makes `applies()` propose the minimum. `company_type_raw` is the
+ * `companies.company_type` string the mapping reads, `null` when the client has
+ * no company row.
+ */
+export interface ClientProfileAttributes {
+  company_type: string;
+  has_employees: boolean;
+  employee_count: number;
+  has_foreign_employees: boolean;
+  pkp: boolean;
+  annual_turnover_idr: number | null;
+  investment_stage: string | null;
+  fiscal_year_end: string;
+  serves_indonesian_users_online: boolean;
+  pse_registered: boolean;
+  pmse_vat_appointed: boolean;
+  has_expat_staff_over_6_months: boolean;
+}
+
+export interface ProfileOut {
+  client_id: number;
+  profile: ClientProfileAttributes;
+  present_keys: string[];
+  missing_keys: string[];
+  company_type_raw: string | null;
+  needs_manual_classification: boolean;
+}
+
+/** The subset of ATTRIBUTES one save writes: only the fields the reviewer touched. */
+export type ProfilePatch = Partial<{
+  company_type: string;
+  investment_stage: string;
+  fiscal_year_end: string;
+  employee_count: number;
+  annual_turnover_idr: number;
+  has_employees: boolean;
+  has_foreign_employees: boolean;
+  pkp: boolean;
+  serves_indonesian_users_online: boolean;
+  pse_registered: boolean;
+  pmse_vat_appointed: boolean;
+  has_expat_staff_over_6_months: boolean;
+}>;
+
+/**
+ * The two closed domains PATCH validates against, mirrored from the engine's
+ * COMPANY_TYPES / INVESTMENT_STAGES frozensets. Unlike the rule catalog no
+ * endpoint serves them, so the select options have to live here; if they ever
+ * drift the PATCH answers 422 naming the allowed set, and this screen shows
+ * that detail verbatim instead of swallowing it.
+ */
+export const COMPANY_TYPE_OPTIONS = [
+  "PT_PMA",
+  "PT_PMDN",
+  "CV",
+  "KP3A",
+  "KPPA",
+  "FOREIGN_PLATFORM",
+  "OTHER",
+] as const;
+
+export const INVESTMENT_STAGE_OPTIONS = ["construction", "commercial"] as const;
+
+/** Engine BOOL_ATTRS, in the order the panel shows them. */
+export const PROFILE_BOOLEAN_FIELDS: ReadonlyArray<
+  readonly [keyof ClientProfileAttributes, string]
+> = [
+  ["has_employees", "Has employees"],
+  ["has_foreign_employees", "Has foreign employees"],
+  ["pkp", "Registered for VAT (PKP)"],
+  ["serves_indonesian_users_online", "Serves Indonesian users online"],
+  ["pse_registered", "Registered as PSE"],
+  ["pmse_vat_appointed", "Appointed PMSE VAT collector"],
+  ["has_expat_staff_over_6_months", "Expat staff over 6 months"],
+];

--- a/apps/mouth/src/app/(workspace)/obligations/components/useClientProfile.ts
+++ b/apps/mouth/src/app/(workspace)/obligations/components/useClientProfile.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+
+import { describeError } from "./describe-error";
+import type { ProfileOut } from "./types";
+
+export interface ClientProfileState {
+  data: ProfileOut | null;
+  loading: boolean;
+  error: string | null;
+  /** Re-read the profile from the server; used after a successful save. */
+  reload: () => Promise<void>;
+}
+
+/**
+ * Load `GET /api/compliance/obligations/profile/{clientId}` for the client the
+ * register is filtered to.
+ *
+ * `clientId` is the trimmed client filter; "" means no client is selected and
+ * nothing is read. The response carries client data (the company's compliance
+ * attributes), so like `useClientNames` it stays in component state for the
+ * life of the tab: never logged, never persisted, never forwarded.
+ */
+export function useClientProfile(clientId: string): ClientProfileState {
+  const [data, setData] = useState<ProfileOut | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Sequence number of the newest read. A response whose number is no longer
+  // current is DROPPED: two reads can be open at once (the mount read and the
+  // reload a save triggers), and applying them in arrival order would let an
+  // older profile overwrite a newer one.
+  const latest = useRef(0);
+
+  const load = useCallback(async (): Promise<void> => {
+    if (!clientId) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    const mine = ++latest.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.get<ProfileOut>(
+        `/api/compliance/obligations/profile/${clientId}`,
+      );
+      if (mine !== latest.current) return;
+      setData(res);
+    } catch (e) {
+      if (mine !== latest.current) return;
+      // The thrown error is NOT passed to the log sink: its message comes from a
+      // client-record read (same reason as useClientNames).
+      logger.warn("obligations client profile load failed", {
+        component: "ObligationsPage",
+        action: "loadClientProfile",
+        metadata: { client_id: clientId },
+      });
+      setData(null);
+      setError(describeError(e, "Could not load the client profile."));
+    } finally {
+      if (mine === latest.current) setLoading(false);
+    }
+  }, [clientId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { data, loading, error, reload: load };
+}

--- a/apps/mouth/src/app/(workspace)/obligations/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/page.test.tsx
@@ -14,6 +14,7 @@ vi.mock("next/navigation", () => ({
 const apiMock = vi.hoisted(() => ({
   get: vi.fn(),
   post: vi.fn(),
+  patch: vi.fn(),
 }));
 
 vi.mock("@/lib/api", () => ({ api: apiMock }));
@@ -93,6 +94,44 @@ const CLIENT_NAMES: Record<string, string> = {
   "43": "Fixture Client Beta",
 };
 
+/**
+ * `GET /obligations/profile/{id}` (M3): the all-defaults profile every client
+ * currently has, with `fiscal_year_end` the one attribute actually on file.
+ */
+const PROFILE = {
+  client_id: 42,
+  profile: {
+    company_type: "OTHER",
+    has_employees: false,
+    employee_count: 0,
+    has_foreign_employees: false,
+    pkp: false,
+    annual_turnover_idr: null,
+    investment_stage: null,
+    fiscal_year_end: "12-31",
+    serves_indonesian_users_online: false,
+    pse_registered: false,
+    pmse_vat_appointed: false,
+    has_expat_staff_over_6_months: false,
+  },
+  present_keys: ["fiscal_year_end"],
+  missing_keys: [
+    "company_type",
+    "has_employees",
+    "employee_count",
+    "has_foreign_employees",
+    "pkp",
+    "annual_turnover_idr",
+    "investment_stage",
+    "serves_indonesian_users_online",
+    "pse_registered",
+    "pmse_vat_appointed",
+    "has_expat_staff_over_6_months",
+  ],
+  company_type_raw: "PT PERSEROAN LAINNYA",
+  needs_manual_classification: true,
+};
+
 interface Deferred {
   status: string;
   resolve: (total: number) => void;
@@ -113,15 +152,27 @@ function installApiGet(
     deferCounters?: Deferred[];
     /** Collects one resolver per CRM client read instead of answering at once. */
     deferClients?: Array<{ id: string; resolve: () => void }>;
+    /** Answered for every profile read; the second read can differ from the first. */
+    profile?: unknown;
+    profileAfterSave?: unknown;
   } = {},
 ) {
   const listCalls: string[] = [];
   const counterCalls: string[] = [];
   const clientCalls: string[] = [];
+  const profileCalls: string[] = [];
 
   apiMock.get.mockImplementation((url: string) => {
     if (url.startsWith("/api/compliance/obligations/catalog")) {
       return Promise.resolve(opts.catalog ?? CATALOG);
+    }
+    if (url.startsWith("/api/compliance/obligations/profile/")) {
+      profileCalls.push(url);
+      const body =
+        profileCalls.length > 1 && opts.profileAfterSave
+          ? opts.profileAfterSave
+          : (opts.profile ?? PROFILE);
+      return Promise.resolve(body);
     }
     if (url.startsWith("/api/compliance/obligations?")) {
       const params = new URLSearchParams(url.split("?")[1] ?? "");
@@ -176,7 +227,7 @@ function installApiGet(
     return Promise.reject(new Error(`unexpected GET ${url}`));
   });
 
-  return { listCalls, counterCalls, clientCalls };
+  return { listCalls, counterCalls, clientCalls, profileCalls };
 }
 
 describe("ObligationsPage", () => {
@@ -184,6 +235,7 @@ describe("ObligationsPage", () => {
     vi.clearAllMocks();
     installApiGet();
     apiMock.post.mockResolvedValue({});
+    apiMock.patch.mockResolvedValue(PROFILE);
   });
 
   it("renders proposed rows from the list response", async () => {
@@ -521,5 +573,302 @@ describe("ObligationsPage", () => {
     expect(
       screen.getByText("Could not load the rule catalog — showing rule ids."),
     ).toBeVisible();
+  });
+});
+
+describe("ObligationsPage — client profile panel (U2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.post.mockResolvedValue({});
+    apiMock.patch.mockResolvedValue(PROFILE);
+  });
+
+  /** Set the client filter: the panel is only rendered for one client. */
+  async function selectClient(clientId = "42") {
+    render(<ObligationsPage />);
+    await screen.findByText("PPh 21 — employee withholding deposit");
+    fireEvent.change(screen.getByPlaceholderText("all clients"), {
+      target: { value: clientId },
+    });
+    return screen.findByLabelText("Company type");
+  }
+
+  it("loads the profile only once a client filter is set", async () => {
+    const { profileCalls } = installApiGet({ listForClient: LIST_RESPONSE });
+
+    render(<ObligationsPage />);
+    await screen.findByText("PPh 21 — employee withholding deposit");
+    expect(profileCalls.length).toBe(0);
+    expect(screen.queryByLabelText("Company type")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("all clients"), {
+      target: { value: "42" },
+    });
+
+    await screen.findByLabelText("Company type");
+    expect(profileCalls).toEqual(["/api/compliance/obligations/profile/42"]);
+  });
+
+  it("highlights every attribute the engine read as a default", async () => {
+    installApiGet({ listForClient: LIST_RESPONSE });
+    await selectClient();
+
+    // missing_keys -> flagged; the one key on file is not.
+    expect(screen.getByTestId("profile-field-company_type")).toHaveAttribute(
+      "data-missing",
+      "true",
+    );
+    expect(screen.getByTestId("profile-field-pkp")).toHaveAttribute(
+      "data-missing",
+      "true",
+    );
+    expect(screen.getByTestId("profile-field-fiscal_year_end")).toHaveAttribute(
+      "data-missing",
+      "false",
+    );
+    expect(screen.getAllByText("not set").length).toBe(
+      PROFILE.missing_keys.length,
+    );
+    expect(screen.getByText("11 of 12 attributes not set")).toBeVisible();
+
+    // company_type_raw and needs_manual_classification, both set here.
+    expect(screen.getByText("PT PERSEROAN LAINNYA")).toBeVisible();
+    expect(screen.getByText(/Company type reads as OTHER/)).toBeVisible();
+  });
+
+  it("sends a PATCH carrying only the touched keys", async () => {
+    installApiGet({ listForClient: LIST_RESPONSE });
+    const select = await selectClient();
+
+    // Save is inert until something is touched.
+    expect(screen.getByRole("button", { name: "Save profile" })).toBeDisabled();
+
+    fireEvent.change(select, { target: { value: "PT_PMA" } });
+    fireEvent.change(screen.getByLabelText("Employee count"), {
+      target: { value: "12" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
+
+    await waitFor(() => expect(apiMock.patch).toHaveBeenCalledTimes(1));
+    // Exact object: the untouched ten attributes must NOT be written, or every
+    // default would be stored as if a reviewer had asserted it.
+    expect(apiMock.patch).toHaveBeenCalledWith(
+      "/api/compliance/obligations/profile/42",
+      { company_type: "PT_PMA", employee_count: 12 },
+    );
+  });
+
+  it("sends a touched boolean as a boolean", async () => {
+    installApiGet({ listForClient: LIST_RESPONSE });
+    await selectClient();
+
+    fireEvent.click(screen.getByLabelText("Registered for VAT (PKP)"));
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
+
+    await waitFor(() =>
+      expect(apiMock.patch).toHaveBeenCalledWith(
+        "/api/compliance/obligations/profile/42",
+        { pkp: true },
+      ),
+    );
+  });
+
+  it("rejects a malformed fiscal year end before the round-trip", async () => {
+    installApiGet({ listForClient: LIST_RESPONSE });
+    await selectClient();
+
+    fireEvent.change(screen.getByLabelText("Fiscal year end (MM-DD)"), {
+      target: { value: "31 December" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
+
+    expect(
+      await screen.findByText(
+        "Fiscal year end must be MM-DD, for example 12-31.",
+      ),
+    ).toBeVisible();
+    expect(apiMock.patch).not.toHaveBeenCalled();
+  });
+
+  it("shows the no-company message on a 409", async () => {
+    installApiGet({ listForClient: LIST_RESPONSE });
+    apiMock.patch.mockRejectedValueOnce(
+      new ApiError("Client has no company row to store the profile on", 409, {
+        detail: "Client has no company row",
+      }),
+    );
+    await selectClient();
+
+    fireEvent.click(screen.getByLabelText("Has employees"));
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
+
+    expect(
+      await screen.findByText(/No company on file for this client/),
+    ).toBeVisible();
+    // The register's own 409 copy ("already decided") must not appear here.
+    expect(screen.queryByText(/already decided/)).not.toBeInTheDocument();
+  });
+
+  it("shows the 422 detail verbatim when the server rejects a value", async () => {
+    installApiGet({ listForClient: LIST_RESPONSE });
+    apiMock.patch.mockRejectedValueOnce(
+      new ApiError("invalid value for 'company_type'", 422, {
+        detail: "invalid value for 'company_type'",
+      }),
+    );
+    await selectClient();
+
+    fireEvent.click(screen.getByLabelText("Has employees"));
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
+
+    expect(
+      await screen.findByText("invalid value for 'company_type'"),
+    ).toBeVisible();
+  });
+
+  it("refreshes the profile after a successful save and offers generate", async () => {
+    const saved = {
+      ...PROFILE,
+      profile: { ...PROFILE.profile, company_type: "PT_PMA" },
+      present_keys: ["fiscal_year_end", "compliance_company_type"],
+      missing_keys: PROFILE.missing_keys.filter((k) => k !== "company_type"),
+      needs_manual_classification: false,
+    };
+    const { profileCalls } = installApiGet({
+      listForClient: LIST_RESPONSE,
+      profileAfterSave: saved,
+    });
+    const select = await selectClient();
+
+    fireEvent.change(select, { target: { value: "PT_PMA" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
+
+    // The save re-reads the profile rather than trusting local state.
+    await waitFor(() => expect(profileCalls.length).toBe(2));
+    expect(
+      await screen.findByText("Profile saved. Generate proposals to apply it."),
+    ).toBeVisible();
+    expect(screen.getByTestId("profile-field-company_type")).toHaveAttribute(
+      "data-missing",
+      "false",
+    );
+    expect(
+      screen.queryByText(/Company type reads as OTHER/),
+    ).not.toBeInTheDocument();
+    // Nothing left to save: the draft was cleared by the successful PATCH.
+    expect(screen.getByRole("button", { name: "Save profile" })).toBeDisabled();
+
+    // The offered action is the page's own generate path, for the filtered client.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Generate proposals for client 42" }),
+    );
+    await waitFor(() =>
+      expect(apiMock.post).toHaveBeenCalledWith(
+        "/api/compliance/obligations/generate",
+        { client_id: 42, horizon_days: 90 },
+      ),
+    );
+  });
+
+  it("drops an unsaved draft when the client filter moves to another client", async () => {
+    // Regression: the panel holds the draft, so without a remount per client the
+    // previous client's unsaved edits stayed on screen and a save would have
+    // written them to the NEW client.
+    installApiGet({ listForClient: LIST_RESPONSE });
+    const select = await selectClient("42");
+
+    fireEvent.change(select, { target: { value: "PT_PMA" } });
+    fireEvent.change(screen.getByLabelText("Employee count"), {
+      target: { value: "7" },
+    });
+    expect(screen.getByRole("button", { name: "Save profile" })).toBeEnabled();
+
+    fireEvent.change(screen.getByPlaceholderText("all clients"), {
+      target: { value: "43" },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Company type")).toHaveValue("OTHER"),
+    );
+    expect(screen.getByLabelText("Employee count")).toHaveValue(0);
+    expect(screen.getByRole("button", { name: "Save profile" })).toBeDisabled();
+    expect(apiMock.patch).not.toHaveBeenCalled();
+  });
+
+  it("keeps an attribute edited while the PATCH was in flight", async () => {
+    // Regression: clearing the whole draft on success dropped any edit made
+    // while the request was open, and said "Profile saved" over the loss.
+    installApiGet({ listForClient: LIST_RESPONSE });
+    let resolvePatch: (value: unknown) => void = () => {};
+    apiMock.patch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await selectClient();
+
+    fireEvent.click(screen.getByLabelText("Registered for VAT (PKP)"));
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
+    await waitFor(() => expect(apiMock.patch).toHaveBeenCalledTimes(1));
+
+    // Second edit lands while the first save is still open.
+    fireEvent.change(screen.getByLabelText("Employee count"), {
+      target: { value: "5" },
+    });
+    resolvePatch(PROFILE);
+
+    expect(
+      await screen.findByText("Profile saved. Generate proposals to apply it."),
+    ).toBeVisible();
+    expect(screen.getByLabelText("Employee count")).toHaveValue(5);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
+    await waitFor(() => expect(apiMock.patch).toHaveBeenCalledTimes(2));
+    expect(apiMock.patch).toHaveBeenLastCalledWith(
+      "/api/compliance/obligations/profile/42",
+      { employee_count: 5 },
+    );
+  });
+
+  it("refuses a turnover too large to carry exactly", async () => {
+    installApiGet({ listForClient: LIST_RESPONSE });
+    await selectClient();
+
+    fireEvent.change(screen.getByLabelText("Annual turnover (IDR)"), {
+      target: { value: "9007199254740993" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
+
+    expect(
+      await screen.findByText(
+        "annual_turnover_idr is too large to store exactly.",
+      ),
+    ).toBeVisible();
+    expect(apiMock.patch).not.toHaveBeenCalled();
+  });
+
+  it("shows the admin-only message when the profile read is forbidden", async () => {
+    installApiGet({ listForClient: LIST_RESPONSE });
+    const rejectingGet = apiMock.get.getMockImplementation();
+    apiMock.get.mockImplementation((url: string) => {
+      if (url.startsWith("/api/compliance/obligations/profile/")) {
+        return Promise.reject(
+          new ApiError("CRM admin required", 403, {
+            detail: "CRM admin required",
+          }),
+        );
+      }
+      return rejectingGet?.(url);
+    });
+
+    render(<ObligationsPage />);
+    await screen.findByText("PPh 21 — employee withholding deposit");
+    fireEvent.change(screen.getByPlaceholderText("all clients"), {
+      target: { value: "42" },
+    });
+
+    expect(await screen.findByText("Admin only.")).toBeVisible();
+    expect(screen.queryByLabelText("Company type")).not.toBeInTheDocument();
   });
 });

--- a/apps/mouth/src/app/(workspace)/obligations/page.tsx
+++ b/apps/mouth/src/app/(workspace)/obligations/page.tsx
@@ -28,6 +28,12 @@
  * the frontend and a resolved client name never leaves the browser tab: no
  * log, no storage, no other request carries it (see `useClientNames`).
  *
+ * Client profile (U2): with a client filter set, `ClientProfilePanel` reads
+ * `GET /obligations/profile/{client_id}` and lets the reviewer fill in the
+ * attributes the engine reads out of `companies.custom_fields`. A save PATCHes
+ * only the touched keys — see that component for why sending the whole profile
+ * back would destroy the `missing_keys` signal.
+ *
  * Auth + transport reuse the shared `api` client (httpOnly cookie + bearer),
  * same as `(workspace)/review/page.tsx`.
  */
@@ -38,6 +44,7 @@ import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
 
+import { ClientProfilePanel } from "./components/ClientProfilePanel";
 import { ObligationsTable } from "./components/ObligationsTable";
 import { StatusCounters } from "./components/StatusCounters";
 import { describeError } from "./components/describe-error";
@@ -141,40 +148,49 @@ export default function ObligationsPage() {
     setOffset(0);
   }, [filterClientId, filterStatus]);
 
-  const handleGenerate = useCallback(async () => {
-    setGenerateError(null);
-    const cid = Number(genClientId);
-    if (!genClientId.trim() || !Number.isInteger(cid) || cid <= 0) {
-      setGenerateError("Enter a valid client id.");
-      return;
-    }
-    const horizon = Number(genHorizonDays);
-    if (!Number.isInteger(horizon) || horizon < 1 || horizon > 730) {
-      setGenerateError("Horizon days must be an integer between 1 and 730.");
-      return;
-    }
-    setGenerating(true);
-    setGenerateResult(null);
-    setNotice(null);
-    try {
-      const res = await api.post<GenerateOut>(
-        "/api/compliance/obligations/generate",
-        { client_id: cid, horizon_days: horizon },
-      );
-      setGenerateResult(res);
-      setRefreshTick((t) => t + 1);
-      await loadList();
-    } catch (e) {
-      logger.error(
-        "obligations generate failed",
-        { component: "ObligationsPage", action: "generate" },
-        e instanceof Error ? e : new Error(String(e)),
-      );
-      setGenerateError(describeError(e, "Could not generate proposals."));
-    } finally {
-      setGenerating(false);
-    }
-  }, [genClientId, genHorizonDays, loadList]);
+  /**
+   * `clientIdOverride` lets the profile panel (U2) reuse this exact path after a
+   * save instead of owning a second generate implementation: same validation,
+   * same result banner, same list refresh. Omitted, it reads the form field.
+   */
+  const handleGenerate = useCallback(
+    async (clientIdOverride?: string) => {
+      setGenerateError(null);
+      const rawClientId = clientIdOverride ?? genClientId;
+      const cid = Number(rawClientId);
+      if (!rawClientId.trim() || !Number.isInteger(cid) || cid <= 0) {
+        setGenerateError("Enter a valid client id.");
+        return;
+      }
+      const horizon = Number(genHorizonDays);
+      if (!Number.isInteger(horizon) || horizon < 1 || horizon > 730) {
+        setGenerateError("Horizon days must be an integer between 1 and 730.");
+        return;
+      }
+      setGenerating(true);
+      setGenerateResult(null);
+      setNotice(null);
+      try {
+        const res = await api.post<GenerateOut>(
+          "/api/compliance/obligations/generate",
+          { client_id: cid, horizon_days: horizon },
+        );
+        setGenerateResult(res);
+        setRefreshTick((t) => t + 1);
+        await loadList();
+      } catch (e) {
+        logger.error(
+          "obligations generate failed",
+          { component: "ObligationsPage", action: "generate" },
+          e instanceof Error ? e : new Error(String(e)),
+        );
+        setGenerateError(describeError(e, "Could not generate proposals."));
+      } finally {
+        setGenerating(false);
+      }
+    },
+    [genClientId, genHorizonDays, loadList],
+  );
 
   const handleApprove = useCallback(
     async (row: ObligationOut) => {
@@ -382,6 +398,24 @@ export default function ObligationsPage() {
           </div>
         )}
       </section>
+
+      {/* ── Client profile (U2) ──────────────────────────────────────────
+          Only meaningful for ONE client, so it follows the client filter the
+          same way the counter strip does. It sits under the generate card
+          because its "Generate proposals" action reports into that card. */}
+      {trimmedClientFilter !== "" && (
+        <ClientProfilePanel
+          // `key` on the client id, deliberately: the panel holds an unsaved
+          // DRAFT. Without a remount, switching the filter from one client to
+          // another keeps the previous client's edits on screen and a save would
+          // write them to the new client. Remounting throws the draft away with
+          // the client it belonged to.
+          key={trimmedClientFilter}
+          clientId={trimmedClientFilter}
+          generating={generating}
+          onGenerate={(cid) => void handleGenerate(cid)}
+        />
+      )}
 
       {/* ── Status counters ──────────────────────────────────────────── */}
       <StatusCounters

--- a/evidence/2026-09/agent-air-m5-mouth-obligations-client-profile-fo-616f4ee7/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-obligations-client-profile-fo-616f4ee7/brief.yml
@@ -1,0 +1,76 @@
+task: >-
+  U2 of the compliance-stack second wave: give the tax team a place to fill in the client
+  attributes the obligations engine reads. `profile_from_rows` reads company attributes out of
+  `companies.custom_fields`, no client carries them, so every profile collapses to the
+  ClientProfile defaults and `applies()` proposes the minimum — the PPh 21, BPJS and LKPM rules
+  the compliance offer sells never reach the reviewer queue. M3 shipped the endpoints
+  (`GET`/`PATCH /api/compliance/obligations/profile/{client_id}`) and U1 split the reviewer
+  screen into components; this PR adds the panel that uses them. It renders the computed
+  profile with `missing_keys` flagged, `company_type_raw` and the OTHER-classification warning,
+  edits the twelve engine ATTRIBUTES, and PATCHes ONLY the keys the reviewer touched — sending
+  the whole computed profile back would write every default as an asserted value and empty
+  `missing_keys` on the first save, destroying the "nothing is known about this client" signal.
+lane: mouth/obligations-client-profile-form
+machine: M5
+date: 2026-09-13
+
+gear: 2
+gear_reason: >-
+  Deterministic floor 2, source `size`: `scripts/evidence_pack_lint.py --print-floor` over the
+  staged diff (1085+/37- across 6 files plus this brief) printed 2. No hot-zone path: one Next.js workspace route
+  and its components, no router, no migration, no ingestion. One concern — the profile panel —
+  and the bulk is a twelve-attribute form plus its fixtures.
+
+appetite:
+  wall_clock_hours: 2
+  adversarial_rounds: 1
+
+acceptance:
+  A1: >-
+    With a client filter set, the panel reads the profile once and flags every attribute the
+    engine read as a default; the one attribute on file is not flagged, and
+    `needs_manual_classification` plus `company_type_raw` are shown when set.
+    probe: >-
+      cd apps/mouth && npx vitest run 'src/app/(workspace)/obligations'
+  A2: >-
+    A save PATCHes exactly the touched keys and nothing else (asserted as an exact object, not a
+    subset), booleans as booleans and counts as numbers; a malformed fiscal year end is refused
+    before the round-trip.
+    probe: >-
+      cd apps/mouth && npx vitest run 'src/app/(workspace)/obligations'
+  A3: >-
+    409 reads as "No company on file for this client" rather than the register's "already
+    decided" conflict copy, 422 shows the server detail verbatim, 401/403 read "Admin only." —
+    all through the single `describeError` mapping, which now takes per-status overrides.
+    probe: >-
+      cd apps/mouth && npx vitest run 'src/app/(workspace)/obligations'
+  A4: >-
+    A successful save re-reads the profile from the server rather than trusting local state, the
+    draft is cleared, and the page's own generate path is offered for the filtered client.
+    probe: >-
+      cd apps/mouth && npx vitest run 'src/app/(workspace)/obligations'
+  A5: >-
+    The U1 tests stay green and the screen still builds: 26 tests in the obligations suite,
+    `npm run lint`, `npx tsc --noEmit`, `npm run build` all exit 0.
+    probe: >-
+      cd apps/mouth && npm run lint && npx tsc --noEmit && npm run build
+
+adversarial_findings_disposed: >-
+  Codex spalla, read-only, high effort. P1 draft surviving a client change: fixed before the
+  review landed with `key={trimmedClientFilter}` on the panel plus a regression test. P1
+  out-of-order profile reads: fixed with a sequence number in `useClientProfile`, newest read
+  wins. P1 a successful save wiping an edit made while the PATCH was open: fixed — only the keys
+  still at the value that was SENT are cleared, with a test using a deferred PATCH. P2
+  `Number()` past 2^53 storing a rounded turnover: fixed with a `Number.isSafeInteger` refusal
+  and a test. P3 the "not set" marker not reaching a screen reader: the field group is now named
+  "<label>, not set" / "<label>, on file", leaving the control's own accessible name alone.
+
+out_of_scope: >-
+  Clearing an attribute: PATCH only ever SETS a key (the endpoint's JSONB merge never removes
+  one), so the panel refuses an empty investment stage with that explanation instead of
+  round-tripping a 422 it cannot satisfy. Creating a company row for a client that has none —
+  the endpoint answers 409 by design and the panel says so. Writing the pilot client's real
+  attributes: that is the imperator's observation after Zero names the client_id. Serving
+  COMPANY_TYPES / INVESTMENT_STAGES from an endpoint so the selects stop mirroring the engine's
+  frozensets — no route exposes them today, and the 422 detail names the allowed set when they
+  drift.


### PR DESCRIPTION
## What

U2 of the compliance-stack second wave: a **Client profile** panel on the obligations reviewer
(`kita.balizero.com/obligations`), shown when the client filter is set.

`profile_from_rows` reads a client's applicability attributes out of `companies.custom_fields`.
No client carries them, so every profile collapses to the `ClientProfile` defaults, `applies()`
proposes the minimum, and the PPh 21 / BPJS / LKPM rules the compliance offer sells never reach
the queue. M3 (#6330) shipped the endpoints; this PR is the screen that uses them.

- `components/ClientProfilePanel.tsx` (new): reads `GET /api/compliance/obligations/profile/{client_id}`,
  renders all twelve engine ATTRIBUTES with `missing_keys` flagged, plus `company_type_raw` and the
  OTHER-classification warning when set. Editable: `company_type` (select over COMPANY_TYPES), the
  seven booleans, `employee_count`, `annual_turnover_idr`, `fiscal_year_end` (MM-DD), `investment_stage`.
- **Save PATCHes only the keys the reviewer touched.** The endpoint merges JSONB and never removes a
  key, so sending the whole computed profile back would write every DEFAULT as an asserted value and
  empty `missing_keys` on the first save — the "nothing is known about this client" signal would be
  destroyed. The test asserts the payload as an exact object, not a subset.
- On success the profile is re-read from the server and the page's own generate path is offered for
  that client (`handleGenerate` now takes an optional client id instead of owning a second copy).
- `describeError` takes per-status overrides, so 409 reads "No company on file for this client"
  instead of the register's "already decided" conflict copy, while 401/403/404/422 keep one mapping.

PII: the attributes are client data. They stay in component state for the life of the tab, the save
logs keys only and never values, and the fixtures use ids with two invented names.

## Checks (from `apps/mouth`, in the worktree)

| command | exit |
| --- | --- |
| `npm run lint` | 0 |
| `npx tsc --noEmit` | 0 |
| `npx vitest run 'src/app/(workspace)/obligations'` | 0 — 26 tests (U1's 17 still green) |
| `npm run build` | 0 |

Evidence: `evidence/2026-09/agent-air-m5-mouth-obligations-client-profile-fo-616f4ee7/brief.yml`,
gear 2 as printed by `scripts/evidence_pack_lint.py --print-floor`.

Bites: consumer = the tax team's reviewer on kita.balizero.com/obligations, preparing the first
pilot client. Observation = with the client filter set, the panel lists the eleven attributes the
engine read as defaults and one save sends exactly the touched keys — asserted in
`page.test.tsx` ("highlights every attribute the engine read as a default", "sends a PATCH carrying
only the touched keys"), and on the live page by the imperator once Zero names the pilot `client_id`:
a PATCH followed by `/generate` proposing PPh 21 rules the default profile did not.

## Adversarial review

Codex spalla, `codex exec --sandbox read-only -c model_reasoning_effort=high`, on the staged diff.
Verdict: **BLOCKER, 3×P1 + 1×P2 + 1×P3.** All five disposed in this head:

1. **P1 — the draft survived a client change** (edit A, select B, save → A's values PATCHed onto B).
   Fixed before the review landed: `key={trimmedClientFilter}` on the panel, so the draft is thrown
   away with the client it belonged to. Test: "drops an unsaved draft when the client filter moves to
   another client".
2. **P1 — out-of-order profile reads.** `useClientProfile` now carries a sequence number and drops any
   response that is no longer the newest; two reads can be open at once (mount read plus the reload a
   save triggers).
3. **P1 — a successful save wiped an edit made while the PATCH was open**, under a "Profile saved"
   banner. Fixed: only the keys still AT the value that was sent are cleared. Test uses a deferred
   PATCH and asserts the later edit survives and is what the next save sends.
4. **P2 — `Number()` past 2^53** would store a rounded turnover. Refused now with
   `Number.isSafeInteger`, with a test on 9007199254740993.
5. **P3 — the "not set" marker never reached a screen reader.** The field group is named
   "<label>, not set" / "<label>, on file", leaving each control's own accessible name alone.

Codex also confirmed: the ordinary PATCH carries only touched keys, no profile values appear in the
new logs, copy is English, 403/409/422 handling consistent. Its review was static; the tests above
were run here.

## Left out

Clearing an attribute (PATCH only ever SETS a key, so an empty investment stage is refused with that
explanation rather than round-tripped as a 422), creating a company row for a client that has none
(409 by design, and the panel says so), and serving COMPANY_TYPES / INVESTMENT_STAGES from an
endpoint — no route exposes them today, so the selects mirror the engine's frozensets and the 422
detail names the allowed set if they drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151rdiec2WR4Lf2BG4UUYqP
