### PR TITLE
feat(visa-engine): seq-21 rule pack for 5 of the 9 zero-support products — unsigned, awaiting Zero (PR-D4b)

### DIFF
--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-021.source.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-021.source.json
@@ -6308,7 +6308,7 @@
       },
       "rule_id": "el.e33a.government-invitation",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": [
         "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
         "9248b1d7-9172-54d9-ad61-251e83a2285b"
@@ -6332,9 +6332,9 @@
             "values": ["EMPLOYMENT"]
           },
           {
-            "op": "in",
+            "op": "eq",
             "fact": "sponsor.type",
-            "values": ["GOVERNMENT", "NONE"]
+            "value": "GOVERNMENT"
           }
         ]
       },
@@ -6347,7 +6347,7 @@
       },
       "rule_id": "el.e33b.government-collaboration",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": [
         "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
         "9248b1d7-9172-54d9-ad61-251e83a2285b"
@@ -6371,9 +6371,9 @@
             "values": ["INVESTMENT"]
           },
           {
-            "op": "in",
+            "op": "eq",
             "fact": "sponsor.type",
-            "values": ["GOVERNMENT", "NONE"]
+            "value": "GOVERNMENT"
           }
         ]
       },
@@ -6386,7 +6386,7 @@
       },
       "rule_id": "el.e33c.world-figure-invitation",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": [
         "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
         "9248b1d7-9172-54d9-ad61-251e83a2285b"
@@ -6414,7 +6414,7 @@
       },
       "rule_id": "hf.e23u.sponsor-not-individual",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": [
         "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
         "e3572ad2-08a9-55bd-b818-353b3e9db715"
@@ -6453,7 +6453,7 @@
       },
       "rule_id": "el.e23u.diplomatic-household",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": [
         "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
         "e3572ad2-08a9-55bd-b818-353b3e9db715"
@@ -6481,7 +6481,7 @@
       },
       "rule_id": "hf.e23v.sponsor-not-government",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": [
         "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
         "e3572ad2-08a9-55bd-b818-353b3e9db715"
@@ -6520,7 +6520,7 @@
       },
       "rule_id": "el.e23v.trade-office",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": [
         "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
         "e3572ad2-08a9-55bd-b818-353b3e9db715"

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-021.source.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-021.source.json
@@ -616,7 +616,7 @@
       },
       "rule_id": "review.e28b.usd-threshold-manual",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
       "valid_period": {
         "to": null,
@@ -651,7 +651,7 @@
       },
       "rule_id": "review.e28c.usd-threshold-manual",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
       "valid_period": {
         "to": null,
@@ -686,7 +686,7 @@
       },
       "rule_id": "review.e28d.usd-threshold-turnover-manual",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
       "valid_period": {
         "to": null,
@@ -721,7 +721,7 @@
       },
       "rule_id": "review.e28f.ikn-threshold-manual",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
       "valid_period": {
         "to": null,
@@ -1087,7 +1087,7 @@
       },
       "rule_id": "review.e33a.central-government-invitation",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
       "valid_period": {
         "to": null,
@@ -1122,7 +1122,7 @@
       },
       "rule_id": "review.e33b.expertise-qualification",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
       "valid_period": {
         "to": null,
@@ -1157,7 +1157,7 @@
       },
       "rule_id": "review.e33c.central-government-invitation",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
       "valid_period": {
         "to": null,
@@ -6095,7 +6095,7 @@
       },
       "rule_id": "review.e23u.requested-product",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
       "valid_period": {
         "to": null,
@@ -6130,7 +6130,7 @@
       },
       "rule_id": "review.e23v.requested-product",
       "priority": 100,
