### PR TITLE
docs(evidence): make PR-D3 half-2's probe 3 runnable off this machine (C4/D3 of the #6345 row)

### DIFF
--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml
@@ -42,7 +42,7 @@ acceptance:
       WHEN the backend walk-census test runs, THEN every walk SHALL match its EXPECTED_OUTCOME —
       the eleven new walks included.
     status: verified
-    probe: "cd apps/backend-rag && PYTHONPATH=. /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python -m pytest backend/tests/services/visa_engine/test_interview_walk_census.py -q -o addopts=''"
+    probe: "cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest backend/tests/services/visa_engine/test_interview_walk_census.py -q -o addopts=''"
   - text: >-
       WHEN the corpus is counted, THEN it SHALL carry more walks than the 67 it had before this PR,
       and the STEPCHILD sponsor-permit branches SHALL both be present — the walks are what turn a


### PR DESCRIPTION
## What

One line in `evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3b-2026091-2cae648a/brief.yml`. **Discharges C4/D3 of the #6345 gate row.**

Probe 3 invoked `/Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python` — an absolute path that exists on exactly one host, so no gate, peer or CI could re-run it. It is now `.venv/bin/python`, relative to the repo root the probe already `cd`s into.

## Why it travels alone

PR-D3c carried this same fix and thereby put **two** `brief.yml` files in one three-dot diff. `evidence_paths.py` then failed closed on the ambiguity rather than guess whose evidence it was reading, and Harness went red. The rule that leaves behind: **a PR never edits another PR's evidence.** Evidence belongs to the change that produced it; a second editor makes the resolver ambiguous for both.

## The proof, chosen so it can fail

The first report of this condition as discharged was wrong — it was measured on the machine where the absolute path exists, which is a check that cannot fail.

- under `sandbox-exec` denying read and exec on the old absolute path: the **old** probe exits **126**
- the **fixed** probe, run from an independent repo root under the same denial: exit **0**, 15 passed
- re-run by the orchestrator from a different worktree (a repo root it was not written on): exit **0**, 15 passed

## Gear

Evidence-only, one line; floor 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)