### PR TITLE
test(visaoracle): guard the twin-basis premise, pin the signed pack, and unstate four unbacked legal figures (PR-D3c)

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -591,28 +591,50 @@ describe("support reasons are sentences, not machine codes", () => {
   });
 
   /**
+   * D3c/C-D2 (2026-09-13): the tests below read the SIGNED pack specifically
+   * — a `.source.json` is a draft that need not have gone through signing at
+   * all, so it is not "the pack" any decision was made under. Globbing
+   * `*.signed.json` and reading rules from the envelope's `payload` (never
+   * top-level, which only exists on the unsigned `.source.json` shape).
+   */
+  function signedProductionPackFiles(): string[] {
+    const files = fs
+      .readdirSync(PACKS_DIR)
+      .filter((name) => /^rulepack-prod-\d+\.signed\.json$/.test(name))
+      .map((name) => path.join(PACKS_DIR, name));
+    if (files.length === 0) {
+      throw new Error(`no signed production packs found under ${PACKS_DIR}`);
+    }
+    return files;
+  }
+
+  /**
    * The tripwire above walks SUPPORT effects only, but an EXCLUDE code reaches
    * a reader through the SAME `reasonMessage` fallback: `NO_SUPPORTED_PATH`
    * maps `no_path_reasons` through `reason()`. So a new hard filter can print
    * a machine code on the no-path sheet without failing anything above. seq-20
    * adds exactly one such rule — `hf.d2.indonesia-source-compensation`,
    * CL-D2-01's local-compensation prohibition — and its code is read OUT of
-   * the highest-sequence pack on disk rather than typed here, so a rename in
-   * the fold moves this test with it instead of leaving it quietly stale.
+   * the highest-sequence SIGNED pack on disk rather than typed here, so a
+   * rename in the fold moves this test with it instead of leaving it quietly
+   * stale.
    */
   function highestSequencePack(): { rules?: Array<Record<string, unknown>> } {
     let best: {
       payload: { sequence: number; rules?: Array<Record<string, unknown>> };
       sequence: number;
     } | null = null;
-    for (const full of productionPackFiles()) {
-      const payload = JSON.parse(fs.readFileSync(full, "utf-8")) as {
-        sequence?: unknown;
-        rules?: Array<Record<string, unknown>>;
+    for (const full of signedProductionPackFiles()) {
+      const envelope = JSON.parse(fs.readFileSync(full, "utf-8")) as {
+        payload?: {
+          sequence?: unknown;
+          rules?: Array<Record<string, unknown>>;
+        };
       };
+      const payload = envelope.payload;
       // A pack without a numeric `sequence` cannot be compared — skip it
       // rather than let it win via a sentinel default.
-      if (typeof payload.sequence !== "number") continue;
+      if (!payload || typeof payload.sequence !== "number") continue;
       if (best === null || payload.sequence > best.sequence) {
         best = {
           payload: payload as {
@@ -624,7 +646,9 @@ describe("support reasons are sentences, not machine codes", () => {
       }
     }
     if (best === null) {
-      throw new Error(`no pack under ${PACKS_DIR} had a numeric sequence`);
+      throw new Error(
+        `no signed pack under ${PACKS_DIR} had a numeric sequence`,
+      );
     }
     return best.payload;
   }
@@ -709,6 +733,188 @@ describe("support reasons are sentences, not machine codes", () => {
     expect(SECOND_HOME_DEPOSIT_THRESHOLD_USD).toBe(
       gteThresholdInPack("el.e33.deposit-basis", "secondhome.bank_deposit_usd"),
     );
+  });
+
+  // D3c/C-D5 (owner order, 2026-09-13): three more SUPPORT_REASON_COPY
+  // sentences state a literal figure that a signed-pack rule actually backs
+  // (`el.e28a.investment`, `el.e33e.retirement`, `el.e33f.retirement` — the
+  // Second Home basis pair above is already covered by the pinned-constant
+  // test). The figure is extracted from the PROSE STRING (never the pack
+  // JSON — that stays a structural `when`-tree walk via `gteThresholdInPack`)
+  // and compared to the rule's own `gte` threshold, in both languages, with
+  // an explicit copy-key -> rule-id/fact map so a reader can see which rule
+  // is claimed to back which sentence.
+  function usdFromProse(copy: string): number {
+    const match = copy.match(/USD\s+([\d,]+)/);
+    if (!match) {
+      throw new Error(`no "USD <n>" figure found in: ${copy}`);
+    }
+    return Number(match[1].replace(/,/g, ""));
+  }
+
+  function usdFromProseId(copy: string): number {
+    const match = copy.match(/USD\s+([\d.]+)/);
+    if (!match) {
+      throw new Error(`no "USD <n>" figure found in: ${copy}`);
+    }
+    return Number(match[1].replace(/\./g, ""));
+  }
+
+  function idrBillionFromProse(copy: string): number {
+    const match = copy.match(/IDR\s+([\d.]+)\s+billion/i);
+    if (!match) {
+      throw new Error(`no "IDR <n> billion" figure found in: ${copy}`);
+    }
+    return Math.round(Number(match[1]) * 1_000_000_000);
+  }
+
+  function rpMiliarFromProse(copy: string): number {
+    const match = copy.match(/Rp\s+([\d,]+)\s+miliar/i);
+    if (!match) {
+      throw new Error(`no "Rp <n> miliar" figure found in: ${copy}`);
+    }
+    return Math.round(Number(match[1].replace(",", ".")) * 1_000_000_000);
+  }
+
+  const FIGURE_BACKED_BY_RULE: Record<
+    string,
+    {
+      ruleId: string;
+      fact: string;
+      readEn: (copy: string) => number;
+      readId: (copy: string) => number;
+    }
+  > = {
+    E28A_INVESTMENT_ELIGIBLE: {
+      ruleId: "el.e28a.investment",
+      fact: "investment.paid_up_capital_idr",
+      readEn: idrBillionFromProse,
+      readId: rpMiliarFromProse,
+    },
+    E33E_RETIREMENT_ELIGIBLE: {
+      ruleId: "el.e33e.retirement",
+      fact: "secondhome.bank_deposit_usd",
+      readEn: usdFromProse,
+      readId: usdFromProseId,
+    },
+    E33F_RETIREMENT_ELIGIBLE: {
+      ruleId: "el.e33f.retirement",
+      fact: "secondhome.passive_monthly_income_usd",
+      readEn: usdFromProse,
+      readId: usdFromProseId,
+    },
+  };
+
+  it("anchors every remaining SUPPORT-copy figure with a backing rule to that rule's gte threshold, EN and ID", () => {
+    // Guard the guard: an empty map would make the loop below vacuously pass.
+    expect(Object.keys(FIGURE_BACKED_BY_RULE).length).toBeGreaterThan(0);
+    for (const [key, spec] of Object.entries(FIGURE_BACKED_BY_RULE)) {
+      const copy = SUPPORT_REASON_COPY[key];
+      const expected = gteThresholdInPack(spec.ruleId, spec.fact);
+      expect(spec.readEn(copy.en)).toBe(expected);
+      expect(spec.readId(copy.id)).toBe(expected);
+    }
+  });
+
+  // Mirror image: these SUPPORT reasons named a dollar figure on `main` with
+  // NO backing rule anywhere in the signed pack (verified: no fact for
+  // proof-of-funds, living cost or an income threshold exists in ANY rule's
+  // `when` tree). Per the same rule as the anchor test above, an unbacked
+  // figure may not be stated — this pins that the fix stays applied.
+  it("states no figure for SUPPORT reasons the signed pack has no rule to back", () => {
+    const NO_BACKING_KEYS = [
+      "PROOF_OF_FUNDS_D1",
+      "PROOF_OF_FUNDS_D2",
+      "PROOF_OF_FUNDS_D12",
+      "REQ_FUNDS_2000",
+      "LIVING_COST_USD2000",
+      "E33G_INCOME_60K_ADVISOR_CHECK",
+    ] as const;
+    for (const key of NO_BACKING_KEYS) {
+      const copy = SUPPORT_REASON_COPY[key];
+      expect(copy.en).not.toMatch(/\d/);
+      expect(copy.id).not.toMatch(/\d/);
+    }
+  });
+
+  // D3c/C-D1 gate finding (2026-09-13): `fact-mapper.ts`'s
+  // `depositBasisDecisivelyNotChosen`/`propertyBasisDecisivelyNotChosen`
+  // synthesise KNOWN(0)/KNOWN(false) for the sibling Second Home basis's four
+  // facts once the interview has decisively routed to the OTHER basis. That
+  // synthesis is innocent only while every signed-pack rule reading these
+  // facts stays SUPPORT-only: the moment a HARD_FILTER/EXCLUDE rule reads one
+  // of them, or any rule compares one with `eq false`, the synthesised
+  // "known false" stops meaning "not claimed here" and starts actively
+  // EXCLUDING a visitor who never answered the question. Nobody else guards
+  // this premise, so this walks the highest-sequence SIGNED pack's `when`
+  // trees structurally (`all`/`any` via `args`, `not` via its singular `arg`
+  // — never regexed off the JSON text) and must go RED the moment a future
+  // pack rule breaks it.
+  it("never lets a HARD_FILTER/EXCLUDE rule, or an eq-false comparison, read a synthesised Second-Home twin-basis fact", () => {
+    const GUARDED_FACTS = [
+      "secondhome.bank_deposit_usd",
+      "secondhome.bank_deposit_at_state_bank",
+      "secondhome.bank_deposit_in_own_name",
+      "secondhome.qualifying_property_value_usd",
+    ];
+
+    function findGuardedFactNodes(
+      node: unknown,
+      out: Array<Record<string, unknown>>,
+    ): void {
+      if (Array.isArray(node)) {
+        node.forEach((item) => findGuardedFactNodes(item, out));
+        return;
+      }
+      if (node === null || typeof node !== "object") return;
+      const record = node as Record<string, unknown>;
+      if (
+        typeof record.fact === "string" &&
+        GUARDED_FACTS.includes(record.fact)
+      ) {
+        out.push(record);
+      }
+      if (Array.isArray(record.args)) {
+        findGuardedFactNodes(record.args, out);
+      }
+      if (record.arg !== undefined) {
+        findGuardedFactNodes(record.arg, out);
+      }
+    }
+
+    const rules = highestSequencePack().rules ?? [];
+    let rulesReferencingGuardedFacts = 0;
+    const offendingStageRuleIds: string[] = [];
+    const offendingEqFalseRuleIds: string[] = [];
+
+    for (const rule of rules) {
+      const nodes: Array<Record<string, unknown>> = [];
+      findGuardedFactNodes(rule.when, nodes);
+      if (nodes.length === 0) continue;
+      rulesReferencingGuardedFacts += 1;
+
+      const stage = rule.stage;
+      const effectType = (rule.effect as Record<string, unknown> | undefined)
+        ?.type;
+      if (
+        stage === "HARD_FILTER" ||
+        stage === "EXCLUDE" ||
+        effectType === "EXCLUDE"
+      ) {
+        offendingStageRuleIds.push(String(rule.rule_id));
+      }
+      for (const node of nodes) {
+        if (node.op === "eq" && node.value === false) {
+          offendingEqFalseRuleIds.push(String(rule.rule_id));
+        }
+      }
+    }
+
+    // Guard the guard: a glob/parse that silently found nothing would make
+    // the assertions below vacuously pass.
+    expect(rulesReferencingGuardedFacts).toBeGreaterThan(0);
+    expect(offendingStageRuleIds).toEqual([]);
+    expect(offendingEqFalseRuleIds).toEqual([]);
   });
 
   function firstNoPathReason(code: string, facts?: OracleFacts) {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -89,6 +89,22 @@ const PUBLIC_ID = /^[a-z0-9]{16,20}$/;
  * of surfacing it. (The REVIEW map above chooses the opposite fallback on
  * purpose — there, a wrong-sounding specific is worse than a safe generic.)
  */
+function usd(value: number, locale: "en-US" | "id-ID"): string {
+  return `USD ${value.toLocaleString(locale)}`;
+}
+
+// Exported so `engine-adapter.test.ts` can pin these against the signed
+// pack's own `el.e33.property-basis` / `el.e33.deposit-basis` `gte` values
+// (same technique as fact-mapper.test.ts's "AMBIGUOUS_SPONSOR relation
+// proxy tracks the signed pack") — a second copy of a number the pack owns
+// is a silent-drift risk with a seq-21 threshold revision already in
+// preparation, and a wrong VERDICT is caught by other tests while a stale
+// NUMBER INSIDE A SENTENCE is not. Declared ahead of `SUPPORT_REASON_COPY`
+// (D3c/C-D5, 2026-09-13) because the E33 Second Home entries below
+// interpolate them instead of restating the digits a third time.
+export const SECOND_HOME_PROPERTY_THRESHOLD_USD = 1_000_000;
+export const SECOND_HOME_DEPOSIT_THRESHOLD_USD = 130_000;
+
 export const SUPPORT_REASON_COPY: Record<string, LocalizedText> = {
   A1_BVK_ELIGIBLE: text(
     "Your nationality is on the visa-free (BVK) list for tourism or transit, and your stay is 30 days or less.",
@@ -133,12 +149,12 @@ export const SUPPORT_REASON_COPY: Record<string, LocalizedText> = {
     "Visa Rumah Kedua Pensiun (E33F) mensyaratkan sponsor keluarga yang telah dikonfirmasi, dan Anda menyatakan sponsor Anda belum mengonfirmasi. Konfirmasi sponsor adalah yang akan membuka jalur ini.",
   ),
   E33_DEPOSIT_BASIS_ELIGIBLE: text(
-    "Second Home on the deposit basis: USD 130,000 or more held in your own name at a state bank.",
-    "Rumah Kedua berbasis deposito: minimal USD 130.000 atas nama sendiri di bank BUMN.",
+    `Second Home on the deposit basis: ${usd(SECOND_HOME_DEPOSIT_THRESHOLD_USD, "en-US")} or more held in your own name at a state bank.`,
+    `Rumah Kedua berbasis deposito: minimal ${usd(SECOND_HOME_DEPOSIT_THRESHOLD_USD, "id-ID")} atas nama sendiri di bank BUMN.`,
   ),
   E33_PROPERTY_BASIS_ELIGIBLE: text(
-    "Second Home on the property basis: qualifying property valued at USD 1,000,000 or more.",
-    "Rumah Kedua berbasis properti: properti memenuhi syarat senilai minimal USD 1.000.000.",
+    `Second Home on the property basis: qualifying property valued at ${usd(SECOND_HOME_PROPERTY_THRESHOLD_USD, "en-US")} or more.`,
+    `Rumah Kedua berbasis properti: properti memenuhi syarat senilai minimal ${usd(SECOND_HOME_PROPERTY_THRESHOLD_USD, "id-ID")}.`,
   ),
   REMOTE_WORK_ELIGIBLE: text(
     "You work remotely for a non-Indonesian employer, serve no Indonesian clients, and take no Indonesian-source compensation.",
@@ -177,25 +193,36 @@ export const SUPPORT_REASON_COPY: Record<string, LocalizedText> = {
     "Your passport must be valid for at least 6 months on the date you enter.",
     "Paspor Anda harus berlaku minimal 6 bulan pada tanggal Anda masuk.",
   ),
+  // D3c/C-D5 (2026-09-13): no fact in the signed pack models a proof-of-funds
+  // amount at all (`el.d1-funds-usd-2000`/`el.d2-funds-usd-2000`/
+  // `el.e31a-funds-2000`/`el.d12-funds-usd-5000`'s `when` trees test only
+  // purpose/stay-days/entry-pattern — verified, no `gte` node on any funds
+  // fact exists anywhere in the pack). A dollar figure with nothing tying it
+  // to the pack is the same class of risk the pinned Second Home thresholds
+  // guard against, so it is not stated here — same treatment as
+  // `CV_REQUIRED`/`ITINERARY_REQUIRED` above, which never claimed a number
+  // either.
   PROOF_OF_FUNDS_D1: text(
-    "You will need to show proof of funds of USD 2,000 or more.",
-    "Anda perlu menunjukkan bukti dana minimal USD 2.000.",
+    "You will need to show proof of funds.",
+    "Anda perlu menunjukkan bukti dana.",
   ),
   PROOF_OF_FUNDS_D2: text(
-    "You will need to show proof of funds of USD 2,000 or more.",
-    "Anda perlu menunjukkan bukti dana minimal USD 2.000.",
+    "You will need to show proof of funds.",
+    "Anda perlu menunjukkan bukti dana.",
   ),
   PROOF_OF_FUNDS_D12: text(
-    "You will need to show proof of funds of USD 5,000 or more.",
-    "Anda perlu menunjukkan bukti dana minimal USD 5.000.",
+    "You will need to show proof of funds.",
+    "Anda perlu menunjukkan bukti dana.",
   ),
   REQ_FUNDS_2000: text(
-    "You will need to show proof of funds of USD 2,000 or more.",
-    "Anda perlu menunjukkan bukti dana minimal USD 2.000.",
+    "You will need to show proof of funds.",
+    "Anda perlu menunjukkan bukti dana.",
   ),
+  // D3c/C-D5: same reasoning — `el.e30-living-cost-2000.*`'s `when` trees
+  // test only purpose/admission/sponsor facts, no living-cost fact exists.
   LIVING_COST_USD2000: text(
-    "You will need to show living costs of USD 2,000 or more for your studies.",
-    "Anda perlu menunjukkan biaya hidup minimal USD 2.000 untuk masa studi Anda.",
+    "You will need to show living costs for your studies.",
+    "Anda perlu menunjukkan biaya hidup untuk masa studi Anda.",
   ),
   REQ_SPONSOR_ITAS_ITAP: text(
     "Your sponsor must hold a valid ITAS or ITAP.",
@@ -301,9 +328,14 @@ export const SUPPORT_REASON_COPY: Record<string, LocalizedText> = {
   // so. Zero's ruling (2026-08-09): offer the route and name the check.
   // Where the figure is not in the rule itself it is deliberately NOT stated
   // here rather than guessed.
+  // D3c/C-D5: no rule in the signed pack carries this reason code at all
+  // (verified: no `E33G_INCOME_60K_ADVISOR_CHECK` reason_code anywhere, and
+  // no income fact exists to hold a `gte` threshold), so the figure is
+  // dropped — same "confirm the current figure" template already used by
+  // the three sibling advisor checks below, for the same reason.
   E33G_INCOME_60K_ADVISOR_CHECK: text(
-    "This route asks for annual income of USD 60,000 or more. We confirm the figure and the evidence with one of our advisors.",
-    "Jalur ini mensyaratkan penghasilan tahunan minimal USD 60.000. Kami memastikan angka dan buktinya bersama konsultan kami.",
+    "This route has a minimum annual income threshold. We confirm the current figure and your evidence with one of our advisors.",
+    "Jalur ini memiliki ambang penghasilan tahunan minimum. Kami memastikan angka terkini dan bukti Anda bersama konsultan kami.",
   ),
   E28B_USD_THRESHOLD_ADVISOR_CHECK: text(
     "This Golden Visa route has a minimum investment threshold in USD. We confirm the current figure and your evidence with one of our advisors.",
@@ -412,20 +444,6 @@ function reasonMessage(code: string): LocalizedText {
 // the generic sentence) whenever the facts do not actually show a
 // below-threshold Second Home basis, so a future cause of this same code
 // is never mis-attributed to a threshold it did not fail.
-// Exported so `engine-adapter.test.ts` can pin these against the signed
-// pack's own `el.e33.property-basis` / `el.e33.deposit-basis` `gte` values
-// (same technique as fact-mapper.test.ts's "AMBIGUOUS_SPONSOR relation
-// proxy tracks the signed pack") — a second copy of a number the pack owns
-// is a silent-drift risk with a seq-21 threshold revision already in
-// preparation, and a wrong VERDICT is caught by other tests while a stale
-// NUMBER INSIDE A SENTENCE is not.
-export const SECOND_HOME_PROPERTY_THRESHOLD_USD = 1_000_000;
-export const SECOND_HOME_DEPOSIT_THRESHOLD_USD = 130_000;
-
-function usd(value: number, locale: "en-US" | "id-ID"): string {
-  return `USD ${value.toLocaleString(locale)}`;
-}
-
 function secondHomeBelowThresholdReason(
   facts: OracleFacts,
 ): LocalizedText | undefined {

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml
@@ -42,7 +42,7 @@ acceptance:
       WHEN the backend walk-census test runs, THEN every walk SHALL match its EXPECTED_OUTCOME —
       the eleven new walks included.
     status: verified
-    probe: "cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest backend/tests/services/visa_engine/test_interview_walk_census.py -q -o addopts=''"
+    probe: "cd apps/backend-rag && PYTHONPATH=. /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/visa_engine/test_interview_walk_census.py -q -o addopts=''"
   - text: >-
       WHEN the corpus is counted, THEN it SHALL carry more walks than the 67 it had before this PR,
       and the STEPCHILD sponsor-permit branches SHALL both be present — the walks are what turn a

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml
@@ -42,7 +42,7 @@ acceptance:
       WHEN the backend walk-census test runs, THEN every walk SHALL match its EXPECTED_OUTCOME —
       the eleven new walks included.
     status: verified
-    probe: "cd apps/backend-rag && PYTHONPATH=. /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/visa_engine/test_interview_walk_census.py -q -o addopts=''"
+    probe: "cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest backend/tests/services/visa_engine/test_interview_walk_census.py -q -o addopts=''"
   - text: >-
       WHEN the corpus is counted, THEN it SHALL carry more walks than the 67 it had before this PR,
       and the STEPCHILD sponsor-permit branches SHALL both be present — the walks are what turn a

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3c-63c05659/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3c-63c05659/brief.yml
@@ -1,14 +1,13 @@
-gear: 1
+gear: 2
 gear_reason: >-
-  `git diff --stat` against the base commit touches exactly two files under apps/mouth/.../_lib
-  (engine-adapter.ts, engine-adapter.test.ts — 261 insertions / 39 deletions, net well under the
-  ~400-line PR contract target) plus a two-line probe-path fix in an already-merged evidence
-  brief. No hot-zone path (rule pack, backend evaluator, secrets, deploy config) is touched, no
-  runtime behaviour of the visa engine changes — only tests, one evidence-doc fix, and copy text
-  in engine-adapter.ts. `scripts/evidence_pack_lint.py --print-floor` was NOT run (its `import
-  yaml` fails under this worktree's ambient python3, and this brief follows the D3b brief.yml
-  lineage rather than the pack.yml schema that script validates) — flagged here rather than
-  silently assumed measured.
+  Measured the way CI measures it, with BOTH inputs:
+  `scripts/evidence_pack_lint.py --print-floor --changed-files-file <f> --numstat-file <n>`
+  returns 2 and `--print-floor-source` returns `size`. An earlier revision of this brief declared
+  1 after reasoning from the shape of the diff without running the tool — the same mistake that
+  got #6240 rejected in this mandate and that PR-O2's brief repeated. Run both invocations to
+  check; no digit is typed here, because a count written into a file that is itself in the diff is
+  stale the moment it is written. Frontend tests and copy only: no rule pack, no evaluator, no
+  deploy config, no runtime behaviour of the engine.
 task_id: shweb-w-oracle-d3c-20260913
 mandate_id: SHWEB-20260911/W-ORACLE/PR-D3c
 colour: BLUE

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3c-63c05659/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3c-63c05659/brief.yml
@@ -1,0 +1,193 @@
+gear: 1
+gear_reason: >-
+  `git diff --stat` against the base commit touches exactly two files under apps/mouth/.../_lib
+  (engine-adapter.ts, engine-adapter.test.ts — 261 insertions / 39 deletions, net well under the
+  ~400-line PR contract target) plus a two-line probe-path fix in an already-merged evidence
+  brief. No hot-zone path (rule pack, backend evaluator, secrets, deploy config) is touched, no
+  runtime behaviour of the visa engine changes — only tests, one evidence-doc fix, and copy text
+  in engine-adapter.ts. `scripts/evidence_pack_lint.py --print-floor` was NOT run (its `import
+  yaml` fails under this worktree's ambient python3, and this brief follows the D3b brief.yml
+  lineage rather than the pack.yml schema that script validates) — flagged here rather than
+  silently assumed measured.
+task_id: shweb-w-oracle-d3c-20260913
+mandate_id: SHWEB-20260911/W-ORACLE/PR-D3c
+colour: BLUE
+l_level: L1
+gate_class: opus
+objective: >-
+  Closes the three conditions the PR-D3 half-2 gate left open, plus a fourth (C-D5) the owner
+  added mid-task: (C-D1) an anchor test guarding the premise that lets the frontend synthesise the
+  twin Second Home basis's four facts as KNOWN(0)/KNOWN(false) — safe only while no signed-pack
+  rule reads them in a HARD_FILTER/EXCLUDE stage or compares one with `eq false`; (C-D2) a pin test
+  named for "the signed pack" that actually read the unsigned `.source.json`, now reading
+  `.signed.json` and taking rules from `payload`; (C-C4) a hardcoded machine-local absolute path in
+  the already-committed D3b evidence brief's probe 3, made repo-relative and proven portable
+  somewhere the old path cannot resolve; (C-D5) three more SUPPORT_REASON_COPY legal figures
+  anchored to the signed pack's own `gte` thresholds (six more found to have NO backing rule at
+  all and had their figures removed), and the Second Home deposit/property sentences rewritten to
+  interpolate the two constants D3 half-2 already pinned instead of restating the digits a third
+  time. Frontend tests + one evidence-doc fix only; no rule-pack change, no backend change.
+scope:
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+  - evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml (probe-3 path only)
+  - this brief
+constraints:
+  - >-
+    fact-mapper.ts, flow.ts, tree.ts and every walk fixture are untouched — a sibling PR (D4a) is
+    live on them, and the owner later confirmed this PR owns engine-adapter.ts/.test.ts
+    exclusively. `git diff --stat` (this brief's gear_reason) names only the three files above.
+  - No client PII in any file added or edited.
+  - >-
+    Depth 1: every fix is a single-round change, no fix-of-a-fix. Where a SUPPORT-copy figure had
+    no backing rule, the figure was removed or flagged — never a fabricated rule mapping and never
+    a quiet deletion of a figure a rule DOES support (owner's explicit instruction).
+acceptance:
+  - text: >-
+      WHEN a future signed-pack rule reads a synthesised twin-basis Second Home fact
+      (`secondhome.bank_deposit_usd` / `..._at_state_bank` / `..._in_own_name` /
+      `secondhome.qualifying_property_value_usd`) in a HARD_FILTER/EXCLUDE stage, or compares one
+      with `eq false`, THEN the new anchor test SHALL go red.
+    status: verified
+    ts: "2026-09-13T03:11:19+08:00"
+    probe: "cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' -t 'never lets a HARD_FILTER'"
+  - text: >-
+      Mutation proof for the same test: setting `el.e33e.retirement`'s stage/effect to
+      HARD_FILTER/EXCLUDE in the signed pack on disk turns it red; reverting turns it green.
+    status: verified
+    ts: "2026-09-13T03:11:34+08:00"
+    probe: "cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' 2>&1 | tail -10"
+  - text: >-
+      WHEN the pin test named for "the signed pack" runs, THEN it SHALL read
+      `rulepack-prod-*.signed.json` and take rules from the envelope's `payload`, never the
+      unsigned `.source.json` its old body actually read.
+    status: verified
+    ts: "2026-09-13T03:09:49+08:00"
+    probe: "cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' -t 'track the signed pack'"
+  - text: >-
+      Mutation proof for the pin: SECOND_HOME_DEPOSIT_THRESHOLD_USD set to 131_000 fails 3 tests
+      (the pin itself plus two `secondHomeBelowThresholdReason` regex checks); reverted to
+      130_000, all 54 tests in the file pass again.
+    status: verified
+    ts: "2026-09-13T03:10:58+08:00"
+    probe: |
+      sed -i '' 's/SECOND_HOME_DEPOSIT_THRESHOLD_USD = 130_000/SECOND_HOME_DEPOSIT_THRESHOLD_USD = 131_000/' apps/mouth/src/app/\(visa-oracle\)/visa-oracle/_lib/engine-adapter.ts
+      (cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' 2>&1 | tail -6)
+      sed -i '' 's/SECOND_HOME_DEPOSIT_THRESHOLD_USD = 131_000/SECOND_HOME_DEPOSIT_THRESHOLD_USD = 130_000/' apps/mouth/src/app/\(visa-oracle\)/visa-oracle/_lib/engine-adapter.ts
+      (cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' 2>&1 | tail -6)
+  - text: >-
+      WHEN D3b brief probe 3's OLD hardcoded absolute path
+      (`/Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python`) is made genuinely
+      unreachable, THEN the OLD probe text SHALL fail and the FIXED, repo-relative probe text
+      (`.venv/bin/python`, run after `cd apps/backend-rag`) SHALL still succeed, run from an
+      independent repo root. An exit 0 obtained on the host that owns the hardcoded path proves
+      nothing by itself (D3b's own defect) — the path was made unreachable with `sandbox-exec`
+      denying file-read-data/file-read-metadata/process-exec on that exact absolute subpath, and
+      the FIXED probe was run from a SEPARATE repo root whose own `apps/backend-rag/.venv` is an
+      independent APFS clonefile copy (different inode, different absolute path entirely; every
+      other file symlinked back to the real worktree) under the identical denial.
+    status: verified
+    ts: "2026-09-13T03:20:18+08:00"
+    probe: |
+      cat > /tmp/deny-old-venv.sb <<'EOF'
+      (version 1)
+      (allow default)
+      (deny file-read-data (subpath "/Users/nuzantara/nuzantara/apps/backend-rag/.venv"))
+      (deny file-read-metadata (subpath "/Users/nuzantara/nuzantara/apps/backend-rag/.venv"))
+      (deny process-exec (subpath "/Users/nuzantara/nuzantara/apps/backend-rag/.venv"))
+      EOF
+      sandbox-exec -f /tmp/deny-old-venv.sb bash -c 'cd apps/backend-rag && PYTHONPATH=. /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/visa_engine/test_interview_walk_census.py -q -o addopts=""'
+      # OLD probe: exit 126, "Operation not permitted"
+      sandbox-exec -f /tmp/deny-old-venv.sb bash -c 'cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest backend/tests/services/visa_engine/test_interview_walk_census.py -q -o addopts=""'
+      # FIXED probe, run from the independent clone repo root: exit 0, "15 passed"
+  - text: >-
+      WHEN every SUPPORT_REASON_COPY figure with a backing signed-pack rule is compared to that
+      rule's own `gte` threshold, THEN EN and ID SHALL both match exactly; WHEN a
+      SUPPORT_REASON_COPY entry has NO backing rule anywhere in the signed pack, THEN neither its
+      EN nor its ID text SHALL contain a digit.
+    status: verified
+    ts: "2026-09-13T03:09:49+08:00"
+    probe: "cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' -t 'anchors every remaining SUPPORT-copy figure'"
+  - text: >-
+      WHEN the full visa-oracle frontend suite runs, THEN every test SHALL pass; WHEN the project
+      typechecks, THEN it SHALL succeed.
+    status: verified
+    ts: "2026-09-13T03:21:10+08:00"
+    probe: "cd apps/mouth && npx --no-install vitest run 'src/app/(visa-oracle)' --maxWorkers=2 && npx --no-install tsc --noEmit -p ."
+figure_audit:
+  method: >-
+    Every `gte` (fact, value) pair in the highest-sequence SIGNED pack (rulepack-prod-020.signed.json,
+    sequence 20) was enumerated by walking every rule's `when` tree structurally (`all`/`any` via
+    `args`, `not` via its singular `arg` — never regexed off the JSON text). Every
+    SUPPORT_REASON_COPY entry naming a USD/IDR/Rp figure was then checked against it by
+    (reason_code -> rule_id -> fact). Counts below are commands, not typed numbers.
+  anchored_count_probe: >-
+    cd apps/mouth && awk '/const FIGURE_BACKED_BY_RULE/,/^  \};$/'
+    'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' | grep -cE '^    [A-Z0-9_]+: \{$'
+  anchored_count: 3
+  anchored:
+    - key: E28A_INVESTMENT_ELIGIBLE
+      rule_id: el.e28a.investment
+      fact: investment.paid_up_capital_idr
+      pack_gte_value: 2500000000
+    - key: E33E_RETIREMENT_ELIGIBLE
+      rule_id: el.e33e.retirement
+      fact: secondhome.bank_deposit_usd
+      pack_gte_value: 50000
+    - key: E33F_RETIREMENT_ELIGIBLE
+      rule_id: el.e33f.retirement
+      fact: secondhome.passive_monthly_income_usd
+      pack_gte_value: 3000
+  already_pinned_by_d3_half2_now_interpolated:
+    - key: E33_DEPOSIT_BASIS_ELIGIBLE
+      rule_id: el.e33.deposit-basis
+      fact: secondhome.bank_deposit_usd
+      note: >-
+        Was a THIRD literal copy of the number SECOND_HOME_DEPOSIT_THRESHOLD_USD already pins;
+        this PR rewrote the sentence to interpolate the constant (via a shared `usd()` formatter)
+        instead of restating 130,000.
+    - key: E33_PROPERTY_BASIS_ELIGIBLE
+      rule_id: el.e33.property-basis
+      fact: secondhome.qualifying_property_value_usd
+      note: Same treatment, SECOND_HOME_PROPERTY_THRESHOLD_USD.
+  removed_count_probe: >-
+    cd apps/mouth && awk '/const NO_BACKING_KEYS/,/\] as const;/'
+    'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' | grep -cE '^\s*"[A-Z0-9_]+",?$'
+  removed_count: 6
+  removed_no_open_questions:
+    - key: PROOF_OF_FUNDS_D1
+      was: "USD 2,000"
+      why: "el.d1-funds-usd-2000's when-tree tests purpose/entry-pattern/stay-days only — no funds fact exists anywhere in the pack (verified: full fact-name enumeration across all 109 rules has no proof-of-funds field)."
+    - key: PROOF_OF_FUNDS_D2
+      was: "USD 2,000"
+      why: "el.d2-funds-usd-2000, same reason."
+    - key: PROOF_OF_FUNDS_D12
+      was: "USD 5,000"
+      why: "el.d12-funds-usd-5000, same reason."
+    - key: REQ_FUNDS_2000
+      was: "USD 2,000"
+      why: "el.e31a-funds-2000, same reason."
+    - key: LIVING_COST_USD2000
+      was: "USD 2,000"
+      why: "el.e30-living-cost-2000.* (three rule ids) test purpose/admission/sponsor only — no living-cost fact exists."
+    - key: E33G_INCOME_60K_ADVISOR_CHECK
+      was: "USD 60,000"
+      why: >-
+        No rule anywhere in the pack carries this reason_code at all, and no income fact exists.
+        Rewritten to the same figure-free template the three sibling Golden Visa advisor checks
+        (E28B/C/D) already use for the identical documented reason (no engine fact to test).
+  open_questions: []
+pii: none
+self_report:
+  probe_portability_defect: >-
+    D3b's committed brief reported probe 3 discharged on an exit 0 obtained on the one host that
+    owns the hardcoded absolute path — that measurement proved nothing about portability. This PR
+    is the correction: the fixed probe is proven to still succeed while the old absolute path is
+    made genuinely unreachable, from an independent repo root, not merely re-run in place.
+  scratch_artifacts: >-
+    The independent repo-root clone used for the portability proof (APFS `cp -c` clonefile of
+    .venv, symlinks for everything else) was built and torn down under this session's own
+    scratchpad directory; nothing under the tracked repo or the main checkout was modified by it.
+  note: >-
+    `figure_audit`, this `self_report` block and this note are this session's record, not a
+    machine-re-verified artifact beyond the counted probes named above.


### PR DESCRIPTION
## What

**PR-D3c — the four conditions the D3 half-2 gate left open.** Tests, one copy file, and evidence. No runtime logic: `fact-mapper.ts`, `flow.ts`, `tree.ts` and the walk fixtures are untouched (a sibling PR owns them).

## D1 — the premise nobody was guarding

D3 half-2 closed three dead ends by having the frontend synthesise the **twin** Second Home basis's facts as KNOWN(0)/KNOWN(false) once the interview routes to the other basis. That is innocent **only while those four facts are SUPPORT-only**. The day a pack rule reads `secondhome.bank_deposit_usd`, `…_at_state_bank`, `…_in_own_name` or `qualifying_property_value_usd` in a HARD_FILTER/EXCLUDE stage, or compares one with `eq false`, the synthesised "not claimed here" stops being harmless and starts **excluding a product for a visitor who never claimed anything of the kind**.

New test: *"never lets a HARD_FILTER/EXCLUDE rule, or an eq-false comparison, read a synthesised Second-Home twin-basis fact"*. It walks the highest-sequence **signed** pack's `when` trees structurally (`args`/`arg`, never a regex over JSON).

**Verified by mutation, independently by the orchestrator**: forcing `el.e33.deposit-basis` to HARD_FILTER turns it red, naming the rule — `expected [ 'el.e33.deposit-basis' ] to deeply equal []` — and reverting returns 54/54 green.

## D2 — the pin was reading the wrong file

The threshold pin was named for the **signed** pack while reading `rulepack-prod-*.source.json`. `highestSequencePack()` now globs `*.signed.json` and reads `payload.rules` / `payload.sequence`. The name is true now, rather than the file being tolerated because the name sounded right. Mutation re-proved: `SECOND_HOME_DEPOSIT_THRESHOLD_USD` 130_000 → 131_000 turns **3** tests red; reverted, 54/54 green.

## C4 — moved to its own PR (#6366)

**C4 is NOT discharged by this PR.** It was, briefly, and that is what broke Harness: carrying the fix here put a second `brief.yml` — PR-D3 half-2's — into this PR's three-dot diff, and `evidence_paths.py` failed closed on the ambiguity rather than guess whose evidence it was reading. Same class as the double `pack.yml` on #6327.

PR-D3 half-2's brief is restored byte-for-byte to `origin/main` here, and the fix now travels in **#6366** (evidence-only, floor 1, armed at open), which is what discharges **C4/D3 of the #6345 row** and carries the `sandbox-exec` proof.

The rule worth keeping from it: **a PR never edits another PR's evidence.** Evidence belongs to the change that produced it; a second editor makes the resolver ambiguous for both.

<details><summary>What the fix is, for the record (shipped in #6366)</summary>

D3 half-2's brief still pointed probe 3 at `/Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python`. Now repo-relative.

**Proven the way that can actually fail** — the earlier report of this condition as discharged was wrong precisely because it was measured where the path exists: `sandbox-exec` denying read/exec on the old absolute path makes the OLD probe exit 126, while the fixed probe, run from an independent repo root under the same denial, exits 0 with 15 passed.

</details>

## D5 — legal figures stated as literals, and four that no rule backs

`engine-adapter.ts` stated figures with legal weight as literals in the copy, outside any pin. The Second Home sentences now interpolate the two already-pinned constants — a number the pack owns appears in the frontend **once**, not three times.

Three figures are anchored to the rule that actually asserts them, via an explicit copy-key → rule-id map in the test:

| copy | rule | asserted |
|---|---|---|
| `E28A_INVESTMENT_ELIGIBLE` | `el.e28a.investment` | `investment.paid_up_capital_idr gte 2_500_000_000` |
| `E33E_RETIREMENT_ELIGIBLE` | `el.e33e.retirement` | `secondhome.bank_deposit_usd gte 50_000` |
| `E33F_RETIREMENT_ELIGIBLE` | `el.e33f.retirement` | `secondhome.passive_monthly_income_usd gte 3_000` |

**Four figures were removed, because no rule in the signed pack asserts them** — and this is the subtle part, worth stating plainly because it is a trap for the next reader:

`PROOF_OF_FUNDS_D1/D2/D12`, `REQ_FUNDS_2000`, `LIVING_COST_USD2000`, `E33G_INCOME_60K_ADVISOR_CHECK`.

The pack **does** contain rules named `el.d1-funds-usd-2000`, `el.d2-funds-usd-2000`, `el.d12-funds-usd-5000` and `el.e30-living-cost-2000.*`. But their conditions compare `intent.stay_days lte 180/360` and `study.admission_confirmed` / `study.sponsor_confirmed` — **not one of them asserts a funds amount**. The amount lives in the rule's *name*, never in its logic. Anchoring the copy to those rules by name would have produced a check that looks verified and proves nothing. `60000` does not appear as a comparison anywhere in the pack at all.

So those sentences keep their meaning and drop the unbacked number: *"You will need to show proof of funds."*, *"You will need to show living costs for your studies."* Zero open questions — nothing was left asserted-but-unbacked, and nothing backed was silently deleted.

## Gates

- full `visa-oracle` vitest → exit 0, **727/727**
- `tsc --noEmit` → exit 0
- anchor test and pin both mutation-verified, in both directions
- harness floor → **2**; the brief declares gear accordingly

## Bites

Bites: consumer = every applicant who reads a figure in an outcome sentence, and the next pack revision; observation = on `origin/main` after merge, the copy table contains no `USD`/`IDR` figure that is not either interpolated from a pinned constant or anchored by the copy-key → rule-id map, and mutating `el.e33.deposit-basis` to HARD_FILTER turns the anchor test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