-      "on_unknown": "NEEDS_INPUT",
+      "on_unknown": "NO_EFFECT",
       "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
       "valid_period": {
         "to": null,

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-021.source.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-021.source.json
@@ -1,0 +1,9481 @@
+{
+  "rules": [
+    {
+      "when": {
+        "op": "eq",
+        "fact": "derived.has_indonesian_citizenship",
+        "value": true
+      },
+      "scope": "GLOBAL",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "APPLICANT_IS_INDONESIAN_CITIZEN"
+      },
+      "rule_id": "hf.citizen",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["derived.has_indonesian_citizenship"],
+      "explanation_key": "explain.hf.citizen",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 60
+      },
+      "scope": "GLOBAL",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "OVERSTAY_EXCEEDS_60_DAYS"
+      },
+      "rule_id": "hf.overstay-exceeds-60-days",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["immigration.overstay_days"],
+      "explanation_key": "explain.hf.overstay-exceeds-60-days",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "when": {
+        "op": "intersects",
+        "fact": "person.nationalities",
+        "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+      },
+      "scope": "GLOBAL",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CALLING_VISA_REVIEW"
+      },
+      "rule_id": "review.calling-visa",
+      "priority": 100,
+      "on_unknown": "HUMAN_REVIEW",
+      "source_refs": ["bc309fa9-d14e-5625-b914-72fe4a68c19d"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["person.nationalities"],
+      "explanation_key": "explain.review.calling-visa",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 0
+      },
+      "scope": "GLOBAL",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ACTIVE_OVERSTAY"
+      },
+      "rule_id": "review.active-overstay",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["immigration.overstay_days"],
+      "explanation_key": "explain.review.active-overstay",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "BN",
+            "MY",
+            "TH",
+            "SG",
+            "PH",
+            "KH",
+            "LA",
+            "MM",
+            "VN",
+            "TL",
+            "SR",
+            "CO",
+            "HK",
+            "TR",
+            "BR",
+            "PE",
+            "MO",
+            "KZ",
+            "BY"
+          ]
+        }
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BVK_NATIONALITY_ONLY"
+      },
+      "rule_id": "hf.a1.not-bvk-nationality",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["person.nationalities"],
+      "explanation_key": "explain.hf.a1.not-bvk-nationality",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "TRANSIT"]
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "BN",
+              "MY",
+              "TH",
+              "SG",
+              "PH",
+              "KH",
+              "LA",
+              "MM",
+              "VN",
+              "TL",
+              "SR",
+              "CO",
+              "HK",
+              "TR",
+              "BR",
+              "PE",
+              "MO",
+              "KZ",
+              "BY"
+            ]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "A1_BVK_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "TRANSIT"]
+      },
+      "rule_id": "el.a1.tourism",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "explanation_key": "explain.el.a1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "ZA",
+              "AL",
+              "US",
+              "AD",
+              "SA",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "NL",
+              "BY",
+              "BE",
+              "BR",
+              "BN",
+              "BA",
+              "BG",
+              "CZ",
+              "CL",
+              "DK",
+              "EC",
+              "EE",
+              "PH",
+              "FI",
+              "GT",
+              "HK",
+              "HU",
+              "IN",
+              "GB",
+              "IE",
+              "IT",
+              "IS",
+              "JP",
+              "DE",
+              "KH",
+              "CA",
+              "KZ",
+              "KE",
+              "CO",
+              "KR",
+              "HR",
+              "KW",
+              "LA",
+              "LV",
+              "LI",
+              "LT",
+              "LU",
+              "MV",
+              "MY",
+              "MT",
+              "MA",
+              "MU",
+              "MX",
+              "EG",
+              "MC",
+              "MN",
+              "MZ",
+              "MM",
+              "NO",
+              "OM",
+              "PS",
+              "PG",
+              "FR",
+              "PE",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "NZ",
+              "RS",
+              "SC",
+              "SG",
+              "CY",
+              "SK",
+              "SI",
+              "ES",
+              "SR",
+              "SE",
+              "CH",
+              "TW",
+              "TZ",
+              "TH",
+              "TL",
+              "CN",
+              "TN",
+              "TR",
+              "AE",
+              "UZ",
+              "UA",
+              "VA",
+              "VE",
+              "VN",
+              "JO",
+              "GR"
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "B1_VOA_ELIGIBLE",
+        "covered_purposes": ["TOURISM"]
+      },
+      "rule_id": "el.b1.tourism",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "explanation_key": "explain.el.b1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "FAMILY"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 180
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C1_VISIT_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "FAMILY"]
+      },
+      "rule_id": "el.c1.tourism-family",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.c1.tourism-family",
+      "safety_critical": false,
+      "product_version_ids": ["7a07cbb0-564f-5c3f-9720-6ad62c4789cd"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 180
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C2_BUSINESS_ELIGIBLE",
+        "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"]
+      },
+      "rule_id": "el.c2.business",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "explanation_key": "explain.el.c2.business",
+      "safety_critical": false,
+      "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 180
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C6_SOCIAL_ELIGIBLE",
+        "covered_purposes": ["OTHER"]
+      },
+      "rule_id": "el.c6.social",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "explanation_key": "explain.el.c6.social",
+      "safety_critical": false,
+      "product_version_ids": ["8cf5e09b-6e02-536f-aeca-4aaecaca09c7"]
+    },
+    {
+      "when": {
+        "op": "lt",
+        "fact": "investment.paid_up_capital_idr",
+        "value": 2500000000
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_PAID_CAPITAL_BELOW_MIN"
+      },
+      "rule_id": "hf.e28a.paid-capital-below-min",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["investment.paid_up_capital_idr"],
+      "explanation_key": "explain.hf.e28a.paid-capital-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "when": {
+        "op": "lt",
+        "fact": "investment.investment_capital_idr",
+        "value": 10000000000
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_TOTAL_INVESTMENT_BELOW_MIN"
+      },
+      "rule_id": "hf.e28a.total-investment-below-min",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["investment.investment_capital_idr"],
+      "explanation_key": "explain.hf.e28a.total-investment-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          },
+          {
+            "op": "in",
+            "fact": "investment.proposed_role",
+            "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+          },
+          {
+            "op": "gte",
+            "fact": "investment.paid_up_capital_idr",
+            "value": 2500000000
+          },
+          {
+            "op": "gte",
+            "fact": "investment.investment_capital_idr",
+            "value": 10000000000
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E28A_INVESTMENT_ELIGIBLE",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "rule_id": "el.e28a.investment",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "investment.investment_capital_idr",
+        "investment.paid_up_capital_idr",
+        "investment.proposed_role",
+        "investment.pt_pma_committed"
+      ],
+      "explanation_key": "explain.el.e28a.investment",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28B"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28B_USD_THRESHOLD_MANUAL_CHECK"
+      },
+      "rule_id": "review.e28b.usd-threshold-manual",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.review.e28b.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ca8c1177-ad94-5261-82a6-68bc912d31bb"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28C"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK"
+      },
+      "rule_id": "review.e28c.usd-threshold-manual",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.review.e28c.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["b074270f-fa7c-598b-a728-81ca89432364"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28D"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK"
+      },
+      "rule_id": "review.e28d.usd-threshold-turnover-manual",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ee4fef98-3497-507c-8486-225932364e26"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28F"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28F_IKN_THRESHOLD_MANUAL_CHECK"
+      },
+      "rule_id": "review.e28f.ikn-threshold-manual",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.review.e28f.ikn-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["2df6f723-7fc3-585a-b26f-0e8c060a2d8d"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.bank_deposit_usd",
+            "value": 130000
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_at_state_bank",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_in_own_name",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "rule_id": "el.e33.deposit-basis",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd"
+      ],
+      "explanation_key": "explain.el.e33.deposit-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.qualifying_property_value_usd",
+            "value": 1000000
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "rule_id": "el.e33.property-basis",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "explanation_key": "explain.el.e33.property-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.qualifying_property_value_usd",
+                "value": 1000000
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_QUALIFICATION_ADVISOR_CHECK",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "rule_id": "el.e33.property-qualification",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "explanation_key": "explain.el.e33.property-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "any",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "rule_id": "el.e33.guarantee-maintenance",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "explanation_key": "explain.el.e33.guarantee-maintenance",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33_WORK_RANGKAP_KEGIATAN_GATED"
+      },
+      "rule_id": "review.e33.work-rangkap-kegiatan",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes"],
+      "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33A"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "rule_id": "review.e33a.central-government-invitation",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.review.e33a.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33B"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33B_EXPERTISE_QUALIFICATION_CHECK"
+      },
+      "rule_id": "review.e33b.expertise-qualification",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.review.e33b.expertise-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33C"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "rule_id": "review.e33c.central-government-invitation",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.review.e33c.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "rule_id": "hf.e33e.age-below-55",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["derived.age_years"],
+      "explanation_key": "explain.hf.e33e.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "between",
+                "fact": "derived.age_years",
+                "lower": 55,
+                "upper": 59
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "gte",
+                "fact": "derived.age_years",
+                "value": 55
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 50000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.passive_monthly_income_usd",
+                "value": 3000
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_AGE_55_59_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY", "RETIREMENT", "SECOND_HOME", "TOURISM"]
+      },
+      "rule_id": "el.e33e.age-55-59-disputed-band",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "explanation_key": "explain.el.e33e.age-55-59-disputed-band",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "derived.age_years",
+            "value": 55
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "gte",
+                "fact": "secondhome.bank_deposit_usd",
+                "value": 50000
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_at_state_bank",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_in_own_name",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_RETIREMENT_ELIGIBLE",
+        "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"]
+      },
+      "rule_id": "el.e33e.retirement",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "explanation_key": "explain.el.e33e.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "when": {
+        "op": "eq",
+        "fact": "family.sponsor_confirmed",
+        "value": false
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "SPONSOR_REQUIRED"
+      },
+      "rule_id": "hf.e33f.sponsor-required",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["family.sponsor_confirmed"],
+      "explanation_key": "explain.hf.e33f.sponsor-required",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33F_RETIREMENT_ELIGIBLE",
+        "covered_purposes": [
+          "RETIREMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ]
+      },
+      "rule_id": "el.e33f.retirement",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "explanation_key": "explain.el.e33f.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "when": {
+        "op": "eq",
+        "fact": "work.employer_is_indonesian_entity",
+        "value": true
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_EMPLOYER_NOT_ALLOWED"
+      },
+      "rule_id": "hf.e33g.indonesian-employer",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["work.employer_is_indonesian_entity"],
+      "explanation_key": "explain.hf.e33g.indonesian-employer",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "when": {
+        "op": "eq",
+        "fact": "work.indonesia_source_compensation",
+        "value": true
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_SOURCE_COMPENSATION_BANNED"
+      },
+      "rule_id": "hf.e33g.indonesian-source-compensation",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["work.indonesia_source_compensation"],
+      "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "LOCAL_MARKET_ACTIVITY_REVIEW"
+      },
+      "rule_id": "review.e33g.local-market",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "work.serves_indonesian_clients"],
+      "explanation_key": "explain.review.e33g.local-market",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP"
+      },
+      "rule_id": "review.e33g.local-company-ownership",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "explanation_key": "explain.review.e33g.local-company-ownership",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REMOTE_WORK_ELIGIBLE",
+        "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"]
+      },
+      "rule_id": "el.e33g.remote-work",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "explanation_key": "explain.el.e33g.remote-work",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "when": {
+        "op": "eq",
+        "fact": "immigration.currently_in_indonesia",
+        "value": false
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_ONSHORE_ONLY"
+      },
+      "rule_id": "hf.bridging.offshore",
+      "priority": 100,
+      "on_unknown": "HUMAN_REVIEW",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["immigration.currently_in_indonesia"],
+      "explanation_key": "explain.hf.bridging.offshore",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "when": {
+        "op": "in",
+        "fact": "immigration.current_status_code",
+        "values": [
+          "ITK_FROM_BVK",
+          "ITK_FROM_VISIT_C",
+          "ITK_FROM_VISIT_D",
+          "A1",
+          "C1",
+          "C2",
+          "C6"
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_FROM_VISIT_ITK_PROHIBITED"
+      },
+      "rule_id": "hf.bridging.from-visit-itk",
+      "priority": 100,
+      "on_unknown": "HUMAN_REVIEW",
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["immigration.current_status_code"],
+      "explanation_key": "explain.hf.bridging.from-visit-itk",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "when": {
+        "op": "eq",
+        "fact": "immigration.current_status_code",
+        "value": "ITK_PERALIHAN"
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_TO_BRIDGING_PROHIBITED"
+      },
+      "rule_id": "hf.bridging.to-bridging",
+      "priority": 100,
+      "on_unknown": "HUMAN_REVIEW",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["immigration.current_status_code"],
+      "explanation_key": "explain.hf.bridging.to-bridging",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          },
+          {
+            "op": "known",
+            "fact": "intent.requested_product_code"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_T3_WINDOW_ADVISOR_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "rule_id": "el.bridging.t3-window-manual",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "explanation_key": "explain.el.bridging.t3-window-manual",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          },
+          {
+            "op": "known",
+            "fact": "intent.requested_product_code"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "rule_id": "el.bridging.overstay-shield-payment",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "explanation_key": "explain.el.bridging.overstay-shield-payment",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_code"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          },
+          {
+            "op": "known",
+            "fact": "intent.requested_product_code"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY",
+        "covered_purposes": ["OTHER"]
+      },
+      "rule_id": "el.bridging.source-status-verify",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "immigration.current_status_code",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "explanation_key": "explain.el.bridging.source-status-verify",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "intersects",
+            "fact": "immigration.violation_history",
+            "values": [
+              "OVERSTAY",
+              "DEPORTATION",
+              "BLACKLIST",
+              "IMMIGRATION_INVESTIGATION"
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_ADVERSE_HISTORY"
+      },
+      "rule_id": "review.bridging.adverse-history",
+      "priority": 100,
+      "on_unknown": "HUMAN_REVIEW",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "immigration.currently_in_indonesia",
+        "immigration.violation_history"
+      ],
+      "explanation_key": "explain.review.bridging.adverse-history",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "neq",
+            "fact": "intent.requested_product_code",
+            "value": "BRIDGING"
+          },
+          {
+            "op": "known",
+            "fact": "intent.requested_product_code"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_DESTINATION_STATED",
+        "covered_purposes": ["OTHER"]
+      },
+      "rule_id": "el.bridging.destination-stated",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.el.bridging.destination-stated",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT", "TOURISM"]
+      },
+      "rule_id": "el.e23-employment-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e23-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "op": "in",
+                "fact": "investment.proposed_role",
+                "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "op": "eq",
+                "fact": "work.employer_is_indonesian_entity",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "work.indonesian_work_sponsor_confirmed",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR",
+        "covered_purposes": ["EMPLOYMENT", "TOURISM"]
+      },
+      "rule_id": "el.e23-operational-work-boundary",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "investment.proposed_role",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e23-operational-work-boundary",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.relation_to_sponsor",
+            "value": "SPOUSE"
+          },
+          {
+            "op": "intersects",
+            "fact": "family.sponsor_nationalities",
+            "values": ["ID"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.marriage_registered",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31a-spouse-wni-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "family.marriage_registered"
+      ],
+      "explanation_key": "explain.el.e31a-spouse-wni-support",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["FAMILY"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.relation_to_sponsor",
+                "value": "SPOUSE"
+              },
+              {
+                "op": "intersects",
+                "fact": "family.sponsor_nationalities",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["FAMILY"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.relation_to_sponsor",
+                "value": "SPOUSE"
+              },
+              {
+                "op": "intersects",
+                "fact": "family.sponsor_nationalities",
+                "values": ["ID"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.marriage_registered",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_FUNDS_2000",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31a-funds-2000",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.el.e31a-funds-2000",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["FAMILY"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.relation_to_sponsor",
+                "value": "SPOUSE"
+              },
+              {
+                "op": "intersects",
+                "fact": "family.sponsor_nationalities",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["FAMILY"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.relation_to_sponsor",
+                "value": "SPOUSE"
+              },
+              {
+                "op": "intersects",
+                "fact": "family.sponsor_nationalities",
+                "values": ["ID"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.marriage_registered",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SPOUSAL_WORK_ARTICLE_61_CONTEXT",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31a-spousal-work-article-61",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.el.e31a-spousal-work-article-61",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "process.wants_onshore_conversion",
+            "value": true
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["FAMILY"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.relation_to_sponsor",
+                "value": "SPOUSE"
+              },
+              {
+                "op": "intersects",
+                "fact": "family.sponsor_nationalities",
+                "values": ["ID"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.marriage_registered",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "KITAP_TWO_YEAR_MARRIAGE_AND_INTEGRATION_NOT_VERIFIED",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31a-kitap-prerequisites",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes",
+        "process.wants_onshore_conversion"
+      ],
+      "explanation_key": "explain.el.e31a-kitap-prerequisites",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "in",
+            "values": [
+              "E23",
+              "E23U",
+              "E23V",
+              "E28A",
+              "E28B",
+              "E28C",
+              "E28D",
+              "E28F",
+              "E30",
+              "E30A",
+              "E30B",
+              "E30E",
+              "E30F",
+              "E31A",
+              "E31B",
+              "E31C",
+              "E31D",
+              "E31E",
+              "E31F",
+              "E31G",
+              "E31H",
+              "E31J",
+              "E33",
+              "E33A",
+              "E33B",
+              "E33C",
+              "E33E",
+              "E33F",
+              "E33G"
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31b-spouse-itas-support",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.marriage_registered",
+        "family.sponsor_status_code"
+      ],
+      "explanation_key": "explain.el.e31b-spouse-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "E23",
+                  "E23U",
+                  "E23V",
+                  "E28A",
+                  "E28B",
+                  "E28C",
+                  "E28D",
+                  "E28F",
+                  "E30",
+                  "E30A",
+                  "E30B",
+                  "E30E",
+                  "E30F",
+                  "E31A",
+                  "E31B",
+                  "E31C",
+                  "E31D",
+                  "E31E",
+                  "E31F",
+                  "E31G",
+                  "E31H",
+                  "E31J",
+                  "E33",
+                  "E33A",
+                  "E33B",
+                  "E33C",
+                  "E33E",
+                  "E33F",
+                  "E33G"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31b-sponsor-itas-itap",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.el.e31b-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT"
+          },
+          {
+            "op": "intersects",
+            "fact": "family.sponsor_nationalities",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31c-child-mixed-marriage-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT"
+          },
+          {
+            "op": "intersects",
+            "fact": "family.sponsor_nationalities",
+            "values": ["ID"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.marriage_registered",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_MIXED_MARRIAGE_PARENTS",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31c-mixed-marriage-parents",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.el.e31c-mixed-marriage-parents",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "STEPCHILD"
+          },
+          {
+            "fact": "family.sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.stepchild_birth_certificate_confirmed",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.stepchild_marriage_certificate_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31d-stepchild-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_confirmed",
+        "family.stepchild_birth_certificate_confirmed",
+        "family.stepchild_marriage_certificate_confirmed"
+      ],
+      "explanation_key": "explain.el.e31d-stepchild-support",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "when": {
+        "op": "gte",
+        "fact": "derived.age_years",
+        "value": 18
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNDER_18"
+      },
+      "rule_id": "hf.e31e-adult-excluded",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["derived.age_years"],
+      "explanation_key": "explain.hf.e31e-adult-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "when": {
+        "op": "neq",
+        "fact": "person.marital_status",
+        "value": "SINGLE"
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNMARRIED"
+      },
+      "rule_id": "hf.e31e-married-excluded",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["person.marital_status"],
+      "explanation_key": "explain.hf.e31e-married-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "in",
+            "values": [
+              "E23",
+              "E23U",
+              "E23V",
+              "E28A",
+              "E28B",
+              "E28C",
+              "E28D",
+              "E28F",
+              "E30",
+              "E30A",
+              "E30B",
+              "E30E",
+              "E30F",
+              "E31A",
+              "E31B",
+              "E31C",
+              "E31D",
+              "E31E",
+              "E31F",
+              "E31G",
+              "E31H",
+              "E31J",
+              "E33",
+              "E33A",
+              "E33B",
+              "E33C",
+              "E33E",
+              "E33F",
+              "E33G"
+            ]
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "lt",
+            "value": 18
+          },
+          {
+            "fact": "person.marital_status",
+            "op": "eq",
+            "value": "SINGLE"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31e-child-itas-support",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "derived.age_years",
+        "person.marital_status"
+      ],
+      "explanation_key": "explain.el.e31e-child-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "E23",
+                  "E23U",
+                  "E23V",
+                  "E28A",
+                  "E28B",
+                  "E28C",
+                  "E28D",
+                  "E28F",
+                  "E30",
+                  "E30A",
+                  "E30B",
+                  "E30E",
+                  "E30F",
+                  "E31A",
+                  "E31B",
+                  "E31C",
+                  "E31D",
+                  "E31E",
+                  "E31F",
+                  "E31G",
+                  "E31H",
+                  "E31J",
+                  "E33",
+                  "E33A",
+                  "E33B",
+                  "E33C",
+                  "E33E",
+                  "E33F",
+                  "E33G"
+                ]
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "lt",
+                "value": 18
+              },
+              {
+                "fact": "person.marital_status",
+                "op": "eq",
+                "value": "SINGLE"
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31e-sponsor-itas-itap",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes",
+        "person.marital_status"
+      ],
+      "explanation_key": "explain.el.e31e-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT"
+          },
+          {
+            "op": "intersects",
+            "fact": "family.sponsor_nationalities",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31f-child-wni-parent-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "explanation_key": "explain.el.e31f-child-wni-parent-support",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["FAMILY"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.relation_to_sponsor",
+                "value": "PARENT"
+              },
+              {
+                "op": "intersects",
+                "fact": "family.sponsor_nationalities",
+                "values": ["ID"]
+              },
+              {
+                "op": "gte",
+                "fact": "derived.age_years",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["FAMILY"]
+              },
+              {
+                "op": "eq",
+                "fact": "family.relation_to_sponsor",
+                "value": "PARENT"
+              },
+              {
+                "op": "intersects",
+                "fact": "family.sponsor_nationalities",
+                "values": ["ID"]
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31F_ADULT_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31f-adult-age-review",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.el.e31f-adult-age-review",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.relation_to_sponsor",
+            "value": "CHILD"
+          },
+          {
+            "op": "intersects",
+            "fact": "family.sponsor_nationalities",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31g-parent-wni-child-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "explanation_key": "explain.el.e31g-parent-wni-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["fbc980d5-47b6-5f16-974d-25158dfffc06"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "in",
+            "values": [
+              "E23",
+              "E23U",
+              "E23V",
+              "E28A",
+              "E28B",
+              "E28C",
+              "E28D",
+              "E28F",
+              "E30",
+              "E30A",
+              "E30B",
+              "E30E",
+              "E30F",
+              "E31A",
+              "E31B",
+              "E31C",
+              "E31D",
+              "E31E",
+              "E31F",
+              "E31G",
+              "E31H",
+              "E31J",
+              "E33",
+              "E33A",
+              "E33B",
+              "E33C",
+              "E33E",
+              "E33F",
+              "E33G"
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31h-parent-itas-child-support",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "explanation_key": "explain.el.e31h-parent-itas-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "E23",
+                  "E23U",
+                  "E23V",
+                  "E28A",
+                  "E28B",
+                  "E28C",
+                  "E28D",
+                  "E28F",
+                  "E30",
+                  "E30A",
+                  "E30B",
+                  "E30E",
+                  "E30F",
+                  "E31A",
+                  "E31B",
+                  "E31C",
+                  "E31D",
+                  "E31E",
+                  "E31F",
+                  "E31G",
+                  "E31H",
+                  "E31J",
+                  "E33",
+                  "E33A",
+                  "E33B",
+                  "E33C",
+                  "E33E",
+                  "E33F",
+                  "E33G"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31h-sponsor-itas-itap",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.el.e31h-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "in",
+            "values": [
+              "E23",
+              "E23U",
+              "E23V",
+              "E28A",
+              "E28B",
+              "E28C",
+              "E28D",
+              "E28F",
+              "E30",
+              "E30A",
+              "E30B",
+              "E30E",
+              "E30F",
+              "E31A",
+              "E31B",
+              "E31C",
+              "E31D",
+              "E31E",
+              "E31F",
+              "E31G",
+              "E31H",
+              "E31J",
+              "E33",
+              "E33A",
+              "E33B",
+              "E33C",
+              "E33E",
+              "E33F",
+              "E33G"
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31j-sibling-itas-support",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "explanation_key": "explain.el.e31j-sibling-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "E23",
+                  "E23U",
+                  "E23V",
+                  "E28A",
+                  "E28B",
+                  "E28C",
+                  "E28D",
+                  "E28F",
+                  "E30",
+                  "E30A",
+                  "E30B",
+                  "E30E",
+                  "E30F",
+                  "E31A",
+                  "E31B",
+                  "E31C",
+                  "E31D",
+                  "E31E",
+                  "E31F",
+                  "E31G",
+                  "E31H",
+                  "E31J",
+                  "E33",
+                  "E33A",
+                  "E33B",
+                  "E33C",
+                  "E33E",
+                  "E33F",
+                  "E33G"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31j-sponsor-itas-itap",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.el.e31j-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "E23",
+                  "E23U",
+                  "E23V",
+                  "E28A",
+                  "E28B",
+                  "E28C",
+                  "E28D",
+                  "E28F",
+                  "E30",
+                  "E30A",
+                  "E30B",
+                  "E30E",
+                  "E30F",
+                  "E31A",
+                  "E31B",
+                  "E31C",
+                  "E31D",
+                  "E31E",
+                  "E31F",
+                  "E31G",
+                  "E31H",
+                  "E31J",
+                  "E33",
+                  "E33A",
+                  "E33B",
+                  "E33C",
+                  "E33E",
+                  "E33F",
+                  "E33G"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31J_DEPENDENCY_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "rule_id": "el.e31j-dependency-age",
+      "priority": 100,
+      "on_unknown": "NO_EFFECT",
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.el.e31j-dependency-age",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "lte",
+                "fact": "intent.stay_days",
+                "value": 180
+              }
+            ]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY",
+          "TRANSIT",
+          "BUSINESS_MEETINGS"
+        ]
+      },
+      "rule_id": "el.d1-multi-entry-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "intent.entry_pattern"
+      ],
+      "explanation_key": "explain.el.d1-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "op": "lte",
+                    "fact": "intent.stay_days",
+                    "value": 180
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "rule_id": "el.d1-passport-validity",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "explanation_key": "explain.el.d1-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "op": "lte",
+                    "fact": "intent.stay_days",
+                    "value": 180
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D1",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "rule_id": "el.d1-funds-usd-2000",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "explanation_key": "explain.el.d1-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "op": "lte",
+                    "fact": "intent.stay_days",
+                    "value": 180
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "rule_id": "el.d1-cv-required",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "explanation_key": "explain.el.d1-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "op": "lte",
+                    "fact": "intent.stay_days",
+                    "value": 180
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "rule_id": "el.d1-itinerary-required",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "explanation_key": "explain.el.d1-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "op": "lte",
+                    "fact": "intent.stay_days",
+                    "value": 180
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "rule_id": "el.d1-support-letter",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "explanation_key": "explain.el.d1-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 180
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "rule_id": "el.d2-multi-entry-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d2-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "lte",
+                "fact": "intent.stay_days",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "rule_id": "el.d2-passport-validity",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d2-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "lte",
+                "fact": "intent.stay_days",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D2",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "rule_id": "el.d2-funds-usd-2000",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d2-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "lte",
+                "fact": "intent.stay_days",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "rule_id": "el.d2-cv-required",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d2-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "lte",
+                "fact": "intent.stay_days",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "rule_id": "el.d2-itinerary-required",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d2-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "lte",
+                "fact": "intent.stay_days",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "rule_id": "el.d2-support-letter",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d2-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 360
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "rule_id": "el.d12-multi-entry-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d12-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 360
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "rule_id": "el.d12-passport-validity",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d12-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 360
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D12",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "rule_id": "el.d12-funds-usd-5000",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d12-funds-usd-5000",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 360
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "rule_id": "el.d12-cv-required",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d12-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 360
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "rule_id": "el.d12-itinerary-required",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d12-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 360
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "rule_id": "el.d12-support-letter",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "explanation_key": "explain.el.d12-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "when": {
+        "op": "eq",
+        "fact": "process.wants_onshore_conversion",
+        "value": true
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "D12_NOT_CONVERTIBLE"
+      },
+      "rule_id": "hf.d12-onshore-conversion-excluded",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["process.wants_onshore_conversion"],
+      "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "eq",
+            "fact": "study.admission_confirmed",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "study.sponsor_confirmed",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30-student-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30-student-support",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+      ]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["STUDY"]
+              },
+              {
+                "op": "eq",
+                "fact": "study.admission_confirmed",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "study.sponsor_confirmed",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30-living-cost-2000.e30",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["STUDY"]
+              },
+              {
+                "op": "eq",
+                "fact": "study.admission_confirmed",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "study.sponsor_confirmed",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30-living-cost-2000.e30a",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["STUDY"]
+              },
+              {
+                "op": "eq",
+                "fact": "study.admission_confirmed",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "study.sponsor_confirmed",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30-living-cost-2000.e30b",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["STUDY"]
+              },
+              {
+                "op": "eq",
+                "fact": "study.admission_confirmed",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "study.sponsor_confirmed",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30-passport-validity.e30",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["STUDY"]
+              },
+              {
+                "op": "eq",
+                "fact": "study.admission_confirmed",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "study.sponsor_confirmed",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30-passport-validity.e30a",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["STUDY"]
+              },
+              {
+                "op": "eq",
+                "fact": "study.admission_confirmed",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "study.sponsor_confirmed",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30-passport-validity.e30b",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "not_in",
+            "fact": "study.level",
+            "values": ["PRIMARY", "SECONDARY"]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DASMEN"
+      },
+      "rule_id": "hf.e30a-level-band",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "study.level"],
+      "explanation_key": "explain.hf.e30a-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "not_in",
+            "fact": "study.level",
+            "values": ["VOCATIONAL", "UNDERGRADUATE", "POSTGRADUATE"]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DIKTI"
+      },
+      "rule_id": "hf.e30b-level-band",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "study.level"],
+      "explanation_key": "explain.hf.e30b-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["STUDY"]
+              },
+              {
+                "op": "eq",
+                "fact": "study.admission_confirmed",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "study.sponsor_confirmed",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "STUDY_PERMIT_KEMDIKBUD",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30b-izin-belajar",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30b-izin-belajar",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "ZA",
+            "AL",
+            "US",
+            "AD",
+            "SA",
+            "AR",
+            "AM",
+            "AU",
+            "AT",
+            "AZ",
+            "BH",
+            "NL",
+            "BY",
+            "BE",
+            "BR",
+            "BN",
+            "BA",
+            "BG",
+            "CZ",
+            "CL",
+            "DK",
+            "EC",
+            "EE",
+            "PH",
+            "FI",
+            "GT",
+            "HK",
+            "HU",
+            "IN",
+            "GB",
+            "IE",
+            "IT",
+            "IS",
+            "JP",
+            "DE",
+            "KH",
+            "CA",
+            "KZ",
+            "KE",
+            "CO",
+            "KR",
+            "HR",
+            "KW",
+            "LA",
+            "LV",
+            "LI",
+            "LT",
+            "LU",
+            "MV",
+            "MY",
+            "MT",
+            "MA",
+            "MU",
+            "MX",
+            "EG",
+            "MC",
+            "MN",
+            "MZ",
+            "MM",
+            "NO",
+            "OM",
+            "PS",
+            "PG",
+            "FR",
+            "PE",
+            "PL",
+            "PT",
+            "QA",
+            "RO",
+            "RU",
+            "RW",
+            "NZ",
+            "RS",
+            "SC",
+            "SG",
+            "CY",
+            "SK",
+            "SI",
+            "ES",
+            "SR",
+            "SE",
+            "CH",
+            "TW",
+            "TZ",
+            "TH",
+            "TL",
+            "CN",
+            "TN",
+            "TR",
+            "AE",
+            "UZ",
+            "UA",
+            "VA",
+            "VE",
+            "VN",
+            "JO",
+            "GR"
+          ]
+        }
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "VOA_NATIONALITY_ONLY"
+      },
+      "rule_id": "hf.b1.not-voa-nationality",
+      "priority": 100,
+      "on_unknown": "HUMAN_REVIEW",
+      "source_refs": ["38a6cb08-041f-51e4-86e4-9e73243acd3a"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["person.nationalities"],
+      "explanation_key": "explain.hf.b1.not-voa-nationality",
+      "safety_critical": true,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "when": {
+        "op": "any",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "ZA",
+                  "AL",
+                  "US",
+                  "AD",
+                  "SA",
+                  "AR",
+                  "AM",
+                  "AU",
+                  "AT",
+                  "AZ",
+                  "BH",
+                  "NL",
+                  "BY",
+                  "BE",
+                  "BR",
+                  "BN",
+                  "BA",
+                  "BG",
+                  "CZ",
+                  "CL",
+                  "DK",
+                  "EC",
+                  "EE",
+                  "PH",
+                  "FI",
+                  "GT",
+                  "HK",
+                  "HU",
+                  "IN",
+                  "GB",
+                  "IE",
+                  "IT",
+                  "IS",
+                  "JP",
+                  "DE",
+                  "KH",
+                  "CA",
+                  "KZ",
+                  "KE",
+                  "CO",
+                  "KR",
+                  "HR",
+                  "KW",
+                  "LA",
+                  "LV",
+                  "LI",
+                  "LT",
+                  "LU",
+                  "MV",
+                  "MY",
+                  "MT",
+                  "MA",
+                  "MU",
+                  "MX",
+                  "EG",
+                  "MC",
+                  "MN",
+                  "MZ",
+                  "MM",
+                  "NO",
+                  "OM",
+                  "PS",
+                  "PG",
+                  "FR",
+                  "PE",
+                  "PL",
+                  "PT",
+                  "QA",
+                  "RO",
+                  "RU",
+                  "RW",
+                  "NZ",
+                  "RS",
+                  "SC",
+                  "SG",
+                  "CY",
+                  "SK",
+                  "SI",
+                  "ES",
+                  "SR",
+                  "SE",
+                  "CH",
+                  "TW",
+                  "TZ",
+                  "TH",
+                  "TL",
+                  "CN",
+                  "TN",
+                  "TR",
+                  "AE",
+                  "UZ",
+                  "UA",
+                  "VA",
+                  "VE",
+                  "VN",
+                  "JO",
+                  "GR"
+                ]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AF",
+                  "AG",
+                  "AI",
+                  "AO",
+                  "AQ",
+                  "AS",
+                  "AW",
+                  "AX",
+                  "BB",
+                  "BD",
+                  "BF",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BO",
+                  "BQ",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BZ",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CI",
+                  "CK",
+                  "CM",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "DJ",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EH",
+                  "ER",
+                  "ET",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "GA",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GS",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HM",
+                  "HN",
+                  "HT",
+                  "ID",
+                  "IL",
+                  "IM",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "JE",
+                  "JM",
+                  "KG",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KP",
+                  "KY",
+                  "LB",
+                  "LC",
+                  "LK",
+                  "LR",
+                  "LS",
+                  "LY",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MW",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NG",
+                  "NI",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "PA",
+                  "PF",
+                  "PK",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PW",
+                  "PY",
+                  "RE",
+                  "SB",
+                  "SD",
+                  "SH",
+                  "SJ",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SO",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TJ",
+                  "TK",
+                  "TM",
+                  "TO",
+                  "TT",
+                  "TV",
+                  "UG",
+                  "UM",
+                  "UY",
+                  "VC",
+                  "VG",
+                  "VI",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AD",
+                  "AE",
+                  "AG",
+                  "AI",
+                  "AL",
+                  "AM",
+                  "AO",
+                  "AQ",
+                  "AR",
+                  "AS",
+                  "AT",
+                  "AU",
+                  "AW",
+                  "AX",
+                  "AZ",
+                  "BA",
+                  "BB",
+                  "BD",
+                  "BE",
+                  "BF",
+                  "BG",
+                  "BH",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BN",
+                  "BO",
+                  "BQ",
+                  "BR",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BY",
+                  "BZ",
+                  "CA",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CH",
+                  "CI",
+                  "CK",
+                  "CL",
+                  "CM",
+                  "CN",
+                  "CO",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "CY",
+                  "CZ",
+                  "DE",
+                  "DJ",
+                  "DK",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EC",
+                  "EE",
+                  "EG",
+                  "EH",
+                  "ER",
+                  "ES",
+                  "ET",
+                  "FI",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "FR",
+                  "GA",
+                  "GB",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GR",
+                  "GS",
+                  "GT",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HK",
+                  "HM",
+                  "HN",
+                  "HR",
+                  "HT",
+                  "HU",
+                  "ID",
+                  "IE",
+                  "IM",
+                  "IN",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "IS",
+                  "IT",
+                  "JE",
+                  "JM",
+                  "JO",
+                  "JP",
+                  "KE",
+                  "KG",
+                  "KH",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KR",
+                  "KW",
+                  "KY",
+                  "KZ",
+                  "LA",
+                  "LB",
+                  "LC",
+                  "LI",
+                  "LK",
+                  "LS",
+                  "LT",
+                  "LU",
+                  "LV",
+                  "LY",
+                  "MA",
+                  "MC",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MM",
+                  "MN",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MT",
+                  "MU",
+                  "MV",
+                  "MW",
+                  "MX",
+                  "MY",
+                  "MZ",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NI",
+                  "NL",
+                  "NO",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "NZ",
+                  "OM",
+                  "PA",
+                  "PE",
+                  "PF",
+                  "PG",
+                  "PH",
+                  "PK",
+                  "PL",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PS",
+                  "PT",
+                  "PW",
+                  "PY",
+                  "QA",
+                  "RE",
+                  "RO",
+                  "RS",
+                  "RU",
+                  "RW",
+                  "SA",
+                  "SB",
+                  "SC",
+                  "SD",
+                  "SE",
+                  "SG",
+                  "SH",
+                  "SI",
+                  "SJ",
+                  "SK",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SR",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TH",
+                  "TJ",
+                  "TK",
+                  "TL",
+                  "TM",
+                  "TN",
+                  "TO",
+                  "TR",
+                  "TT",
+                  "TV",
+                  "TW",
+                  "TZ",
+                  "UA",
+                  "UG",
+                  "UM",
+                  "US",
+                  "UY",
+                  "UZ",
+                  "VA",
+                  "VC",
+                  "VE",
+                  "VG",
+                  "VI",
+                  "VN",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZA",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "scope": "GLOBAL",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CITIZENSHIP_LIST_DIVERGENCE"
+      },
+      "rule_id": "review.citizenship-conflict",
+      "priority": 100,
+      "on_unknown": "HUMAN_REVIEW",
+      "source_refs": [
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+        "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["person.nationalities"],
+      "explanation_key": "explain.review.citizenship-conflict",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "derived.is_minor",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": false
+          }
+        ]
+      },
+      "scope": "GLOBAL",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "MINOR_WITHOUT_CONFIRMED_GUARDIAN"
+      },
+      "rule_id": "review.minor-without-guardian",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-09T00:00:00Z"
+      },
+      "required_facts": ["derived.is_minor", "family.sponsor_confirmed"],
+      "explanation_key": "explain.review.minor-without-guardian",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "rule_id": "hf.e33f.age-below-55",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "required_facts": ["derived.age_years"],
+      "explanation_key": "explain.hf.e33f.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "eq",
+            "fact": "study.admission_confirmed",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "study.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "in",
+            "fact": "sponsor.type",
+            "values": ["EDUCATION", "INDIVIDUAL"]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30e-student-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-19T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30e-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["19e3ea6c-95c6-5998-b9d7-efc77f583589"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "eq",
+            "fact": "study.admission_confirmed",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "study.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "sponsor.type",
+            "value": "EDUCATION"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "rule_id": "el.e30f-student-support",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-19T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "explanation_key": "explain.el.e30f-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["235f5dfc-2feb-5d5b-ab09-0f4e4122819e"]
+    },
+    {
+      "when": {
+        "op": "neq",
+        "fact": "sponsor.type",
+        "value": "GOVERNMENT"
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33A_SPONSOR_NOT_GOVERNMENT"
+      },
+      "rule_id": "hf.e33a.sponsor-not-government",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-19T00:00:00Z"
+      },
+      "required_facts": ["sponsor.type"],
+      "explanation_key": "explain.hf.e33a.sponsor-not-government",
+      "safety_critical": true,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "when": {
+        "op": "not_in",
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33B_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "rule_id": "hf.e33b.sponsor-not-government-or-none",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-19T00:00:00Z"
+      },
+      "required_facts": ["sponsor.type"],
+      "explanation_key": "explain.hf.e33b.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "when": {
+        "op": "not_in",
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33C_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "rule_id": "hf.e33c.sponsor-not-government-or-none",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-19T00:00:00Z"
+      },
+      "required_facts": ["sponsor.type"],
+      "explanation_key": "explain.hf.e33c.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E23U"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23U_DIPLOMATIC_HOUSEHOLD_STAFF_REVIEW"
+      },
+      "rule_id": "review.e23u.requested-product",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-19T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.review.e23u.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E23V"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HUMAN_REVIEW",
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23V_TRADE_OFFICE_STAFF_REVIEW"
+      },
+      "rule_id": "review.e23v.requested-product",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-19T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "explanation_key": "explain.review.e23v.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT"
+          },
+          {
+            "op": "eq",
+            "fact": "family.marriage_registered",
+            "value": false
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_PARENTS_MARRIAGE_REGISTERED"
+      },
+      "rule_id": "hf.e31c-marriage-not-registered",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-19T00:00:00Z"
+      },
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.hf.e31c-marriage-not-registered",
+      "safety_critical": true,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT"
+          },
+          {
+            "op": "not",
+            "arg": {
+              "op": "intersects",
+              "fact": "family.sponsor_nationalities",
+              "values": ["ID"]
+            }
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_PARENT_SPONSOR_INDONESIAN"
+      },
+      "rule_id": "hf.e31c-sponsor-not-indonesian",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-08-23T00:00:00Z"
+      },
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "explanation_key": "explain.hf.e31c-sponsor-not-indonesian",
+      "safety_critical": true,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": true
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BUSINESS_LOCAL_COMPENSATION_NOT_ALLOWED"
+      },
+      "rule_id": "hf.d2.indonesia-source-compensation",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-09-06T00:00:00Z"
+      },
+      "required_facts": [
+        "intent.purposes",
+        "work.indonesia_source_compensation"
+      ],
+      "explanation_key": "explain.hf.d2.indonesia-source-compensation",
+      "safety_critical": true,
+      "product_version_ids": [
+        "de433757-f7af-5762-ad65-41bc16bc2ae1",
+        "374e79e0-f0bf-5291-8cba-974e794e210a",
+        "306725c1-7269-5c45-a4b8-188265fcf4d8"
+      ]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "sponsor.type",
+            "value": "GOVERNMENT"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33A_GOVERNMENT_INVITATION_ELIGIBLE",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "rule_id": "el.e33a.government-invitation",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-09-12T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "sponsor.type"],
+      "explanation_key": "explain.el.e33a.government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "in",
+            "fact": "sponsor.type",
+            "values": ["GOVERNMENT", "NONE"]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33B_GOVERNMENT_COLLABORATION_ELIGIBLE",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "rule_id": "el.e33b.government-collaboration",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-09-12T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "sponsor.type"],
+      "explanation_key": "explain.el.e33b.government-collaboration",
+      "safety_critical": false,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "in",
+            "fact": "sponsor.type",
+            "values": ["GOVERNMENT", "NONE"]
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33C_WORLD_FIGURE_INVITATION_ELIGIBLE",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "rule_id": "el.e33c.world-figure-invitation",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-09-12T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "sponsor.type"],
+      "explanation_key": "explain.el.e33c.world-figure-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "when": {
+        "op": "neq",
+        "fact": "sponsor.type",
+        "value": "INDIVIDUAL"
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E23U_SPONSOR_NOT_INDIVIDUAL"
+      },
+      "rule_id": "hf.e23u.sponsor-not-individual",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-09-12T00:00:00Z"
+      },
+      "required_facts": ["sponsor.type"],
+      "explanation_key": "explain.hf.e23u.sponsor-not-individual",
+      "safety_critical": true,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "sponsor.type",
+            "value": "INDIVIDUAL"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E23U_DIPLOMATIC_HOUSEHOLD_ELIGIBLE",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "rule_id": "el.e23u.diplomatic-household",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-09-12T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "sponsor.type"],
+      "explanation_key": "explain.el.e23u.diplomatic-household",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "when": {
+        "op": "neq",
+        "fact": "sponsor.type",
+        "value": "GOVERNMENT"
+      },
+      "scope": "PRODUCTS",
+      "stage": "HARD_FILTER",
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E23V_SPONSOR_NOT_GOVERNMENT"
+      },
+      "rule_id": "hf.e23v.sponsor-not-government",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-09-12T00:00:00Z"
+      },
+      "required_facts": ["sponsor.type"],
+      "explanation_key": "explain.hf.e23v.sponsor-not-government",
+      "safety_critical": true,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "sponsor.type",
+            "value": "GOVERNMENT"
+          }
+        ]
+      },
+      "scope": "PRODUCTS",
+      "stage": "ELIGIBILITY",
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E23V_TRADE_OFFICE_ELIGIBLE",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "rule_id": "el.e23v.trade-office",
+      "priority": 100,
+      "on_unknown": "NEEDS_INPUT",
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "valid_period": {
+        "to": null,
+        "from": "2026-09-12T00:00:00Z"
+      },
+      "required_facts": ["intent.purposes", "sponsor.type"],
+      "explanation_key": "explain.el.e23v.trade-office",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    }
+  ],
+  "version": "2026.9.13",
+  "products": [
+    {
+      "names": {
+        "en": "Investor Visa (E28A)",
+        "id": "Visa Investor (E28A)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Investor KITAS 2 Years (Offshore)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 730,
+        "minimum_days": 730
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": ["B211"],
+      "legacy_slugs": [],
+      "product_code": "E28A",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INVESTMENT"],
+      "public_catalog": true,
+      "covered_purposes": ["INVESTMENT"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 100
+      },
+      "product_version_id": "c8277316-c29d-5fde-bf9f-2611099a0029",
+      "prohibited_activities": [
+        "operational_work_beyond_management_and_ownership"
+      ]
+    },
+    {
+      "names": {
+        "en": "Investor Golden Visa \u2014 Company Establishment (E28B)",
+        "id": "Visa Investor Pendirian Perusahaan (E28B)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 3650,
+        "minimum_days": 1825
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E28B",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INVESTMENT"],
+      "public_catalog": true,
+      "covered_purposes": ["INVESTMENT"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
+      "prohibited_activities": ["operational_work"]
+    },
+    {
+      "names": {
+        "en": "Investor Golden Visa \u2014 Capital Market (E28C)",
+        "id": "Visa Investor Tanpa Mendirikan Perusahaan (E28C)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 3650,
+        "minimum_days": 1825
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E28C",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": ["INVESTMENT"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "b074270f-fa7c-598b-a728-81ca89432364",
+      "prohibited_activities": ["operational_work", "corporate_establishment"]
+    },
+    {
+      "names": {
+        "en": "Investor Golden Visa \u2014 Branch or Subsidiary (E28D)",
+        "id": "Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 3650,
+        "minimum_days": 1825
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E28D",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INVESTMENT"],
+      "public_catalog": true,
+      "covered_purposes": ["INVESTMENT"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "ee4fef98-3497-507c-8486-225932364e26",
+      "prohibited_activities": ["operational_work_outside_managing_subsidiary"]
+    },
+    {
+      "names": {
+        "en": "Investor Golden Visa \u2014 New Capital (IKN) Subsidiary (E28F)",
+        "id": "Visa Investor Anak Perusahaan Ibukota Nusantara (E28F)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 3650,
+        "minimum_days": 1825
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E28F",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INVESTMENT"],
+      "public_catalog": true,
+      "covered_purposes": ["INVESTMENT"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
+      "prohibited_activities": ["operational_work"]
+    },
+    {
+      "names": {
+        "en": "Second Home Visa (E33)",
+        "id": "Visa Rumah Kedua (E33)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33 Second Home (5 Years)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 1825,
+        "minimum_days": 1825
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E33",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": ["SECOND_HOME", "TOURISM"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "cf4d7f3d-1253-5036-8953-79ab3d3e7009",
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "guarantee_value_below_commitment"
+      ]
+    },
+    {
+      "names": {
+        "en": "Second Home Visa \u2014 Special-Expertise Government Invitation (E33A)",
+        "id": "Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 3650,
+        "minimum_days": 1825
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E33A",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["GOVERNMENT"],
+      "public_catalog": true,
+      "covered_purposes": ["EMPLOYMENT", "TOURISM", "FAMILY"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "5c18e265-ddb2-5010-8d24-a2f19df89850",
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ]
+    },
+    {
+      "names": {
+        "en": "Second Home Golden Visa \u2014 Special-Expertise Collaboration (E33B)",
+        "id": "Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 3650,
+        "minimum_days": 1825
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E33B",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": [
+        "EMPLOYMENT",
+        "BUSINESS_MEETINGS",
+        "INVESTMENT",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "32b6fb5f-5a24-5763-95f9-0b77be18353c",
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ]
+    },
+    {
+      "names": {
+        "en": "Second Home Golden Visa \u2014 World-Figure Government Invitation (E33C)",
+        "id": "Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 3650,
+        "minimum_days": 1825
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E33C",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["GOVERNMENT"],
+      "public_catalog": true,
+      "covered_purposes": [
+        "INVESTMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3",
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ]
+    },
+    {
+      "names": {
+        "en": "Second Home Golden Visa \u2014 Elderly 5-Year (E33E)",
+        "id": "Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa (E33E)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Retirement (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 1825,
+        "minimum_days": 1825
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "product_code": "E33E",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb",
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "deposit_value_below_commitment"
+      ]
+    },
+    {
+      "names": {
+        "en": "Second Home Visa \u2014 Elderly 1-Year (E33F)",
+        "id": "Visa Rumah Kedua Lansia untuk 1 Tahun (E33F)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33F Second Home Senior (1 Year, Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "product_code": "E33F",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": [
+        "RETIREMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "7c1da88f-f7cd-571a-95c2-7da32463d3e6",
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ]
+    },
+    {
+      "names": {
+        "en": "Second Home Visa \u2014 Remote Worker (E33G)",
+        "id": "Visa Rumah Kedua Pekerja Jarak Jauh (E33G)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33G Remote Worker (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E33G",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "51e023ea-3229-5233-b88f-cb204b5df713",
+      "prohibited_activities": [
+        "work_for_indonesian_entity",
+        "indonesian_source_compensation_including_in_kind",
+        "indonesian_company_ownership",
+        "sale_of_goods_or_services_beyond_remote_work"
+      ]
+    },
+    {
+      "names": {
+        "en": "Visa-Free Tourism Visit (A1)",
+        "id": "Bebas Visa Kunjungan Wisata (A1)"
+      },
+      "status": "ACTIVE",
+      "category": "SHORT_STAY",
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "A1 Visa-Free Tourism"
+      },
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 30,
+        "minimum_days": 30
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "A1",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": ["TOURISM", "TRANSIT"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": false,
+        "reason_code": null,
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "aee1a12d-3285-526e-8a6f-3d8467fe5d72",
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ]
+    },
+    {
+      "names": {
+        "en": "Visa on Arrival \u2014 Tourism (B1)",
+        "id": "Visa Saat Kedatangan Wisata (B1)"
+      },
+      "status": "ACTIVE",
+      "category": "SHORT_STAY",
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "B1 Visa on Arrival (VOA)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 30,
+        "minimum_days": 30
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "legacy_codes": ["B213"],
+      "legacy_slugs": [],
+      "product_code": "B1",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": ["TOURISM"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 30,
+        "maximum_extensions": 1
+      },
+      "product_version_id": "4e30cbe0-c4bf-59be-9bf8-513e66946e44",
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ]
+    },
+    {
+      "names": {
+        "en": "Tourist Visit Visa (C1)",
+        "id": "Visa Kunjungan Wisata (C1)"
+      },
+      "status": "ACTIVE",
+      "category": "SHORT_STAY",
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C1 Tourism"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 60,
+        "minimum_days": 60
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "product_code": "C1",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE", "INDIVIDUAL", "EMPLOYER"],
+      "public_catalog": true,
+      "covered_purposes": ["TOURISM", "FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 60,
+        "maximum_extensions": 2
+      },
+      "product_version_id": "7a07cbb0-564f-5c3f-9720-6ad62c4789cd",
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "journalism"
+      ]
+    },
+    {
+      "names": {
+        "en": "Business Visit Visa (C2)",
+        "id": "Visa Kunjungan Bisnis (C2)"
+      },
+      "status": "ACTIVE",
+      "category": "SHORT_STAY",
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C2 Business"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 60,
+        "minimum_days": 60
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "legacy_codes": ["B211B", "B211A"],
+      "legacy_slugs": [],
+      "product_code": "C2",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["EMPLOYER"],
+      "public_catalog": true,
+      "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 60,
+        "maximum_extensions": 2
+      },
+      "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
+      "prohibited_activities": ["paid_employment"]
+    },
+    {
+      "names": {
+        "en": "Social Activity Visit Visa (C6)",
+        "id": "Visa Kunjungan Kegiatan Sosial (C6)"
+      },
+      "status": "ACTIVE",
+      "category": "SHORT_STAY",
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C6 Social Activity"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 60,
+        "minimum_days": 60
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "product_code": "C6",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL", "EMPLOYER"],
+      "public_catalog": true,
+      "covered_purposes": ["OTHER"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 60,
+        "maximum_extensions": 2
+      },
+      "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
+      "prohibited_activities": ["paid_employment", "business_meetings"]
+    },
+    {
+      "names": {
+        "en": "Bridging Visa \u2014 Transitional Stay Permit",
+        "id": "Izin Tinggal Peralihan"
+      },
+      "status": "ACTIVE",
+      "category": "OTHER",
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "Bridging Visa"
+      },
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "3da72c7b-783e-51e3-9168-6c54bce709ed",
+        "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 60,
+        "minimum_days": null
+      },
+      "clock_policy": {
+        "anchor": "NOT_APPLICABLE",
+        "available": false,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "NOT_APPLICABLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "BRIDGING",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": false,
+      "covered_purposes": ["OTHER"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": false,
+        "reason_code": null,
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "760025cf-d51d-5687-9e98-b921010b9018",
+      "prohibited_activities": [
+        "employment_relationship",
+        "exit_terminates_permit"
+      ]
+    },
+    {
+      "names": {
+        "en": "Working Visa (E23)",
+        "id": "Visa Kerja (E23)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Working KITAS (Offshore)"
+      },
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E23",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["EMPLOYER"],
+      "public_catalog": true,
+      "covered_purposes": ["EMPLOYMENT", "TOURISM"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 1
+      },
+      "product_version_id": "e1d761e9-56c5-57c3-9c01-986d3c333157",
+      "prohibited_activities": [
+        "work_for_non_sponsor_entity",
+        "hr_personnel_positions",
+        "passive_investment_management"
+      ]
+    },
+    {
+      "names": {
+        "en": "Working Visa \u2014 Foreign Diplomat House Assistant (E23U)",
+        "id": "Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E23U",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["EMPLOYMENT"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
+      "prohibited_activities": ["work_for_non_diplomat_employer"]
+    },
+    {
+      "names": {
+        "en": "Working Visa \u2014 Trade and Economic Office (E23V)",
+        "id": "Visa Kerja Kantor Dagang dan Ekonomi (E23V)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E23V",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["GOVERNMENT"],
+      "public_catalog": true,
+      "covered_purposes": ["EMPLOYMENT"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
+      "prohibited_activities": ["work_for_standard_corporate_employers"]
+    },
+    {
+      "names": {
+        "en": "Family Visa \u2014 Spouse of Indonesian Citizen (E31A)",
+        "id": "Visa Keluarga Suami/Istri WNI (E31A)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Spouse 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 730,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": ["C317"],
+      "legacy_slugs": [],
+      "product_code": "E31A",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce",
+      "prohibited_activities": []
+    },
+    {
+      "names": {
+        "en": "Family Visa \u2014 Spouse of ITAS/ITAP Holder (E31B)",
+        "id": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": ["C318"],
+      "legacy_slugs": [],
+      "product_code": "E31B",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
+      "prohibited_activities": ["paid_employment"]
+    },
+    {
+      "names": {
+        "en": "Family Visa \u2014 Child of Legal Mixed Marriage (E31C)",
+        "id": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E31C",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
+      "prohibited_activities": ["paid_employment"]
+    },
+    {
+      "names": {
+        "en": "Family Visa \u2014 Stepchild of Foreigner in Legal Mixed Marriage (E31D)",
+        "id": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E31D",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
+      "prohibited_activities": ["paid_employment"]
+    },
+    {
+      "names": {
+        "en": "Family Visa \u2014 Child of ITAS/ITAP Holder (E31E)",
+        "id": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E31E",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
+      "prohibited_activities": ["paid_employment"]
+    },
+    {
+      "names": {
+        "en": "Family Visa \u2014 Child of Indonesian Citizen Parent (E31F)",
+        "id": "Visa Keluarga Anak dengan Orang Tua WNI (E31F)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E31F",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
+      "prohibited_activities": ["paid_employment"]
+    },
+    {
+      "names": {
+        "en": "Family Visa \u2014 Parent of Indonesian Citizen Child (E31G)",
+        "id": "Visa Keluarga Orang Tua dari Anak WNI (E31G)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E31G",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
+      "prohibited_activities": ["paid_employment"]
+    },
+    {
+      "names": {
+        "en": "Family Visa \u2014 Parent of Child ITAS/ITAP Holder (E31H)",
+        "id": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E31H",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
+      "prohibited_activities": ["paid_employment"]
+    },
+    {
+      "names": {
+        "en": "Family Visa \u2014 Child Joining Sibling ITAS/ITAP Holder (E31J)",
+        "id": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 365,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E31J",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 365,
+        "maximum_extensions": 5
+      },
+      "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
+      "prohibited_activities": ["paid_employment"]
+    },
+    {
+      "names": {
+        "en": "Visit Visa Tourism \u2014 Multiple Entry (D1)",
+        "id": "Visa Kunjungan Wisata \u2014 Beberapa Kali Perjalanan (D1)"
+      },
+      "status": "ACTIVE",
+      "category": "MULTIPLE_ENTRY",
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D1 Tourism (1 Year)"
+      },
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 60,
+        "minimum_days": 60
+      },
+      "clock_policy": {
+        "anchor": "ENTRY_DATE",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "D1",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 60,
+        "maximum_extensions": 2
+      },
+      "product_version_id": "374e79e0-f0bf-5291-8cba-974e794e210a",
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ]
+    },
+    {
+      "names": {
+        "en": "Visit Visa Business \u2014 Multiple Entry (D2)",
+        "id": "Visa Kunjungan Bisnis (D2)"
+      },
+      "status": "ACTIVE",
+      "category": "MULTIPLE_ENTRY",
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D2 Business (1 Year)"
+      },
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 60,
+        "minimum_days": 60
+      },
+      "clock_policy": {
+        "anchor": "ENTRY_DATE",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "D2",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": ["BUSINESS_MEETINGS", "TOURISM", "FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 60,
+        "maximum_extensions": 2
+      },
+      "product_version_id": "306725c1-7269-5c45-a4b8-188265fcf4d8",
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "continuous_supervision_production_sales"
+      ]
+    },
+    {
+      "names": {
+        "en": "Visit Visa Pre-Investment \u2014 Multiple Entry (D12)",
+        "id": "Visa Kunjungan Pra-Investasi (D12)"
+      },
+      "status": "ACTIVE",
+      "category": "MULTIPLE_ENTRY",
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D12 Business Investigation (1 Year)"
+      },
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 180,
+        "minimum_days": 180
+      },
+      "clock_policy": {
+        "anchor": "ENTRY_DATE",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "D12",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["NONE"],
+      "public_catalog": true,
+      "covered_purposes": ["INVESTMENT", "TOURISM", "FAMILY"],
+      "extension_policy": {
+        "status": "VERIFIED",
+        "allowed": true,
+        "reason_code": null,
+        "days_per_extension": 180,
+        "maximum_extensions": 1
+      },
+      "product_version_id": "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91",
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ]
+    },
+    {
+      "names": {
+        "en": "Education Visa (E30)",
+        "id": "Visa Pendidikan (E30)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "maximum_days": null,
+        "minimum_days": null
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E30",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "public_catalog": false,
+      "covered_purposes": ["STUDY"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ]
+    },
+    {
+      "names": {
+        "en": "Primary/Secondary Education Visa (E30A)",
+        "id": "Visa Pendidikan Dasar dan Menengah (E30A)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30A Education Visa (1 Year)"
+      },
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 730,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E30A",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["STUDY"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ]
+    },
+    {
+      "names": {
+        "en": "Higher Education Visa (E30B)",
+        "id": "Visa Pendidikan Tinggi (E30B)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30B Higher Education (1 Year)"
+      },
+      "source_refs": [
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "31850f85-8d19-58df-bb66-b04968c9aff0"
+      ],
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "maximum_days": 1460,
+        "minimum_days": 365
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E30B",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "public_catalog": true,
+      "covered_purposes": ["STUDY"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ]
+    },
+    {
+      "names": {
+        "en": "SEZ Education Visa (E30E)",
+        "id": "Visa Pendidikan Kawasan Ekonomi Khusus (E30E)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "maximum_days": null,
+        "minimum_days": null
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E30E",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["EDUCATION"],
+      "public_catalog": true,
+      "covered_purposes": ["STUDY"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ]
+    },
+    {
+      "names": {
+        "en": "Student Exchange Visa (E30F)",
+        "id": "Visa Pertukaran Pelajar (E30F)"
+      },
+      "status": "ACTIVE",
+      "category": "LIMITED_STAY",
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "maximum_days": null,
+        "minimum_days": null
+      },
+      "clock_policy": {
+        "anchor": "PERMIT_ISSUED_AT",
+        "available": true,
+        "checkpoints": []
+      },
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "product_code": "E30F",
+      "valid_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "sponsor_types": ["EDUCATION"],
+      "public_catalog": true,
+      "covered_purposes": ["STUDY"],
+      "extension_policy": {
+        "status": "UNKNOWN",
+        "allowed": false,
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+        "days_per_extension": null,
+        "maximum_extensions": 0
+      },
+      "product_version_id": "235f5dfc-2feb-5d5b-ab09-0f4e4122819e",
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ]
+    }
+  ],
+  "sequence": 21,
+  "created_at": "2026-09-12T00:00:00Z",
+  "created_by": "agent.mini-pro2.backend-rag.shweb-w-oracle-d4b-20260912",
+  "hit_policy": {
+    "ranking": "SUM_TRUE_INTEGER_WEIGHTS",
+    "eligibility": "COVER_ALL_DECLARED_PURPOSES",
+    "hard_filter": "COLLECT_ALL",
+    "human_review": "COLLECT_ALL"
+  },
+  "environment": "PRODUCTION",
+  "jurisdiction": "ID",
+  "rule_pack_id": "57a26fae-a8c0-53b0-b3d9-1d4636bcbe6a",
+  "valid_period": {
+    "to": null,
+    "from": "2026-09-12T00:00:00Z"
+  },
+  "source_records": [
+    {
+      "title": "Kepmen M.IP-08.GR.01.01/2025 \u2014 Indeks Visa Indonesia (katalog daftar-visa imigrasi.go.id)",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28D"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33E"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33G"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/B1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C2"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C6"
+        }
+      ],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "kepmen-mip-08-gr-01-01-2025-visa-catalog",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia",
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "content_sha256": "be6bf44d2d6f8ee8e766ac3b8007c274b84fe7773a516a59ce2f9629049ec3f9",
+      "document_number": "Kepmen M.IP-08.GR.01.01/2025",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "Permenkumham 22/2023 jo. Permenkumham 11/2024 \u2014 Izin Tinggal Keimigrasian (Ps. 33/61/62/63, 86A, 94A, 94B, 113, 185)",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33(2)(j)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 62"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 63"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 86A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94B"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 185"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 39"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 40"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 57"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 58"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 59"
+        }
+      ],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "permenkumham-22-2023-jo-11-2024-stay-permits",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2024-04-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "canonical_url": "https://peraturan.bpk.go.id/Details/285156/permenkumham-no-11-tahun-2024",
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "content_sha256": "052dfa1315385c57d2d92140000a140f99adac25f1449fbddcaca19ca2e4ce1a",
+      "document_number": "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "9248b1d7-9172-54d9-ad61-251e83a2285b",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "Permen Imipas 10/2026 \u2014 Daftar Negara Bebas Visa Kunjungan (BVK)",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "permen-imipas-10-2026-bvk-nationality-list",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2026-07-09T00:00:00Z"
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "content_sha256": "af7287e82df4f96f162ee094608aa40c3d3ce40899fdb685509743597cbd0ff3",
+      "document_number": "Permen Imipas Nomor 10 Tahun 2026",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "808d691c-374e-5581-8186-9eb54d0ca7ab",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "UU 6/2011 jo. UU 63/2024 tentang Keimigrasian \u2014 kewarganegaraan dan ketentuan overstay",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "uu-6-2011-jo-uu-63-2024-keimigrasian",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "canonical_url": "https://www.imigrasi.go.id/id/visa-kunjungan/",
+      "authority_type": "PRIMARY_LAW",
+      "content_sha256": "30aeb54b897b32b07a91f7ce1fdef58cd33f495bffb52e049f0031fd87221428",
+      "document_number": "UU 6/2011 jo. UU 63/2024",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "e76bf823-2b36-522f-b2f7-e51eb7715e44",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "Daftar Negara Calling Visa \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Calling Visa country list; national Ditjen Imigrasi display"
+        }
+      ],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi-calling-visa-country-list",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "cfc36c1b65af69564e9a56b69c3b680288ece3d17350b6b46e9b396b3888f305",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+      "supersedes_source_record_id": "cd613d5b-83da-5150-a7b5-759eb4d224fe"
+    },
+    {
+      "title": "Siaran Pers Ditjen Imigrasi 2024-04-24 \u2014 Izin Tinggal Peralihan Jembatani Proses Transisi Izin Tinggal WNA di RI",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2024-04-24T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "26ab52ca35af9e1d1b18fedff1df355f1cada57a710f49c816d4fe2708447848",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+      "supersedes_source_record_id": "65ffed8d-ccb2-512b-b093-60733b31269d"
+    },
+    {
+      "title": "Permen Imipas 5/2025 \u2014 Pencabutan Permenkumham 36/2021 tentang Penjamin Keimigrasian",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 1"
+        }
+      ],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "permen-imipas-5-2025-penjamin-revocation",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-02-07T00:00:00Z"
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/378168/Permen%20Imipas%20Nomor%205%20Tahun%202025.pdf",
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "content_sha256": "b1c33d5ca2d6fa582ce827dc7caa3b512728186ae40c21c60ec7106ebe9bc759",
+      "document_number": "Permen Imipas 5/2025",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "2eabe49e-b71b-575a-b2e8-2be3f8e5b718",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "Layanan Alih Status \u2014 Izin Tinggal Kunjungan Menjadi Izin Tinggal Terbatas",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi-alih-status-itk-itas-service-page",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "19fb4a4eba22194a3a14fa3a6be76e704835dc4a8fd27b2f2f0536495ead09ce",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+      "supersedes_source_record_id": "0b9d2466-a9e1-556f-8585-7ef501c3c837"
+    },
+    {
+      "title": "Keputusan Menteri Imigrasi dan Pemasyarakatan M.IP-08.GR.01.01/2025 tentang Klasifikasi Visa",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Lampiran"
+        }
+      ],
+      "publisher": "Kementerian Imigrasi dan Pemasyarakatan (Kemenimipas)",
+      "source_key": "kemenimipas.kepmen-mip-08-gr-01-01-2025.klasifikasi-visa",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "canonical_url": "https://kemenimipas.go.id/attachments/2025/peraturan/20250813_09_Kepmen_No_M.IP-08.GR.01.01_Th_2025_Tentang_Klasifikasi_Visa.pdf",
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "content_sha256": "b8e326667c892ab2dfb52be220c82a0716bab6a516fe925c5e45096e9ef81c33",
+      "document_number": "M.IP-08.GR.01.01/2025",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "e3572ad2-08a9-55bd-b818-353b3e9db715",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "Permenkumham Nomor 22 Tahun 2023 tentang Visa dan Izin Tinggal",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 42"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33"
+        }
+      ],
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "source_key": "peraturan-bpk.permenkumham-22-2023.visa-izin-tinggal",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2023-08-22T00:00:00Z"
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/330147/Permenkumham%20Nomor%2022%20Tahun%202023.pdf",
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "content_sha256": "2e9165804c38e9a60b4f1c4a046bd727a97043d7386be90d608c68db31c015d4",
+      "document_number": "22/2023",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "Permenkumham Nomor 11 Tahun 2024 tentang Perubahan atas Permenkumham 22/2023",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105 ayat (7)"
+        }
+      ],
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "source_key": "peraturan-bpk.permenkumham-11-2024.perubahan-22-2023",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2024-04-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/344251/Permenkumham%20Nomor%2011%20Tahun%202024.pdf",
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "content_sha256": "ecbbeccc196145f47f24e68473a27c19d6f0408e607abb365ce9acd22cbf5f02",
+      "document_number": "11/2024",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "31850f85-8d19-58df-bb66-b04968c9aff0",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian \u2014 Pasal 60 ayat (2) dan Pasal 61",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 60 ayat (2)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "publisher": "Badan Pemeriksa Keuangan Republik Indonesia",
+      "source_key": "peraturan.bpk.go.id.uu-6-2011-keimigrasian",
+      "verified_at": "2026-08-10T00:00:00Z",
+      "verified_by": "agent.air-m5.visa-seq6-semantics",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2011-05-05T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-10T00:00:00Z",
+      "canonical_url": "https://peraturan.bpk.go.id/Home/Download/28550/UU%206%20Tahun%202011.pdf",
+      "authority_type": "PRIMARY_LAW",
+      "content_sha256": "63708ca9b50ac067834a50c395385fdc6abda22e6e51def88983cd1ad685edc4",
+      "document_number": "UU 6/2011",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-08-10T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "5a0d367b-bf64-535d-83e4-f40c45de2008",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian \u2014 Bab V (Izin Tinggal), reproduksi Ditjen Imigrasi",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.uu-6-2011-keimigrasian.bab-5",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2011-05-05T00:00:00Z"
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "canonical_url": "https://www.imigrasi.go.id/uu_imigrasi/bab-5",
+      "authority_type": "PRIMARY_LAW",
+      "content_sha256": "7585f108f2ec029b954f42951dcb56c4afa3aca09eb018c02134782661664272",
+      "document_number": "UU 6/2011",
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      },
+      "source_record_id": "4886ebe6-41ae-5c6f-bf5d-b98e182be435",
+      "supersedes_source_record_id": null
+    },
+    {
+      "title": "Visa Keluarga Suami/Istri WNI (E31A) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "7ee2871fa937249756d8f8048067e3444b1aa738ec41737832180807a674932c",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+      "supersedes_source_record_id": "9ed9ed7a-5998-557f-ac98-ceaf2cb520df"
+    },
+    {
+      "title": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "178c059aa106c9e9a338f1c9980e66ca7a3f74b961ebccb372ad07aa20d6102f",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+      "supersedes_source_record_id": "c89c8de0-b131-5491-a604-f0ee79f18fe9"
+    },
+    {
+      "title": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "4cd930e3f7b9ed99a92e0a11b025532d53a2405766fee2d9d8153cc97e129473",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+      "supersedes_source_record_id": "a88e1fe2-b363-5541-94bd-c7bd62ff1649"
+    },
+    {
+      "title": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "f957654b7f9c1ece0c6f162812ff0384e3dab195af1f7ebb7cce30ce458af78e",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+      "supersedes_source_record_id": "8b9a48dc-2f86-5b0c-be51-5dba1e7a64fc"
+    },
+    {
+      "title": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "4dcd01efc33454f722aa01fd3273fd8cca112bc161e4b3edd71710e4751beca5",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+      "supersedes_source_record_id": "8062c9aa-44d7-5aee-8bca-a8446af0c4a0"
+    },
+    {
+      "title": "Visa Keluarga Anak dengan Orang Tua WNI (E31F) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "44054b731caef383470f56dc318c7ff6a9b3e222b513296f777ec61a0def5f0b",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+      "supersedes_source_record_id": "b251f6cb-14df-5997-92b7-37f235a33e89"
+    },
+    {
+      "title": "Visa Keluarga Orang Tua dari Anak WNI (E31G) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "64a3d8c4af611cd072d82abde72f0213e19aa121e367f4c9c58d5a791d86a34b",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+      "supersedes_source_record_id": "6da01441-8a97-5192-89f8-6384486ba4e9"
+    },
+    {
+      "title": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "19dcb960b348bc7a51986fae48e8ae8a08c18ccc65958065c3cbb99c7f30fd1b",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+      "supersedes_source_record_id": "4a6e547e-1a2a-50c4-981d-64638564d546"
+    },
+    {
+      "title": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "fdba98fd4fc827b87d4ae11fd6365fcd7330b174d4e737a6c4d416066055e4c3",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+      "supersedes_source_record_id": "be01ea72-a43d-578d-83fd-6da4f27c0f71"
+    },
+    {
+      "title": "Visa Kunjungan Wisata Beberapa Kali Perjalanan (D1) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "6e918e1fa848260b2fab7673bfe99aef37c248c0b248c35c667238d5e2eaf497",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+      "supersedes_source_record_id": "28775be4-5726-53d2-9126-eea1bd9ef27f"
+    },
+    {
+      "title": "Visa Kunjungan Bisnis (D2) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "24519738205bc39a0befb8f4f0d6dde3ca13dca72add2163ace0b79726882bb0",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+      "supersedes_source_record_id": "4b47cdb0-db95-585d-9d8c-6bba92fe50bb"
+    },
+    {
+      "title": "Visa Kunjungan Pra-Investasi (D12) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "2961a6046e9efa279e4e2411012b41206f502a8db1c7819c2422cca95a93148e",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+      "supersedes_source_record_id": "4ca7cfef-4e5f-51d4-869f-46e9a9c36022"
+    },
+    {
+      "title": "Visa Pendidikan Dasar dan Menengah (E30A) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "a97d5b1c108ffc886d222174b4026e5dc6ad920fdb1f2cb17a0a2b6718f63e2f",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+      "supersedes_source_record_id": "d0218b81-27bf-524b-bf31-6c398844f601"
+    },
+    {
+      "title": "Visa Pendidikan Tinggi (E30B) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 2,
+      "language": "id",
+      "locators": [],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2025-06-01T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "34a8958e439b38e8666d965fb60b64ba5cb04cb3facf92ba2d97ebf7e7c382ad",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+      "supersedes_source_record_id": "49e11be4-32ec-57fd-bd4b-f6e6a8e914e5"
+    },
+    {
+      "title": "Daftar Negara Subjek Visa on Arrival (VoA) \u2014 Direktorat Jenderal Imigrasi",
+      "status": "VERIFIED",
+      "version": 1,
+      "language": "id",
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Daftar Negara, Pemerintah Dari Daerah Administrasi Khusus Suatu Negara, dan Entitas Tertentu (97 entries); cross-verified detik.com d-8322745 and depok.imigrasi.go.id/47666-2"
+        }
+      ],
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "source_key": "imigrasi-voa-country-list",
+      "verified_at": "2026-08-30T13:18:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-freshness-restamp.live-recheck-2026-08-30",
+      "jurisdiction": "ID",
+      "legal_period": {
+        "to": null,
+        "from": "2026-07-24T00:00:00Z"
+      },
+      "retrieved_at": "2026-08-08T00:00:00Z",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+      "authority_type": "OFFICIAL_PORTAL",
+      "content_sha256": "41fe2acb27c70180a8269736abe7eb605e4dfd7f55b4d4bd31b1cbd4b480f265",
+      "document_number": null,
+      "recorded_period": {
+        "to": null,
+        "from": "2026-08-08T00:00:00Z"
+      },
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 2764800
+      },
+      "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+      "supersedes_source_record_id": null
+    }
+  ],
+  "decision_domain": "IMMIGRATION_VISA",
+  "engine_max_version": "1.0.0",
+  "engine_min_version": "1.0.0",
+  "engine_contract_version": "1.0.0",
+  "previous_payload_sha256": "df02287b7fc8f572a9e6674fdf3445a2131c428e8a1492ab8a388dee5bf01a4d",
+  "rollback_of_payload_sha256": null
+}


