### PR TITLE
feat(bot): B2.2 — the domain reliefs stay, and the measurement that keeps them is now falsifiable

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/reasoning_utils.py
+++ b/apps/backend-rag/backend/services/rag/agentic/reasoning_utils.py
@@ -895,41 +895,114 @@ DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT: dict[str, float] = {
 
 
 def _parse_domain_threshold_overrides(spec: str) -> dict[str, float]:
-    """Parse `DOMAIN_ABSTAIN_THRESHOLDS=tax:0.10,kbli:0.20` env var format."""
+    """Parse `DOMAIN_ABSTAIN_THRESHOLDS=tax:0.10,kbli:0.20` env var format.
+
+    RULING I40(d) — fail-closed applies to configuration too. This raises
+    `ValueError` on the FIRST malformed entry, out-of-range value, or
+    unknown domain key it finds, rather than skipping the bad entry and
+    silently keeping the rest. The old behaviour let a spec like
+    `{"tax":0.15,"visa":0.15}` (a JSON typo, not the `key:value,...` format)
+    split into a garbage key (`'{"tax"'` -> 0.15) that silently entered the
+    live threshold dict while the caller only ever logged a warning — a
+    partially-applied, silently-wrong override. The caller
+    (`_build_domain_thresholds`) treats any raise here as "reject the WHOLE
+    spec, use the defaults in full" — never a partial override.
+
+    An empty/blank spec (the default — `DOMAIN_ABSTAIN_THRESHOLDS` unset) is
+    NOT an error: it means "no override" and returns `{}`.
+    """
+    spec = (spec or "").strip()
+    if not spec:
+        return {}
+
+    known_domains = set(DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT)
     out: dict[str, float] = {}
-    for raw in (spec or "").split(","):
+    for raw in spec.split(","):
         raw = raw.strip()
-        if not raw or ":" not in raw:
+        if not raw:
+            # a stray trailing/doubled comma is formatting noise, not an
+            # entry — nothing to validate or apply
             continue
+        if ":" not in raw:
+            raise ValueError(
+                f"DOMAIN_ABSTAIN_THRESHOLDS: malformed entry {raw!r} (expected key:value)",
+            )
         key, _, val = raw.partition(":")
+        key = key.strip().lower()
         try:
             value = float(val)
-        except ValueError:
-            logger.warning(
-                "DOMAIN_ABSTAIN_THRESHOLDS: skipping malformed entry %r",
-                raw,
+        except ValueError as exc:
+            raise ValueError(
+                f"DOMAIN_ABSTAIN_THRESHOLDS: non-numeric value in entry {raw!r}",
+            ) from exc
+        if key not in known_domains:
+            raise ValueError(
+                f"DOMAIN_ABSTAIN_THRESHOLDS: unknown domain {key!r} in entry {raw!r} "
+                f"(known domains: {sorted(known_domains)})",
             )
-            continue
         # Evidence scores live in [0.0, 1.0]; an override outside that range
         # (including nan/inf, which fail this comparison) would silently
-        # disable or force the abstain gate for a whole domain — skip it.
+        # disable or force the abstain gate for a whole domain.
         if not (0.0 <= value <= 1.0):
-            logger.warning(
-                "DOMAIN_ABSTAIN_THRESHOLDS: skipping out-of-range entry %r",
-                raw,
+            raise ValueError(
+                f"DOMAIN_ABSTAIN_THRESHOLDS: out-of-range value in entry {raw!r} "
+                "(must be within [0.0, 1.0])",
             )
-            continue
-        out[key.strip().lower()] = value
+        # Refuted in council round 1 (kimi-code/k3, R10): `tax:0.10,tax:0.20`
+        # used to apply silently with last-wins. An ambiguous spec is not a
+        # spec — reject it whole rather than pick a winner.
+        if key in out:
+            raise ValueError(
+                f"DOMAIN_ABSTAIN_THRESHOLDS: duplicate domain {key!r} in entry {raw!r}",
+            )
+        out[key] = value
     return out
 
 
+def _strict_fallback_thresholds() -> dict[str, float]:
+    """The thresholds to use when the override spec cannot be trusted.
+
+    Refuted and corrected in council round 1 (kimi-code/k3, R9): falling back
+    to the DEFAULTS is not fail-closed for THIS gate. The defaults carry the
+    domain RELIEFS (`tax` 0.10, `visa` 0.12), which are the most PERMISSIVE
+    values in the dict — so an operator tightening a threshold during an
+    incident who mistypes the spec would silently get the relieved gate back.
+    For an abstain gate, closed means STRICT: no domain may sit below the
+    `default` threshold when the configuration is untrusted, so every relief
+    is lifted to `default` and any value already stricter is kept as it is.
+    """
+    baseline = DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT["default"]
+    return {
+        domain: max(value, baseline)
+        for domain, value in DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT.items()
+    }
+
+
 def _build_domain_thresholds() -> dict[str, float]:
+    """Merge `DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT` with the env override.
+
+    RULING I40(d): the override is all-or-nothing. If
+    `_parse_domain_threshold_overrides` raises, this logs the reason at
+    ERROR and falls back to the DEFAULTS IN FULL — never a partial merge.
+    This function itself must never raise: it runs at import time
+    (`_DOMAIN_THRESHOLDS = _build_domain_thresholds()` immediately below),
+    and an uncaught exception here would stop the whole app from booting
+    over a bad env var.
+    """
+    raw_spec = os.environ.get("DOMAIN_ABSTAIN_THRESHOLDS", "")
+    try:
+        overrides = _parse_domain_threshold_overrides(raw_spec)
+    except ValueError as exc:
+        logger.error(
+            "DOMAIN_ABSTAIN_THRESHOLDS=%r is invalid (%s) — falling back to the "
+            "defaults in full, no partial override applied",
+            raw_spec,
+            exc,
+        )
+        return _strict_fallback_thresholds()
+
     merged = dict(DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT)
-    merged.update(
-        _parse_domain_threshold_overrides(
-            os.environ.get("DOMAIN_ABSTAIN_THRESHOLDS", ""),
-        ),
-    )
+    merged.update(overrides)
     return merged
 
 

--- a/apps/backend-rag/backend/tests/benchmarks/evidence_sufficiency/harness.py
+++ b/apps/backend-rag/backend/tests/benchmarks/evidence_sufficiency/harness.py
@@ -56,6 +56,25 @@ def load(path: str | Path) -> dict[str, Any]:
         return json.load(f)
 
 
+def source_sha256(path: str | Path) -> str:
+    """The `source_sha256` pin for a benchmark evidence source (Set B/Set C/
+    ... in `manifest_supplement_b2.json`'s `sets` block).
+
+    ALWAYS hashes the FILE's raw bytes (`Path(path).read_bytes()`) — never
+    an in-memory `json.dumps(data)` re-serialization of its parsed content.
+    The two differ whenever the file's own bytes carry something a
+    round-trip through `json.loads`/`json.dumps` does not reproduce
+    byte-for-byte — a trailing newline being the concrete case found
+    2026-09-13: Set C's recorded pin (`a55aed94...`) was
+    `sha256(json.dumps(data, indent=2))`, i.e. the writer hashed the
+    in-memory string it was about to write rather than the bytes the file
+    ended up holding once the write appended a final `\n`. A pin computed
+    this way verifies against nothing any `shasum -a 256 <file>` will ever
+    produce. Use this helper for every future `source_sha256` this
+    benchmark records, so that class of drift cannot recur."""
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
 def support_record_key(query: str, context: list[str]) -> str:
     """The B2.1 §6 replay key — `sha256` of a CANONICAL JSON serialization of
     `[query, context]`, NEVER `case_id`, so no label can be smuggled through

--- a/apps/backend-rag/backend/tests/benchmarks/evidence_sufficiency/manifest_supplement_b2.json
+++ b/apps/backend-rag/backend/tests/benchmarks/evidence_sufficiency/manifest_supplement_b2.json
@@ -15,12 +15,19 @@
     "C": {
       "name": "D-SETC — hard case: entity present, referent wrong, no meta-commentary",
       "source": "evidence/2026-09/agent-nuzantara-backend-rag-b2-engine-63f75705/set_c_probe.json",
-      "source_sha256": "a55aed9416c6e876efb999c0ad50948b6c805e41a6cfdd5b3f010416c4f25040",
+      "source_sha256": "5f493b6b036954cec3622e6cd03b625061cb2bda54907634b6129344ea7c7910",
+      "source_sha256_note": "Re-pinned 2026-09-13 (B2.2). Old (wrong) value: a55aed9416c6e876efb999c0ad50948b6c805e41a6cfdd5b3f010416c4f25040 — that was sha256(json.dumps(data, indent=2)) over the file's PARSED-then-re-serialized content, which drops the file's own trailing newline; the writer hashed the in-memory string it was about to write, not the bytes the file ended up holding. The current value is `shasum -a 256 set_c_probe.json` over the file's real bytes (harness.source_sha256()).",
       "authored_by": "gemini-3.1-pro via agy --effort high, 2026-09-12T09:30Z, second reader (Codex recused: candidate (iii) is its own family); Dux-cured (two supporting_span elisions replaced with true verbatim substrings; one false Dux digit-search flag on two spelled-out durations reverted)",
       "pair_count": 12,
       "case_count": 24,
       "measures": "Whether the scorer/support-signal is fooled by a confident, on-topic amount or duration that names the SAME entity as the question but answers a DIFFERENT question about it (a neighbouring fact, an indirect sufficiency claim, or an internal contradiction) — with NO announcement of insufficiency anywhere in the text. This is the hard case Set A (which deletes the trigger token) and Set B (whose negatives announce their own insufficiency) do not cover.",
       "does_not_measure": "Cases where the wrong referent is signalled lexically (a negation, a hedge, an explicit 'not stated') — Set B already covers that; and it does not fix a threshold — (iii)/(ii) are measured on Set C BEFORE any threshold is set in B2.2, per the build spec."
+    },
+    "D": {
+      "name": "Set D — the cross-language cell of the SAME Set C hard pairs",
+      "derived_from": "C",
+      "derivation_note": "Set D has no source file of its own: its cases are the cross-language members of Set C's pairs, so Set C's source_sha256 pins them too. Added in B2.2 after council round 1 (kimi-code/k3, R12) found that 12 cases carried set=D while the sets metadata named only B and C — an unpinned set that the new pin guard would have skipped in silence.",
+      "case_count": 12
     }
   },
   "cases": [

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_domain_relief_tripwire.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_domain_relief_tripwire.py
@@ -1,0 +1,227 @@
+"""B2.2 — tripwire for the domain-relief thresholds (RULING I40).
+
+`DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT` (reasoning_utils.py) widens the LABEL
+gate for two domains — tax 0.10, visa 0.12 — below the flat 0.15 every
+other domain uses, because Indonesian-language tax/visa docs have lower
+keyword overlap with IT/EN queries (see that module's own docstring). This
+test does not touch those values; it measures whether the relief they grant
+ever becomes the REASON a negative-stratum benchmark case (insufficient /
+irrelevant context, per `manifest_mandatory.json` +
+`manifest_supplement_b2.json`) clears the label gate.
+
+Mechanism: `harness.decide()` — the same function the frozen benchmark
+report calls — drives the REAL scorer (`calculate_evidence_score`) and the
+REAL `AbstainPolicy` for every negative case, once with the live relief
+thresholds and once with every domain flattened to 0.15. A case whose label
+decision differs between the two runs is passing (or abstaining)
+BECAUSE the relief exists — exactly what RULING I40 forbids.
+
+NOT asserted here: that every negative case abstains under the relief, full
+stop. Six Set-C/D "hard-case" pairs (contradiction-distractor cases in
+`manifest_supplement_b2.json` — sup-c-725a39c8, sup-c-244d993f,
+sup-d-1d738fd7 in the visa domain; sup-c-75d9a21c, sup-c-5fb1b72f in
+pricing; sup-c-d4fff2f6 in default) already PASS the label gate today, at
+scores 0.8 / 0.8 / 0.3 / 0.8 / 0.8 / 0.3, IDENTICALLY under the relief and
+under a flat 0.15 — three of the six aren't even in a relieved domain, so a
+flat threshold cannot be what lets them through. Their own
+`provenance_fixture.note` says their target signal is "the FUTURE support
+judge... not today's provenance-band scorer", and `harness.report()`
+already tracks this class of miss as a `false_acceptance` count rather than
+gating it to zero — measured and accepted, not hidden. That gap is real but
+it is NOT relief-driven and closing it is out of scope for a relief
+tripwire;
+`TestDomainReliefNeverFlipsANegativeCaseToPass.test_the_six_known_hard_case_false_acceptances_are_relief_independent`
+names them explicitly so a future reader is not left to rediscover this.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+import pytest
+
+from backend.services.rag.agentic import reasoning_utils
+from backend.tests.benchmarks.evidence_sufficiency import harness
+
+_BENCH_DIR = Path(harness.__file__).resolve().parent
+_MANDATORY_PATH = _BENCH_DIR / "manifest_mandatory.json"
+_SUPPLEMENT_PATH = _BENCH_DIR / "manifest_supplement_b2.json"
+_SUPPORT_RECORD_PATH = _BENCH_DIR / "support_verdicts_b2.json"
+
+_NEGATIVE_STRATA = (
+    "relevant_insufficient",
+    "irrelevant",
+    "generic_overlap",
+    "company_prefix_chunk",
+)
+
+#: The relief thresholds under scrutiny (RULING I40): tax 0.10, visa 0.12,
+#: pricing/kbli/default unchanged. This module never edits these — only
+#: measures against them.
+RELIEF_THRESHOLDS: dict[str, float] = dict(reasoning_utils.DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT)
+#: The counterfactual the relief is measured against: every domain flattened
+#: to the 0.15 the relief widens away from. Any negative case whose label
+#: decision differs between RELIEF_THRESHOLDS and this dict is passing (or
+#: abstaining) BECAUSE the relief exists.
+#: CORRECTED after the council round (codex-gpt-5.6-sol, P2): flattening EVERY
+#: domain to 0.15 also LOWERS kbli from 0.20, so a negative kbli case scoring
+#: between 0.15 and 0.20 would flip under the counterfactual and be reported as
+#: relief-caused — a false positive about a domain that has no relief. The
+#: counterfactual must move ONLY the domains whose threshold is BELOW the
+#: default 0.15, i.e. the reliefs themselves.
+# Refuted in council round 1 (kimi-code/k3, R6): a literal 0.15 here would
+# silently stop meaning "no relief" the day the engine's own `default` moves.
+# Read it from the engine dict, like the reliefs themselves.
+_DEFAULT_THRESHOLD = RELIEF_THRESHOLDS["default"]
+UNIFORM_THRESHOLDS: dict[str, float] = {
+    domain: (_DEFAULT_THRESHOLD if value < _DEFAULT_THRESHOLD else value)
+    for domain, value in RELIEF_THRESHOLDS.items()
+}
+
+_KNOWN_RELIEF_INDEPENDENT_HARD_CASES = frozenset(
+    {
+        "sup-c-725a39c8",  # visa
+        "sup-c-244d993f",  # visa
+        "sup-d-1d738fd7",  # visa
+        "sup-c-75d9a21c",  # pricing — relief does not even touch this domain
+        "sup-c-5fb1b72f",  # pricing — relief does not even touch this domain
+        "sup-c-d4fff2f6",  # default — relief does not even touch this domain
+    },
+)
+
+
+@contextlib.contextmanager
+def _domain_thresholds(overrides: dict[str, float]):
+    """Swap the module-global dict `reasoning_utils.get_abstain_threshold()`
+    reads, for the duration of the block, then restore it.
+
+    Deliberately a bare context manager rather than the pytest `monkeypatch`
+    fixture: the same helper is used both by the tests below AND by the
+    standalone falsification probe run once (by hand, outside pytest) to
+    prove this mechanism is sensitive — see the PR report.
+    """
+    original = reasoning_utils._DOMAIN_THRESHOLDS
+    reasoning_utils._DOMAIN_THRESHOLDS = dict(overrides)
+    try:
+        yield
+    finally:
+        reasoning_utils._DOMAIN_THRESHOLDS = original
+
+
+def _negative_cases() -> list[dict]:
+    mandatory = harness.load(_MANDATORY_PATH)
+    supplement = harness.load(_SUPPLEMENT_PATH)
+    return [
+        c for c in mandatory["cases"] + supplement["cases"] if c["stratum"] in _NEGATIVE_STRATA
+    ]
+
+
+@pytest.fixture(scope="module")
+def negative_cases() -> list[dict]:
+    cases = _negative_cases()
+    assert cases, "no negative-stratum cases in either manifest — tripwire would be vacuous"
+    for case in cases:
+        # sanity: validate() already enforces this manifest-wide, but a
+        # tripwire that silently included a mislabeled case would be worse
+        # than one that fails loudly here instead.
+        assert case["expected_label_gate"] == "abstain", case["case_id"]
+    return cases
+
+
+@pytest.fixture(scope="module")
+def support_record() -> dict[str, str]:
+    return harness.load_support_record(_SUPPORT_RECORD_PATH)
+
+
+def _label_under(
+    cases: list[dict],
+    support_record: dict[str, str],
+    thresholds: dict[str, float],
+) -> dict[str, str]:
+    with _domain_thresholds(thresholds):
+        return {c["case_id"]: harness.decide(c, support_record)["label"] for c in cases}
+
+
+def _relief_caused_flips(
+    cases: list[dict],
+    support_record: dict[str, str],
+    relief: dict[str, float],
+) -> dict[str, tuple[str, str]]:
+    """`{case_id: (relief_label, uniform_label)}` for every case whose label
+    decision under `relief` differs from its decision under
+    `UNIFORM_THRESHOLDS`. Non-empty means at least one case's outcome
+    depends on `relief` existing at all."""
+    relief_labels = _label_under(cases, support_record, relief)
+    uniform_labels = _label_under(cases, support_record, UNIFORM_THRESHOLDS)
+    return {
+        cid: (relief_labels[cid], uniform_labels[cid])
+        for cid in relief_labels
+        if relief_labels[cid] != uniform_labels[cid]
+    }
+
+
+class TestDomainReliefNeverFlipsANegativeCaseToPass:
+    def test_is_non_vacuous_some_negative_case_is_in_a_relieved_domain(
+        self,
+        negative_cases: list[dict],
+    ) -> None:
+        domains = {reasoning_utils.classify_query_domain(c["query"]) for c in negative_cases}
+        assert domains & {"tax", "visa"}, (
+            "no negative case classifies into tax or visa — the only domains "
+            "the relief loosens below 0.15 — so this tripwire would never fire: "
+            f"observed domains {domains}"
+        )
+
+    def test_no_negative_case_label_decision_depends_on_the_relief(
+        self,
+        negative_cases: list[dict],
+        support_record: dict[str, str],
+    ) -> None:
+        flips = _relief_caused_flips(negative_cases, support_record, RELIEF_THRESHOLDS)
+        assert flips == {}, flips
+
+    def test_the_six_known_hard_case_false_acceptances_are_relief_independent(
+        self,
+        negative_cases: list[dict],
+        support_record: dict[str, str],
+    ) -> None:
+        """Names the module docstring's exception explicitly: these cases DO
+        pass the label gate, but identically so with or without the relief
+        — and every OTHER negative case abstains under the relief."""
+        relief_labels = _label_under(negative_cases, support_record, RELIEF_THRESHOLDS)
+        uniform_labels = _label_under(negative_cases, support_record, UNIFORM_THRESHOLDS)
+
+        present = _KNOWN_RELIEF_INDEPENDENT_HARD_CASES & set(relief_labels)
+        assert present == _KNOWN_RELIEF_INDEPENDENT_HARD_CASES, (
+            "expected hard-case ids missing from the corpora — manifest changed? "
+            f"missing={_KNOWN_RELIEF_INDEPENDENT_HARD_CASES - present}"
+        )
+        for cid in _KNOWN_RELIEF_INDEPENDENT_HARD_CASES:
+            assert relief_labels[cid] == "pass", (cid, relief_labels[cid])
+            assert uniform_labels[cid] == "pass", (cid, uniform_labels[cid])
+
+        other_ids = set(relief_labels) - _KNOWN_RELIEF_INDEPENDENT_HARD_CASES
+        offenders = {cid: relief_labels[cid] for cid in other_ids if relief_labels[cid] == "pass"}
+        assert offenders == {}, offenders
+
+
+class TestTheTripwireIsFalsifiable:
+    """Proves `_relief_caused_flips` is not vacuously green: an extreme
+    relief (every domain at 0.0, so nothing can ever score below threshold)
+    DOES produce a non-empty flip set against the same `UNIFORM_THRESHOLDS`
+    counterfactual the real tests above use — i.e. the detection mechanism
+    the tests above rely on is provably sensitive to a relief that is too
+    generous, not just to the specific values in force today."""
+
+    def test_an_extreme_relief_is_caught_as_a_flip(
+        self,
+        negative_cases: list[dict],
+        support_record: dict[str, str],
+    ) -> None:
+        extreme = dict.fromkeys(RELIEF_THRESHOLDS, 0.0)
+        flips = _relief_caused_flips(negative_cases, support_record, extreme)
+        assert flips, (
+            "an extreme relief (0.0 for every domain) produced NO flips — "
+            "the flip-detection mechanism above is not actually sensitive"
+        )

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_domain_threshold_override_parsing.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_domain_threshold_override_parsing.py
@@ -1,0 +1,166 @@
+"""B2.2 — fail-loud / fail-closed for `DOMAIN_ABSTAIN_THRESHOLDS` (RULING I40(d)).
+
+Before this PR, `_parse_domain_threshold_overrides` accepted a malformed
+`DOMAIN_ABSTAIN_THRESHOLDS` env var (e.g. a JSON spec like
+`{"tax":0.15,"visa":0.15}` instead of `tax:0.15,visa:0.15`) and silently
+produced a GARBAGE key (`'{"tax"'` -> 0.15) that entered the live threshold
+dict alongside whatever valid entries happened to parse — a
+partially-applied, silently-wrong override, with only a `logger.warning`
+to notice it by. RULING I40(d): fail-closed applies to configuration too.
+
+`_parse_domain_threshold_overrides` now raises `ValueError` on the first
+malformed entry / out-of-range value / unknown domain key, and
+`_build_domain_thresholds` (the function actually bound to
+`_DOMAIN_THRESHOLDS` at module import) catches that, logs at ERROR, and
+falls back to `DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT` IN FULL — never a partial
+merge. `_build_domain_thresholds` itself must never raise: it runs at
+import time, and an uncaught exception there would stop the whole app from
+booting over a bad env var.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+import pytest
+
+from backend.services.rag.agentic import reasoning_utils
+
+_KNOWN_DOMAINS = set(reasoning_utils.DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT)
+
+
+class TestParseDomainThresholdOverridesRaisesOnBadInput:
+    def test_valid_colon_comma_spec_parses_and_applies(self) -> None:
+        result = reasoning_utils._parse_domain_threshold_overrides("tax:0.10,kbli:0.20")
+        assert result == {"tax": 0.10, "kbli": 0.20}
+
+    def test_empty_spec_is_not_an_error_and_yields_no_overrides(self) -> None:
+        assert reasoning_utils._parse_domain_threshold_overrides("") == {}
+        assert reasoning_utils._parse_domain_threshold_overrides("   ") == {}
+
+    def test_json_spec_raises_instead_of_producing_a_garbage_key(self) -> None:
+        with pytest.raises(ValueError):
+            reasoning_utils._parse_domain_threshold_overrides('{"tax":0.15,"visa":0.15}')
+
+    def test_entry_with_no_colon_raises(self) -> None:
+        with pytest.raises(ValueError):
+            reasoning_utils._parse_domain_threshold_overrides("garbage")
+
+    def test_non_numeric_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            reasoning_utils._parse_domain_threshold_overrides("tax:not-a-number")
+
+    def test_unknown_domain_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown domain"):
+            reasoning_utils._parse_domain_threshold_overrides("notadomain:0.5")
+
+    @pytest.mark.parametrize("bad_value", ("1.5", "-0.1", "nan", "inf"))
+    def test_out_of_range_value_raises(self, bad_value: str) -> None:
+        with pytest.raises(ValueError, match="out-of-range"):
+            reasoning_utils._parse_domain_threshold_overrides(f"tax:{bad_value}")
+
+    def test_boundary_values_zero_and_one_are_accepted(self) -> None:
+        result = reasoning_utils._parse_domain_threshold_overrides("tax:0.0,visa:1.0")
+        assert result == {"tax": 0.0, "visa": 1.0}
+
+    def test_one_bad_entry_poisons_the_whole_spec_not_just_itself(self) -> None:
+        """Fail-closed is ALL-OR-NOTHING: a spec with one good entry and one
+        bad entry must not silently keep the good one — the caller
+        (`_build_domain_thresholds`) is the one responsible for discarding
+        the whole thing, but `_parse_domain_threshold_overrides` must raise
+        before returning anything partial in the first place."""
+        with pytest.raises(ValueError):
+            reasoning_utils._parse_domain_threshold_overrides("tax:0.10,notadomain:0.5")
+
+
+class TestBuildDomainThresholdsNeverRaisesAndFallsBackInFull:
+    def test_valid_override_applies_on_top_of_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The values MUST differ from the defaults, or the assertion cannot
+        # tell an applied override from an ignored one (council round,
+        # codex-gpt-5.6-sol, P3). Defaults here are tax 0.10 / kbli 0.20.
+        monkeypatch.setenv("DOMAIN_ABSTAIN_THRESHOLDS", "tax:0.13,kbli:0.17")
+        result = reasoning_utils._build_domain_thresholds()
+        expected = dict(reasoning_utils.DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT)
+        expected.update({"tax": 0.13, "kbli": 0.17})
+        assert result == expected
+        assert result["tax"] != reasoning_utils.DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT["tax"]
+
+    def test_json_spec_applies_nothing_and_logs_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("DOMAIN_ABSTAIN_THRESHOLDS", '{"tax":0.15,"visa":0.15}')
+        with caplog.at_level(logging.ERROR, logger=reasoning_utils.logger.name):
+            result = reasoning_utils._build_domain_thresholds()
+
+        assert result == reasoning_utils._strict_fallback_thresholds()
+        # no garbage key entered the dict
+        assert not any(k.startswith("{") for k in result)
+        assert set(result) == _KNOWN_DOMAINS
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert error_records, "expected an ERROR log record for the invalid spec"
+        assert "DOMAIN_ABSTAIN_THRESHOLDS" in error_records[0].getMessage()
+
+    def test_unknown_domain_key_applies_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DOMAIN_ABSTAIN_THRESHOLDS", "notadomain:0.5")
+        result = reasoning_utils._build_domain_thresholds()
+        assert result == reasoning_utils._strict_fallback_thresholds()
+        assert "notadomain" not in result
+
+    def test_out_of_range_value_applies_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DOMAIN_ABSTAIN_THRESHOLDS", "tax:1.5")
+        result = reasoning_utils._build_domain_thresholds()
+        assert result == reasoning_utils._strict_fallback_thresholds()
+
+    def test_one_bad_entry_falls_back_in_full_not_just_for_that_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A spec with one VALID entry and one BAD entry must not apply the
+        valid one either — fail-closed is all-or-nothing at the spec level,
+        not per-entry."""
+        # tax:0.13 differs from the default 0.10, so "the valid entry was not
+        # applied either" is observable rather than indistinguishable.
+        monkeypatch.setenv("DOMAIN_ABSTAIN_THRESHOLDS", "tax:0.13,notadomain:0.5")
+        result = reasoning_utils._build_domain_thresholds()
+        assert result == reasoning_utils._strict_fallback_thresholds()
+        # Fail-STRICT, not fail-to-defaults (council round 1, kimi-code/k3 R9):
+        # an untrusted spec must never hand back the RELIEF, which is the most
+        # permissive value in the dict.
+        assert result["tax"] > reasoning_utils.DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT["tax"]
+        assert result["tax"] == reasoning_utils.DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT["default"]
+
+    def test_unset_env_var_yields_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DOMAIN_ABSTAIN_THRESHOLDS", raising=False)
+        result = reasoning_utils._build_domain_thresholds()
+        assert result == reasoning_utils.DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT
+
+
+class TestImportingTheModuleWithAMalformedEnvVarDoesNotRaise:
+    """The literal claim in both functions' docstrings: a bad
+    `DOMAIN_ABSTAIN_THRESHOLDS` must never prevent the module — and by
+    extension the app that imports it — from booting. Proven by reloading
+    the real module (not just calling its function directly) under the
+    malformed env var, then restoring it so no other test in this session
+    observes a polluted `_DOMAIN_THRESHOLDS`."""
+
+    def test_reload_under_a_malformed_env_var_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DOMAIN_ABSTAIN_THRESHOLDS", '{"tax":0.15,"visa":0.15}')
+        try:
+            reloaded = importlib.reload(reasoning_utils)
+        except Exception as exc:  # pragma: no cover - the thing under test
+            pytest.fail(f"importing reasoning_utils raised under a malformed env var: {exc!r}")
+
+        assert reloaded._DOMAIN_THRESHOLDS == reloaded._strict_fallback_thresholds()
+
+        # restore real state for every other test in this session — monkeypatch
+        # un-sets the env var on teardown, but the module-level
+        # `_DOMAIN_THRESHOLDS` computed during THIS reload would otherwise
+        # stay poisoned (to defaults, harmlessly, but still not the state a
+        # clean import would have produced) for whoever imports this module
+        # object next.
+        monkeypatch.undo()
+        importlib.reload(reasoning_utils)

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_evidence_sufficiency_benchmark.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_evidence_sufficiency_benchmark.py
@@ -170,6 +170,61 @@ class TestSupplementIsWellFormedAndNeverPooledWithMandatory:
         assert decided_ids.isdisjoint(supplement_ids)
 
 
+def _repo_root() -> Path:
+    p = Path(__file__).resolve()
+    while p != p.parent:
+        if (p / "apps").is_dir():
+            return p
+        p = p.parent
+    raise AssertionError("repo root (dir containing apps/) not found from test file")
+
+
+class TestSupplementSourceShaPinsVerifyAgainstFileBytes:
+    """B2.2 — both `sets.*.source_sha256` pins in `manifest_supplement_b2.json`
+    must verify against their named evidence file's real BYTES
+    (`harness.source_sha256()`), never an in-memory `json.dumps()`
+    re-serialization of the parsed content.
+
+    Set C's pin was wrong for exactly that reason (2026-09-13): the
+    recorded value was `sha256(json.dumps(data, indent=2))`, which silently
+    drops the file's own trailing newline. `shasum -a 256` on the real file
+    never agreed with it. Re-pinned to the file-bytes hash in this same PR;
+    this test is the regression guard against that class of drift recurring
+    for Set B, Set C, or any future set."""
+
+    def test_set_b_and_set_c_source_pins_verify_against_file_bytes(
+        self, supplement: dict
+    ) -> None:
+        repo_root = _repo_root()
+        # Non-vacuity, found by the council round (codex-gpt-5.6-sol, P2): with
+        # `sets` emptied this loop asserted nothing and stayed green, and
+        # `harness.validate()` stayed green too. Name the sets that MUST be
+        # pinned, so deleting one fails here instead of passing silently.
+        # Every set that APPEARS IN THE CASES must be accounted for — council
+        # round 1 (kimi-code/k3, R12): 12 cases carried set=D while the metadata
+        # named only B and C, so an unpinned set slipped past a guard that only
+        # walked the metadata.
+        sets_in_cases = {c.get("set") for c in supplement["cases"]} - {None}
+        assert sets_in_cases <= set(supplement["sets"]), (
+            sets_in_cases,
+            set(supplement["sets"]),
+        )
+        assert set(supplement["sets"]) >= {"B", "C"}, supplement["sets"].keys()
+        for set_name, entry in supplement["sets"].items():
+            if "source" not in entry:
+                # A derived set carries no file of its own; it must SAY so and
+                # name the set whose pin covers it, rather than simply lack one.
+                assert entry.get("derived_from") in supplement["sets"], entry
+                continue
+            source_path = repo_root / entry["source"]
+            assert source_path.is_file(), f"set {set_name}: {source_path} does not exist"
+            actual = harness.source_sha256(source_path)
+            assert actual == entry["source_sha256"], (
+                f"set {set_name}: recorded source_sha256 {entry['source_sha256']!r} "
+                f"does not match {source_path}'s real file-bytes hash {actual!r}"
+            )
+
+
 class TestBalancePerCell:
     """Balance contract (B1-3-build-spec.md): per cell >= 3 sufficient and
     >= 1 of each of the four negative strata."""

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b2-2-thresholds-dab4a6c0/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b2-2-thresholds-dab4a6c0/brief.yml
@@ -1,0 +1,59 @@
+task_id: backend-rag-b2-2-thresholds
+gear: 2
+l_level: L2
+gate_class: opus
+base_sha: 429e54d208f25efccde443a9f523b868e81c10b7 # pragma: allowlist secret
+mandate: B2
+colour: BLUE
+pr: B2.2-thresholds
+objective: >-
+  B2 §4 PR B2.2, criterion 5 — the domain abstain reliefs. The question the
+  mandate asks is whether `tax: 0.10` and `visa: 0.12` should be restored
+  toward `default: 0.15`. Measured on the replay record before any live call,
+  the answer this corpus can give is NEITHER: raising both to 0.15 changes no
+  decision at either gate in any cell, because not one case in the frozen
+  mandatory manifest or in the Set B/C/D supplement lands in the band where a
+  relief is the difference. So the reliefs STAY (RULING I40, option 2), the
+  reason is written as a measurement rather than a preference, and a TRIPWIRE
+  makes the claim falsifiable: it goes red the day a negative case passes a
+  gate only because of a relief. Two defects found while measuring are cured
+  in the same PR because they are defects OF the measurement instruments: the
+  supplement's Set C pin, and the env parser that discards a malformed
+  override silently and partially.
+appetite:
+  wall_clock_hours: 3
+  adversarial_rounds: 1
+  tokens: 1200000
+acceptance:
+  - id: A1
+    text: >-
+      The reliefs are unchanged at tax 0.10 / visa 0.12 and the pack carries the
+      per-cell numbers on the mandatory set AND on Set B/C/D, BEFORE and AFTER a
+      uniform 0.15, with the byte-identity of the two reports as the receipt.
+  - id: A2
+    text: >-
+      A tripwire test goes RED if any case whose expected label is negative
+      (insufficient / irrelevant) ever passes a gate only because of a relief.
+      Its falsifiability is demonstrated by a recorded mutation, not asserted.
+  - id: A3
+    text: >-
+      The supplement's Set C `source_sha256` is re-pinned to the FILE's sha256
+      with the trailing-newline diagnosis recorded, and a test verifies BOTH
+      set pins by hashing file bytes.
+  - id: A4
+    text: >-
+      A malformed `DOMAIN_ABSTAIN_THRESHOLDS` never applies a partial override:
+      it is rejected whole, logged at ERROR, and the defaults stay in force —
+      and it never raises at import time.
+  - id: A5
+    text: >-
+      The panel-ruled divergence (generation gate flat 0.15 vs per-domain label
+      gate) is NOT collapsed, and no threshold moves without the §4 numbers.
+seats:
+  dux: "Opus 5 xhigh (session ffe321b0, Pro)"
+  implementer: "Sonnet 5"
+  adversarial_reviewer: "codex-gpt-5.6-sol (CODEX_HOME=~/.codex-acct2, read-only sandbox)"
+  refuter: "kimi-code/k3"
+  second_reader: "Gemini 3.1 Pro (agy) — contracts/data, not counted toward quorum"
+  gate: "a FRESH Opus 5 session outside the contribution chain"
+brief_ref: evidence/brief.yml

--- a/evidence/2026-09/agent-nuzantara-backend-rag-b2-2-thresholds-dab4a6c0/pack.yml
+++ b/evidence/2026-09/agent-nuzantara-backend-rag-b2-2-thresholds-dab4a6c0/pack.yml
@@ -1,0 +1,214 @@
+task_id: backend-rag-b2-2-thresholds
+brief_ref: evidence/brief.yml
+base_sha: 429e54d208f25efccde443a9f523b868e81c10b7 # pragma: allowlist secret
+mandate: B2
+pr: B2.2-thresholds
+ruling: "I40 (imperator, 2026-09-12T18:35Z) — option 2: the reliefs stay, with the measured reason and a tripwire."
+
+the_question_and_why_this_corpus_cannot_answer_it:
+  asked_by: "B2 §4 PR B2.2, criterion 5 — restore `tax: 0.10` / `visa: 0.12` toward `default: 0.15`, or keep them with a written reason and a tripwire."
+  method: >-
+    harness.py on the replay record, run four times on base 429e54d208: the frozen
+    mandatory manifest and the Set B/C/D supplement, each under the DEFAULT reliefs
+    and under a uniform 0.15 applied through the documented env override
+    (`DOMAIN_ABSTAIN_THRESHOLDS='tax:0.15,visa:0.15'` — colon-comma, the only
+    format the parser accepts; a JSON spec is NOT equivalent, see the parser finding).
+    No live call, no paid call, no send, no generation.
+  receipt_byte_identity:
+    mandatory_before_sha256: "67322f4876c1…"
+    mandatory_after_sha256: "67322f4876c1…"
+    supplement_before_sha256: "48ceff1a0c39…"
+    supplement_after_sha256: "48ceff1a0c39…"
+    reading: "Same sha both ways, on both corpora: raising the reliefs to 0.15 changes NO decision at either gate in any cell."
+  why_measured_per_case: >-
+    All 58 + 44 cases driven through harness.decide, not sampled. The mandatory
+    manifest classifies 5 cases as `visa` and ZERO as `tax` (8 pricing, 45 default);
+    the supplement has 12 `visa` and 6 `tax`. Their scores: 0.02 / 0.06 × 4
+    (mandatory) and 0.08 × 7, 0.30 × 3, 0.60 × 3, 0.80 × 5 (supplement). NOT ONE
+    case in either corpus lands in [0.10, 0.15) or [0.12, 0.15) — the band where a
+    relief is the difference. Nearest below 0.08, nearest above 0.30.
+  conclusion: >-
+    "0 false acceptances before and after" is NOT evidence that the reliefs are safe
+    here; it is evidence that nothing in these corpora exercises them. The reliefs
+    therefore stay, the reason is this measurement, and the tripwire makes the claim
+    falsifiable. They are re-examined when the live sample puts a real tax/visa score
+    in the band — and not before.
+
+per_cell_numbers:
+  gates: "each cell reports generation and label; FA = false acceptance, FAb = false abstention, count/denominator"
+  mandatory_58_cases_before_and_after_identical:
+    "ID>EN": "generation FA 0/11 · FAb 0/6 | label FA 0/11 · FAb 0/6"
+    "EN>ID": "generation FA 0/10 · FAb 0/6 | label FA 0/10 · FAb 0/6"
+    "EN>EN": "generation FA 0/9 · FAb 0/4 | label FA 0/9 · FAb 0/4"
+    "ID>ID": "generation FA 0/8 · FAb 0/4 | label FA 0/8 · FAb 0/4"
+  supplement_44_cases_before_and_after_identical:
+    "EN>EN": "generation FA 2/8 · FAb 0/8 | label FA 2/8 · FAb 0/8"
+    "ID>ID": "generation FA 3/8 · FAb 0/8 | label FA 3/8 · FAb 0/8"
+    "EN>ID": "generation FA 1/6 · FAb 2/6 | label FA 1/6 · FAb 2/6"
+  the_supplement_residual_named_rather_than_buried: >-
+    The supplement carries SIX false acceptances and TWO false abstentions, and they
+    are IDENTICAL before and after — so they are not a threshold defect and no
+    threshold change touches them. Set C is the D-SETC hard case by construction
+    (entity present, referent wrong, no meta-commentary), which is exactly what the
+    support signal, not the abstain threshold, is supposed to decide. Reported
+    separately from the mandatory set per B2 §3, carried as a named residual for the
+    live sample and for B2.3's review — never counted as a safety pass here.
+  mandatory_is_clean: "0/0 in every cell at both gates, unchanged by the thresholds."
+
+receipts:
+  - ts: "2026-09-12T18:47:46Z"
+    what: "the four harness runs and the per-case domain/score census"
+    cmd: "PYTHONPATH=. .venv/bin/python backend/tests/benchmarks/evidence_sufficiency/harness.py [--manifest …supplement…] --support-record …support_verdicts_b2.json --json"
+    result: "reports byte-identical under default and uniform-0.15 thresholds on both corpora; 0 cases in the relief band"
+
+what_this_pr_changes:
+  reliefs: "UNCHANGED — tax 0.10, visa 0.12. Verified by the Dux on disk after every edit: DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT == {tax 0.1, visa 0.12, pricing 0.15, kbli 0.2, default 0.15}."
+  tripwire:
+    file: "backend/tests/unit/services/rag/test_domain_relief_tripwire.py (new, 214 lines)"
+    what_it_pins: >-
+      For every case whose expected label is negative, the LABEL decision must be
+      IDENTICAL under the reliefs and under a uniform 0.15 — i.e. no negative case
+      may pass a gate BECAUSE OF a relief. It reads the thresholds from
+      `reasoning_utils.DOMAIN_ABSTAIN_THRESHOLDS_DEFAULT`, not from a literal, so a
+      change to the engine's own dict moves the test.
+    falsifiability_measured_by_the_dux: >-
+      Independent of the implementer's own check: the Dux mutated the ENGINE
+      (`"visa": 0.12` -> `"visa": 0.02` in reasoning_utils.py, not in the test) and
+      the tripwire went RED — 2 failed / 2 passed, naming bs-2ae24f1c, bs-797ff307,
+      bs-dd593d7a and the other flipped cases. The file was restored from a `cp`
+      backup (never `git checkout --`, which would have taken the uncommitted cure
+      with it) and the dict re-read from the module afterwards to prove the revert.
+  known_exceptions_pinned_not_hidden: >-
+    SIX Set-C/D hard cases already pass the label gate today (scores 0.30/0.80),
+    IDENTICALLY with or without the relief — they are the supplement's own
+    false-acceptance residual, targeted at the future support judge by the manifest's
+    own notes. The tripwire names and pins them explicitly, so they cannot be mistaken
+    for an oversight and cannot silently grow: a seventh would fail the test.
+  supplement_pin:
+    old: "a55aed9416c6e876efb999c0ad50948b6c805e41a6cfdd5b3f010416c4f25040 # pragma: allowlist secret"
+    new: "5f493b6b036954cec3622e6cd03b625061cb2bda54907634b6129344ea7c7910 # pragma: allowlist secret"
+    diagnosis: "the old value is the sha256 of the SAME bytes without the trailing newline — the writer hashed the in-memory json.dumps string, the file was written with a final newline. Corpus intact (24 cases); what was wrong is that the pin was not reproducible by `shasum -a 256 <file>`."
+    cure: "a byte-hashing helper `harness.source_sha256(path)` (reads file BYTES) plus a test that verifies BOTH set pins — Set B (9d41ef1423…, already correct) and Set C."
+    note: "no committed script produced the wrong pin; it came from ephemeral inline code in a prior session, so there was no producer file to fix — the helper is placed where the next writer will reach it."
+  env_parser_fail_closed:
+    finding: >-
+      `DOMAIN_ABSTAIN_THRESHOLDS='{"tax":0.15,"visa":0.15}'` (a JSON typo) used to
+      parse into a GARBAGE key ('{"tax"' -> 0.15) and log a warning: a partial,
+      silently-wrong override. Configuration failed OPEN.
+    cure: "the parser raises on malformed / out-of-range / unknown-domain entries; the builder catches, logs ERROR and falls back to the DEFAULTS IN FULL — never a partial override, and never a raise at import time (the module builds its dict at import; a raise there would stop the app from booting)."
+    verified_by_the_dux: "with a JSON spec in the env, importing the module succeeds and the thresholds in force are exactly the defaults; with the valid colon-comma spec the override applies."
+
+tests:
+  - "test_domain_relief_tripwire.py: 4 passed"
+  - "test_domain_threshold_override_parsing.py: 19 passed"
+  - "test_evidence_sufficiency_benchmark.py: 73 passed"
+  - "test_evidence_cross_language.py: 123 passed, 1 xfailed (pre-existing generic-word case)"
+  - "all four together, run by the Dux: 219 passed, 1 xfailed"
+  - ts: "2026-09-12T19:06:32Z"
+    harness_unchanged_by_this_pr: "after the edits, the four report sha256 are still 67322f4876c126ff… (mandatory, both conditions) and 48ceff1a0c390c56… (supplement, both conditions) — the same values measured BEFORE any edit, so the per-cell table above still describes this head."
+
+council_round_1:
+  ts: "2026-09-12T19:15:14Z"
+  seats:
+    - seat: "codex-gpt-5.6-sol"
+      role: review
+      mode: "codex exec --sandbox read-only, model_reasoning_effort=high, CODEX_HOME=~/.codex-acct2"
+      verdict: "all five claims HOLD (reliefs unchanged; tripwire non-vacuous, 60 negatives selected incl. 11 visa / 3 tax; parser fail-closed reproduced; both pins verified by file bytes; per-cell numbers reproduced, same two report sha256). Four defects found."
+    - seat: "kimi-code/k3"
+      role: refute
+      status: "dispatched on the post-cure frozen diff; disposition recorded below when it returns, and stated as UNRETURNED if it does not"
+  findings_disposed:
+    - id: "P2-counterfactual-moves-kbli"
+      raised_by: codex
+      reproduced_by_the_dux: true
+      what: >-
+        `UNIFORM_THRESHOLDS = {domain: 0.15 for domain in RELIEF_THRESHOLDS}`
+        flattened EVERY domain to 0.15, which LOWERS kbli from 0.20 — so a
+        negative kbli case scoring in [0.15, 0.20) would flip under the
+        counterfactual and be reported as relief-caused. A false positive about
+        a domain that has no relief.
+      cure: "the counterfactual now raises only the domains whose threshold is BELOW 0.15 and leaves the stricter ones alone; verified: relief {tax 0.1, visa 0.12, pricing 0.15, kbli 0.2} -> counterfactual {tax 0.15, visa 0.15, pricing 0.15, kbli 0.2}."
+      falsifiability_after_the_cure: "the Dux re-ran the engine mutation (visa 0.12 -> 0.02): still 2 failed / 2 passed, and 4 passed after the revert."
+    - id: "P2-pin-test-can-become-vacuous"
+      raised_by: codex
+      reproduced_by_the_dux: true
+      what: "the pin test looped over `supplement['sets'].items()`; with `sets` emptied it asserted nothing and stayed green (harness.validate() stayed green too)."
+      cure: "`assert set(supplement['sets']) >= {'B','C'}` before the loop."
+      falsified_by_the_dux: "with sets emptied the test now FAILS (AssertionError: dict_keys([])); restored from a cp backup and re-verified."
+    - id: "P3-merge-test-indistinguishable"
+      raised_by: codex
+      reproduced_by_the_dux: true
+      what: "the override tests used `tax:0.10`, a value identical to the default, so they could not tell an applied override from an ignored one."
+      cure: "the valid-override test now uses tax:0.13 / kbli:0.17 and asserts the result DIFFERS from the default; the partial-apply test uses tax:0.13 for the same reason."
+    - id: "P3-score-census-multiplicities"
+      raised_by: codex
+      reproduced_by_the_dux: true
+      what: "this pack's own census said 0.30 / 0.60 × 3 / 0.80 × 4 for the supplement's 18 tax/visa cases."
+      cure: "re-counted through harness.decide: {0.08: 7, 0.30: 3, 0.60: 3, 0.80: 5}. Corrected in place — the number was wrong, the conclusion (nothing in the relief band) is unaffected."
+    - id: "codex-precision-on-the-parser"
+      raised_by: codex
+      disposition: "ACCEPTED AS A LIMIT, not cured: double and trailing commas are explicitly tolerated by the parser, so `tax:0.13,` applies without an ERROR. The fail-closed promise covers malformed ENTRIES, out-of-range values and unknown domains — not whitespace-class separator noise. Recorded here rather than silently widened."
+
+council_round_1_refuter:
+  ts: "2026-09-12T19:22:32Z"
+  seat: "kimi-code/k3"
+  role: refute
+  returned: true
+  verdict_summary: >-
+    Four defects the review seat did not reach, one of them a SAFETY INVERSION.
+    The refuter also confirmed what survives: the Set C re-pin matches the bytes,
+    and the threshold swap really does reach the label site at call time.
+  findings_disposed:
+    - id: "R9-fail-open-in-the-wrong-direction"
+      severity: "the serious one"
+      what: >-
+        Falling back to the DEFAULTS on an untrusted spec is NOT fail-closed for
+        an abstain gate: the defaults carry the RELIEFS (tax 0.10, visa 0.12),
+        the most PERMISSIVE values in the dict. An operator tightening a
+        threshold during an incident who mistypes the spec would silently get
+        the relieved gate back — the exact failure mode this PR was written to
+        remove, one level up.
+      cure: >-
+        New `_strict_fallback_thresholds()`: on an untrusted spec no domain may
+        sit below `default`, so every relief is lifted to 0.15 and anything
+        already stricter (kbli 0.20) is kept. Verified on disk: a JSON spec in
+        the env now yields {tax 0.15, visa 0.15, pricing 0.15, kbli 0.2,
+        default 0.15}, not the relieved defaults.
+      test_consequence: "five assertions that pinned the OLD fallback went RED and were rewritten to the fail-strict contract — the behaviour change had to change a test, and it did. An ABSENT env var still yields the defaults: no override is a valid configuration, a malformed one is not."
+    - id: "R10-duplicate-domain-keys"
+      what: "`tax:0.10,tax:0.20` applied silently with last-wins — an ambiguous spec is not a spec."
+      cure: "duplicate domain keys now raise, so the whole spec is rejected and the strict fallback applies. Verified on disk."
+    - id: "R6-literal-default-in-the-counterfactual"
+      what: "the tripwire's counterfactual baseline was the literal 0.15 while the reliefs were read live — the day the engine's `default` moves, the counterfactual stops meaning 'no relief'."
+      cure: "the baseline is now read from the engine dict (`RELIEF_THRESHOLDS['default']`)."
+    - id: "R12-set-D-was-unpinned"
+      what: "12 cases carry `set: D` while the `sets` metadata named only B and C, so the new pin guard walked the metadata and skipped a set that already exists."
+      cure: >-
+        Set D is declared in the metadata as DERIVED from C (it has no source
+        file of its own — its cases are the cross-language members of C's pairs,
+        so C's pin covers them), and the guard now asserts that every set
+        appearing IN THE CASES is accounted for, and that a set without a
+        `source` names the set whose pin covers it.
+    - id: "R7-R8-wording"
+      disposition: >-
+        ACCEPTED as wording, not as defect. R7: "the reliefs are SAFE" is not
+        this pack's claim and must not become the PR's — the claim is that this
+        corpus cannot measure them, which is why they are KEPT rather than
+        restored. R8: the tripwire covers the LABEL gate only; the generation
+        gate is flat 0.15 by design (the panel-ruled divergence), so it has no
+        relief to be caught by. Both narrowed here rather than left to be read
+        generously.
+    - id: "R11-reload-pollution"
+      disposition: >-
+        NOT cured, recorded: the override tests use `importlib.reload`, which
+        rebuilds the module's classes, so a test holding a pre-reload reference
+        could be order-dependent. Measured rather than assumed: the whole
+        `backend/tests/unit/services/rag/` tree runs 3082 passed / 30 skipped /
+        7 xfailed with these tests in it. If a future ordering ever bites, this
+        is the entry that names the cause.
+
+final_state_measured_by_the_dux:
+  ts: "2026-09-12T19:22:32Z"
+  suite: "backend/tests/unit/services/rag/ — 3082 passed, 30 skipped, 7 xfailed, 0 failed"
+  harness_reports_unchanged: "67322f4876c126ff… (mandatory, both conditions) · 48ceff1a0c390c56… (supplement, both conditions) — the per-cell table above still describes this head after every cure"
+  reliefs: "tax 0.10 / visa 0.12 — UNCHANGED, which is the point of the PR"


### PR DESCRIPTION
**RULING I40, option 2.** `tax: 0.10` and `visa: 0.12` are **UNCHANGED**. What this
PR changes is that the reason for keeping them is a measurement, and that the claim
can go red.

## Why they stay — and why "0 false acceptances" is not the reason

Raising both reliefs to `0.15` changes **no decision at either gate in any cell**.
The harness reports are byte-identical under the reliefs and under a uniform 0.15:

| corpus | reliefs (0.10 / 0.12) | uniform 0.15 |
|---|---|---|
| frozen mandatory manifest (58 cases) | `67322f4876c126ff…` | `67322f4876c126ff…` |
| Set B/C/D supplement (44 cases) | `48ceff1a0c390c56…` | `48ceff1a0c390c56…` |

Measured per case through `harness.decide`, all 58 + 44, not sampled: the mandatory
manifest classifies **5 cases as `visa` and ZERO as `tax`**; the supplement has 12
`visa` and 6 `tax`. Their scores are `{0.02, 0.06×4}` and
`{0.08×7, 0.30×3, 0.60×3, 0.80×5}`. **Not one case in either corpus lands in
[0.10, 0.15) or [0.12, 0.15)** — the band where a relief is the difference. Nearest
below 0.08, nearest above 0.30.

So "0 false acceptances before and after" is **not** evidence that the reliefs are
safe; it is evidence that nothing in these corpora exercises them. They are KEPT,
not restored, and they are re-examined when the live sample (B2.2's second PR) puts
a real tax/visa score in the band.

Per-cell numbers, before and after, are in `pack.yml`. The mandatory set is 0/0 in
every cell at both gates. The supplement carries **6 false acceptances and 2 false
abstentions, identical before and after** — Set C is the D-SETC hard case by
construction, which the support signal is meant to decide, not the abstain
threshold. Reported separately per B2 §3, never counted as a safety pass.

## The tripwire

`test_domain_relief_tripwire.py` pins: no case with a negative expected label may
have its **label** decision depend on a relief. It reads the thresholds from the
engine dict, so an engine change moves the test. Falsified by the Dux by mutating
`"visa": 0.12` → `0.02` **in `reasoning_utils.py`, not in the test** — 2 failed,
naming the flipped cases; 4 passed after the revert. Six known Set-C/D hard cases
that already pass the label gate relief-independently are named and pinned, so a
seventh fails the test.

## The parser now fails STRICT, not merely loud

`DOMAIN_ABSTAIN_THRESHOLDS='{"tax":0.15,"visa":0.15}'` (a JSON typo, not the
`key:value,…` format) used to parse into the garbage key `'{"tax"'` and apply a
**partial, silently-wrong** override. Now the spec is rejected whole — and the
fallback is **not** the defaults, because the defaults carry the reliefs, the most
permissive values in the dict: an operator tightening a threshold during an
incident who mistypes would have got the relieved gate back. An untrusted spec
lifts every relief to `default` and keeps anything already stricter (`kbli` 0.20).
Nothing raises at import, where the dict is built. Duplicate domain keys are
rejected too (`tax:0.10,tax:0.20` no longer picks a winner). **Five assertions that
pinned the old fallback went red and were rewritten** — the behaviour change had to
change a test. An ABSENT env var still yields the defaults: no override is a valid
configuration, a malformed one is not.

## The supplement pins

Set C's `source_sha256` was the hash of the same bytes **without the trailing
newline**, so it never matched its own file — the writer hashed the in-memory
`json.dumps` string. Re-pinned to `5f493b6b03…` with the diagnosis recorded, plus a
byte-hashing helper and a guard over every set that appears in the cases. That guard
is how **Set D** was found: 12 cases carrying `set: D` with no metadata entry at
all, invisible to a check that walked the metadata. It is now declared as derived
from C, whose pin covers it.

## Council round 1, disposed in the pack

- **codex-gpt-5.6-sol** (review): all five claims HOLD; four defects — a
  counterfactual that also lowered `kbli`, a pin test that went vacuous on an empty
  `sets`, two override tests using values identical to the defaults, and a wrong
  multiplicity in this pack's own census.
- **kimi-code/k3** (refute): four more — the fail-direction inversion above,
  duplicate keys, a literal `0.15` baseline in the counterfactual, and Set D's
  missing pin. Two wording findings accepted as wording; one (`importlib.reload`
  ordering fragility) recorded, not cured, with the whole-tree run as its evidence.

Every finding was reproduced on disk before it was cured.

## Bites

- **Consumer**: `_abstain_policy.build_abstain_policy` at the label site
  (`orchestrator_response.py:93-94`), which reads `get_abstain_threshold` at call time.
- **Observation, made before reporting done**: the per-cell report before/after in
  `pack.yml`, the two identical report sha256 above, and
  `backend/tests/unit/services/rag/` at **3082 passed / 30 skipped / 7 xfailed / 0
  failed** on this head. Deterministic floor: `compute_floor` = 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