### PR DESCRIPTION
## What

**PR-D4b — the seq-21 rule pack, prepared to the signature and stopped there.** One new file: `rulepack-prod-021.source.json`, sequence 21, `previous_payload_sha256` chaining to seq-20's signed payload. seq-20 is untouched: packs are immutable, so seq-21 is a new file, never an edit.

Zero's D4 ruling: the Oracle names the product and never asks which visa; all 37 products must be reachable by a deterministic path. Nine products had **zero support rules** in seq-20 — only requested-product review rules, which is exactly the shape the ruling forbids.

## Shipped: 7 rules covering 5 of the 9

| product | rules | cited source records |
|---|---|---|
| E33A | `el.e33a.government-invitation` | `6f5135f2…` + `9248b1d7…` |
| E33B | `el.e33b.government-collaboration` | same |
| E33C | `el.e33c.world-figure-invitation` | same |
| E23U | `hf.e23u.sponsor-not-individual`, `el.e23u.diplomatic-household` | `6f5135f2…` + `e3572ad2…` |
| E23V | `hf.e23v.sponsor-not-government`, `el.e23v.trade-office` | same |

Every rule cites a `source_record_id` **already present in seq-20** — the same records seq-20's own `hf.e33*` and review rules cite. Verified independently by the orchestrator: **28 source records before, 28 after, zero new, zero with a changed `content_sha256`.** No document was asserted to have been retrieved, hashed or verified by anyone for this PR, because nothing was.

`compile_pack.py` → `OK — zero compilation errors`, exit 0, `rule_pack_id=57a26fae-…`, `sequence=21`.

## Withheld, each with the document it would need

Four of the nine did not get rules, and one first-class candidate was **retracted on the regulation**. This is the intended outcome, not a shortfall: a wrong immigration threshold is a person refused at a border or told they qualify when they do not.

- **E28B/C/D/F** — the USD thresholds are cited and verified in `research/visa/doctrine-factory/cards/E28*.md`, but **no fact in the engine carries a USD amount** for them today. Introducing one broke 74 + 33 gold-fixture tests through a closed-fact-set invariant, and the attempt was reverted. Needs a fact-vocabulary change first, which is its own PR.
- **C1/C6 paid-activity hard filter** — built, verified correct in isolation, then **dropped on measurement**: the 67-walk replay showed **35 regressions**, because the tourism/family branch never asks `work.indonesia_source_compensation`. Correct in a rule, wrong in a funnel.
- **`hf.e31d.sponsor-permit-required` — RETRACTED, and this corrects earlier PRs.** **Corrected pinpoint (2026-09-13):** the earlier drafts of this section cited "Pasal 33(7)", which is wrong. The enumeration is **Permenkumham 11/2024, Pasal 33 ayat (2) huruf h**: its E31D entry names **no permit at all**, while the neighbouring E31E entry says *"pemegang Izin Tinggal Terbatas atau Izin Tinggal Tetap"* — the contrast between the two entries is the evidence. The guarantor is **Pasal 193**, *Penanggung Jawab WNI*, an Indonesian citizen — who cannot hold a KITAS/KITAP, so asking whether E31D's sponsor holds one asks for something that category rules out by definition. The repo's own doctrine card agrees: E31D's sponsor requirement is identity and relationship documents (Kartu Keluarga, Pasal 46(2)), not the sponsor's own stay permit. And the pack agrees: the nine rules reading `family.sponsor_status_code` are E31B/E/H/J only. **PR-D3 half-2's body lists this rule as a seq-21 candidate; that recommendation is wrong and is withdrawn here.** See "what this means for the STEPCHILD hold" below.
- **`other_purpose`** — confirmed unseen by any rule, as PR-D3 found. But the disclosed values do not need one: `transit` is already served by A1/D1's TRANSIT purpose (a mouth-side mapping fix, not a backend gap), and medical/journalism/arts/crew have no product code in the 38-code catalogue at all. A rule reading `other_purpose` would have had nothing to decide.

## What this means for the STEPCHILD hold — escalated, not acted on

PR-D3 half-2 keeps two STEPCHILD walks in HUMAN_REVIEW and asks the applicant whether the sponsor holds a KITAS/KITAP. If the regulation does not make E31D depend on the sponsor's permit, then that hold rests on a requirement that does not exist for this product — which is the same over-match shape Zero ruled against in D2. This PR does **not** change it: the question is an owner decision, not a pack one, and it is raised here rather than resolved quietly.

## Pre-sign change — a dead end the new rules would have opened, closed in the pack

The pre-sign review measured a regression the corpus had not shown: inside the new rules' validity, the work tile with a non-Indonesian employer moved from NO_SUPPORTED_PATH to **NEEDS_INPUT on `intent.requested_product_code`**. Cause: pre-existing HUMAN_REVIEW rules carry `on_unknown: NEEDS_INPUT` on that fact, the frontend never asks it by design, and they were inert only because those products had no SUPPORT. Giving them support woke them.

**The fix is in the pack, not in the question**: those rules are now `on_unknown: NO_EFFECT` — still active when the code IS known, inert when it was never asked. The alternative — adding a `requested_product_code eq CODE` conjunct to the new rules — was explicitly rejected: it would make the products opt-in on a code the applicant would have to name first, which is the inverse of Zero's D4 ruling that the Oracle names the product.

**Count, corrected against the file rather than taken from the review**: 13 rules reference that fact, but only **9** are HUMAN_REVIEW with `on_unknown: NEEDS_INPUT`, and those 9 are what changed — `review.e28b/e28c/e28d/e28f`, `review.e33a/e33b/e33c`, `review.e23u/e23v`. The other 4 are ELIGIBILITY bridging rules (3 already `NO_EFFECT`; `el.bridging.destination-stated` still `NEEDS_INPUT`) and are untouched: bridging gained no SUPPORT here, so its behaviour is exactly seq-20's. That last rule is a pre-existing shape, named here so it need not be rediscovered — it is not introduced by this PR.

Diff of the fix: **9 line-pairs, nothing else moved.** `compile_pack.py` → OK, exit 0.

## Replay

Corpus replayed offline at the same instant for seq-20 (signed) vs seq-21 (unsigned): identical state counts, **0 verdicts changed**, reachable-product delta **+0 on this corpus** — the new rules are simply not exercised by it. Confirmed live via direct `evaluate_product()` that `el.e33a.government-invitation` reaches SUPPORTED once `intent.requested_product_code` is KNOWN, and is blocked when truly unasked by seq-20's pre-existing review rule (`on_unknown=NEEDS_INPUT`) — a named follow-up, not a defect of these rules.

**Measurement bound, stated**: this worktree branched before PR-D3 half-2 merged, so the replay ran against the **67**-walk corpus, not today's 78. The 11 newer walks are not represented.

### Second pre-sign delta — a false SUPPORT, caught on the 78-walk corpus

The first replay ran on 67 walks and looked clean. On **78** it was not, and the worse of the two findings was not a dead end:

- **`el.e33b` and `el.e33c` accepted `sponsor.type = NONE`**, so walks with **no sponsor at all** were handed E33B/E33C — ordinary investors being recommended a government-invitation Second Home, with no review reason as a net. Five walks gained a false E33C and two a false E33B. A dead end wastes someone's time; this tells them they qualify when they do not.
- `offshore/other/paid/employer_no` moved NO_SUPPORTED_PATH → **NEEDS_INPUT on `sponsor.type`**: the `other` tile never asks `sponsor_category`, and the seven new rules carried `on_unknown: NEEDS_INPUT`.

**Both cured in `f8381ed04b`** (11 line-pairs): all seven new rules are now `on_unknown: NO_EFFECT`, and `el.e33b`/`el.e33c` gate on `eq sponsor.type GOVERNMENT` — the same condition `el.e33a` already used. No `NONE` remains on `sponsor.type` in any new rule.

The bar for keeping `NONE` was a citation making "no sponsor" *enabling*. Neither source record contains one. An exclusion list's sentinel does not transfer to an eligibility list.

### Replay, restated after the cure

Corpus pulled **read-only from `origin/main`** into a detached worktree and evaluated against this branch's pack — no merge, no rebase, because this branch is pushed and a merge of main would drag its files through the off-limits pre-commit gate.

| 78 walks | before the cure (`9a134c52de`) | after (`f8381ed04b`) |
|---|---|---|
| at seq-20's `signed_at` | — | **62 / 14 / 2, 0 changed** |
| now | 62 / 13 / 3, **8 changed** | **62 / 14 / 2, 0 changed** |

Identical to the seq-20 baseline at both instants. Personas: `GOVERNMENT → [E23V, E33A, E33B]`, `INDIVIDUAL → [E23U]`, `NONE → NO_SUPPORTED_PATH`.

**Reachable products: 14, unchanged** — and the earlier "13 → 15" is withdrawn, because that gain was the false-positive artifact of accepting `NONE`, not reachability. Reaching E33B/E33C needs a walk with a government sponsor, and the corpus has none; the personas show the products are reachable when the facts are there. **So this pack changes no corpus verdict** — that is the correct outcome for rules whose facts the current walks never supply, and it is stated here rather than dressed up as an improvement.

### Old replay (superseded, kept for the record)

Both instants, 67-walk corpus:

- at seq-20's `signed_at` (before seq-21's `valid_period.from`): **identical to seq-20, 0 changed**
- now: **0 regressions**, and 7 walks gain an additional correct candidate (E33C beside C2 on the invest walks, E33B beside E23 on the work walks). No walk moved to NEEDS_INPUT or worse. ~~Reachable products 13 → 15 (+E33B, +E33C).~~

**Two figures in the block above are WITHDRAWN, not merely superseded** — struck here so that no one reads a retired number as a result:

- *"four invest walks"* → the walks gaining E33C were **five**. That is the pre-sign grader's count on the 78-walk corpus, taken before the merge rather than before the signature.
- *"Reachable products 13 → 15"* → **never happened.** That gain was the artifact of accepting `NONE` as an enabling sponsor value, which the cure removed. Reachability stays at **14**, as the current replay above states, and it moves only when the corpus carries a walk with a real government sponsor (PR-D4d).

**Two gaps stated rather than papered over.** The reviewer's three named personas could not be run — their fixtures are not in this worktree — so an equivalent isolated check was run instead (`evaluate_product()` for E33A before and after) plus the full corpus; the persona IDs were not fabricated to fill the row. And this worktree predates PR-D3 half-2's merge, so the replay is the **67**-walk corpus, not today's 78.

**Correction of record**: commit `2c9aa50c2c`'s message cites "Pasal 33(7)" for the E31D reading. That pinpoint is wrong — it is **Pasal 33 ayat (2) huruf h** plus **Pasal 193**, as corrected above and in commit `9a134c52de`. The commit is already pushed, so its message is not rewritten; this section is the correction of record.

### seq-22 plan — one line that must not be forgotten

The four `review.e28*` rules stay `on_unknown: NO_EFFECT`. That is a no-op **today**, because E28B/C/D/F carry zero SUPPORT rules. The day D4c gives them one, the silence stops being a no-op: the manual USD-threshold review must be **explicitly re-armed** — its `on_unknown` decided deliberately — in the same PR that adds their SUPPORT rule. Do not assume it is still automatic.

### seq-21 rule defaults — for the next author, not a description of this one

1. A new SUPPORT or HARD_FILTER rule is born `on_unknown: NO_EFFECT` **unless its fact is asked on every tile that can reach the rule's product**.
2. A sentinel value (`NONE`, `UNKNOWN`) is never treated as enabling without a citation stating so. An exclusion list's sentinel does not transfer to an eligibility list.
3. Every change to this pack is measured on the **full** walk corpus at **both** the currently-signed pack's `signed_at` instant and now, **before** it is a candidate — not after.

This section exists because the same file needed three rounds: the defaults were implicit, and each round rediscovered them.

## MERGE DOES NOT ACTIVATE

Merging this PR changes nothing in production. The active pack is whatever the **activation ledger** says; a merged seq-21 file is inert until the operator ceremony runs. `activate_pack.py` verifies the signature against the trust store, runs the anti-rollback pre-gate, inserts, then activates through a **separate database identity** — production refuses a combined login.

## Awaiting Zero's signature

This PR carries the **unsigned** source. The gate runs on the signed artifact, so preparation stops here. Signing and activation are Zero's.

```
sign_pack.py backend/services/visa_engine/contracts/packs/rulepack-prod-021.source.json \
  --kid prod-2026-07-1 --key-file <Ed25519 PEM, 0600> \
  --environment PRODUCTION --i-know-this-is-production --sequence 21 \
  --output backend/services/visa_engine/contracts/packs/rulepack-prod-021.signed.json

activate_pack.py backend/services/visa_engine/contracts/packs/rulepack-prod-021.signed.json \
  --actor <Zero> --reason "seq-21 W-ORACLE PR-D4b activation" \
  --current-sequence 20 \
  --current-payload-sha256 df02287b7fc8f572a9e6674fdf3445a2131c428e8a1492ab8a388dee5bf01a4d \
  --pack-writer-database-url-env <...> --activation-database-url-env <...> --yes
```

Not signed. Not activated. `VISA_ENGINE_EVALUATE_MODE` untouched.

## Bites

Bites: consumer = **the engine after `activate_pack.py`, not the merge** — a merged pack is inert until the ceremony runs; observation = once activated, `probe_evaluate --traffic-source synthetic_driver` reports `rule_pack_id` equal to seq-21's and the work-tile walk with a non-Indonesian employer returns NO_SUPPORTED_PATH rather than NEEDS_INPUT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




