### PR TITLE
feat(mouth): portal sign-in becomes concept F's split gate (R19P W5)

### DIFF
--- a/apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+++ b/apps/mouth/e2e/portal-prodlike-smoke.spec.ts
@@ -141,7 +141,7 @@ async function loginViaPortalUi(
     waitUntil: "domcontentloaded",
   });
   const emailInput = page.getByRole("textbox", { name: "Corporate Email" });
-  const emailSubmit = page.getByRole("button", { name: "Pass the Portal" });
+  const emailSubmit = page.getByRole("button", { name: "Continue" });
   await expect(emailInput).toBeEnabled();
   await emailInput.fill(email);
   await expect(emailSubmit).toBeEnabled();
@@ -186,7 +186,7 @@ async function loginPartnerViaPortalUi(
     waitUntil: "domcontentloaded",
   });
   await page.getByRole("textbox", { name: "Corporate Email" }).fill(email);
-  await page.getByRole("button", { name: "Pass the Portal" }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
   await page.getByLabel("Access PIN").fill(pin);
   const loginResponsePromise = page.waitForResponse((response) => {
     const url = new URL(response.url());
@@ -363,7 +363,7 @@ test("@qa-be-003 portal-disabled PIN credentials fail closed without a session",
   });
   const emailInput = page.getByRole("textbox", { name: "Corporate Email" });
   await emailInput.fill(environment.disabledClientEmail);
-  await page.getByRole("button", { name: "Pass the Portal" }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
   await page.getByLabel("Access PIN").fill(environment.disabledClientPin);
 
   const loginResponsePromise = page.waitForResponse((response) => {

--- a/apps/mouth/src/app/portal/login-upgraded/error.tsx
+++ b/apps/mouth/src/app/portal/login-upgraded/error.tsx
@@ -18,17 +18,19 @@ export default function LoginError({
 
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center p-6">
-      {/* WS3 final slice: bg-destructive/text-destructive are dead classes in
-          mouth (no such Tailwind token) → real --state-danger tokens with a
-          color-mix tint of the same AA step. */}
+      {/* R19 concept F: red does not exist on the portal surface — a failed
+          load is copper ("needs you"), and the word carries the state. */}
       <div
         className="flex h-20 w-20 items-center justify-center rounded-full"
         style={{
           background:
-            "color-mix(in srgb, var(--state-danger) 10%, transparent)",
+            "color-mix(in srgb, var(--bz-copper-text) 10%, transparent)",
         }}
       >
-        <LogIn className="h-10 w-10" style={{ color: "var(--state-danger)" }} />
+        <LogIn
+          className="h-10 w-10"
+          style={{ color: "var(--bz-copper-text)" }}
+        />
       </div>
       <div className="mt-6 text-center space-y-2 max-w-md">
         <h2 className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]">

--- a/apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+++ b/apps/mouth/src/app/portal/login-upgraded/page.test.tsx
@@ -5,7 +5,6 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockLogin, mockLoggerError, mockLoggerInfo, mockRouterReplace } =
@@ -25,46 +24,6 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-// Login behaviour does not depend on animation timing. Keeping this unit test
-// on semantic DOM elements also prevents motion's RAF loop from obscuring the
-// submit and accessibility assertions.
-vi.mock("framer-motion", async () => {
-  const React = await vi.importActual<typeof import("react")>("react");
-  const makeMotionElement = (tag: "button" | "div" | "form" | "p") =>
-    React.forwardRef<
-      HTMLElement,
-      Record<string, unknown> & { children?: ReactNode }
-    >(function MotionElement(
-      {
-        animate: _animate,
-        exit: _exit,
-        initial: _initial,
-        transition: _transition,
-        whileHover: _whileHover,
-        whileTap: _whileTap,
-        children,
-        ...domProps
-      },
-      ref,
-    ) {
-      return React.createElement(
-        tag,
-        { ...domProps, ref },
-        children as ReactNode,
-      );
-    });
-
-  return {
-    AnimatePresence: ({ children }: { children?: ReactNode }) => children,
-    motion: {
-      button: makeMotionElement("button"),
-      div: makeMotionElement("div"),
-      form: makeMotionElement("form"),
-      p: makeMotionElement("p"),
-    },
-  };
-});
-
 vi.mock("@/lib/api/public-auth", () => ({
   publicAuth: { login: mockLogin },
 }));
@@ -80,78 +39,78 @@ vi.mock("@/lib/logger", () => ({
 
 import UpgradedLoginPage from "./page";
 
-describe("UpgradedLoginPage (WS3 day pass)", () => {
+describe("UpgradedLoginPage (R19 concept F sign-in)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.history.replaceState({}, "", "/portal/login-upgraded");
   });
 
-  it("shell reads --bz-base and the gate scene carries its re-light class", () => {
+  it("renders the split gate and no illustration survives", () => {
     const { container } = render(<UpgradedLoginPage />);
 
-    const shell = container.querySelector(".min-h-screen");
-    expect(shell?.className).toContain("bg-[var(--bz-base)]");
-    expect(shell?.className).not.toContain("bg-black");
-
-    // The day re-light is scoped to this class via attribute-selector CSS.
-    expect(container.querySelector(".gate-scene")).not.toBeNull();
+    expect(container.querySelector(".r19-gate")).not.toBeNull();
+    expect(container.querySelector(".r19-hero")).not.toBeNull();
+    // The candi-bentar gate scene, its starfield and its re-light class are gone.
+    expect(container.querySelector(".gate-scene")).toBeNull();
+    expect(container.querySelector("svg circle")).toBeNull();
   });
 
-  it("masthead slogan reads day tokens (copper headline: AA on the gate passage)", () => {
+  it("the forest panel carries the brand mark and the hero sentence", () => {
+    const { container } = render(<UpgradedLoginPage />);
+
+    const hero = container.querySelector(".r19-hero");
+    expect(hero).not.toBeNull();
+    expect(hero?.textContent).toContain("Bali Zero");
+    expect(hero?.textContent).toContain("Client portal");
+    expect(hero?.querySelector("h2")?.textContent).toBe(
+      "Your Bali file,kept in order.",
+    );
+    // Zero's order: the real logo, never cropped into a circle.
+    const mark = hero?.querySelector("img");
+    expect(mark).not.toBeNull();
+    expect(mark?.getAttribute("alt")).toBe("Bali Zero");
+    expect(mark?.className ?? "").not.toContain("rounded-full");
+  });
+
+  it("the email field is the paper form control with a copper focus ring", () => {
     render(<UpgradedLoginPage />);
-
-    // The headline spans the sky AND the dark gate passage: copper-text
-    // keeps ≥3:1 large-text contrast on both (3.28:1 on the passage,
-    // 5.05:1 on paper) where ink would drop to ~1.2:1 on the passage.
-    const h1 = screen.getByText("Your Bali Life.");
-    expect(h1.className).toContain("text-[var(--bz-copper-text)]");
-
-    const kicker = screen.getByText("Turn On");
-    expect(kicker.className).toContain("text-[var(--bz-copper-text)]");
-  });
-
-  it("spotlight card is the token surface; inputs are warm paper with copper focus", () => {
-    const { container } = render(<UpgradedLoginPage />);
-
-    const card = container.querySelector(".bg-\\[var\\(--bz-card\\)\\]\\/95");
-    expect(card).not.toBeNull();
-    expect(card?.className).toContain("border-[var(--bz-border)]");
 
     const email = screen.getByPlaceholderText("client@company.com");
-    expect(email.className).toContain("bg-[var(--bz-base)]");
-    expect(email.className).toContain("border-[var(--bz-border)]");
-    expect(email.className).toContain("text-[var(--tx-primary)]");
-    expect(email.className).toContain("focus:border-[var(--bz-copper)]");
+    expect(email.className).toContain("r19-input");
+
+    const eyebrow = screen.getByText("Sign in · step 1 of 2");
+    expect(eyebrow.className).toContain("r19-eyebrow");
   });
 
-  it("CTA uses the darker copper step + --bz-on-warm (AA pair)", () => {
+  it("the primary CTA is filled forest — copper never fills a button", () => {
     render(<UpgradedLoginPage />);
 
-    const cta = screen.getByRole("button", { name: /Pass the Portal/ });
-    expect(cta.style.background).toBe("var(--bz-copper-text)");
-    expect(cta.style.color).toBe("var(--bz-on-warm)");
+    const cta = screen.getByRole("button", { name: /Continue/ });
+    expect(cta.style.background).toBe("var(--r19-forest)");
+    expect(cta.style.color).toBe("var(--r19-paper)");
   });
 
-  it("email step advances to the PIN step with token-styled controls", async () => {
+  it("email step advances to the PIN step with the R19 controls", async () => {
     render(<UpgradedLoginPage />);
 
     fireEvent.change(screen.getByPlaceholderText("client@company.com"), {
       target: { value: "synthetic.user@example.test" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /Pass the Portal/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
 
     const pin = await screen.findByLabelText("Access PIN");
-    expect(pin.className).toContain("bg-[var(--bz-base)]");
-    expect(pin.className).toContain("border-[var(--bz-border)]");
+    expect(pin.className).toContain("r19-input");
+    expect(pin.className).toContain("r19-pin");
+    expect(screen.getByText("Sign in · step 2 of 2")).toBeTruthy();
 
     const verify = screen.getByRole("button", { name: /Verify Identity/ });
-    expect(verify.style.background).toBe("var(--bz-copper-text)");
-    expect(verify.style.color).toBe("var(--bz-on-warm)");
+    expect(verify.style.background).toBe("var(--r19-forest)");
+    expect(verify.style.color).toBe("var(--r19-paper)");
 
     const magicLink = screen.getByRole("link", {
       name: /Sign in with an email link instead/,
     });
-    expect(magicLink.className).toContain("text-[var(--bz-accent-warm)]");
+    expect(magicLink.className).toContain("r19-link");
   });
 
   it("exposes durable labels and password-manager semantics", async () => {
@@ -366,5 +325,7 @@ describe("UpgradedLoginPage (WS3 day pass)", () => {
     expect(html).not.toContain("text-[#f0ece4]"); // token-lint-ok: drain-guard assertion string, not a color use
     expect(html).not.toContain("text-[#f8e89a]"); // token-lint-ok: drain-guard assertion string, not a color use
     expect(html).not.toContain("accent-gold-muted");
+    expect(html).not.toContain("starDrift");
+    expect(html).not.toContain("passageGlow");
   });
 });

--- a/apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+++ b/apps/mouth/src/app/portal/login-upgraded/page.test.tsx
@@ -60,7 +60,8 @@ describe("UpgradedLoginPage (R19 concept F sign-in)", () => {
 
     const hero = container.querySelector(".r19-hero");
     expect(hero).not.toBeNull();
-    expect(hero?.textContent).toContain("Bali Zero");
+    // The logo asset carries the wordmark; the hero does not repeat it in text.
+    expect(hero?.textContent).not.toContain("Bali Zero");
     expect(hero?.textContent).toContain("Client portal");
     expect(hero?.querySelector("h2")?.textContent).toBe(
       "Your Bali file,kept in order.",

--- a/apps/mouth/src/app/portal/login-upgraded/page.tsx
+++ b/apps/mouth/src/app/portal/login-upgraded/page.tsx
@@ -1,13 +1,11 @@
 // apps/mouth/src/app/portal/login-upgraded/page.tsx
 "use client";
 
-import React, { useEffect, useState, useRef, MouseEvent } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import Link from "next/link";
 import { Loader2 } from "lucide-react";
-import { motion, AnimatePresence } from "framer-motion";
-import { cormorant } from "@balizero/core/fonts/cormorant";
+import { BZLogo } from "@balizero/core/components/BZLogo";
 import { useSystemSound } from "@/hooks/useSystemSound";
 import { publicAuth } from "@/lib/api/public-auth";
 import { sanitizeRedirect } from "@/lib/auth/sanitizeRedirect";
@@ -18,16 +16,91 @@ import { I18nProvider, useTranslation } from "@/i18n";
 const REDIRECT_DELAY_MS = 1500;
 const ERROR_RESET_DELAY_MS = 2000;
 
-// WS3 final slice (GARUDA Day Edition): CTA = darker copper step
-// --bz-copper-text with theme-aware --bz-on-warm fg (white on #9d5230 =
-// 5.70:1 light; ink #0c0c0e on #d4845a = 6.74:1 dark — the #b5633a copper
-// step with white would be 4.37:1, below the 4.5:1 AA floor). Was a
-// #d9bd7a→#a07838 gradient with black text.
+// R19 concept F ("RAPI"): forest is the ONLY primary-button fill. Copper
+// carries "needs you" as text, numerals and outline — never as a filled
+// surface — and red does not exist on this surface at all.
 const LOGIN_CTA_STYLE = {
-  background: "var(--bz-copper-text)",
-  color: "var(--bz-on-warm)",
-  boxShadow: "0 4px 24px color-mix(in srgb, var(--bz-copper) 30%, transparent)",
+  background: "var(--r19-forest)",
+  color: "var(--r19-paper)",
 } as const;
+
+// Page-local presentation layer. Scoped under .r19-gate so nothing here can
+// reach kita/prime; the palette lives as page-local custom properties until
+// the my-product token seam carries the R19 values.
+const R19_STYLES = `
+.r19-gate{
+  --r19-paper:#f7f4ee;--r19-surface:#fffcf7;--r19-ink:#1d2c3b;--r19-muted:#58626b; /* token-lint-ok: concept-F paper/ink scale, page-local until the my-product token seam lands */
+  --r19-line:#dad8d1;--r19-line-strong:#a8aca9; /* token-lint-ok: concept-F hairlines */
+  --r19-copper:#a44b36;--r19-forest:#253e33; /* token-lint-ok: concept-F copper (needs-you) and forest (done) meanings */
+  position:relative;display:grid;grid-template-columns:minmax(0,5fr) minmax(0,6fr);
+  min-height:100vh;background:var(--r19-paper);color:var(--r19-ink);
+  font-size:15px;line-height:1.75;
+}
+.r19-serif{font-family:var(--font-serif),Georgia,serif;font-weight:450;letter-spacing:-0.03em}
+.r19-eyebrow{font-size:10px;line-height:1.4;font-weight:650;letter-spacing:0.14em;text-transform:uppercase;color:var(--r19-muted)}
+.r19-gate button{cursor:pointer;border:0;background:none;color:inherit;font:inherit}
+.r19-gate a{color:inherit;text-decoration:none}
+
+.r19-hero{background:var(--r19-forest);color:var(--r19-paper);display:flex;flex-direction:column;justify-content:space-between;gap:32px;padding:40px 48px}
+.r19-brand{display:flex;align-items:center;gap:10px}
+.r19-brand-text{display:flex;flex-direction:column}
+.r19-brand-name{font-size:17px;line-height:1;font-weight:500;letter-spacing:-0.01em}
+.r19-brand-role{margin-top:5px;color:rgba(247,244,238,0.6)}
+.r19-hero-rule{width:56px;height:3px;border-radius:2px;background:var(--r19-copper);margin-bottom:22px}
+.r19-hero h2{margin:0;font-size:clamp(40px,4vw,56px);line-height:1.04}
+.r19-hero-lede{margin:20px 0 0;max-width:34ch;font-size:15px;color:rgba(247,244,238,0.78)}
+.r19-hero-foot{display:flex;justify-content:space-between;gap:16px;color:rgba(247,244,238,0.55)}
+
+.r19-form{display:flex;flex-direction:column;justify-content:center;align-items:center;padding:48px 32px}
+.r19-box{width:100%;max-width:400px}
+.r19-steps{display:flex;align-items:center;gap:6px;margin-bottom:18px}
+.r19-steps i{display:block;width:28px;height:3px;border-radius:2px;background:var(--r19-line)}
+.r19-steps i.on{background:var(--r19-forest)}
+.r19-form h1{margin:10px 0 8px;font-size:40px;line-height:1.06}
+.r19-hint{margin:0 0 26px;color:var(--r19-muted)}
+.r19-field{margin-bottom:16px}
+.r19-field-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:8px}
+.r19-input{display:block;width:100%;height:52px;padding:0 16px;font-size:15px;color:var(--r19-ink);background:var(--r19-surface);border:1px solid var(--r19-line-strong);border-radius:0.25rem;outline:none}
+.r19-input::placeholder{color:var(--r19-muted)}
+.r19-input:focus{border-color:var(--r19-copper);box-shadow:0 0 0 3px rgba(164,75,54,0.18)}
+.r19-input:disabled{opacity:0.55;cursor:not-allowed}
+.r19-pin{font-size:22px;text-align:center;letter-spacing:14px;font-variant-numeric:tabular-nums}
+.r19-gate .r19-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;width:100%;height:48px;margin-top:6px;padding:0 22px;border-radius:0.25rem;font-size:13px;font-weight:650;letter-spacing:0.02em}
+.r19-gate .r19-btn:disabled{opacity:0.5;cursor:not-allowed}
+.r19-gate .r19-back{font-size:12px;font-weight:650;color:var(--r19-copper)}
+.r19-alt{margin-top:22px;display:flex;flex-direction:column;gap:10px;font-size:13px}
+.r19-gate .r19-link{color:var(--r19-copper);font-weight:650}
+.r19-gate .r19-link:hover{text-decoration:underline}
+.r19-alt-sep{border-top:1px solid var(--r19-line);margin:6px 0}
+.r19-quiet{color:var(--r19-muted)}
+.r19-formfoot{margin-top:40px;display:flex;gap:16px;font-size:12px;color:var(--r19-muted);font-variant-numeric:tabular-nums}
+.r19-formfoot a:hover{text-decoration:underline}
+
+.r19-overlay{position:absolute;inset:0;z-index:50;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:24px;text-align:center;background:color-mix(in srgb, var(--r19-paper) 92%, transparent);backdrop-filter:blur(8px)}
+.r19-overlay h1{margin:0;font-size:clamp(34px,5vw,56px);line-height:1.05}
+.r19-overlay-ok h1{color:var(--r19-forest)}
+.r19-overlay-denied h1{color:var(--r19-copper)}
+.r19-overlay p{margin:0;max-width:34rem;font-size:15px;color:var(--r19-ink)}
+
+.r19-input:-webkit-autofill,
+.r19-input:-webkit-autofill:hover,
+.r19-input:-webkit-autofill:focus,
+.r19-input:-webkit-autofill:active{
+  -webkit-box-shadow:0 0 0 30px var(--r19-surface) inset !important;
+  -webkit-text-fill-color:var(--r19-ink) !important;
+  caret-color:var(--r19-copper) !important;
+}
+
+@media (max-width:767px){
+  .r19-gate{grid-template-columns:1fr}
+  .r19-hero{padding:28px 22px 30px;gap:28px}
+  .r19-hero h2{font-size:34px}
+  .r19-hero-lede{margin-top:12px;font-size:14px}
+  .r19-hero-foot{display:none}
+  .r19-form{padding:32px 22px 40px;align-items:stretch}
+  .r19-form h1{font-size:34px}
+}
+`;
 
 // Map HTTP status code → i18n error key. Unknown → server_error (5xx) or
 // network_error (anything else, including status=0 from opaque fetch failures).
@@ -85,18 +158,23 @@ function UpgradedLoginPageInner() {
     setIsHydrated(true);
   }, []);
 
-  // Spotlight mouse tracking state
-  const cardRef = useRef<HTMLDivElement>(null);
-  const [{ mouseX, mouseY }, setMousePos] = useState({ mouseX: 0, mouseY: 0 });
-
-  const handleMouseMove = (e: MouseEvent<HTMLDivElement>) => {
-    if (!cardRef.current) return;
-    const { left, top } = cardRef.current.getBoundingClientRect();
-    setMousePos({
-      mouseX: e.clientX - left,
-      mouseY: e.clientY - top,
-    });
-  };
+  // Same persona declaration the authenticated portal layout makes at mount
+  // (portal/(authenticated)/layout.tsx): the sign-in page is part of My, so
+  // the product token seam has to apply here too. No cleanup — the layout
+  // does not remove the attribute either, and a removal on unmount would
+  // strip the persona during the redirect into the portal itself.
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.product = "my";
+    if (root.dataset.theme === "light") root.dataset.theme = "operative-light";
+    if (root.dataset.theme === "dark") root.dataset.theme = "operative-dark";
+    if (
+      root.dataset.theme !== "operative-light" &&
+      root.dataset.theme !== "operative-dark"
+    ) {
+      root.dataset.theme = "operative-light";
+    }
+  }, []);
 
   const playClickSound = () => {
     play("focus");
@@ -206,1370 +284,215 @@ function UpgradedLoginPageInner() {
     }
   };
 
+  // The two existing alternative paths, equal and visible on both steps.
+  const alternatives = (
+    <div className="r19-alt">
+      <Link href="/portal/magic-link" className="r19-link">
+        Sign in with an email link instead
+      </Link>
+      <Link href="/portal/forgot-password" className="r19-link">
+        {t("portal.login.forgot_password")}
+      </Link>
+      <div className="r19-alt-sep" aria-hidden="true" />
+      <span className="r19-quiet">
+        New here? Your Bali Zero contact sends the invitation — there is nothing
+        to register.
+      </span>
+    </div>
+  );
+
+  const formFooter = (
+    <div className="r19-formfoot">
+      <span>© 2026 Bali Zero</span>
+      <Link href="/privacy">Privacy</Link>
+      <Link href="/terms">Terms</Link>
+    </div>
+  );
+
   return (
-    // WS3 final slice (GARUDA Day Edition, 2026-07-26): the shell reads
-    // --bz-base (paper on operative-light, near-black navy on
-    // operative-dark) instead of a forced bg-black. The SVG gate scene JSX
-    // is untouched — the day re-light lives in the <style> block below as
-    // [data-theme="operative-light"] attribute-selector overrides (CSS
-    // beats SVG presentation attributes), so the dark theme renders the
-    // original night scene pixel-identically. The UI layer (card, forms,
-    // CTAs, overlays) reads day tokens throughout.
-    <div className="min-h-screen relative overflow-hidden flex flex-col bg-[var(--bz-base)]">
+    <div className="r19-gate">
+      {/* Safe: static presentation CSS, no external input. */}
+      <style dangerouslySetInnerHTML={{ __html: R19_STYLES }} />
+
       {/* ACCESS GRANTED OVERLAY */}
       {loginStage === "success" && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.1 }}
-          className="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md"
+        <div
+          className="r19-overlay r19-overlay-ok"
           role="status"
           aria-live="polite"
-          style={{
-            background: "color-mix(in srgb, var(--bz-base) 80%, transparent)",
-          }}
         >
-          <div className="text-center group">
-            <h1
-              className={`${cormorant.className} text-4xl md:text-6xl text-[var(--bz-copper-text)] tracking-[0.2em] font-light shadow-[0_0_40px_rgba(201,169,110,0.4)]`}
-            >
-              Portal Unlocked
-            </h1>
-          </div>
-        </motion.div>
+          <h1 className="r19-serif">Portal Unlocked</h1>
+        </div>
       )}
 
-      {/* ACCESS DENIED OVERLAY */}
+      {/* ACCESS DENIED OVERLAY — copper, never red: the state carries a word. */}
       {loginStage === "denied" && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.1 }}
-          className="absolute inset-0 z-50 flex flex-col items-center justify-center backdrop-blur-md"
+        <div
+          className="r19-overlay r19-overlay-denied"
           role="alert"
           aria-live="assertive"
-          style={{
-            background: "color-mix(in srgb, var(--bz-base) 92%, transparent)",
-          }}
         >
-          <h1
-            className={`${cormorant.className} text-4xl md:text-6xl tracking-[0.2em] font-light uppercase`}
-            style={{ color: "var(--state-danger)" }}
-          >
-            Access Denied
-          </h1>
-          {errorMessage && (
-            <p
-              id="portal-login-error"
-              className="mt-4 text-sm tracking-wide max-w-md text-center px-4"
-              style={{ color: "var(--state-danger)" }}
-            >
-              {errorMessage}
-            </p>
-          )}
-        </motion.div>
+          <h1 className="r19-serif">Access Denied</h1>
+          {errorMessage && <p id="portal-login-error">{errorMessage}</p>}
+        </div>
       )}
 
-      {/* Safe: hardcoded CSS for autofill styling, no external input.
-          WS3: tokenized — card inset + theme text + copper caret (was a
-          dark inset with hardcoded cream text and gold caret). */}
-      <style
-        dangerouslySetInnerHTML={{
-          __html: `
-        input:-webkit-autofill,
-        input:-webkit-autofill:hover,
-        input:-webkit-autofill:focus,
-        input:-webkit-autofill:active {
-            -webkit-box-shadow: 0 0 0 30px var(--bz-card) inset !important;
-            -webkit-text-fill-color: var(--tx-primary) !important;
-            caret-color: var(--bz-copper) !important;
-        }
-      `,
-        }}
-      />
-      <style>{`
-        @keyframes twinkle {
-          0%, 100% { opacity: var(--op-base); transform: scale(1); }
-          50%       { opacity: var(--op-peak); transform: scale(1.5); }
-        }
-        @keyframes starDriftFast {
-          0%, 100% { transform: translate(0px, 0px); }
-          50%      { transform: translate(15px, -5px); }
-        }
-        @keyframes starDriftMid {
-          0%, 100% { transform: translate(0px, 0px); }
-          50%      { transform: translate(10px, -3px); }
-        }
-        @keyframes starDriftSlow {
-          0%, 100% { transform: translate(0px, 0px); }
-          50%      { transform: translate(5px, -1.5px); }
-        }
-
-        /* ── WS3 Day re-light (operative-light only) ────────────────────
-           The gate SVG keeps its single-source night palette in JSX; these
-           attribute-selector overrides re-light it for the Day Edition
-           (CSS beats SVG presentation attributes). Decorative illustration
-           colors, not UI colors. Dark theme: zero rules match → the night
-           scene renders unchanged. */
-        [data-theme="operative-light"] .gate-scene #skyGrad stop[stop-color="#000000"] { stop-color: #f7f3ea; } /* token-lint-ok: decorative illustration day sky */
-        [data-theme="operative-light"] .gate-scene #skyGrad stop[stop-color="#030306"] { stop-color: #e6dcc8; } /* token-lint-ok: decorative illustration day sky depth */
-        [data-theme="operative-light"] .gate-scene #goldEdge stop[stop-color="#f8e89a"] { stop-color: #8a6d3b; } /* token-lint-ok: decorative illustration daylight gold edge */
-        [data-theme="operative-light"] .gate-scene #goldEdge stop[stop-color="#e8c96a"] { stop-color: #b5633a; } /* token-lint-ok: decorative illustration copper edge */
-        [data-theme="operative-light"] .gate-scene #goldEdge stop[stop-color="#c9a96e"] { stop-color: #c07a48; } /* token-lint-ok: decorative illustration copper edge fade */
-        [data-theme="operative-light"] .gate-scene #goldEdge stop[stop-color="#7a5020"] { stop-color: #d4b483; } /* token-lint-ok: decorative illustration sand edge end */
-        [data-theme="operative-light"] .gate-scene [fill="#0a0804"] { fill: #4a3b26; } /* token-lint-ok: decorative illustration umber stone */
-        [data-theme="operative-light"] .gate-scene [fill="#0c0a05"] { fill: #55452e; } /* token-lint-ok: decorative illustration umber stone tier */
-        [data-theme="operative-light"] .gate-scene [fill="#080602"] { fill: #5f4e36; } /* token-lint-ok: decorative illustration umber step */
-        [data-theme="operative-light"] .gate-scene [fill="#060401"] { fill: #6a5840; } /* token-lint-ok: decorative illustration umber step light */
-        [data-theme="operative-light"] .gate-scene [stroke="#f8e89a"] { stroke: #8a6d3b; } /* token-lint-ok: decorative illustration daylight gold stroke */
-        [data-theme="operative-light"] .gate-scene [stroke="#e8c96a"] { stroke: #b5633a; } /* token-lint-ok: decorative illustration copper stroke */
-        [data-theme="operative-light"] .gate-scene [fill="#c9a96e"] { fill: #b08a5a; } /* token-lint-ok: decorative illustration warm carving fill */
-        [data-theme="operative-light"] .gate-scene [stroke="#c9a96e"] { stroke: #a08050; } /* token-lint-ok: decorative illustration warm carving stroke */
-        [data-theme="operative-light"] .gate-scene [stroke="#8a6030"] { stroke: #9c7c4e; } /* token-lint-ok: decorative illustration dim gold stroke */
-        [data-theme="operative-light"] .gate-scene [fill="#000000"] { fill: #d8cdb6; } /* token-lint-ok: decorative illustration sand silhouette (moon cover, ground, foliage) */
-        [data-theme="operative-light"] .gate-scene [fill="#0a0a0a"] { fill: #d9a441; } /* token-lint-ok: decorative illustration sun disc */
-        /* #passageGlow was still the night-only ember (#1a1008 → #000000,
-           opaque both stops), so in daylight the central passage rendered
-           as a near-black slab instead of a glimpse of sky through the
-           gate. Re-lit with the same two skyGrad tones so the passage
-           reads as daylight, not a void — both stops clear WCAG 3:1
-           against the copper title text that overlaps this rect. */
-        [data-theme="operative-light"] .gate-scene #passageGlow stop[stop-color="#1a1008"] { stop-color: #f7f3ea; } /* token-lint-ok: decorative illustration daylight passage glow (reuses day sky) */
-        [data-theme="operative-light"] .gate-scene #passageGlow stop[stop-color="#000000"] { stop-color: #e6dcc8; } /* token-lint-ok: decorative illustration daylight passage glow depth (reuses day sky depth) */
-      `}</style>
-
-      {/* ═══════════════════════════════════════
-          LAYER 0 — STARFIELD + VOLUMETRIC GATE
-      ═══════════════════════════════════════ */}
-      <motion.div
-        initial={{ opacity: 0, scale: 1.05 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 2, ease: "easeOut" }}
-        className="absolute inset-0 gate-scene"
-      >
-        <svg
-          className="absolute inset-0 w-full h-full"
-          viewBox="0 0 1440 900"
-          preserveAspectRatio="xMidYMid slice"
-        >
-          <defs>
-            <linearGradient id="skyGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stopColor="#000000" />
-              <stop offset="100%" stopColor="#030306" />
-            </linearGradient>
-
-            <linearGradient id="goldEdge" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stopColor="#f8e89a" stopOpacity="1" />
-              <stop offset="25%" stopColor="#e8c96a" stopOpacity="0.95" />
-              <stop offset="65%" stopColor="#c9a96e" stopOpacity="0.7" />
-              <stop offset="100%" stopColor="#7a5020" stopOpacity="0.3" />
-            </linearGradient>
-
-            <radialGradient id="gateGlow" cx="50%" cy="85%" r="40%">
-              <stop offset="0%" stopColor="#c9a96e" stopOpacity="0.3" />
-              <stop offset="60%" stopColor="#c9a96e" stopOpacity="0.08" />
-              <stop offset="100%" stopColor="#c9a96e" stopOpacity="0" />
-            </radialGradient>
-
-            <radialGradient id="passageGlow" cx="50%" cy="40%" r="50%">
-              <stop offset="0%" stopColor="#1a1008" stopOpacity="1" />
-              <stop offset="100%" stopColor="#000000" stopOpacity="1" />
-            </radialGradient>
-
-            <filter id="displacement" x="0%" y="0%" width="100%" height="100%">
-              <feTurbulence
-                type="fractalNoise"
-                baseFrequency="0.02"
-                numOctaves="3"
-                result="noise"
-              />
-              <feDisplacementMap
-                in="SourceGraphic"
-                in2="noise"
-                scale="5"
-                xChannelSelector="R"
-                yChannelSelector="G"
-              />
-            </filter>
-          </defs>
-
-          <rect width="1440" height="900" fill="url(#skyGrad)" />
-
-          {/* ── ANIMATED STARFIELD ── */}
-          <g style={{ animation: "starDriftSlow 300s ease-in-out infinite" }}>
-            {[
-              [88, 45, 0.18, 4.2],
-              [144, 72, 0.22, 6.1],
-              [201, 28, 0.16, 8.3],
-              [267, 91, 0.25, 5.0],
-              [312, 55, 0.19, 7.2],
-              [389, 38, 0.14, 3.8],
-              [445, 82, 0.23, 9.1],
-              [501, 19, 0.17, 6.7],
-              [563, 66, 0.21, 4.5],
-              [618, 33, 0.15, 7.9],
-              [674, 77, 0.26, 5.5],
-              [785, 88, 0.18, 8.8],
-              [841, 22, 0.13, 3.2],
-              [897, 67, 0.22, 6.4],
-              [953, 41, 0.19, 4.8],
-              [1009, 79, 0.24, 7.3],
-              [1065, 31, 0.16, 9.5],
-              [1121, 58, 0.2, 5.1],
-              [1177, 84, 0.17, 6.8],
-              [1289, 73, 0.23, 4.1],
-              [1345, 26, 0.14, 7.6],
-              [1401, 62, 0.21, 3.5],
-              [1430, 89, 0.18, 8.2],
-              [110, 140, 0.16, 5.4],
-              [178, 163, 0.2, 7.1],
-              [244, 128, 0.13, 4.0],
-              [310, 157, 0.24, 6.3],
-              [376, 134, 0.17, 8.9],
-              [442, 169, 0.22, 3.7],
-              [508, 142, 0.15, 5.8],
-              [574, 118, 0.19, 7.4],
-              [640, 155, 0.23, 4.6],
-              [706, 131, 0.16, 6.0],
-              [772, 148, 0.2, 8.5],
-              [838, 122, 0.14, 3.9],
-              [904, 159, 0.25, 5.2],
-              [970, 136, 0.18, 7.8],
-              [1036, 152, 0.22, 4.3],
-              [1102, 127, 0.15, 6.6],
-              [1168, 144, 0.19, 8.1],
-              [1234, 161, 0.23, 5.7],
-              [1300, 129, 0.16, 3.4],
-              [1366, 156, 0.21, 7.0],
-            ].map(([x, y, op, dur], i) => (
-              <circle
-                key={`sa-${i}`}
-                cx={x}
-                cy={y}
-                r={0.5 + (i % 3) * 0.2}
-                fill="#ffffff"
-                style={
-                  {
-                    "--op-base": String(op),
-                    "--op-peak": String(Math.min(1, (op as number) * 2.5)),
-                    opacity: op as number,
-                    animation: `twinkle ${dur}s ease-in-out infinite`,
-                    animationDelay: `${(i * 0.37) % dur}s`,
-                  } as React.CSSProperties
-                }
-              />
-            ))}
-          </g>
-
-          <g style={{ animation: "starDriftMid 200s ease-in-out infinite" }}>
-            {[
-              [55, 220, 0.15, 5.9],
-              [123, 248, 0.19, 7.2],
-              [191, 235, 0.22, 4.4],
-              [259, 212, 0.13, 8.6],
-              [327, 244, 0.17, 6.1],
-              [395, 228, 0.24, 3.8],
-              [463, 241, 0.16, 5.5],
-              [531, 217, 0.2, 7.7],
-              [599, 238, 0.14, 9.2],
-              [667, 223, 0.23, 4.9],
-              [735, 245, 0.18, 6.3],
-              [803, 219, 0.21, 8.0],
-              [871, 236, 0.15, 5.1],
-              [939, 251, 0.25, 7.4],
-              [1007, 224, 0.17, 3.6],
-              [1075, 242, 0.22, 6.8],
-              [1143, 229, 0.19, 8.4],
-              [1211, 246, 0.14, 4.7],
-              [1279, 213, 0.23, 5.9],
-              [1347, 240, 0.16, 7.1],
-              [170, 52, 0.22, 6.5],
-              [320, 38, 0.18, 8.3],
-              [470, 62, 0.25, 4.0],
-              [620, 29, 0.19, 7.6],
-              [820, 51, 0.16, 5.2],
-              [970, 35, 0.23, 3.7],
-              [1120, 58, 0.2, 8.9],
-              [1290, 42, 0.17, 6.1],
-              [245, 155, 0.24, 7.3],
-              [415, 131, 0.15, 4.8],
-              [565, 168, 0.21, 6.0],
-              [715, 144, 0.18, 8.5],
-              [915, 162, 0.25, 5.4],
-              [1065, 138, 0.13, 7.0],
-              [1215, 155, 0.22, 4.2],
-              [1385, 169, 0.19, 6.7],
-            ].map(([x, y, op, dur], i) => (
-              <circle
-                key={`sb-${i}`}
-                cx={x}
-                cy={y}
-                r={0.6 + (i % 2) * 0.3}
-                fill="#f5e8c0"
-                style={
-                  {
-                    "--op-base": String(op),
-                    "--op-peak": String(Math.min(1, (op as number) * 2.8)),
-                    opacity: op as number,
-                    animation: `twinkle ${dur}s ease-in-out infinite`,
-                    animationDelay: `${(i * 0.53) % dur}s`,
-                  } as React.CSSProperties
-                }
-              />
-            ))}
-          </g>
-
-          <g style={{ animation: "starDriftFast 120s ease-in-out infinite" }}>
-            {[
-              [180, 88, 0.65, 3.8],
-              [520, 45, 0.7, 5.1],
-              [860, 72, 0.6, 4.4],
-              [1200, 55, 0.72, 3.2],
-              [350, 195, 0.58, 6.2],
-              [750, 168, 0.68, 4.7],
-              [1100, 182, 0.62, 5.5],
-              [140, 285, 0.55, 7.1],
-              [580, 294, 0.7, 3.9],
-              [980, 289, 0.63, 5.8],
-              [1380, 292, 0.67, 4.3],
-            ].map(([x, y, op, dur], i) => (
-              <g
-                key={`sc-${i}`}
-                style={
-                  {
-                    "--op-base": String((op as number) * 0.7),
-                    "--op-peak": String(op),
-                    animation: `twinkle ${dur}s ease-in-out infinite`,
-                    animationDelay: `${(i * 0.7) % dur}s`,
-                  } as React.CSSProperties
-                }
-              >
-                <circle cx={x} cy={y} r={1.4} fill="#fffbe8" />
-                <line
-                  x1={(x as number) - 5}
-                  y1={y as number}
-                  x2={(x as number) + 5}
-                  y2={y as number}
-                  stroke="#fffbe8"
-                  strokeWidth="0.4"
-                  opacity="0.4"
-                />
-                <line
-                  x1={x as number}
-                  y1={(y as number) - 5}
-                  x2={x as number}
-                  y2={(y as number) + 5}
-                  stroke="#fffbe8"
-                  strokeWidth="0.4"
-                  opacity="0.4"
-                />
-              </g>
-            ))}
-          </g>
-
-          {/* Moon — crescent upper left */}
-          <circle cx="200" cy="110" r="48" fill="#0a0a0a" />
-          <circle cx="218" cy="96" r="48" fill="#000000" />
-          <circle
-            cx="200"
-            cy="110"
-            r="47"
-            fill="none"
-            stroke="#c9a96e"
-            strokeWidth="0.6"
-            opacity="0.25"
-          />
-
-          {/* Ambient gate glow */}
-          <ellipse cx="720" cy="830" rx="360" ry="150" fill="url(#gateGlow)" />
-
-          <g filter="url(#displacement)" className="opacity-90">
-            {/* ═══════════════════════════════════════
-              AUTHENTIC CANDI BENTAR
-          ═══════════════════════════════════════ */}
-
-            {/* ── LEFT HALF ── */}
-            <g filter="url(#pillarGlow)">
-              {/* Tower body */}
-              <path
-                d="M510 780 L510 430 L535 410 L535 390 L545 375 L560 365 L620 365 L640 380 L640 780 Z"
-                fill="#0a0804"
-                stroke="url(#goldEdge)"
-                strokeWidth="1.5"
-              />
-              <line
-                x1="510"
-                y1="430"
-                x2="510"
-                y2="780"
-                stroke="#f8e89a"
-                strokeWidth="2"
-                opacity="0.88"
-              />
-              <line
-                x1="640"
-                y1="380"
-                x2="640"
-                y2="780"
-                stroke="#e8c96a"
-                strokeWidth="1.5"
-                opacity="0.7"
-              />
-              {/* Stone bands */}
-              {[410, 445, 480, 515, 550, 585, 620, 655, 690, 725, 760].map(
-                (y, i) => (
-                  <g key={`lb-${i}`}>
-                    <rect
-                      x="510"
-                      y={y}
-                      width="130"
-                      height="2"
-                      fill="#c9a96e"
-                      opacity={0.16 + (i % 3) * 0.06}
-                    />
-                    <line
-                      x1="510"
-                      y1={y}
-                      x2="640"
-                      y2={y}
-                      stroke="#e8c96a"
-                      strokeWidth="0.5"
-                      opacity={0.1}
-                    />
-                  </g>
-                ),
-              )}
-              {/* Carved panels */}
-              <rect
-                x="518"
-                y="440"
-                width="114"
-                height="90"
-                rx="1"
-                fill="none"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.22"
-              />
-              <rect
-                x="518"
-                y="545"
-                width="114"
-                height="90"
-                rx="1"
-                fill="none"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.22"
-              />
-              <rect
-                x="518"
-                y="650"
-                width="114"
-                height="90"
-                rx="1"
-                fill="none"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.22"
-              />
-              <path
-                d="M575 465 Q565 480 575 495 Q585 480 575 465Z"
-                fill="#c9a96e"
-                opacity="0.18"
-              />
-              <path
-                d="M575 570 Q565 585 575 600 Q585 585 575 570Z"
-                fill="#c9a96e"
-                opacity="0.18"
-              />
-              <path
-                d="M575 675 Q565 690 575 700 Q585 690 575 675Z"
-                fill="#c9a96e"
-                opacity="0.18"
-              />
-              {/* Meru stepped arch tiers */}
-              <path
-                d="M500 390 L640 390 L640 375 L555 375 L545 360 L500 360Z"
-                fill="#0c0a05"
-                stroke="#e8c96a"
-                strokeWidth="1.2"
-                opacity="0.92"
-              />
-              <line
-                x1="500"
-                y1="360"
-                x2="500"
-                y2="390"
-                stroke="#f8e89a"
-                strokeWidth="2.2"
-                opacity="0.92"
-              />
-              <path
-                d="M508 360 L640 360 L640 346 L562 346 L552 332 L508 332Z"
-                fill="#0c0a05"
-                stroke="#e8c96a"
-                strokeWidth="1.1"
-                opacity="0.87"
-              />
-              <line
-                x1="508"
-                y1="332"
-                x2="508"
-                y2="360"
-                stroke="#f8e89a"
-                strokeWidth="2"
-                opacity="0.87"
-              />
-              <path
-                d="M516 332 L640 332 L640 319 L569 319 L559 306 L516 306Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="1"
-                opacity="0.82"
-              />
-              <line
-                x1="516"
-                y1="306"
-                x2="516"
-                y2="332"
-                stroke="#f8e89a"
-                strokeWidth="1.7"
-                opacity="0.82"
-              />
-              <path
-                d="M524 306 L638 306 L638 294 L575 294 L566 282 L524 282Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.9"
-                opacity="0.77"
-              />
-              <line
-                x1="524"
-                y1="282"
-                x2="524"
-                y2="306"
-                stroke="#e8c96a"
-                strokeWidth="1.5"
-                opacity="0.77"
-              />
-              <path
-                d="M531 282 L636 282 L636 270 L581 270 L573 259 L531 259Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.8"
-                opacity="0.72"
-              />
-              <line
-                x1="531"
-                y1="259"
-                x2="531"
-                y2="282"
-                stroke="#e8c96a"
-                strokeWidth="1.3"
-                opacity="0.72"
-              />
-              <path
-                d="M538 259 L635 259 L635 248 L587 248 L580 238 L538 238Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.7"
-                opacity="0.67"
-              />
-              <line
-                x1="538"
-                y1="238"
-                x2="538"
-                y2="259"
-                stroke="#e8c96a"
-                strokeWidth="1.1"
-                opacity="0.67"
-              />
-              <path
-                d="M545 238 L634 238 L634 228 L592 228 L586 219 L545 219Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.62"
-              />
-              <line
-                x1="545"
-                y1="219"
-                x2="545"
-                y2="238"
-                stroke="#e8c96a"
-                strokeWidth="0.9"
-                opacity="0.62"
-              />
-              {/* Karang ornament */}
-              <path
-                d="M550 219 C555 200 570 185 590 175 C605 168 615 165 622 162 L630 175 C622 178 613 183 602 191 C586 202 574 215 568 228 L550 228Z"
-                fill="#0c0a05"
-                stroke="#e8c96a"
-                strokeWidth="1.2"
-                filter="url(#goldGlow)"
-              />
-              {/* Meru tumpang pavilions */}
-              <path
-                d="M590 162 L638 162 L638 152 L614 148 L590 152Z"
-                fill="#0c0a05"
-                stroke="#e8c96a"
-                strokeWidth="1"
-                opacity="0.92"
-              />
-              <path
-                d="M596 148 L636 148 L636 139 L616 135 L596 139Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.8"
-                opacity="0.87"
-              />
-              <path
-                d="M601 135 L634 135 L634 127 L617 123 L601 127Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.7"
-                opacity="0.82"
-              />
-              <path
-                d="M606 123 L632 123 L632 116 L619 112 L606 116Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.77"
-              />
-              <path
-                d="M611 112 L630 112 L630 106 L620 102 L611 106Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.5"
-                opacity="0.72"
-              />
-              <path
-                d="M614 102 L628 102 L628 97 L621 94 L614 97Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.4"
-                opacity="0.67"
-              />
-              {/* Finial */}
-              <path
-                d="M617 94 L623 94 L621 70 L619 70Z"
-                fill="#c9a96e"
-                opacity="0.92"
-                filter="url(#tipGlow)"
-              />
-              <ellipse
-                cx="620"
-                cy="68"
-                rx="4.5"
-                ry="4.5"
-                fill="#f8e89a"
-                opacity="0.97"
-                filter="url(#tipGlow)"
-              />
-              <ellipse
-                cx="620"
-                cy="68"
-                rx="2"
-                ry="2"
-                fill="#ffffff"
-                opacity="0.95"
-              />
-            </g>
-
-            {/* ── RIGHT HALF (mirror) ── */}
-            <g filter="url(#pillarGlow)">
-              <path
-                d="M930 780 L930 430 L905 410 L905 390 L895 375 L880 365 L820 365 L800 380 L800 780Z"
-                fill="#0a0804"
-                stroke="url(#goldEdge)"
-                strokeWidth="1.5"
-              />
-              <line
-                x1="930"
-                y1="430"
-                x2="930"
-                y2="780"
-                stroke="#f8e89a"
-                strokeWidth="2"
-                opacity="0.88"
-              />
-              <line
-                x1="800"
-                y1="380"
-                x2="800"
-                y2="780"
-                stroke="#e8c96a"
-                strokeWidth="1.5"
-                opacity="0.7"
-              />
-              {[410, 445, 480, 515, 550, 585, 620, 655, 690, 725, 760].map(
-                (y, i) => (
-                  <g key={`rb-${i}`}>
-                    <rect
-                      x="800"
-                      y={y}
-                      width="130"
-                      height="2"
-                      fill="#c9a96e"
-                      opacity={0.16 + (i % 3) * 0.06}
-                    />
-                    <line
-                      x1="800"
-                      y1={y}
-                      x2="930"
-                      y2={y}
-                      stroke="#e8c96a"
-                      strokeWidth="0.5"
-                      opacity={0.1}
-                    />
-                  </g>
-                ),
-              )}
-              <rect
-                x="808"
-                y="440"
-                width="114"
-                height="90"
-                rx="1"
-                fill="none"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.22"
-              />
-              <rect
-                x="808"
-                y="545"
-                width="114"
-                height="90"
-                rx="1"
-                fill="none"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.22"
-              />
-              <rect
-                x="808"
-                y="650"
-                width="114"
-                height="90"
-                rx="1"
-                fill="none"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.22"
-              />
-              <path
-                d="M865 465 Q855 480 865 495 Q875 480 865 465Z"
-                fill="#c9a96e"
-                opacity="0.18"
-              />
-              <path
-                d="M865 570 Q855 585 865 600 Q875 585 865 570Z"
-                fill="#c9a96e"
-                opacity="0.18"
-              />
-              <path
-                d="M865 675 Q855 690 865 700 Q875 690 865 675Z"
-                fill="#c9a96e"
-                opacity="0.18"
-              />
-              <path
-                d="M940 390 L800 390 L800 375 L885 375 L895 360 L940 360Z"
-                fill="#0c0a05"
-                stroke="#e8c96a"
-                strokeWidth="1.2"
-                opacity="0.92"
-              />
-              <line
-                x1="940"
-                y1="360"
-                x2="940"
-                y2="390"
-                stroke="#f8e89a"
-                strokeWidth="2.2"
-                opacity="0.92"
-              />
-              <path
-                d="M932 360 L800 360 L800 346 L878 346 L888 332 L932 332Z"
-                fill="#0c0a05"
-                stroke="#e8c96a"
-                strokeWidth="1.1"
-                opacity="0.87"
-              />
-              <line
-                x1="932"
-                y1="332"
-                x2="932"
-                y2="360"
-                stroke="#f8e89a"
-                strokeWidth="2"
-                opacity="0.87"
-              />
-              <path
-                d="M924 332 L800 332 L800 319 L871 319 L881 306 L924 306Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="1"
-                opacity="0.82"
-              />
-              <line
-                x1="924"
-                y1="306"
-                x2="924"
-                y2="332"
-                stroke="#f8e89a"
-                strokeWidth="1.7"
-                opacity="0.82"
-              />
-              <path
-                d="M916 306 L802 306 L802 294 L865 294 L874 282 L916 282Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.9"
-                opacity="0.77"
-              />
-              <line
-                x1="916"
-                y1="282"
-                x2="916"
-                y2="306"
-                stroke="#e8c96a"
-                strokeWidth="1.5"
-                opacity="0.77"
-              />
-              <path
-                d="M909 282 L804 282 L804 270 L859 270 L867 259 L909 259Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.8"
-                opacity="0.72"
-              />
-              <line
-                x1="909"
-                y1="259"
-                x2="909"
-                y2="282"
-                stroke="#e8c96a"
-                strokeWidth="1.3"
-                opacity="0.72"
-              />
-              <path
-                d="M902 259 L805 259 L805 248 L853 248 L860 238 L902 238Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.7"
-                opacity="0.67"
-              />
-              <line
-                x1="902"
-                y1="238"
-                x2="902"
-                y2="259"
-                stroke="#e8c96a"
-                strokeWidth="1.1"
-                opacity="0.67"
-              />
-              <path
-                d="M895 238 L806 238 L806 228 L848 228 L854 219 L895 219Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.62"
-              />
-              <line
-                x1="895"
-                y1="219"
-                x2="895"
-                y2="238"
-                stroke="#e8c96a"
-                strokeWidth="0.9"
-                opacity="0.62"
-              />
-              <path
-                d="M890 219 C885 200 870 185 850 175 C835 168 825 165 818 162 L810 175 C818 178 827 183 838 191 C854 202 866 215 872 228 L890 228Z"
-                fill="#0c0a05"
-                stroke="#e8c96a"
-                strokeWidth="1.2"
-                filter="url(#goldGlow)"
-              />
-              <path
-                d="M802 162 L850 162 L850 152 L826 148 L802 152Z"
-                fill="#0c0a05"
-                stroke="#e8c96a"
-                strokeWidth="1"
-                opacity="0.92"
-              />
-              <path
-                d="M804 148 L844 148 L844 139 L824 135 L804 139Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.8"
-                opacity="0.87"
-              />
-              <path
-                d="M806 135 L839 135 L839 127 L823 123 L806 127Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.7"
-                opacity="0.82"
-              />
-              <path
-                d="M808 123 L834 123 L834 116 L821 112 L808 116Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.6"
-                opacity="0.77"
-              />
-              <path
-                d="M810 112 L831 112 L831 106 L820 102 L810 106Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.5"
-                opacity="0.72"
-              />
-              <path
-                d="M812 102 L828 102 L828 97 L820 94 L812 97Z"
-                fill="#0c0a05"
-                stroke="#c9a96e"
-                strokeWidth="0.4"
-                opacity="0.67"
-              />
-              <path
-                d="M817 94 L823 94 L821 70 L819 70Z"
-                fill="#c9a96e"
-                opacity="0.92"
-                filter="url(#tipGlow)"
-              />
-              <ellipse
-                cx="820"
-                cy="68"
-                rx="4.5"
-                ry="4.5"
-                fill="#f8e89a"
-                opacity="0.97"
-                filter="url(#tipGlow)"
-              />
-              <ellipse
-                cx="820"
-                cy="68"
-                rx="2"
-                ry="2"
-                fill="#ffffff"
-                opacity="0.95"
-              />
-            </g>
-
-            {/* ── CENTRAL PASSAGE ── */}
-            <rect
-              x="640"
-              y="365"
-              width="160"
-              height="415"
-              fill="url(#passageGlow)"
-            />
-            <line
-              x1="640"
-              y1="365"
-              x2="640"
-              y2="780"
-              stroke="#f8e89a"
-              strokeWidth="1.8"
-              opacity="0.55"
-            />
-            <line
-              x1="800"
-              y1="365"
-              x2="800"
-              y2="780"
-              stroke="#f8e89a"
-              strokeWidth="1.8"
-              opacity="0.55"
-            />
-
-            {/* Base steps */}
-            <rect
-              x="480"
-              y="780"
-              width="480"
-              height="12"
-              rx="1"
-              fill="#0a0804"
-              stroke="#e8c96a"
-              strokeWidth="1"
-              opacity="0.7"
-            />
-            <line
-              x1="480"
-              y1="780"
-              x2="960"
-              y2="780"
-              stroke="#f8e89a"
-              strokeWidth="1.5"
-              opacity="0.7"
-            />
-            <rect
-              x="460"
-              y="792"
-              width="520"
-              height="10"
-              rx="1"
-              fill="#080602"
-              stroke="#c9a96e"
-              strokeWidth="0.8"
-              opacity="0.45"
-            />
-            <rect
-              x="440"
-              y="802"
-              width="560"
-              height="10"
-              rx="1"
-              fill="#060401"
-              stroke="#8a6030"
-              strokeWidth="0.6"
-              opacity="0.25"
-            />
-
-            {/* Ground */}
-            <rect x="0" y="812" width="1440" height="88" fill="#000000" />
-            <line
-              x1="0"
-              y1="812"
-              x2="1440"
-              y2="812"
-              stroke="#c9a96e"
-              strokeWidth="0.4"
-              opacity="0.1"
-            />
-
-            {/* Foliage silhouettes */}
-            <path
-              d="M0 900 L0 680 Q30 620 80 580 Q50 650 100 630 Q60 700 130 680 Q80 750 160 740 Q120 800 220 790 L180 900Z"
-              fill="#000000"
-            />
-            <path
-              d="M80 900 Q110 800 180 760 Q150 830 230 810 L200 900Z"
-              fill="#000000"
-            />
-            <path
-              d="M1440 900 L1440 680 Q1410 620 1360 580 Q1390 650 1340 630 Q1380 700 1310 680 Q1360 750 1280 740 Q1320 800 1220 790 L1260 900Z"
-              fill="#000000"
-            />
-            <path
-              d="M1360 900 Q1330 800 1260 760 Q1290 830 1210 810 L1240 900Z"
-              fill="#000000"
-            />
-
-            {/* Animated fireflies */}
-            {[
-              [280, 620, 4.5, 0.5, 8],
-              [340, 570, 5.2, 0.4, 11],
-              [200, 680, 6.0, 0.45, 9],
-              [1160, 615, 4.8, 0.5, 7],
-              [1100, 660, 5.5, 0.4, 12],
-              [1220, 575, 4.2, 0.55, 10],
-              [680, 430, 6.5, 0.35, 8],
-              [760, 410, 5.0, 0.3, 13],
-            ].map(([x, y, dur, op, del], i) => (
-              <g
-                key={`ff-${i}`}
-                style={{
-                  animation: `firefly ${dur}s ease-in-out infinite`,
-                  animationDelay: `${del}s`,
-                }}
-              >
-                <circle
-                  cx={x}
-                  cy={y}
-                  r="3"
-                  fill="#c9a96e"
-                  opacity={op as number}
-                />
-                <circle
-                  cx={x}
-                  cy={y}
-                  r="9"
-                  fill="#c9a96e"
-                  opacity={(op as number) * 0.1}
-                />
-              </g>
-            ))}
-          </g>
-
-          {/* Volumetric Light Ray */}
-          <polygon
-            points="640,365 800,365 1000,900 440,900"
-            fill="url(#gateGlow)"
-            className="mix-blend-screen opacity-50 pointer-events-none"
-          />
-        </svg>
-
-        {/* WS3: theme-aware veil (was from-black/50 to-black/95) — darkens
-            the scene foot in dark, veils it in paper on operative-light. */}
-        <div className="absolute inset-0 bg-gradient-to-b from-[var(--bz-base)]/50 via-transparent to-[var(--bz-base)]/95 pointer-events-none" />
-      </motion.div>
-
-      {/* ═══════════════════════════════════════
-          LAYER 1 — Animated Logo
-      ═══════════════════════════════════════ */}
-      <motion.div
-        initial={{ y: -50, opacity: 0 }}
-        animate={{ y: 0, opacity: 0.96 }}
-        transition={{ duration: 1.2, delay: 0.5, ease: [0.16, 1, 0.3, 1] }}
-        className="absolute inset-x-0 flex justify-center pointer-events-none z-20"
-        style={{ top: "13%" }}
-      >
-        <Image
-          src="/assets/logo/balizero-logo-clean.png"
-          alt="Bali Zero"
-          width={92}
-          height={92}
-          className="rounded-full drop-shadow-[0_0_22px_rgba(201,169,110,0.55)]"
-          priority
-        />
-      </motion.div>
-
-      {/* ═══════════════════════════════════════
-          LAYER 2 — Content
-      ═══════════════════════════════════════ */}
-      <div className="relative z-20 flex flex-col min-h-screen">
-        <div className="flex-1" />
-
-        <div className="px-6 pb-12 max-w-[420px] w-full mx-auto">
-          {/* Slogan */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 1, delay: 0.8 }}
-            className="mb-8 text-center"
-          >
-            <p
-              className={`${cormorant.className} text-[13px] uppercase tracking-[4px] mb-2 text-[var(--bz-copper-text)] font-light`}
-            >
-              Turn On
-            </p>
-            <h1
-              className={`${cormorant.className} text-[42px] leading-tight tracking-[0.06em] uppercase text-[var(--bz-copper-text)] font-light`}
-            >
-              Your Bali Life.
-            </h1>
-          </motion.div>
-
-          {/* ══════════════════════════════════════
-              SPOTLIGHT CARD (Liquid Glass + Framer)
-          ══════════════════════════════════════ */}
-          <motion.div
-            initial={{ opacity: 0, y: 40, scale: 0.95 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            transition={{
-              type: "spring",
-              stiffness: 50,
-              damping: 20,
-              delay: 1,
-            }}
-            ref={cardRef}
-            onMouseMove={handleMouseMove}
-            className="relative rounded-2xl overflow-hidden group shadow-[0_14px_34px_rgba(22,33,58,0.07)]"
-          >
-            {/* Ambient Base Glow */}
-            <div className="absolute inset-x-0 -top-px h-px bg-gradient-to-r from-transparent via-[var(--bz-copper)]/50 to-transparent opacity-30" />
-
-            {/* Mouse Spotlight Effect - The Magic */}
-            <div
-              className="pointer-events-none absolute -inset-px rounded-2xl opacity-0 transition duration-300 group-hover:opacity-100 z-30"
-              style={{
-                background: `radial-gradient(400px circle at ${mouseX}px ${mouseY}px, color-mix(in srgb, var(--bz-copper) 15%, transparent), transparent 40%)`,
-              }}
-            />
-
-            {/* Card surface — WS3: token card + hairline (was a forced-dark
-                glass gradient with gold inset shadows). */}
-            <div className="bg-[var(--bz-card)]/95 backdrop-blur-[40px] saturate-150 p-1 rounded-2xl border border-[var(--bz-border)]">
-              <div className="relative z-40 h-[240px]">
-                {/* ANIMATED FORM TRANSITIONS */}
-                <AnimatePresence mode="popLayout">
-                  {step === "email" ? (
-                    <motion.form
-                      key="email-step"
-                      initial={{ opacity: 0, x: -30 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      exit={{ opacity: 0, x: -30, filter: "blur(5px)" }}
-                      transition={{
-                        type: "spring",
-                        stiffness: 200,
-                        damping: 25,
-                      }}
-                      onSubmit={handleSubmitEmail}
-                      className="p-6 space-y-6 h-full flex flex-col justify-center"
-                    >
-                      <div className="space-y-2">
-                        <label
-                          htmlFor="portal-email"
-                          className={`${cormorant.className} block text-[10px] uppercase tracking-[2.5px] text-[var(--bz-accent-warm)] font-bold`}
-                        >
-                          Corporate Email
-                        </label>
-                        <input
-                          id="portal-email"
-                          type="email"
-                          name="email"
-                          autoComplete="username"
-                          autoCapitalize="none"
-                          spellCheck={false}
-                          value={email}
-                          onChange={(e) => setEmail(e.target.value)}
-                          onFocus={() => play("focus")}
-                          disabled={!isHydrated || loginStage !== "idle"}
-                          placeholder="client@company.com"
-                          required
-                          autoFocus
-                          className="w-full rounded-xl px-4 py-4 text-[13px] outline-none transition-all bg-[var(--bz-base)] border border-[var(--bz-border)] text-[var(--tx-primary)] placeholder:text-[var(--tx-tertiary)] focus:border-[var(--bz-copper)] focus:ring-2 focus:ring-[color-mix(in_srgb,var(--bz-copper)_25%,transparent)] disabled:opacity-50 disabled:cursor-not-allowed"
-                        />
-                      </div>
-
-                      <motion.button
-                        whileHover={{ scale: 1.01 }}
-                        whileTap={{ scale: 0.98 }}
-                        type="submit"
-                        disabled={
-                          !isHydrated || loginStage !== "idle" || !email.trim()
-                        }
-                        className="w-full py-4 rounded-xl text-[13px] tracking-[0.08em] uppercase font-bold relative overflow-hidden"
-                        style={LOGIN_CTA_STYLE}
-                      >
-                        Pass the Portal →
-                      </motion.button>
-                    </motion.form>
-                  ) : (
-                    <motion.form
-                      key="pin-step"
-                      initial={{ opacity: 0, x: 30 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      exit={{ opacity: 0, x: 30 }}
-                      transition={{
-                        type: "spring",
-                        stiffness: 200,
-                        damping: 25,
-                      }}
-                      onSubmit={handleLogin}
-                      className="p-6 space-y-6 h-full flex flex-col justify-center"
-                    >
-                      <div className="space-y-2">
-                        <div className="flex justify-between items-center">
-                          <label
-                            htmlFor="portal-pin"
-                            className={`${cormorant.className} block text-[10px] uppercase tracking-[2.5px] text-[var(--bz-accent-warm)] font-bold`}
-                          >
-                            Access PIN
-                          </label>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              playClickSound();
-                              setStep("email");
-                            }}
-                            className="text-[11px] text-[var(--bz-accent-warm)] hover:underline transition-colors"
-                          >
-                            ← {email.split("@")[0]}
-                          </button>
-                        </div>
-                        <input
-                          id="portal-pin"
-                          type="password"
-                          name="password"
-                          autoComplete="current-password"
-                          inputMode="numeric"
-                          aria-describedby={
-                            errorMessage ? "portal-login-error" : undefined
-                          }
-                          aria-invalid={loginStage === "denied"}
-                          value={pin}
-                          onChange={(e) => {
-                            setPin(e.target.value);
-                            if (
-                              e.target.value.length === 6 &&
-                              typeof window !== "undefined" &&
-                              "vibrate" in navigator
-                            )
-                              navigator.vibrate(20);
-                          }}
-                          onFocus={() => play("focus")}
-                          disabled={loginStage !== "idle"}
-                          placeholder="••••••"
-                          required
-                          autoFocus
-                          minLength={4}
-                          maxLength={8}
-                          className="w-full rounded-xl px-4 py-4 text-[22px] text-center tracking-[14px] outline-none transition-all bg-[var(--bz-base)] border border-[var(--bz-border)] text-[var(--tx-primary)] placeholder:text-[var(--tx-tertiary)] focus:border-[var(--bz-copper)] focus:ring-2 focus:ring-[color-mix(in_srgb,var(--bz-copper)_25%,transparent)] disabled:opacity-50 disabled:cursor-not-allowed"
-                        />
-                        <div className="flex justify-end pt-1">
-                          <Link
-                            href="/portal/forgot-password"
-                            className="text-[11px] text-[var(--bz-accent-warm)] hover:underline transition-colors"
-                          >
-                            {t("portal.login.forgot_password")}
-                          </Link>
-                        </div>
-                      </div>
-
-                      <motion.button
-                        whileTap={{ scale: 0.98 }}
-                        type="submit"
-                        disabled={
-                          loginStage !== "idle" ||
-                          pin.length < 4 ||
-                          pin.length > 8
-                        }
-                        aria-label={
-                          loginStage === "authenticating"
-                            ? "Verifying identity"
-                            : "Verify Identity"
-                        }
-                        className={`w-full py-4 rounded-xl text-[13px] tracking-[0.08em] uppercase flex items-center justify-center gap-2 font-bold transition-all ${loginStage !== "idle" ? "opacity-70 cursor-not-allowed" : ""}`}
-                        style={LOGIN_CTA_STYLE}
-                      >
-                        {loginStage === "authenticating" ? (
-                          <Loader2
-                            className="w-5 h-5 animate-spin"
-                            aria-hidden="true"
-                          />
-                        ) : (
-                          "Verify Identity"
-                        )}
-                      </motion.button>
-
-                      <div className="pt-3 text-center">
-                        <Link
-                          href="/portal/magic-link"
-                          className="text-[11px] uppercase tracking-[2px] text-[var(--bz-accent-warm)] hover:underline transition-colors"
-                        >
-                          Sign in with an email link instead
-                        </Link>
-                      </div>
-                    </motion.form>
-                  )}
-                </AnimatePresence>
-              </div>
-
-              <div className="px-6 pb-6 text-center text-[10px] leading-relaxed text-[var(--tx-secondary)]">
-                No PIN? Check your invitation email or contact support.
-              </div>
-            </div>
-          </motion.div>
-
-          <motion.p
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 1.5, duration: 2 }}
-            className={`${cormorant.className} text-center mt-6 text-[9px] tracking-[3px] uppercase text-[var(--tx-secondary)] font-bold`}
-          >
-            Bali Zero · Private Client Portal
-          </motion.p>
+      {/* The one forest surface of the portal. No personal data before auth. */}
+      <aside className="r19-hero" aria-label="Bali Zero">
+        <span className="r19-brand">
+          <BZLogo variant="mark" size={28} priority />
+          <span className="r19-brand-text">
+            <span className="r19-brand-name r19-serif">Bali Zero</span>
+            <span className="r19-brand-role r19-eyebrow">Client portal</span>
+          </span>
+        </span>
+        <div>
+          <div className="r19-hero-rule" aria-hidden="true" />
+          <h2 className="r19-serif">
+            Your Bali file,
+            <br />
+            kept in order.
+          </h2>
+          <p className="r19-hero-lede">
+            Visas, company, taxes and documents — one place, one team, and
+            always a clear next step.
+          </p>
         </div>
-      </div>
+        <div className="r19-hero-foot r19-eyebrow">
+          <span>my.balizero.com</span>
+          <span>Denpasar · Bali</span>
+        </div>
+      </aside>
+
+      {/* The existing two-step flow: email, then the PIN. */}
+      <section className="r19-form" aria-label="Sign in">
+        {step === "email" ? (
+          <form className="r19-box" onSubmit={handleSubmitEmail}>
+            <div className="r19-steps" aria-hidden="true">
+              <i className="on" />
+              <i />
+            </div>
+            <p className="r19-eyebrow">Sign in · step 1 of 2</p>
+            <h1 className="r19-serif">Welcome back.</h1>
+            <p className="r19-hint">
+              Enter the email registered with Bali Zero. We will ask for your
+              PIN next.
+            </p>
+            <div className="r19-field">
+              <div className="r19-field-head">
+                <label className="r19-eyebrow" htmlFor="portal-email">
+                  Corporate Email
+                </label>
+              </div>
+              <input
+                id="portal-email"
+                type="email"
+                name="email"
+                autoComplete="username"
+                autoCapitalize="none"
+                spellCheck={false}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                onFocus={() => play("focus")}
+                disabled={!isHydrated || loginStage !== "idle"}
+                placeholder="client@company.com"
+                required
+                autoFocus
+                className="r19-input"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={!isHydrated || loginStage !== "idle" || !email.trim()}
+              className="r19-btn"
+              style={LOGIN_CTA_STYLE}
+            >
+              Continue
+            </button>
+            {alternatives}
+            {formFooter}
+          </form>
+        ) : (
+          <form className="r19-box" onSubmit={handleLogin}>
+            <div className="r19-steps" aria-hidden="true">
+              <i className="on" />
+              <i className="on" />
+            </div>
+            <p className="r19-eyebrow">Sign in · step 2 of 2</p>
+            <h1 className="r19-serif">Welcome back.</h1>
+            <p className="r19-hint">
+              Enter the PIN from your invitation email.
+            </p>
+            <div className="r19-field">
+              <div className="r19-field-head">
+                <label className="r19-eyebrow" htmlFor="portal-pin">
+                  Access PIN
+                </label>
+                <button
+                  type="button"
+                  onClick={() => {
+                    playClickSound();
+                    setStep("email");
+                  }}
+                  className="r19-back"
+                >
+                  ← {email.split("@")[0]}
+                </button>
+              </div>
+              <input
+                id="portal-pin"
+                type="password"
+                name="password"
+                autoComplete="current-password"
+                inputMode="numeric"
+                aria-describedby={
+                  errorMessage ? "portal-login-error" : undefined
+                }
+                aria-invalid={loginStage === "denied"}
+                value={pin}
+                onChange={(e) => {
+                  setPin(e.target.value);
+                  if (
+                    e.target.value.length === 6 &&
+                    typeof window !== "undefined" &&
+                    "vibrate" in navigator
+                  )
+                    navigator.vibrate(20);
+                }}
+                onFocus={() => play("focus")}
+                disabled={loginStage !== "idle"}
+                placeholder="••••••"
+                required
+                autoFocus
+                minLength={4}
+                maxLength={8}
+                className="r19-input r19-pin"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={
+                loginStage !== "idle" || pin.length < 4 || pin.length > 8
+              }
+              aria-label={
+                loginStage === "authenticating"
+                  ? "Verifying identity"
+                  : "Verify Identity"
+              }
+              className="r19-btn"
+              style={LOGIN_CTA_STYLE}
+            >
+              {loginStage === "authenticating" ? (
+                <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+              ) : (
+                "Verify Identity"
+              )}
+            </button>
+            {alternatives}
+            {formFooter}
+          </form>
+        )}
+      </section>
     </div>
   );
 }

--- a/apps/mouth/src/app/portal/login-upgraded/page.tsx
+++ b/apps/mouth/src/app/portal/login-upgraded/page.tsx
@@ -44,12 +44,11 @@ const R19_STYLES = `
 .r19-hero{background:var(--r19-forest);color:var(--r19-paper);display:flex;flex-direction:column;justify-content:space-between;gap:32px;padding:40px 48px}
 .r19-brand{display:flex;align-items:center;gap:10px}
 .r19-brand-text{display:flex;flex-direction:column}
-.r19-brand-name{font-size:17px;line-height:1;font-weight:500;letter-spacing:-0.01em}
-.r19-brand-role{margin-top:5px;color:rgba(247,244,238,0.6)}
+.r19-brand-role{color:rgba(247,244,238,0.72)}
 .r19-hero-rule{width:56px;height:3px;border-radius:2px;background:var(--r19-copper);margin-bottom:22px}
 .r19-hero h2{margin:0;font-size:clamp(40px,4vw,56px);line-height:1.04}
 .r19-hero-lede{margin:20px 0 0;max-width:34ch;font-size:15px;color:rgba(247,244,238,0.78)}
-.r19-hero-foot{display:flex;justify-content:space-between;gap:16px;color:rgba(247,244,238,0.55)}
+.r19-hero-foot{display:flex;justify-content:space-between;gap:16px;color:rgba(247,244,238,0.72)}
 
 .r19-form{display:flex;flex-direction:column;justify-content:center;align-items:center;padding:48px 32px}
 .r19-box{width:100%;max-width:400px}
@@ -74,6 +73,7 @@ const R19_STYLES = `
 .r19-alt-sep{border-top:1px solid var(--r19-line);margin:6px 0}
 .r19-quiet{color:var(--r19-muted)}
 .r19-formfoot{margin-top:40px;display:flex;gap:16px;font-size:12px;color:var(--r19-muted);font-variant-numeric:tabular-nums}
+.r19-formfoot a{display:inline-flex;align-items:center;min-height:24px}
 .r19-formfoot a:hover{text-decoration:underline}
 
 .r19-overlay{position:absolute;inset:0;z-index:50;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:24px;text-align:center;background:color-mix(in srgb, var(--r19-paper) 92%, transparent);backdrop-filter:blur(8px)}
@@ -340,9 +340,8 @@ function UpgradedLoginPageInner() {
       {/* The one forest surface of the portal. No personal data before auth. */}
       <aside className="r19-hero" aria-label="Bali Zero">
         <span className="r19-brand">
-          <BZLogo variant="mark" size={28} priority />
+          <BZLogo variant="full" size={36} priority />
           <span className="r19-brand-text">
-            <span className="r19-brand-name r19-serif">Bali Zero</span>
             <span className="r19-brand-role r19-eyebrow">Client portal</span>
           </span>
         </span>

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
@@ -1,0 +1,40 @@
+gear: 2
+ruling: RULED 2026-09-12 SAETTA
+mission: SAETTA-R19P window W5 (BLUE, host M5) — the client-portal sign-in page becomes concept F's split gate
+objective: >-
+  apps/mouth/src/app/portal/login-upgraded/page.tsx was 1575 lines of night
+  scene: an SVG candi-bentar gate, three animated starfield layers, a moon, a
+  passage glow, a framer-motion spotlight glass card and a block of
+  attribute-selector CSS whose only job was to re-light that illustration for
+  the day theme. Replace the whole presentation with concept F ("RAPI"):
+  a forest left panel carrying the real Bali Zero mark, the serif hero
+  "Your Bali file, kept in order." and one lede; a paper right panel carrying
+  two step ticks, "Welcome back.", the email/PIN field, one forest button and
+  the two existing alternative sign-in paths as copper text links. Keep the
+  two-step state machine, publicAuth.login, the HTTP-status -> i18n error map,
+  the hydration guard, the rate-limit handling, the overlays with their
+  role=status / role=alert, the sound and haptics calls, and the CSP
+  expectations, all unchanged. Declare the "my" product persona at mount so the
+  sign-in page sits on the same token seam as the authenticated portal.
+scope:
+  - apps/mouth/src/app/portal/login-upgraded/page.tsx
+  - apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+  - apps/mouth/src/app/portal/login-upgraded/error.tsx
+constraints:
+  - PRESENTATION ONLY — no route, no field, no hook, no fetch, no API type, no i18n key removed, no behavioural change.
+  - Forbidden — magic-link, forgot-password and register pages, publicAuth, i18n JSON, middleware, csp.test.ts (must pass unchanged), globals.css and every shared primitive.
+  - No red hex and no --state-danger fill in what is written; forest is the only primary-button fill; copper is text, numeral and outline only.
+  - No client PII — synthetic identities only.
+  - No ledger PR, no PENDING-ARMS.md edit (SAETTA rule 2).
+acceptance:
+  - A1 git diff origin/main --stat <= 4 files, all under login-upgraded/; net lines negative or <= 400 added.
+  - A2 npx vitest --run src/app/portal/login-upgraded green (page.test.tsx + csp.test.ts), with the origin/main test-case count preserved.
+  - A3 no <svg illustration blocks remain except icons <= 24px; no red hex; the primary button fill is forest.
+  - A4 typecheck + eslint green.
+  - A5 dev-server screenshots of /portal/login at 1440x900 and 390x844, step 1 and step 2, saved under the mission build directory and compared against concepts/concept-F/01-entry.*.png.
+consumer_map:
+  - The live my.balizero.com/portal/login sign-in page served by the apps/mouth Vercel deploy on merge to main — the 308 route /portal/login lands on this component.
+  - The required GitHub check "Frontend Tests (Next.js) (mouth, true)", which runs page.test.tsx and csp.test.ts on every future PR touching this route.
+appetite:
+  budget: 75 minutes active, 1 PR
+  stop_loss: three reds on the same cause suspends; a harness-caused red is reported, never cured by rebuilding the branch

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
@@ -1,4 +1,4 @@
-gear: 2
+gear: 3
 ruling: RULED 2026-09-12 SAETTA
 mission: SAETTA-R19P window W5 (BLUE, host M5) — the client-portal sign-in page becomes concept F's split gate
 objective: >-

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/council/codex-gpt-5.6-sol.txt
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/council/codex-gpt-5.6-sol.txt
@@ -1,0 +1,6353 @@
+Reading additional input from stdin...
+OpenAI Codex v0.154.0
+--------
+workdir: /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+model: gpt-5.6-sol
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 01a097c5-c76c-7f53-a940-58892145704c
+--------
+user
+Independent correctness review of a presentation-only refactor of a Next.js client-portal sign-in page (apps/mouth/src/app/portal/login-upgraded/ plus three locator updates in apps/mouth/e2e/portal-prodlike-smoke.spec.ts). The unified diff against the merge base is in the file /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff (read it; the post-change sources are in this checkout). Verify, citing file:line: (a) the two-step email→PIN state machine, the publicAuth.login call, the HTTP-status→i18n error mapping, the rate-limit retry-after handling, the hydration guard, the success/denied overlays with role=status/alert, and every data-testid the tests use are behaviourally unchanged; (b) no i18n key removed, no route changed, no new dependency; (c) the tests in page.test.tsx still assert the same behaviours; (d) any accessibility regression (focus, contrast, target size) or any red colour introduced. Do not modify any file. End with exactly one line: VERDICT: OK or VERDICT: DEFECT — followed by the defects, if any, as file:line + one sentence each.
+hook: SessionStart
+hook: SessionStart
+hook: SessionStart Completed
+hook: SessionStart Failed
+hook: UserPromptSubmit
+hook: UserPromptSubmit Completed
+codex
+[Air-M5] Avvio una revisione indipendente e sola lettura. Missione BLUE, seat esterno prepare-only (non Dux), mandato `r19p-w5-council`, worktree `/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5`. Userò il protocollo di differential review per verificare diff, sorgenti e test con riferimenti file:riga.
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "pwd && hostname && sed -n '1,240p' .claude/skills/modus/SKILL.md && sed -n '1,240p' /Users/balizero/.agents/skills/stadio-zero/SKILL.md && sed -n '1,260p' /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/SKILL.md" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 379ms:
+/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+Air-M5
+---
+name: modus
+description: "USE FOR EVERY non-trivial mandate — feature, fix, refactor, research, audit, ops, content. TRIAGE into a gear (1/2/3), drive GROUND→BUILD→VERIFY→SHIP→CAPTURE. SKIP true one-liners — declare it."
+---
+
+## Notes (moved from description 2026-09-02)
+
+Full stage list: GROUND → DESIGN → BUILD → VERIFY → SHIP+ARM → PROVE-LIVE → ALIGN-FLEET → CLEAN → CAPTURE. Routes the full arsenal at maximum-without-waste: Opus 5 xhigh effort architect + sequential final on-disk gate as an independent-verifier assignment on the Opus 5 xhigh seat (two imperators Fable 5.1/Astra, two generals Opus 5/Sol, temporary Dux — RULED 2026-09-06→08, `docs/architecture/dual-consul/army-map.md`; Fable 5.1 only as the owner-opened imperator window, never auto-routed), Sonnet 5 implementers, Codex GPT-5.6 red-team+sandbox, Gemini agy constructive width, Kimi K3 permanent refuter, Ollama local for PII, NotebookLM ground-truth. Supersedes opus-mythos (2026-07-02): Fable is native again — the width-surrogate retires; its deep/wide TAC patterns live on as Gear 3. Declare a skip as: "GEAR 1: <why>".
+
+# MODUS — the master loop (request → prod → fleet → clean → learned)
+
+> **Lineage.** `research/operations/2026-06-30-claude-code-perfect-session-doctrine.md` is the
+> LAW (4 failure axes + 7 session-organs + 3 disciplines, adversarially validated). This skill is
+> the LOOP that executes those laws across the whole **task arc** — a task may span sessions,
+> machines and days; the doctrine's organs stop at session CLOSE, modus does not stop until the
+> change is **live in prod, propagated to the fleet, cleaned up after, and learned from**.
+> Born 2026-07-02: Fable 5 returned (Mythos-class native), Sonnet 5 exists. The doctrine explains
+> WHY; modus tells you WHAT TO DO NEXT. Council-reviewed at birth (Codex red-team + Gemini
+> costruttivo; the former DeepSeek seat is retired after repeated live HTTP-402 probes).
+
+> **The one line:** _triage before ceremony; ground before reasoning; isolate before building;
+> probe the work, not the proxy; armed is not built; live is not merged; the fleet is not one
+> machine; clean after yourself; write down what bit you._
+
+---
+
+## STAGE 0 — TRIAGE: pick the gear (the anti-sperpero brain)
+
+**Before the gear, the COLOUR** (PARABELLUM, RULED 2026-09-10 — `docs/rules/RULINGS.md`). Zero
+declares it with Fable 5.1 and Astra at mission start, and it is the ONLY axis on which this loop
+differs. **The colour table lives in `docs/architecture/dual-consul/army-map.md` §1bis and is never
+copied anywhere** — read it there; every row below that says "the colour's seat" resolves against it.
+BLUE is Claude-native (Dux Opus 5, Codex spalla, fresh Opus 5 gate); ORANGE is Codex-native (Dux Sol,
+Claude spalla via `claude` CLI OAuth, Terra implementer, fresh Sol gate). No automatic colour
+fallback: a dead seat SUSPENDS, it never turns the mission the other colour, and an undeclared
+mission is BLUE. **One window = one mandate = one organ = one worktree**, never two on the same path,
+two or three at a time at most; open against `.claude/skills/modus/battle-window-spec.md` and state
+colour, Dux role, mandate id and worktree before executing.
+
+Classify the mandate from its text + the loop ledgers — a PROVISIONAL gear, announced in 1 line:
+`GEAR <n>: <mandate> — <why this gear>`. GROUND then confirms or RE-GEARS it: the gear is
+falsifiable, not a vow — blast-radius is often unknowable before reading, and under-gearing
+tasks that merely look small is the systematic failure mode. Read the ledgers:
+`.claude/skills/modus/PENDING-ARMS.md` (anything suspended from previous runs that this task
+touches?) — AMENDMENTS.md is maintained at CAPTURE, read by the bench.
+
+Before creating an evidence pack, compute its directory; never derive it by hand:
+`python3 scripts/ci/evidence_paths.py --ref "$(git rev-parse --abbrev-ref HEAD)"`.
+Write its sibling `brief.yml`, `pack.yml`, and optional `journal.jsonl` under the emitted
+`evidence/<YYYY-MM>/<slug>/` directory. Alongside the gear, declare an OPTIONAL `appetite:`
+block in that dated `brief.yml` — three
+ceilings, each optional: `wall_clock_hours`, `adversarial_rounds`, `tokens`.
+`scripts/evidence_pack_lint.py`'s `check_appetite_acknowledgment` (rule 14, the ONLY rule in
+the evidence-pack lane that can FAIL — every other rule there is NOTICE-only) compares them
+ex-post against `spend:` in that dated `pack.yml`; exceeding a declared ceiling with no
+non-empty `appetite_exceeded: "<reason>"` acknowledgment in the pack is a lint FAIL,
+mirroring `gear_override`'s acknowledgment discipline exactly. This is EX-POST / PR-LIFETIME
+ACCOUNTING, NEVER AN IN-FLIGHT BREAKER: the linter has no clock and no session-runtime
+access, so it cannot interrupt a live session — it only makes an overrun visible and demands
+acknowledgment after the fact. Absence of the block is silent, never a gap.
+
+| Gear                    | When                                                                                                                                                        | Effort (orchestration/TRIAGE-BUILD — the on-disk VERIFY/harness gate itself is unaffected, always `xhigh`+; see Gate taxonomy in §Arsenal)                                                                                                                                                                                                                                                      | Ceremony                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **1 · LISCIO** (smooth) | typo, rename, known-cause 1-file fix, pure question, mechanical edit                                                                                        | **`medium`** — Gear 1's ceremony is already minimal; `medium` is the matching cost lever (CLAUDE.md §5: on Opus 5, `low`/`medium` punch far above their weight), not `xhigh` by default. Sonnet 5 implementer + Opus 5 `medium` orchestrator.                                                                                                                                                   | Skip to BUILD→VERIFY→CLEAN (micro). No council, no fan-out, no Workflow, ≤1 grader dispatch. Declare the skip.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **2 · STANDARD**        | feature / fix / research with deliverable; anything producing a PR                                                                                          | **`xhigh`** — the coding/agentic sweet spot (CLAUDE.md §5).                                                                                                                                                                                                                                                                                                                                     | Full loop, solo-orchestrator. 1 adversarial spalla (independent reviewer, LLM ≠ author) at VERIFY. Subagents only for independent READS or ≥3 parallel well-specified units.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **3 · PROFONDO** (deep) | deep/wide audit (TAC), architectural decision, migration, cross-system investigation, pre-deploy critical path, client quotes, "vai da solo e non fermarti" | **`xhigh`** by default; **`max` is opt-in ONLY on a declared Gear-3 adjudication, never a blanket default** (RULED 2026-08-20/08-21, CLAUDE.md §5) — effort is the primary cost/latency lever on Opus 5 (~86% of output tokens measured as thinking, `research/operations/2026-08-21-token-ceremony-ci-system-audit.md`), rigor comes from the gate itself, not from spending `max` everywhere. | Full loop + Workflow-tool orchestration + the TAC patterns (ex opus-mythos): decompose by ANATOMY not to-do; hunt the SECOND-ORDER pattern (the malattia-delle-malattie — a MANDATORY "§Meta-pattern" section in the deliverable report: what repeats across the findings, which single defective belief generates them); cure-while-diagnosing (spawn fixers for clear+low-risk+in-perimeter findings — in their OWN worktrees, only after the evidence they touch is snapshotted in the report; never mutate a surface still under diagnosis); stop at the operator boundary (a "§Solo-operatore" section in the report: physical / strategic / operator-only actions). Council only if its gate fires (the anti-sperpero rules under TRIAGE). |
+
+**Anti-sperpero rules (BUDGET made a router):**
+
+- **Council is NOT automatic at Gear 3.** Convene it only if ALL THREE: divergent priors can change
+  the answer ∧ error costs >15× tokens ∧ genuinely parallel breadth. Else: solo + more reasoning
+  budget + 1 red-team spalla (evidence: 1 agent with 10× budget beats homogeneous debate at ⅓ cost).
+- Fan-out only when items ≥3 and independent. Fan-out for READS, funnel-in for WRITES.
+  Subagents can spawn their own subagents (v2.1.172, chains capped at 5 levels): at Gear 3 one
+  coordinator subagent per anatomical organ may fan out its own readers, keeping the orchestrator
+  context clean — but the declared budget shape counts DESCENDANTS, not just direct children
+  (`/agents` shows the tree).
+- Prefer one agent + more budget over N agents (coding barely parallelizes — Anthropic/Cognition).
+- Cache-aware waiting (session polling only — the cadence for an external system matches THAT
+  system's rate of change): ≤270s (inside the prompt-cache window) or commit to 1200s+; never ~300s.
+- Stop-loss: at Gear 3 declare the budget shape up front ("~N agents, ~1 council").
+- Escalate gear mid-flight if the terrain grows (RECONCILE); NEVER de-escalate silently — say it.
+- **The FLOOR is enforced by `harness-floor.yml`; the CEILING is enforced too** (`compute_ceiling()`
+  in `scripts/evidence_pack_lint.py`, PR #4474): a docs/ledger-only diff, or a ≤2-file/≤60-net-line
+  diff outside hot zones, is Gear-1-shaped by construction — declaring it Gear 3 with a council or
+  ≥3 grader dispatches FAILS the lint unless the dated `pack.yml` carries a `gear_override:` naming
+  the reason (then it's a NOTICE, not a fail). The ceiling never overrides the floor — a hot-zone
+  hit still floors at Gear 3 regardless of how small the diff looks.
+
+---
+
+## THE STAGES (1→9)
+
+| #   | Stage           | Goal                    | Driver                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | The PROBE (what proves it, not what claims it)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Scars killed          |
+| --- | --------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| 1   | **GROUND**      | Terrain before plan     | `/stadio-zero`: mem+scar query, hot-files verified ON DISK, PII scope, falsifiable acceptance. **Quote the applicable scar ANTIDOTE lines into your working notes** — a scar you only counted doesn't restrict you. Plus reuse-first (search existing code/world before building). **SIBLINGS, run and timestamped:** open PRs' changed paths (`gh pr list --state open --json files`), worktree leases (`python3 scripts/agent_start.py --list`), the native agent tree (`ListAgents`), and the fleet mailbox (`scripts/fleet_mail.sh <host> --list`). Another window already on your paths is a coordination act, not a race — comment there. The four outputs go in the evidence pack with their timestamp and ONE reference in `Bites:`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Every LOAD-BEARING file:line — one you are about to build on — re-executed THIS turn (current evidence for critical claims, not blanket re-reads of every citation). A path from memory/report/spec is a PHANTOM until re-grepped. A NotebookLM verdict on a number/threshold is a LEAD, not a fact, until its SOURCE DATE is compared against the date of the last official re-grounding of that layer (W90: NB-3 confirmed pre-resolution PMA caps with clean citations, indistinguishable in tone/format from a fresh verdict — the only defense is source-date vs resolution-date, never apparent answer quality). Before acting on an NLM numeric/threshold verdict, verify the NB source predates or postdates the relevant dataset provenance flag (e.g. `pma_cap_verified`/`pma_cap_note`).                                                                                                                                                                                                                                                   | #6 phantom            |
+| 2   | **DESIGN**      | Decide, adversarially   | `sota-architecture-loop` steps 0-4: frame → ground → reason → council-gate → decision. **Output = a durable spec artifact on disk** (scratchpad or `specs/` — BUILD consumes the file, not the chat memory). Operator GO for L2/L3 risk classes (AUTONOMOUS_OPS preflight). NLM is the ground-truth VERIFIER of facts here, not a reasoning seat.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | A falsifiable metric on the decision. Council verdicts are LEADS — re-verify what they attack AND what they bless (W65: even the refuter hallucinates).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | #3, groupthink        |
+| 3   | **BUILD**       | Execute, isolated       | Worktree via `scripts/agent_start.py` (main checkout read-only; hotfix-preemption gets its OWN lane — worktrees make stashing unnecessary). TDD where testable (code); for non-code deliverables the falsifiable acceptance criteria from GROUND play the test's role. `karpathy-discipline` (no silent assumptions, no collateral edits). Implementer routing → Arsenal. Leave-dirty toward siblings' files.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Tests written first fail→pass. Diff scoped to the mandate — every changed line traceable to it.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | #5 sibling            |
+| 4   | **VERIFY**      | Prove each increment    | CONTINUOUS, not close-loaded (context-anxiety makes CLOSE the worst first-verify point). Generator≠grader: `infra/workflows/verify-template.js`, `codex-second-opinion`, devils-advocate. Adversarial fixtures (edges, not happy path). Risk-proportional depth. **Pattern-fix = class-audit (W89/W70):** when the change cures one instance of a repeated pattern (auth call, hardcoded path, secret handling, env sourcing), grep ALL sibling call-sites THIS turn — fix the in-perimeter ones, write one PENDING-ARMS line per sibling left out; a cure applied to 1-of-N paths is a time bomb (#1825 cured `base_worker`, left `stream_tools` unauthed → 3 days blind); the sweep MUST include tests that ASSERT on the removed/migrated symbol (backend/tests or equivalent), not just prod call-sites — a symbol-removal that class-audits app code but skips test-source-asserts still dies in CI on a file the local subtree run never touches (AMENDMENTS 2026-07-05).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | The WORK by CONTENT (W88 blob-compare; never SHA-ancestor / timestamp / substring / exit-code). A FRESH session on the mission COLOUR's gate seat (army-map §1bis: Opus 5 xhigh in BLUE, Sol xhigh in ORANGE), outside the contribution chain, does the last grep (RULED 2026-09-06→08 and 2026-09-10; Fable 5.1 only as the owner-opened imperator window) — never delegable, never cascadable, never cross-colour; it SIGNS and never arms or alters the candidate, and its receipt carries mission id, colour, HEAD sha, gate thread id, commands with exit codes, verdict: the final gate is an EMPIRICAL disk/live check, not a quality opinion (quality already had its independent grader; empiricism needs execution, not heterogeneity). Before blessing any subagent's "done" — load `final-gate-discipline` skill and answer its 5 questions (who calls it, what else describes it, what will expire, does the probe know how to say yes, where does the work actually live) with a command run THIS turn, not the subagent's self-report. | #2, #6, #9, W89       |
+| 5   | **SHIP+ARM**    | Land it end-to-end      | **Re-run the SIBLING check before you push** (same four probes as GROUND — an hour of building is enough for another window to land on your paths). Atomic commits (conventional msg + co-author). The RELEASE OWNER is the mission's Dux on the colour's seat (army-map §1bis): the Dux Opus 5 in BLUE, the appointed Dux Sol in ORANGE (RULED 2026-09-10) — the gate never releases, in either colour. PR — opened only AFTER VERIFY passed, so **arming `gh pr merge --auto --squash` immediately** (standing rule 2026-06-25) never merges unreviewed work, by construction (exceptions → operator merges: guardrails, config-critical, migrations, force-push). Before arming, confirm the diff's author didn't exceed a review-only mandate (`final-gate-discipline` skill — scar 2026-08-03, a subagent dispatched to red-team a draft instead self-orchestrated a whole pipeline, committed, opened this class of PR, and armed it unsupervised): a subagent that committed/opened/armed on its own initiative is a governance finding to contain, not content to ship as-is. **Derived contracts travel IN the commit you arm on (W86):** if the diff moves a DOCSYNC-counted surface (backend tests/routers/services), run `python scripts/docs_sync.py` and fold the regen into the SAME commit BEFORE arming `--auto` — with `--auto` there is no 'later': merge fires at first green and any post-arm commit is orphaned. Bump already missing on a pushed PR → open a 1-line repair PR (like #1672), never re-push racing the merge. CI watch async — fire-and-sleep, never busy-wait; merge-train awareness on strict CI. **Deploy follows MERGE** — main is the only deployable ref (Vercel auto-deploys main; `fly deploy` runs from post-merge main via `nuzantara-deploy`; never deploy an unmerged branch). **Capture a pre-deploy baseline** (public health, key endpoints, log tail) so the post-deploy delta is attributable; **migrations get a post-deploy DB-state probe BEFORE public exposure** (upgrade applied? schema as expected?). Then the **ARMED reconciliation**: merged? deployed? installed? loaded? env propagated? cron armed? — anything built-but-not-armed = **SUSPENDED: write a line in `.claude/skills/modus/PENDING-ARMS.md`** (the W81 ledger — read back at every TRIAGE). | Each arming step probed by its own state (PR state=MERGED; `fly status`; `launchctl print` exit AND log content), not by "I ran the command".                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | W81, W86, #7          |
+| 6   | **PROVE-LIVE**  | Done = live in prod     | curl/smoke on the PUBLIC domain against the pre-deploy baseline; runtime state; READ THE OUTPUT/log, not the exit code. Post-deploy browser QA when frontend. **Probe FAILS → STOP-THE-LINE**: no CLEAN, no CAPTURE-as-done — rollback (`fly releases` / revert PR / flag off / migration backout), keep the branch alive, escalate to the operator if prod isn't restored; a broken prod outranks every downstream stage. What cannot be proven this turn (cron liveness, async jobs, propagation) → a DURABLE RECEPTOR + reconciliation at the next boundary — never a fake this-turn check.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | The feature observed working in production, by content. Green ≠ working. `✔ Connected` = TCP handshake, not auth — run `SELECT 1`. A producer's own log/counter is STILL a proxy (W89: '56 harvested' printed every cycle while the stream stayed frozen 69.5h) — prove by the DOWNSTREAM state-delta: stream length / row count / artifact content, before vs after.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | #2, 503-RAG, W87, W89 |
+| 7   | **ALIGN-FLEET** | 3 machines = 1 organism | M5/Pro/Mini — MAIN checkouts only (per-task worktrees are exempt; never disturb a sibling's live session: dirty main or active session on a node → skip + `PENDING-ALIGN:<machine>`, never stash/checkout someone else's state): `git pull --ff-only` on siblings (Pro first); restart consumers of changed code; skill/symlink liveness; HOME-fork lint (`cmp -s` repo-vs-live for anything executed from $HOME); plist/TCC liveness where launchd touched (W84: exit-code green can mask TCC death — read the log). Machine-aware paths (`balizero` on M5, `nuzantara` on Pro/Mini). **Partial fleet: if a sibling is unreachable, write `PENDING-ALIGN:<machine>` to PENDING-ARMS.md and PROCEED — never block the loop on a dead node.**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `git rev-parse HEAD` identical on all reachable MAIN checkouts; restarted consumers show a fresh heartbeat/log line, not just a PID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | #1, #10, W84          |
+| 8   | **CLEAN**       | Deep hygiene            | Worktree reap only at 3-AND (no live process ∧ no active lease ∧ content-on-main). **Branch delete only after BOTH: PROVE-LIVE passed AND content-on-main verified by BLOB-per-file** (W88 — the three-dot diff lies post-squash; a failed prod verification needs the branch alive for rollback). Scratchpad purged. Leases released. Background tasks stopped. `git status` clean OR leave-dirty declared with owner+reason.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `git worktree list` back to baseline; no zombie branch of this task; no orphaned process.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | #5, W62/W80, W88      |
+| 9   | **CAPTURE**     | Learn, then close       | `mem save` (decision 8-10, discovery 7-8 — don't ask, save). `scar` + superscar family if a trauma occurred. Research capture if ≥400 words + ≥3 sources. **AMENDMENTS entry if the LOOP ITSELF misfired** (wrong gear, wasted council, skipped probe that bit — see Self-refinement). Close line: `result:` / `needs input:` / `failed:` — self-contained.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | The memory/scar exists on disk after writing (re-`ls` it — Write can succeed and the file still vanish).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | memory-loss, W78      |
+
+---
+
+## STATE & RE-ENTRY (tasks outlive sessions)
+
+- **Durable state lives in files, not in the window:** the DESIGN spec artifact, PENDING-ARMS.md,
+  the worktree itself. If it matters past this turn, it is on disk.
+- **A "durable receptor" is one of three CONCRETE mechanisms, never an abstract intention:**
+  (1) a PENDING-ARMS.md line — reconciled at every TRIAGE; (2) a SessionStart hook injecting live
+  state at boot (escalations / organism receptors); (3) a harness background task — completion
+  re-invokes the loop — CAVEAT (v2.1.193): the harness auto-reaps IDLE background shells under
+  memory pressure, so receptor (3) is no longer guaranteed-durable on RAM-tight nodes (Mini 24GB);
+  for a load-bearing monitor set `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP=1` (Monitor-kind
+  tasks are exempt), or carry the proof on receptor (1) PENDING-ARMS instead. When you defer a proof, NAME which receptor carries it. A receptor whose HEALTHY output is silence must expose a self-probe that distinguishes healthy-silent from dead (a `--selftest` mode or synthetic-item injection), and a proof-of-armed may NEVER be 'silence observed' — a fail-open snapshot receptor is W84 green-but-dead by construction otherwise.
+- **On wake** (sleep, compaction, quota reset, session resume): emit a dense recap block
+  (done / verified-live / next) **and re-run a light GROUND** — re-verify the hot files on disk
+  before resuming the interrupted stage. The disk may have moved while you slept.
+- **Preemption** (a Gear-1 hotfix interrupts a Gear-3 task): park the current worktree as-is
+  (it is isolated by construction), run the hotfix in its own lane, return via the recap block. `/cd` (v2.1.169) can relocate THIS session into the hotfix worktree
+  and back without rebuilding the prompt cache (the new dir's CLAUDE.md is appended, not
+  substituted) — preemption no longer forces a fresh session or a cache rebuild.
+- **Quota exhaustion:** implementation seats may cascade (Arsenal). **The final gate may NOT** —
+  if the gate's window on the colour's seat dies mid-task (Opus 5 in BLUE, Sol in ORANGE), the task SUSPENDS (PENDING-ARMS line + wakeup after
+  reset), it does not hand the last grep to a weaker judge (nor to Fable — Fable 5.1 is the owner-opened imperator window, never a gate seat, RULED 2026-09-06→08). Availability-death >24h (regulatory, not
+  quota) → escalate to the operator instead of waiting on a receptor that may never fire.
+
+---
+
+## THE ARSENAL — routing v2 (the Fable-5 inversion)
+
+**The inversion.** opus-mythos dispatched external AIs to _surrogate the width Fable wasn't there
+to provide_ (~75% strategy / ~25% power, the 25% prosthetic). Fable is here. External AIs now
+serve what they are GENUINELY better for: **(a) heterogeneity** — adversarial gates need different
+training priors; a Claude judging Claude is self-approval in costume; **(b) quota economics** —
+MAX windows are finite, subscriptions are flat; **(c) specialized organs** — sandbox execution,
+1M-context ingestion, $0 local PII processing.
+
+| Role | Who | Invocation | When |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| **Architect · orchestrator · judge · final on-disk gate** | **The mission COLOUR's general seat — read the table in `docs/architecture/dual-consul/army-map.md` §1bis, never a copy of it: Opus 5 `xhigh` in BLUE, Sol `xhigh` in ORANGE (RULED 2026-09-10); no cross-colour fallback, a dead seat SUSPENDS.** In BLUE that is **Opus 5** (xhigh effort) as general/Dux and the mandatory seat of the final on-disk gate assignment (distinct from the independent review; no substitution without a ruling) — Fable 5.1 is an imperator window only (RULED 2026-09-06→08, `docs/rules/RULINGS.md`; owner-opened with `--model`, never auto-routed, never fan-out) | interactive session default | **All gears.** Gear 1-2 already closed on Opus 5 (ruling Zero 2026-08-19); Gear-3's final on-disk gate now does too, superseding that ruling's Fable-on-Gear-3 carve-out. NEVER delegate or cascade the last grep (W65). Window dead → SUSPEND, don't substitute. Gate-death can be regulatory, not just quota (precedent: Fable 5 was export-control-disabled 2026-06-12→30 while it held this role). Quota-death (hours) → SUSPEND per the standing rule; availability-death >24h → still no substitution, but escalate to the operator as §Solo-operatore (the organism must not freeze silently for weeks). |
+| **Implementer fan-out** | **Sonnet 5** (default in BLUE; in ORANGE the default is Terra `gpt-5.6-terra` and Sol implements small work directly — army-map §1bis) — task-shaped across the full roster since Zero's 2026-08-14 ruling; see `MODEL_ROSTER.md` for every model × strength × effort × door | `Agent`/`Workflow` `model:"sonnet"` (`claude-sonnet-5`) | BUILD: well-specified, parallel, testable units. Opus 5 designs, Sonnet builds, Opus 5 verifies. Sonnet is the sane default, not an obligation — grunt lanes may go Haiku/Codex-luna/Kimi-highspeed, hard lanes may go Opus-5-xhigh/Codex-sol, and a multi-PR campaign should route at least one lane through a non-Anthropic builder. |
+| **Grunt** | **Haiku 4.5** | `model:"haiku"` | Mechanical lanes inside workflows (format, extract, classify). |
+| **Red-team + empirical sandbox** | **Codex GPT-5.6** (codex-cli 0.144.6; slugs `sol`/`terra`/`luna` **DEAD 2026-07-21** — "not supported when using Codex with a ChatGPT account" after account rotation; the account's **default model** carries the seat) | `codex exec --sandbox read-only / workspace-write -c model_reasoning_effort=<level>` — **`< /dev/null` in scripts** (it blocks on open stdin); re-probe slug names before any `-m` use (PENDING-ARMS 2026-07-21) | **sol** xhigh/max = council red-team, migrations (upgrade+downgrade), high-stakes diffs · **terra** medium (its own model default) = standard second-opinion/sandbox · **luna** low/medium = mechanical/grunt lanes. `ultra` (sol/terra only) = max reasoning + auto task delegation. Legacy `gpt-5.5` (low→xhigh) still available. |
+| **Width / ingestion + costruttivo** | **Gemini via `agy`** | `agy -p` (3.5 Flash High default; 3.1 Pro for final architectural synthesis) | Corpus-scale reading; KBLI/visa/normativa search (Claude hallucinates regulations); pre-deploy red-team; council costruttivo. |
+| **Refuter (council 3rd seat + general Gear-3 ladder)** | **FLEET_TOPOLOGY v1.2 general Gear-3 chain: codex-sol → glm-5.2 → kimi-k3 → gemini-agy-redteam → deepseek-v4-pro (TP1 reserve).** GLM 5.2 is LIVE through Alibaba TP1 seat `tp1-glm-5.2`; use it for compact refutations when family-exclusion permits. | `no door: line in roster` — probe with `python3 scripts/arsenal_probe.py --seats tp1-glm-5.2`; OpenAI-compatible base `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`, key loaded by `load_tp1_settings_key()` from `~/.qwen/settings.json`. | **Family-exclusion (hard, spec §3.2):** a family that built OR counter-built on the task is excluded from ITS OWN refuter chain. Two refuters from two different families are required; probe every seat live first. GLM-as-refuter still requires GLM ≠ implementer on the same task. |
+| **Second brain (quota relief)** | **GLM 5.2 via Alibaba TP1 seat `tp1-glm-5.2` — ARMED** | `no door: line in roster`; direct OpenAI-compatible TP1 API, key loaded by `load_tp1_settings_key()` from `~/.qwen/settings.json` | When MAX OAuth windows are cap-exhausted mid-task. Implementation only — never the final gate. |
+| **Cross-family coding + width (flat sub)** | **Kimi K3 «Vivace» / kimi-for-coding 2.7** (Moonshot, Allegro subscription — Zero GO 2026-07-19; «Vivace» designation Zero 2026-07-21 after the 14h PR-queue run: 34 open → 2 drafts, 57 merged, 9 cured directly) | `kimi -p "..." -m kimi-code/k3` (reasoning/refuter) · `-m kimi-code/kimi-for-coding` (coding lanes) · `-m kimi-code/kimi-for-coding-highspeed` (grunt); bin `~/.kimi-code/bin/kimi`; probed by `arsenal_probe.py` (seat `kimi`) | Heterogeneity seat #4 for councils/second-opinion (training prior ≠ Claude/GPT/Gemini/GLM) and flat-quota implementation relief. Armed+PONG-proven on ALL THREE machines 2026-07-19 (Mini device-code authorized same day). Never the final gate. | |
+| **Third strategy voice + non-PII mass engine (TP1)** | **Qwen 3.8 Max** (Alibaba Token Plan, **ARMED 2026-08-14** — 459 calls / 74.1M tokens measured) | Qwen Code CLI (`qwen-cloud-code` seat, UNARMED pending Zero's ratification of the 2026-08-08 study) or direct OpenAI/Anthropic-compatible API against `~/.qwen/settings.json` (0600) | 3rd voice in `strategy_panel` (with Opus 5 + Gemini deepthink) and `normative_search` (the Qwen leg needs mandatory NotebookLM/Anthropic-seat verification — documented hallucination weakness on compliance-exact extraction, and our trade IS exact compliance); non-PII doc/video mass engine; fenced GUI-agent. **`eligible_for_quorum:true` since the 2026-08-14 ARMED promotion** — it IS one of the three `COUNCIL_REVIEW_SEATS` in `scripts/evidence_pack_lint.py` (R9). This row is the root cause of a contradiction that ran from 2026-08-14 to 2026-09-02: it stated the eligibility as a CONDITIONAL ("never counts ... until promoted ARMED"), the promotion then happened, and nothing walked the flipped condition back to `MODEL_ROSTER.md` or `seat_build_tp1.sh`, both of which went on asserting the pre-promotion answer as a flat fact while the lint counted the seat anyway. A conditional written where only a reader can evaluate it does not update itself — put it where a machine can, or the event that flips it must also edit every doc that restated it. |
+| **Counter-builder** | **GLM 5.2 via Alibaba TP1 seat `tp1-glm-5.2`** | `no door: line in roster`; OpenAI-compatible base `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`, key loaded by `load_tp1_settings_key()` from `~/.qwen/settings.json` | Counter-implementations for Gear-3 diffs, long-horizon refactors, and spikes. `clear_thinking:false` mandatory in agent use. Never architecture, client-facing output, final gate, or merge. |
+| **Second reasoner (refuter reserve, TP1)** | **DeepSeek v4-pro / v4-flash / v3.2** (Alibaba Token Plan, PROBATION — RE-ADMITTED 2026-08-10) | direct API via TP1 key (`~/.qwen/settings.json`, 0600) | Last hop of the refuter chain (see Refuter row above); reasoning second-opinion, math/logic chains. Re-admission is economics-only — the 2026-07-19 retirement was a dead standalone per-token balance, not a quality verdict; the Token Plan's flat credits remove the death cause. PII: vendor-parity (Zero ruling 2026-08-24: Chinese-cloud limit ABOLISHED system-wide — same common rules as Anthropic/OpenAI: Law 2 output boundary + Art. 56 basis for PROD transfers). `eligible_for_quorum:false` until promoted ARMED. |
+| **Grinder (throughput, post-PROBE-4)** | **MiniMax M2.5** (Alibaba Token Plan, PROBATION — gated on PROBE-4) | TP1 direct API | Repetitive tests/docs/mechanical batches; quality gate = a sample of every lot verified by an Anthropic seat. Not usable before PROBE-4 (MiniMax sample lot + Anthropic-seat verification) lands. |
+| **PII / offline / $0** | **Ollama** (Mini-first wrapper; local fallback) | `ollama run qwen3.5:9b`; vision `qwen2.5vl:7b`; embed `bge-m3` | Any transform whose PROMPT would carry client PII. If a cloud model must see the case: redact FIRST to `client_id`/placeholders — the gate is redaction-before-egress, not just model choice (Law 2 output boundary). |
+| **Ground truth** | **NotebookLM** (profile `default`) | `mcp__notebooklm-mcp__*` | Facts/normativa at GROUND and VERIFY: bipolar verifier — NLM verifies, it does not synthesize. Gemini = reasoning width; NLM = retrieval width. |
+
+**Kimi TP1 note:** the Token Plan also lists `kimi-k2.5`/`k2.6`/`k2.7-code` — OLDER than K3 and
+second-line redundancy only; the Allegro subscription (K3 + kimi-for-coding, row above) remains the
+load-bearing Kimi door, never displaced by the TP1 copies.
+
+**TP1 wing-wide hard NOs (spec §2.5, no exceptions):** client PII (Law 2 — PII intake is
+SEA-LION/local, never this wing), client-facing outputs (producing/certifying content that reaches
+a client — reading a diff for refutation is fine, provided real-client PII is redacted before
+egress), merge/deploy, final gates, NUZANTARA/infra credentials in the model-visible env (the
+seat's own TP1 token lives in the broker layer, outside the model's context).
+
+**Gate taxonomy (spec §4, 2026-08-10 — the drift-killer; four distinct organs called "gate",
+conflating them is the W86-class drift this table exists to prevent):**
+
+| Gate                                  | What it judges                                               | Who                                                                                                                                                                                                             | Fallback                                                                                                                                                            |
+| ------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Final on-disk gate** (modus VERIFY) | the last empirical grep/disk/live check of every task        | **Independent-verifier assignment on the Opus 5 `xhigh` seat, a Claude session outside the contribution chain — ALL gears** (RULED 2026-09-06→08: no permanent reviewer title; Fable 5.1 imperator window only) | **NONE. Never cascades to a weaker model.** All Anthropic accounts dead → task SUSPENDS (Gear-3 strictness). Gear 1-2: ordinary Opus-5 account rotation (unchanged) |
+| **WR2 content gate**                  | on-disk editorial content                                    | **Opus 5, xhigh effort** (RULED 2026-08-20 — was Fable 5, no fallback then either)                                                                                                                              | **NONE.** Window dead → SUSPEND                                                                                                                                     |
+| **Gear 2-3 harness verdict gate**     | PASS or BLOCK — the verdict a Gear 2 or 3 task ships (09-12) | **Opus 5, xhigh effort**, rotating AZ→A2→A3→A1 (RULED 2026-08-20 — was "Fable 5 first, degrade to Opus on exhaustion" per the 2026-08-09 ruling; that two-tier degradation is now moot, Opus 5 IS the seat)     | **NONE.** All Anthropic accounts dead → task QUEUES in PENDING-ARMS. Never pay                                                                                      |
+| **Gear-2 verdict**                    | standard feature PRs — gated since 2026-09-10                | Opus 5 + AI-review action + CI                                                                                                                                                                                  | ordinary cascade rules                                                                                                                                              |
+
+None of these rows route to Fable — Fable 5.1 is an owner-opened imperator window, never a gate seat (RULED 2026-09-06→08); the old "Fable-paid contingency" is moot for the same reason.
+
+**Sequencing note:** the final on-disk check (modus VERIFY) PRECEDES the harness verdict gate.
+Since RULED 2026-09-10 that gate is required from **Gear 2**, not only Gear 3 (`docs/rules/RULINGS.md`);
+the Evidence Pack it judges at Gear 3 is still a Gear-3-only demand, so a Gear-2 PR is gated on the
+verdict alone.
+Both now run on Opus 5 (RULED 2026-08-20), so there is no cross-model fallback to reason about: if
+Opus 5 is unavailable for either stage, the task suspends/queues rather than cascading to a weaker
+model. No contradiction, no bypass.
+
+**SAETTA rules (RULED 2026-09-12, `docs/rules/RULINGS.md` — the seven amendments, binding on every window from 2026-09-12):**
+
+1. Verdict binary, PASS or BLOCK; evidence-record defects are notices, never conditions; a surviving condition is discharged in the PR's own pack or the mission close row.
+2. One `PENDING-ARMS.md` row per MISSION, written by the imperator at close — no ledger PR per gated PR, healer at most daily.
+3. A window is a customer-visible slice; an infrastructure window opens only with its consumer in the same wave.
+4. The imperator opens, acks within 15 min, rules on BLOCK — nothing else; the gate is a fresh read-only subagent commissioned by the level above the Dux, 20-minute budget.
+5. Silence does not suspend: no ack in 15 min → the Dux proceeds on its declared default; the root deadline counts Dux active time only.
+6. A guarded window with a live successor is never re-enabled; first act on resume = `ListAgents`, stand down if a successor exists.
+7. A harness-caused red never rebuilds the branch: fix the harness in its own PR or waive with the reason in the pack.
+
+**Floor note:** gear classification is the DETERMINISTIC FLOOR computed from the diff (harness §1),
+recomputed by CI — never the conductor's choice. This table is not a downgrade lever: a task cannot
+be talked into Gear-2 when its diff says 3.
+
+**Merge-driver caveat (famiglia #9 pointer, discovered live on PR #3938):** GitHub's mergeability
+computation does not honor custom merge drivers (`merge=union`) — a union-file PR (e.g. two sibling
+PRs both editing `.claude/skills/modus/PENDING-ARMS.md`) can read DIRTY/CONFLICTING against a
+sibling that merged first even though local git resolves the union cleanly; cure = a LOCAL `git
+merge origin/main` (never `update-branch`, which uses GitHub's own merge and hits the same wall),
+inspect the union result, push. Since RULED 2026-09-12 (SAETTA rule 2) sibling ledger PRs do not exist by construction — one row per mission, at close.
+
+Full source: `research/operations/2026-08-10-fleet-order-spec.md` §4.
+
+**REVIEW-È-INVOCABILE (ruling Zero 2026-08-10):** "serve review" is a dispatch instruction, never a
+parking state — the conductor does not wait for graders, it CONVOKES them ("chi conduce non aspetta
+i grader: li convoca") per the role chains above the moment a diff exists to judge. Reference:
+memory `feedback_review_is_summonable_never_a_parking_reason_2026_08_10`, spec §3.2/§4.
+
+**Council composition (when the gate fires):** Phase 1 runs exactly three independent external
+seats: costruttivo = Gemini (_save it by improving it_) · red-team = Codex GPT-5.6 (_find the
+flaw; default to defective_) · refuter = Kimi K3 (_falsify the core claim_). GLM and DeepSeek do
+not sit on this fixed panel (deliberately closed by design, not because either is retired — see
+the Refuter row above for their current general-ladder status). After the orchestrator disposes
+every finding,
+Phase 2 is the sequential **final on-disk gate, an independent-verifier assignment on the Opus 5 xhigh seat** (RULED 2026-09-06→08 — was a permanent Fable, then Opus, seat)
+over the candidate bytes, all three reviews, and the disposition. The gate seat is never concurrent
+with or counted among the three external seats; gate-seat unavailable, a missing/duplicated
+external route, or an unresolved finding suspends the gate. Rounds are capped and NEVER
+consensus-seeking ("do you all agree?" generates conformity hallucinations). Verdicts are leads
+until the gate seat re-verifies them on disk.
+
+**Quota cascade (cron + subprocess):** Sonnet 5 → agy → Codex → Ollama, with a LIVE health-ping
+per tier before trusting it (grep for `out of extra usage|quota|429`, fall through on match).
+Reference: `~/scripts/regulatory-watcher-run.sh`. Cron tier-1: repo pins migrated to `claude-sonnet-5` 2026-07-03 (#1917, probed per-agent; the
+nb-agents slug micro-prompt stays 4-6); HOME wrappers armed 2026-07-03.
+
+**Claude Team org «Balizero» (2026-07-22):** new independent quota pool — `zero@balizero.com`
+premium seat is the M5 interactive default slot (≈6.25× Pro/session, TWO weekly caps: all-models +
+Sonnet-only — unlike MAX there IS a weekly ceiling, so sustained multi-day lanes exhaust it before a
+Max 20x would); Subhi + Krisna standard seats (Claude Code included, ≈1.25× Pro/session, one weekly
+cap). Per-member caps are independent. MAX slots on Pro/Mini and all cron OAuth tokens are UNCHANGED;
+decommission of ONE MAX x20 is PLANNED, not executed — remap cron/wrapper tokens first (PENDING-ARMS
+---
+name: stadio-zero
+description: STADIO-0 STUDY — the pre-task ENTRY GATE of the SOTA meta-dev-loop (FASE-0). Use BEFORE starting any non-trivial task, feature, fix, refactor, or investigation — BEFORE the first Edit/Write. Forces the GROUND upstream so the downstream doesn't pay for it: (1) memory-hits, (2) hot-files VERIFIED on disk, (3) PII-risk scope, (4) falsifiable acceptance criteria. It exists to prevent the "file:line hallucination" class of error (building a plan on a path that doesn't exist). The judgment is yours; this skill is the checklist that makes you do it. TRIGGER on "implementa / costruisci / fix / refactor / investigate / produce X" — anything that will touch code or shared state. SKIP only for true one-liners (typo, rename, known-cause fix) — and say so explicitly.
+allowed-tools: Read, Bash, Grep, Glob
+---
+
+# STADIO-0 STUDY — il gate d'ingresso
+
+> *"Errare è umano, allucinare è diabolico."* L'errore più costoso del loop non è scrivere codice
+> sbagliato — è **costruire un piano su un file:line che non esiste**. Sei pezzi a valle pagano ciò che
+> questo gate previene a monte. È l'anello mancante: lo studio del terreno PRIMA di muovere.
+
+**Costo**: 2-10 min. **Salta** SOLO per veri one-liner (typo, rename, fix a causa nota) — e dichiaralo
+in una riga ("STADIO-0 skip: task triviale, <perché>"). Per tutto il resto, i 4 passi sono il gate.
+
+L'output è un **blocco strutturato in chat** (4 sezioni sotto), il tuo ragionamento reso esplicito.
+NON un file obbligatorio (un file vuoto creato per sbloccare è reward-hacking, non studio). Per task
+grossi può diventare `research/operations/STUDY-<slug>.md`, ma è opzionale.
+
+---
+
+## I 4 passi (eseguili in QUESTO turn, non a memoria)
+
+### 1. Memory-hits — cosa sa già il passato
+
+Il context buffer NON è autoritativo. Interroga la memoria reale:
+
+```bash
+~/.claude/scripts/mem query "<keyword-del-task>"     # decisioni/scoperte/cicatrici sul dominio
+~/.claude/scripts/mem recent 10                       # lavoro recente — scova assunzioni stale
+```
+
+Sintetizza in 2-4 righe: cosa la memoria dice di rilevante per QUESTO task. Cita le cicatrici che si
+applicano (`.claude/rules/cicatrix-scars.md` — grep il dominio). Se la memoria contraddice il tuo
+piano, fermati: la memoria di solito ha ragione (è world-state passato osservato).
+
+### 2. Hot-files VERIFICATI sul disco — l'anti-allucinazione
+
+Per OGNI file che memory / spec / handoff / report citano come load-bearing, verificalo **adesso**:
+
+```bash
+ls -la <path>                 # esiste?
+sed -n '<N>p' <path>          # la riga citata dice davvero quello?
+grep -rn "<symbol>" <dir>     # il simbolo esiste dove pensi?
+```
+
+**Mai fidarsi di un path citato.** Le spec, i report multi-agente e perfino gli handoff citano path
+imprecisi o inesistenti (cicatrice "autopsy phantom file:line": 3 file:line allucinati con precisione che
+*leggeva* come ground-truth). Output: lista dei file **confermati-esistenti** (path reale) + flag
+esplicito di ogni citato-ma-assente. Registra i gate/componenti per path verificato, mai per nome-da-spec.
+
+> Se un report dice `foo.py:63` e `ls foo.py` fallisce — quello è un LEAD, non un fatto. Tratta ogni
+> citazione `file:line` di un documento come da-ri-verificare prima di costruirci sopra.
+
+### 3. Rischi-PII — il confine Law 2 (sovranità)
+
+Il task tocca dati cliente (KTP / passport / NPWP / akta / WhatsApp / CRM / OSINT) o `apps/backend-rag`?
+
+- **Sì** → confine assoluto: **nessuna PII a LLM cloud** (Symbiosis Law 2 / UU PDP). PII solo locale
+  (Ollama). Primitive di redazione: `scripts/_redact_pii.py` (+ `agent-library/config/redaction-rules.yaml`)
+  — ATTENZIONE: ha 3 bug noti (fail-open su DB-down, case-sensitivity, repo-read leak), non fidarti
+  ciecamente. Aggiungi il criterio d'accettazione "zero PII nei prompt verso cloud".
+- **No** → dichiaralo esplicito ("STADIO-0 PII: nessuno — task non tocca dati cliente"). Scope-vuoto è
+  una risposta valida, ma va detta, non assunta.
+
+### 4. Criteri-accettazione FALSIFICABILI — come saprò che è fatto
+
+Definisci come si **testa** che il task è finito, in modo binario/oggettivo — NON soggettivo:
+
+- ✅ "exit 0 di `pytest <file>`" · "endpoint risponde 401 non 503" · "N test verdi" · "`grep X` = 0 hit"
+- ❌ "il codice è pulito" · "funziona meglio" · "sembra a posto"
+
+Se non riesci a scrivere un criterio falsificabile, il task è mal-formato → riformulalo finché lo è.
+Questi criteri diventano la tua verifica finale (e, idealmente, una riga in `TaskCreate`).
+
+---
+
+## Output atteso (incolla in chat all'inizio del task)
+
+```
+## STADIO-0 STUDY — <task>
+1. Memory-hits: <2-4 righe + cicatrici applicabili>
+2. Hot-files verificati: <lista path confermati su disco | flag dei citati-assenti>
+3. PII-risk: <scope + confine Law 2, oppure "nessuno — perché">
+4. Criteri-accettazione: <1-3 check falsificabili>
+```
+
+## Famiglia (questo gate PRECEDE, non duplica)
+
+- `reuse-first` — cerca codice esistente prima di scriverne (passo dopo lo STUDY, quando costruisci).
+- `sota-architecture-loop` — per DECISIONI architetturali (STADIO-0 è per ESECUZIONE task; Step-1 ground è cugino).
+- `karpathy-discipline` — think-before / surgical / goal-driven (lo STUDY è il "think-before" reso checklist).
+- `agent-session-discipline` — worktree isolation (dopo lo STUDY, quando stai per committare).
+
+Lo STADIO-0 è il gate **a monte di tutti**: stabilisci il terreno, poi le altre discipline operano su terreno verificato.
+---
+name: differential-review
+description: "Performs security-focused differential review of code changes. Adapts analysis depth to codebase size, uses git blame for context, calculates blast radius by counting callers, checks test coverage of modified code, and generates a markdown report. Use when reviewing a PR, commit, or diff for security vulnerabilities, checking whether a change re-introduces a previously fixed bug, asking what else a change could break, or finding which modified code has no test covering it."
+allowed-tools: Read Write Grep Glob Bash
+---
+
+# Differential Security Review
+
+Security-focused code review for PRs, commits, and diffs.
+
+## Core Principles
+
+1. **Risk-First**: Focus on auth, crypto, value transfer, external calls
+2. **Evidence-Based**: Every finding backed by git history, line numbers, attack scenarios
+3. **Adaptive**: Scale to codebase size (SMALL/MEDIUM/LARGE)
+4. **Honest**: Explicitly state coverage limits and confidence level
+5. **Output-Driven**: Always generate comprehensive markdown report file
+
+---
+
+## Rationalizations (Do Not Skip)
+
+| Rationalization | Why It's Wrong | Required Action |
+|-----------------|----------------|-----------------|
+| "Small PR, quick review" | Heartbleed was 2 lines | Classify by RISK, not size |
+| "I know this codebase" | Familiarity breeds blind spots | Build explicit baseline context |
+| "Git history takes too long" | History reveals regressions | Never skip Phase 1 |
+| "Blast radius is obvious" | You'll miss transitive callers | Calculate quantitatively |
+| "No tests = not my problem" | Missing tests = elevated risk rating | Flag in report, elevate severity |
+| "Just a refactor, no security impact" | Refactors break invariants | Analyze as HIGH until proven LOW |
+| "I'll explain verbally" | No artifact = findings lost | Always write report |
+
+---
+
+## Quick Reference
+
+### Codebase Size Strategy
+
+| Codebase Size | Strategy | Approach |
+|---------------|----------|----------|
+| SMALL (<20 files) | DEEP | Read all deps, full git blame |
+| MEDIUM (20-200) | FOCUSED | 1-hop deps, priority files |
+| LARGE (200+) | SURGICAL | Critical paths only |
+
+### Risk Level Triggers
+
+| Risk Level | Triggers |
+|------------|----------|
+| HIGH | Auth, crypto, external calls, value transfer, validation removal |
+| MEDIUM | Business logic, state changes, new public APIs |
+| LOW | Comments, tests, UI, logging |
+
+---
+
+## Workflow Overview
+
+```
+Pre-Analysis → Phase 0: Triage → Phase 1: Code Analysis → Phase 2: Test Coverage
+    ↓              ↓                    ↓                        ↓
+Phase 3: Blast Radius → Phase 4: Deep Context → Phase 5: Adversarial → Phase 6: Report
+```
+
+---
+
+## Decision Tree
+
+**Starting a review?**
+
+```
+├─ Need detailed phase-by-phase methodology?
+│  └─ Read: methodology.md
+│     (Pre-Analysis + Phases 0-4: triage, code analysis, test coverage, blast radius)
+│
+├─ Analyzing HIGH RISK change?
+│  ├─ Read: adversarial.md
+│  │  (Phase 5: Attacker modeling, exploit scenarios, exploitability rating)
+│  └─ Or delegate to: differential-review:adversarial-modeler agent
+│     (Autonomous attacker modeling with concrete exploit scenarios)
+│
+├─ Writing the final report?
+│  └─ Read: reporting.md
+│     (Phase 6: Report structure, templates, formatting guidelines)
+│
+├─ Looking for specific vulnerability patterns?
+│  └─ Read: patterns.md
+│     (Regressions, reentrancy, access control, overflow, etc.)
+│
+└─ Quick triage only?
+   └─ Use Quick Reference above, skip detailed docs
+```
+
+---
+
+## Agents
+
+**`differential-review:adversarial-modeler`** — Models attacker perspectives and
+builds exploit scenarios for HIGH RISK code changes. Follows the 5-step
+adversarial methodology (attacker model, attack vectors, exploitability rating,
+exploit scenario, baseline cross-reference) and produces structured vulnerability
+reports. Delegate to this agent when Phase 5 analysis is needed on high-risk
+changes, passing that full namespaced name as `subagent_type` — a bare
+`adversarial-modeler` is unregistered and the dispatch fails at runtime.
+
+---
+
+## Quality Checklist
+
+Before delivering:
+
+- [ ] All changed files analyzed
+- [ ] Git blame on removed security code
+- [ ] Blast radius calculated for HIGH risk
+- [ ] Attack scenarios are concrete (not generic)
+- [ ] Findings reference specific line numbers + commits
+- [ ] Report file generated
+- [ ] User notified with summary
+
+---
+
+## Integration
+
+**audit-context-building skill:**
+- Pre-Analysis: Build baseline context
+- Phase 4: Deep context on HIGH RISK changes
+
+**issue-writer skill:**
+- Transform findings into formal audit reports
+- Command: `issue-writer --input DIFFERENTIAL_REVIEW_REPORT.md --format audit-report`
+
+---
+
+## Example Usage
+
+### Quick Triage (Small PR)
+```
+Input: 5 file PR, 2 HIGH RISK files
+Strategy: Use Quick Reference
+1. Classify risk level per file (2 HIGH, 3 LOW)
+2. Focus on 2 HIGH files only
+3. Git blame removed code
+4. Generate minimal report
+Time: ~30 minutes
+```
+
+### Standard Review (Medium Codebase)
+```
+Input: 80 files, 12 HIGH RISK changes
+Strategy: FOCUSED (see methodology.md)
+1. Full workflow on HIGH RISK files
+2. Surface scan on MEDIUM
+3. Skip LOW risk files
+4. Complete report with all sections
+Time: ~3-4 hours
+```
+
+### Deep Audit (Large, Critical Change)
+```
+Input: 450 files, auth system rewrite
+Strategy: SURGICAL + audit-context-building
+1. Baseline context with audit-context-building
+2. Deep analysis on auth changes only
+3. Blast radius analysis
+4. Adversarial modeling
+5. Comprehensive report
+Time: ~6-8 hours
+```
+
+---
+
+## When NOT to Use This Skill
+
+- **Greenfield code** (no baseline to compare)
+- **Documentation-only changes** (no security impact)
+- **Formatting/linting** (cosmetic changes)
+- **User explicitly requests quick summary only** (they accept risk)
+
+For these cases, use standard code review instead.
+
+---
+
+## Red Flags (Stop and Investigate)
+
+**Immediate escalation triggers:**
+- Removed code from "security", "CVE", or "fix" commits
+- Access control modifiers removed (onlyOwner, internal → external)
+- Validation removed without replacement
+- External calls added without checks
+- High blast radius (50+ callers) + HIGH risk change
+
+These patterns require adversarial analysis even in quick triage.
+
+---
+
+## Tips for Best Results
+
+**Do:**
+- Start with git blame for removed code
+- Calculate blast radius early to prioritize
+- Generate concrete attack scenarios
+- Reference specific line numbers and commits
+- Be honest about coverage limitations
+- Always generate the output file
+
+**Don't:**
+- Skip git history analysis
+- Make generic findings without evidence
+- Claim full analysis when time-limited
+- Forget to check test coverage
+- Miss high blast radius changes
+- Output report only to chat (file required)
+
+---
+
+## Supporting Documentation
+
+- **[methodology.md](methodology.md)** - Detailed phase-by-phase workflow (Phases 0-4)
+- **[adversarial.md](adversarial.md)** - Attacker modeling and exploit scenarios (Phase 5)
+- **[reporting.md](reporting.md)** - Report structure and formatting (Phase 6)
+- **[patterns.md](patterns.md)** - Common vulnerability patterns reference
+
+---
+
+**For first-time users:** Start with [methodology.md](methodology.md) to understand the complete workflow.
+
+**For experienced users:** Use this page's Quick Reference and Decision Tree to navigate directly to needed content.
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+codex
+GEAR 2: refactor dell’interfaccia di autenticazione — il diff è dichiarato presentation-only, ma il percorso auth richiede verifica puntuale. Il protocollo normalmente produrrebbe un report su disco; l’ordine esplicito “do not modify” prevale, quindi il report resterà solo in chat. PII-risk: nessuno, perché revisione di codice e test senza dati cliente. Criterio binario: parità comportamentale su tutti gli invarianti elencati, nessuna variazione a route/i18n/dependency, test mirati verdi, audit accessibilità statico senza regressioni.
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "rg -n \"mouth|portal|login-upgraded|r19p|presentation-only|hydration\" /Users/balizero/.codex/memories/MEMORY.md | head -80
+wc -l .claude/skills/modus/SKILL.md /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/SKILL.md /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/methodology.md /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/adversarial.md /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/reporting.md
+sed -n '1,220p' /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/methodology.md
+sed -n '221,520p' /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/methodology.md
+sed -n '1,260p' /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/adversarial.md
+sed -n '1,260p' /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/reporting.md" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 130ms:
+496:- the frontend ships a generated copy at `apps/mouth/data/bali-zero-prices.json`; regenerate it with `scripts/sync_frontend_prices.py` after backend catalogue changes. [Task 1]
+540:## Task 4: L4 portal / CodeQL secret storage finding
+548:- py/clear-text-storage-sensitive-data, garuda_portal_auth.py, MagicLinkStore, result_session_secret, merge ref
+1285:- shutting everything down overnight would save only about `$19-20/month` but break API/RAG availability, Drive polling, bots, portals, integration tests, and production-dependent coding agents [Task 2]
+2282:scope: browser QA of live Bali Zero CRM/client portal and process board, including WhatsApp Business, live records, browser debugging, and no-submission verification.
+3268:- `apps/mouth/src/data/services_data.ts` still contained the live Second Home catalog/FAQ strings; that is the file to patch for E35/E33 copy [Task 2]
+3407:# Task Group: /Users/balizero/Desktop/nuzantara apps/mouth KBLI Navigator search audit / fallback
+3408:scope: live KBLI search verification and visible failure handling in apps/mouth.
+3443:- `apps/mouth/src/components/kbli/KBLISearch.tsx` currently logs and clears results on error, so the UX failure is silent rather than hard-failing [Task 1] [ad-hoc note]
+3451:# Task Group: /Users/balizero/Desktop/nuzantara apps/mouth article rendering / production crash fix
+3452:scope: root-cause tracing and surgical repair of shared MDX/article render crashes in apps/mouth.
+3459:- /Users/balizero/.codex/memories/rollout_summaries/2026-07-05T20-51-42-FlpY-mouth_driving_license_foreigners_crash_fix.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/sessions/2026/07/05/rollout-2026-07-05T13-51-42-019f340d-1e83-7343-828f-0aabb0bc27d6.jsonl, updated_at=2026-07-06T02:25:35+00:00, thread_id=019f340d-1e83-7343-828f-0aabb0bc27d6, article rendering crash fix [rollout summary])
+3469:- /Users/balizero/.codex/memories/rollout_summaries/2026-07-05T20-51-42-FlpY-mouth_driving_license_foreigners_crash_fix.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/sessions/2026/07/05/rollout-2026-07-05T13-51-42-019f340d-1e83-7343-828f-0aabb0bc27d6.jsonl, updated_at=2026-07-06T02:25:35+00:00, thread_id=019f340d-1e83-7343-828f-0aabb0bc27d6, article rendering crash fix [rollout summary])
+3473:- `compileMDX`, `legacy props`, `DecisionTree`, `JourneyMap`, `MDXContentRSC.test.tsx`, `react hydration`, `production smoke test`
+3479:- /Users/balizero/.codex/memories/rollout_summaries/2026-07-05T20-51-42-FlpY-mouth_driving_license_foreigners_crash_fix.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/sessions/2026/07/05/rollout-2026-07-05T13-51-42-019f340d-1e83-7343-828f-0aabb0bc27d6.jsonl, updated_at=2026-07-06T02:25:35+00:00, thread_id=019f340d-1e83-7343-828f-0aabb0bc27d6, article rendering crash fix [rollout summary])
+3488:- `apps/mouth/src/app/(blog)/[category]/[slug]/page.tsx` is the article page entrypoint, and `MDXContentRSC` is the server-rendered MDX path to inspect first for article render crashes [Task 1]
+3556:- `apps/mouth` uses Vitest; placeholder `expect(true).toBe(true)` tests are not meaningful [Task 2]
+4149:scope: 2026-06-25 later desktop windows that moved from KBLI Navigator source-of-truth checks into portal validation, WR2 publish strategy, model/tool fit, batch recovery, and report review.
+4150:applies_to: cwd=/Users/balizero/Desktop/nuzantara; reuse_rule=use for the same checkout when later-day desktop windows mix KBLI Navigator content parity, portal/onboarding validation, WR2 publishing architecture, or recovery from overloaded batch/model runs; exact tabs and report paths are session-specific.
+4169:- /Users/balizero/.codex/memories/rollout_summaries/2026-06-25T04-34-03-gZzr-portal_client_ready_audit_and_deploy.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/sessions/2026/06/25/rollout-2026-06-25T12-34-03-019efd0e-7492-7213-b68e-9d826d73f3c9.jsonl, updated_at=2026-06-25T18:39:40+00:00, thread_id=019efd0e-7492-7213-b68e-9d826d73f3c9, portal readiness audit/fix/deploy and separate drive cron follow-up [rollout summary])
+4170:- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T08-17-00-CXxX-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T08-17-00-CXxX-10min-memory-summary.md, updated_at=2026-06-25T08:17:00+00:00, thread_id=None, portal onboarding validation / sheet ops / mixed browsing [skysight memory])
+4171:- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T13-00-00-VZed-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T13-00-00-VZed-10min-memory-summary.md, updated_at=2026-06-25T13:00:00+00:00, thread_id=None, portal validation and Google Sheets export deploy status [skysight memory])
+4175:- `Prepara portale onboarding`, `my.balizero.com`, `Playwright`, `browser-live`, `two-step email then PIN`, `PortalNewsRail.tsx`, `gspread`, `List rups`, `GENERAL STATUS`, `fly status`, `PR #1731`, `PR #1730`, `drive_poll_service`, `cron-drive-poll`, `HTTP 502`
+4202:- when later-day desktop work splits across KBLI, portal, WR2 publishing, and model/tooling chores, keep the active lane explicit instead of collapsing the windows [Task 1][Task 2][Task 3][Task 4] [skysight memory]
+4207:- when the user says the portal must be "pronti a far accedere il primo cliente", require repeated live browser checks and HTTP smoke before saying ready [Task 2] [skysight memory]
+4208:- when `cron - drive poll (every 5 min)` throws `HTTP 502`, keep it as a separate Drive-ops follow-up instead of folding it into the portal patch [Task 2] [skysight memory]
+4217:- `my.balizero.com` readiness work treated browser-live verification as part of the prompt, and `/portal/process` plus the home redirect were the practical smoke checks. [Task 2] [skysight memory]
+4231:- Do not declare the portal ready from static inspection alone; keep the live browser and HTTP smoke loop running until the first-client gate is satisfied. [Task 2] [skysight memory]
+4232:- Do not conflate the portal patch with the `cron - drive poll (every 5 min)` 502; treat the drive poller as a separate follow-up lane. [Task 2] [skysight memory]
+4238:# Task Group: /Users/balizero/Desktop/nuzantara 2026-06-25 WR2 / portal-onboarding / intake / compliance desktop session
+4239:scope: 2026-06-25 desktop session split across WR2 carousel validation, portal/onboarding worktree setup, intake/OCR hardening, and browser-based compliance/KBLI checks.
+4240:applies_to: cwd=/Users/balizero/Desktop/nuzantara; reuse_rule=use when the user is splitting a late-session desktop between WR2 carousel validation, portal/onboarding worktree setup, intake/OCR hardening, and browser-based compliance/KBLI checks; the exact panes, titles, and IDs are session-specific.
+4259:- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T05-16-00-QsXE-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T05-16-00-QsXE-10min-memory-summary.md, updated_at=2026-06-25T05:16:00+00:00, thread_id=None, portal/onboarding lane / Desktop TCC / router-registration [skysight memory])
+4263:- Prepara portal e onboarding, portal-client-ready, getcwd, Operation not permitted, Full Disk Access, router_registration.py, accounting, include_light_routers, include_heavy_routers, agent_start.py
+4289:- when the user is splitting one late-session desktop between WR2, portal/onboarding, intake/OCR, and browser compliance work, keep the active lane explicit and do not collapse them into one diagnosis [Task 1][Task 2][Task 3][Task 4] [skysight memory]
+4429:# Task Group: /Users/balizero/Desktop/nuzantara 2026-06-21/2026-06-22 Claude session recovery / WR2 Control / My Balizero portal triage
+4430:scope: recent desktop sessions that mixed Claude overloads and WR2/portal lane selection on the same Nuzantara checkout.
+4433:## Task 1: Claude session recovery for WR2 Control / My Balizero portal triage
+4441:- Claude Code v2.1.185, Opus 4.8, xhigh, API Error: 529 Overloaded, `Redesign portale clienti My Balizero con architettura moderna`, `Costruire app macOS WR2 Control in SwiftUI`, `claude --resume`, `Permissions bypass`, `Study KBLI 2025`, `Analizzare KBLI 2025 da app desktop`, `WR2_WARROOM_ROOT`, `build.sh`, `test.sh`, `test-integration.sh`, `git reflog`
+4449:- `API Error: 529 Overloaded` showed up while the user was resuming Claude sessions around WR2 Control / My Balizero portal work, so session recovery and worktree selection mattered more than waiting on the overloaded shell [Task 1] [skysight memory]
+4529:- relevant code paths for future HR leave changes: `apps/backend-rag/backend/app/routers/hr.py`, `apps/backend-rag/backend/app/services/hr/hr_service.py`, `apps/backend-rag/backend/core/cache.py`, `apps/mouth/src/app/(workspace)/hr/leave/page.tsx` [Task 1]
+4920:scope: Findings-first security reviews across backend-rag, mouth, and scripts in this checkout/worktree family.
+4943:- rollout_summaries/2026-06-11T16-50-34-oCOX-security_review_whatsapp_team_allowlist_rate_limit_bypass.md (cwd=/Users/balizero/Desktop/nuzantara/.worktrees/mouth-b2-homepage, rollout_path=/Users/balizero/.codex/sessions/2026/06/12/rollout-2026-06-12T00-50-34-019eb797-b96d-7be1-be46-728821d1608f.jsonl, updated_at=2026-06-11T16:50:36+00:00, thread_id=019eb797-b96d-7be1-be46-728821d1608f, rate-limit bypass finding)
+5358:# Task Group: /Users/balizero/Desktop/nuzantara apps/mouth KBLI post-deadline copy sweep / production sync
+5359:scope: KBLI public-copy cleanup in apps/mouth plus production sync after merge/deploy verification.
+5753:- localhost:3010, Nezha Seffane, Failed to load AI Summary, Failed to load WhatsApp intelligence, System Health, HTTP 404, Intake Gate, PR #3460, feat(mouth): unify Bali Zero day-first product surfaces, codeql-262-triage, 18/18 agents done, documents_proxy, router_registration.py, crm_enhanced.py
+5758:- preserve exact on-screen labels and queue names like `Brief giornaliero`, `Orchestrate M5 sessions and manage PR queue`, `Analizza commit aperti e organizza workflow di deploy`, `Nezha Seffane`, and `feat(mouth): unify Bali Zero day-first product surfaces` [Task 1][Task 3]
+     317 .claude/skills/modus/SKILL.md
+     225 /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/SKILL.md
+     234 /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/methodology.md
+     203 /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/adversarial.md
+     369 /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/reporting.md
+    1348 total
+# Differential Review Methodology
+
+Detailed phase-by-phase workflow for security-focused code review.
+
+## Pre-Analysis: Baseline Context Building
+
+**FIRST ACTION - Build complete baseline understanding:**
+
+If `audit-context-building` skill is available:
+
+```bash
+# Checkout baseline commit
+git checkout <baseline_commit>
+
+# Invoke audit-context-building skill on baseline codebase
+# Scope = entire relevant project (e.g., packages/contracts/contracts/ for Solidity, src/ for Rust, etc.)
+audit-context-building --scope [entire project or main contract directory] --focus invariants,trust-boundaries,validation-patterns,call-graphs,state-flows
+
+# Examples:
+# For Solidity: audit-context-building --scope packages/contracts/contracts
+# For Rust: audit-context-building --scope src
+# For full repo: audit-context-building --scope .
+```
+
+**Capture from baseline analysis:**
+- System-wide invariants (what must ALWAYS be true across all code)
+- Trust boundaries and privilege levels (who can do what)
+- Validation patterns (what gets checked where - defense-in-depth)
+- Complete call graphs for critical functions (who calls what)
+- State flow diagrams (how state changes)
+- External dependencies and trust assumptions
+
+**Why this matters:**
+- Understand what the code was SUPPOSED to do before changes
+- Identify implicit security assumptions in baseline
+- Detect when changes violate baseline invariants
+- Know which patterns are system-wide vs local
+- Catch when changes break defense-in-depth
+
+**Store baseline context for reference during differential analysis.**
+
+After baseline analysis, checkout back to head commit to analyze changes.
+
+---
+
+## Phase 0: Intake & Triage
+
+**Extract changes:**
+```bash
+# For commit range
+git diff <base>..<head> --stat
+git log <base>..<head> --oneline
+
+# For PR
+gh pr view <number> --json files,additions,deletions
+
+# Get all changed files
+git diff <base>..<head> --name-only
+```
+
+**Assess codebase size:**
+```bash
+find . -name "*.sol" -o -name "*.rs" -o -name "*.go" -o -name "*.ts" | wc -l
+```
+
+**Classify complexity:**
+- **SMALL**: <20 files → Deep analysis (read all deps)
+- **MEDIUM**: 20-200 files → Focused analysis (1-hop deps)
+- **LARGE**: 200+ files → Surgical (critical paths only)
+
+**Risk score each file:**
+- **HIGH**: Auth, crypto, external calls, value transfer, validation removal
+- **MEDIUM**: Business logic, state changes, new public APIs
+- **LOW**: Comments, tests, UI, logging
+
+---
+
+## Phase 1: Changed Code Analysis
+
+For each changed file:
+
+1. **Read both versions** (baseline and changed)
+
+2. **Analyze each diff region:**
+   ```
+   BEFORE: [exact code]
+   AFTER: [exact code]
+   CHANGE: [behavioral impact]
+   SECURITY: [implications]
+   ```
+
+3. **Git blame removed code:**
+   ```bash
+   # When was it added? Why?
+   git log -S "removed_code" --all --oneline
+   git blame <baseline> -- file.sol | grep "pattern"
+   ```
+
+   **Red flags:**
+   - Removed code from "fix", "security", "CVE" commits → CRITICAL
+   - Recently added (<1 month) then removed → HIGH
+
+4. **Check for regressions (re-added code):**
+   ```bash
+   git log -S "added_code" --all -p
+   ```
+
+   Pattern: Code added → removed for security → re-added now = REGRESSION
+
+5. **Micro-adversarial analysis** for each change:
+   - What attack did removed code prevent?
+   - What new surface does new code expose?
+   - Can modified logic be bypassed?
+   - Are checks weaker? Edge cases covered?
+
+6. **Generate concrete attack scenarios:**
+   ```
+   SCENARIO: [attack goal]
+   PRECONDITIONS: [required state]
+   STEPS:
+     1. [specific action]
+     2. [expected outcome]
+     3. [exploitation]
+   WHY IT WORKS: [reference code change]
+   IMPACT: [severity + scope]
+   ```
+
+---
+
+## Phase 2: Test Coverage Analysis
+
+**Identify coverage gaps:**
+```bash
+# Production code changes (exclude tests)
+git diff <range> --name-only | grep -v "test"
+
+# Test changes
+git diff <range> --name-only | grep "test"
+
+# For each changed function, search for tests
+grep -r "test.*functionName" test/ --include="*.sol" --include="*.js"
+```
+
+**Risk elevation rules:**
+- NEW function + NO tests → Elevate risk MEDIUM→HIGH
+- MODIFIED validation + UNCHANGED tests → HIGH RISK
+- Complex logic (>20 lines) + NO tests → HIGH RISK
+
+---
+
+## Phase 3: Blast Radius Analysis
+
+**Calculate impact:**
+```bash
+# Count callers for each modified function
+grep -r "functionName(" --include="*.sol" . | wc -l
+```
+
+**Classify blast radius:**
+- 1-5 calls: LOW
+- 6-20 calls: MEDIUM
+- 21-50 calls: HIGH
+- 50+ calls: CRITICAL
+
+**Priority matrix:**
+
+| Change Risk | Blast Radius | Priority | Analysis Depth |
+|-------------|--------------|----------|----------------|
+| HIGH | CRITICAL | P0 | Deep + all deps |
+| HIGH | HIGH/MEDIUM | P1 | Deep |
+| HIGH | LOW | P2 | Standard |
+| MEDIUM | CRITICAL/HIGH | P1 | Standard + callers |
+
+---
+
+## Phase 4: Deep Context Analysis
+
+**If `audit-context-building` skill is available**, invoke it to help answer all the questions below for each HIGH RISK changed function:
+
+```bash
+# Run audit-context-building on the changed function and its dependencies
+audit-context-building --scope [file containing changed function] --focus flow-analysis,call-graphs,invariants,root-cause
+```
+
+**The audit-context-building skill will help you answer:**
+
+1. **Map complete function flow:**
+   - Entry conditions (preconditions, requires, modifiers)
+   - State reads (which variables accessed)
+   - State writes (which variables modified)
+   - External calls (to contracts, APIs, system)
+   - Return values and side effects
+
+2. **Trace internal calls:**
+   - List all functions called
+   - Recursively map their flows
+   - Build complete call graph
+
+3. **Trace external calls:**
+   - Identify trust boundaries crossed
+   - List assumptions about external behavior
+   - Check for reentrancy risks
+
+4. **Identify invariants:**
+   - What must ALWAYS be true?
+   - What must NEVER happen?
+   - Are invariants maintained after changes?
+
+5. **Five Whys root cause:**
+   - WHY was this code changed?
+   - WHY did the original code exist?
+   - WHY might this break?
+   - WHY is this approach chosen?
+   - WHY could this fail in production?
+
+**If `audit-context-building` skill is NOT available**, manually perform the line-by-line analysis above using Read, Grep, and code tracing.
+
+**Cross-cutting pattern detection:**
+```bash
+# Find repeated validation patterns
+grep -r "require.*amount > 0" --include="*.sol" .
+grep -r "onlyOwner" --include="*.sol" .
+
+# Check if any removed in diff
+git diff <range> | grep "^-.*require.*amount > 0"
+```
+
+**Flag if removal breaks defense-in-depth.**
+
+---
+
+**Next steps:**
+- For HIGH RISK changes, proceed to [adversarial.md](adversarial.md)
+- For report generation, see [reporting.md](reporting.md)
+# Adversarial Vulnerability Analysis (Phase 5)
+
+Structured methodology for finding vulnerabilities through attacker modeling.
+
+**When to use:** After completing deep context analysis (Phase 4), apply this to all HIGH RISK changes.
+
+---
+
+## 1. Define Specific Attacker Model
+
+**WHO is the attacker?**
+- Unauthenticated external user
+- Authenticated regular user
+- Malicious administrator
+- Compromised contract/service
+- Front-runner/MEV bot
+
+**WHAT access/privileges do they have?**
+- Public API access only
+- Authenticated user role
+- Specific permissions/tokens
+- Contract call capabilities
+
+**WHERE do they interact with the system?**
+- Specific HTTP endpoints
+- Smart contract functions
+- RPC interfaces
+- External APIs
+
+---
+
+## 2. Identify Concrete Attack Vectors
+
+```
+ENTRY POINT: [Exact function/endpoint attacker can access]
+
+ATTACK SEQUENCE:
+1. [Specific API call/transaction with parameters]
+2. [How this reaches the vulnerable code]
+3. [What happens in the vulnerable code]
+4. [Impact achieved]
+
+PROOF OF ACCESSIBILITY:
+- Show the function is public/external
+- Demonstrate attacker has required permissions
+- Prove attack path exists through actual interfaces
+```
+
+---
+
+## 3. Rate Realistic Exploitability
+
+**EASY:** Exploitable via public APIs with no special privileges
+- Single transaction/call
+- Common user access level
+- No complex conditions required
+
+**MEDIUM:** Requires specific conditions or elevated privileges
+- Multiple steps or timing requirements
+- Elevated but obtainable privileges
+- Specific system state needed
+
+**HARD:** Requires privileged access or rare conditions
+- Admin/owner privileges needed
+- Rare edge case conditions
+- Significant resources required
+
+---
+
+## 4. Build Complete Exploit Scenario
+
+```
+ATTACKER STARTING POSITION:
+[What the attacker has at the beginning]
+
+STEP-BY-STEP EXPLOITATION:
+Step 1: [Concrete action through accessible interface]
+  - Command: [Exact call/request]
+  - Parameters: [Specific values]
+  - Expected result: [What happens]
+
+Step 2: [Next action]
+  - Command: [Exact call/request]
+  - Why this works: [Reference to code change]
+  - System state change: [What changed]
+
+Step 3: [Final impact]
+  - Result: [Concrete harm achieved]
+  - Evidence: [How to verify impact]
+
+CONCRETE IMPACT:
+[Specific, measurable impact - not "could cause issues"]
+- Exact amount of funds drained
+- Specific privileges escalated
+- Particular data exposed
+```
+
+---
+
+## 5. Cross-Reference with Baseline Context
+
+From baseline analysis (see [methodology.md](methodology.md#pre-analysis-baseline-context-building)), check:
+- Does this violate a system-wide invariant?
+- Does this break a trust boundary?
+- Does this bypass a validation pattern?
+- Is this a regression of a previous fix?
+
+---
+
+## Vulnerability Report Template
+
+Generate this for each finding:
+
+```markdown
+## [SEVERITY] Vulnerability Title
+
+**Attacker Model:**
+- WHO: [Specific attacker type]
+- ACCESS: [Exact privileges]
+- INTERFACE: [Specific entry point]
+
+**Attack Vector:**
+[Step-by-step exploit through accessible interfaces]
+
+**Exploitability:** EASY/MEDIUM/HARD
+**Justification:** [Why this rating]
+
+**Concrete Impact:**
+[Specific, measurable harm - not theoretical]
+
+**Proof of Concept:**
+```code
+// Exact code to reproduce
+```
+
+**Root Cause:**
+[Reference specific code change at file.sol:L123]
+
+**Blast Radius:** [N callers affected]
+**Baseline Violation:** [Which invariant/pattern broken]
+```
+
+---
+
+## Example: Complete Adversarial Analysis
+
+**Change:** Removed `require(amount > 0)` check from `withdraw()` function
+
+### 1. Attacker Model
+- **WHO:** Unauthenticated external user
+- **ACCESS:** Can call public contract functions
+- **INTERFACE:** `withdraw(uint256 amount)` at 0x1234...
+
+### 2. Attack Vector
+**ENTRY POINT:** `withdraw(0)`
+
+**ATTACK SEQUENCE:**
+1. Call `withdraw(0)` from attacker address
+2. Code bypasses amount check (removed)
+3. Withdraw event emitted with 0 amount
+4. Accounting updated incorrectly
+
+**PROOF:** Function is `external`, no auth required
+
+### 3. Exploitability
+**RATING:** EASY
+- Single transaction
+- Public function
+- No special state required
+
+### 4. Exploit Scenario
+**ATTACKER POSITION:** Has user account with 0 balance
+
+**EXPLOITATION:**
+```solidity
+Step 1: attacker.withdraw(0)
+  - Passes removed validation
+  - Emits Withdraw(user, 0)
+  - Updates withdrawnAmount[user] += 0
+
+Step 2: Off-chain indexer sees Withdraw event
+  - Credits attacker for 0 withdrawal
+  - But accounting thinks withdrawal happened
+
+Step 3: Accounting mismatch exploited
+  - Total supply decremented
+  - User balance not changed
+  - System invariants broken
+```
+
+**IMPACT:**
+- Protocol accounting corrupted
+- Can be used to manipulate LP calculations
+- Estimated $50K impact on pool prices
+
+### 5. Baseline Violation
+- Violates invariant: "All withdrawals must transfer non-zero value"
+- Breaks validation pattern: Amount checks present in all other value transfers
+- Regression: Check added in commit abc123 "Fix zero-amount exploit"
+
+---
+
+**Next:** Document all findings in final report (see [reporting.md](reporting.md))
+# Report Generation (Phase 6)
+
+Comprehensive markdown report structure and formatting guidelines.
+
+---
+
+## Report Structure
+
+Generate markdown report with these mandatory sections:
+
+### 1. Executive Summary
+
+- Severity distribution table
+- Risk assessment (CRITICAL/HIGH/MEDIUM/LOW)
+- Final recommendation (APPROVE/REJECT/CONDITIONAL)
+- Key metrics (test gaps, blast radius, red flags)
+
+**Template:**
+```markdown
+# Executive Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 CRITICAL | X |
+| 🟠 HIGH | Y |
+| 🟡 MEDIUM | Z |
+| 🟢 LOW | W |
+
+**Overall Risk:** CRITICAL/HIGH/MEDIUM/LOW
+**Recommendation:** APPROVE/REJECT/CONDITIONAL
+
+**Key Metrics:**
+- Files analyzed: X/Y (Z%)
+- Test coverage gaps: N functions
+- High blast radius changes: M functions
+- Security regressions detected: P
+```
+
+---
+
+### 2. What Changed
+
+- Commit timeline with visual
+- File summary table
+- Lines changed stats
+
+**Template:**
+```markdown
+## What Changed
+
+**Commit Range:** `base..head`
+**Commits:** X
+**Timeline:** YYYY-MM-DD to YYYY-MM-DD
+
+| File | +Lines | -Lines | Risk | Blast Radius |
+|------|--------|--------|------|--------------|
+| file1.sol | +50 | -20 | HIGH | CRITICAL |
+| file2.sol | +10 | -5 | MEDIUM | LOW |
+
+**Total:** +N, -M lines across K files
+```
+
+---
+
+### 3. Critical Findings
+
+For each HIGH/CRITICAL issue:
+
+```markdown
+### [SEVERITY] Title
+
+**File**: path/to/file.ext:lineNumber
+**Commit**: hash
+**Blast Radius**: N callers (HIGH/MEDIUM/LOW)
+**Test Coverage**: YES/NO/PARTIAL
+
+**Description**: [clear explanation]
+
+**Historical Context**:
+- Git blame: Added in commit X (date)
+- Message: "[original commit message]"
+- [Why this code existed]
+
+**Attack Scenario**:
+[Concrete exploitation steps from adversarial.md]
+
+**Proof of Concept**:
+```code demonstrating issue```
+
+**Recommendation**:
+[Specific fix with code]
+```
+
+**Example:**
+```markdown
+### 🔴 CRITICAL: Authorization Bypass in Withdraw
+
+**File**: TokenVault.sol:156
+**Commit**: abc123def
+**Blast Radius**: 23 callers (HIGH)
+**Test Coverage**: NO
+
+**Description**:
+Removed `require(msg.sender == owner)` check allows any user to withdraw funds.
+
+**Historical Context**:
+- Git blame: Added 2024-06-15 (commit def456)
+- Message: "Add owner check per audit finding #45"
+- Code existed to prevent unauthorized withdrawals
+
+**Attack Scenario**:
+1. Attacker calls `withdraw(1000 ether)`
+2. No authorization check (removed)
+3. 1000 ETH transferred to attacker
+4. Protocol funds drained
+
+**Proof of Concept**:
+```solidity
+// As any address
+vault.withdraw(vault.balance());
+// Success - funds stolen
+```
+
+**Recommendation**:
+```solidity
+function withdraw(uint256 amount) external {
++   require(msg.sender == owner, "Unauthorized");
+    // ... rest of function
+}
+```
+```
+
+---
+
+### 4. Test Coverage Analysis
+
+- Coverage statistics
+- Untested changes list
+- Risk assessment
+
+**Template:**
+```markdown
+## Test Coverage Analysis
+
+**Coverage:** X% of changed code
+
+**Untested Changes:**
+| Function | Risk | Impact |
+|----------|------|--------|
+| functionA() | HIGH | No validation tests |
+| functionB() | MEDIUM | Logic untested |
+
+**Risk Assessment:**
+N HIGH-risk functions without tests → Recommend blocking merge
+```
+
+---
+
+### 5. Blast Radius Analysis
+
+- High-impact functions table
+- Dependency graph
+- Impact quantification
+
+**Template:**
+```markdown
+## Blast Radius Analysis
+
+**High-Impact Changes:**
+| Function | Callers | Risk | Priority |
+|----------|---------|------|----------|
+| transfer() | 89 | HIGH | P0 |
+| validate() | 45 | MEDIUM | P1 |
+```
+
+---
+
+### 6. Historical Context
+
+- Security-related removals
+- Regression risks
+- Commit message red flags
+
+**Template:**
+```markdown
+## Historical Context
+
+**Security-Related Removals:**
+- Line 45: `require` removed (added 2024-03 for CVE-2024-1234)
+- Line 78: Validation removed (added 2023-12 "security hardening")
+
+**Regression Risks:**
+- Code pattern removed in commit X, re-added in commit Y
+```
+
+---
+
+### 7. Recommendations
+
+- Immediate actions (blocking)
+- Before production (tracking)
+- Technical debt (future)
+
+**Template:**
+```markdown
+## Recommendations
+
+### Immediate (Blocking)
+- [ ] Fix CRITICAL issue in TokenVault.sol:156
+- [ ] Add tests for withdraw() function
+
+### Before Production
+- [ ] Security audit of auth changes
+- [ ] Load test blast radius functions
+
+### Technical Debt
+- [ ] Refactor validation pattern consistency
+```
+
+---
+
+### 8. Analysis Methodology
+
+- Strategy used (DEEP/FOCUSED/SURGICAL)
+- Files analyzed
+- Coverage estimate
+- Techniques applied
+- Limitations
+- Confidence level
+
+**Template:**
+```markdown
+## Analysis Methodology
+
+**Strategy:** FOCUSED (80 files, medium codebase)
+
+**Analysis Scope:**
+- Files reviewed: 45/80 (56%)
+- HIGH RISK: 100% coverage
+- MEDIUM RISK: 60% coverage
+- LOW RISK: Excluded
+
+**Techniques:**
+- Git blame on all removals
+- Blast radius calculation
+- Test coverage analysis
+- Adversarial modeling for HIGH RISK
+
+**Limitations:**
+- Did not analyze external dependencies
+- Limited to 1-hop caller analysis
+
+**Confidence:** HIGH for analyzed scope, MEDIUM overall
+```
+
+---
+
+### 9. Appendices
+
+- Commit reference table
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "sed -n '1,180p' .claude/skills/modus/SKILL.md
+sed -n '181,360p' .claude/skills/modus/SKILL.md
+sed -n '1,140p' /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/SKILL.md
+sed -n '141,260p' /Users/balizero/.codex/plugins/cache/trailofbits/differential-review/1.1.2/skills/differential-review/SKILL.md
+sed -n '4149,4232p' /Users/balizero/.codex/memories/MEMORY.md
+ls -l /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+wc -l /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+sed -n '1,260p' /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 236ms:
+---
+name: modus
+description: "USE FOR EVERY non-trivial mandate — feature, fix, refactor, research, audit, ops, content. TRIAGE into a gear (1/2/3), drive GROUND→BUILD→VERIFY→SHIP→CAPTURE. SKIP true one-liners — declare it."
+---
+
+## Notes (moved from description 2026-09-02)
+
+Full stage list: GROUND → DESIGN → BUILD → VERIFY → SHIP+ARM → PROVE-LIVE → ALIGN-FLEET → CLEAN → CAPTURE. Routes the full arsenal at maximum-without-waste: Opus 5 xhigh effort architect + sequential final on-disk gate as an independent-verifier assignment on the Opus 5 xhigh seat (two imperators Fable 5.1/Astra, two generals Opus 5/Sol, temporary Dux — RULED 2026-09-06→08, `docs/architecture/dual-consul/army-map.md`; Fable 5.1 only as the owner-opened imperator window, never auto-routed), Sonnet 5 implementers, Codex GPT-5.6 red-team+sandbox, Gemini agy constructive width, Kimi K3 permanent refuter, Ollama local for PII, NotebookLM ground-truth. Supersedes opus-mythos (2026-07-02): Fable is native again — the width-surrogate retires; its deep/wide TAC patterns live on as Gear 3. Declare a skip as: "GEAR 1: <why>".
+
+# MODUS — the master loop (request → prod → fleet → clean → learned)
+
+> **Lineage.** `research/operations/2026-06-30-claude-code-perfect-session-doctrine.md` is the
+> LAW (4 failure axes + 7 session-organs + 3 disciplines, adversarially validated). This skill is
+> the LOOP that executes those laws across the whole **task arc** — a task may span sessions,
+> machines and days; the doctrine's organs stop at session CLOSE, modus does not stop until the
+> change is **live in prod, propagated to the fleet, cleaned up after, and learned from**.
+> Born 2026-07-02: Fable 5 returned (Mythos-class native), Sonnet 5 exists. The doctrine explains
+> WHY; modus tells you WHAT TO DO NEXT. Council-reviewed at birth (Codex red-team + Gemini
+> costruttivo; the former DeepSeek seat is retired after repeated live HTTP-402 probes).
+
+> **The one line:** _triage before ceremony; ground before reasoning; isolate before building;
+> probe the work, not the proxy; armed is not built; live is not merged; the fleet is not one
+> machine; clean after yourself; write down what bit you._
+
+---
+
+## STAGE 0 — TRIAGE: pick the gear (the anti-sperpero brain)
+
+**Before the gear, the COLOUR** (PARABELLUM, RULED 2026-09-10 — `docs/rules/RULINGS.md`). Zero
+declares it with Fable 5.1 and Astra at mission start, and it is the ONLY axis on which this loop
+differs. **The colour table lives in `docs/architecture/dual-consul/army-map.md` §1bis and is never
+copied anywhere** — read it there; every row below that says "the colour's seat" resolves against it.
+BLUE is Claude-native (Dux Opus 5, Codex spalla, fresh Opus 5 gate); ORANGE is Codex-native (Dux Sol,
+Claude spalla via `claude` CLI OAuth, Terra implementer, fresh Sol gate). No automatic colour
+fallback: a dead seat SUSPENDS, it never turns the mission the other colour, and an undeclared
+mission is BLUE. **One window = one mandate = one organ = one worktree**, never two on the same path,
+two or three at a time at most; open against `.claude/skills/modus/battle-window-spec.md` and state
+colour, Dux role, mandate id and worktree before executing.
+
+Classify the mandate from its text + the loop ledgers — a PROVISIONAL gear, announced in 1 line:
+`GEAR <n>: <mandate> — <why this gear>`. GROUND then confirms or RE-GEARS it: the gear is
+falsifiable, not a vow — blast-radius is often unknowable before reading, and under-gearing
+tasks that merely look small is the systematic failure mode. Read the ledgers:
+`.claude/skills/modus/PENDING-ARMS.md` (anything suspended from previous runs that this task
+touches?) — AMENDMENTS.md is maintained at CAPTURE, read by the bench.
+
+Before creating an evidence pack, compute its directory; never derive it by hand:
+`python3 scripts/ci/evidence_paths.py --ref "$(git rev-parse --abbrev-ref HEAD)"`.
+Write its sibling `brief.yml`, `pack.yml`, and optional `journal.jsonl` under the emitted
+`evidence/<YYYY-MM>/<slug>/` directory. Alongside the gear, declare an OPTIONAL `appetite:`
+block in that dated `brief.yml` — three
+ceilings, each optional: `wall_clock_hours`, `adversarial_rounds`, `tokens`.
+`scripts/evidence_pack_lint.py`'s `check_appetite_acknowledgment` (rule 14, the ONLY rule in
+the evidence-pack lane that can FAIL — every other rule there is NOTICE-only) compares them
+ex-post against `spend:` in that dated `pack.yml`; exceeding a declared ceiling with no
+non-empty `appetite_exceeded: "<reason>"` acknowledgment in the pack is a lint FAIL,
+mirroring `gear_override`'s acknowledgment discipline exactly. This is EX-POST / PR-LIFETIME
+ACCOUNTING, NEVER AN IN-FLIGHT BREAKER: the linter has no clock and no session-runtime
+access, so it cannot interrupt a live session — it only makes an overrun visible and demands
+acknowledgment after the fact. Absence of the block is silent, never a gap.
+
+| Gear                    | When                                                                                                                                                        | Effort (orchestration/TRIAGE-BUILD — the on-disk VERIFY/harness gate itself is unaffected, always `xhigh`+; see Gate taxonomy in §Arsenal)                                                                                                                                                                                                                                                      | Ceremony                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **1 · LISCIO** (smooth) | typo, rename, known-cause 1-file fix, pure question, mechanical edit                                                                                        | **`medium`** — Gear 1's ceremony is already minimal; `medium` is the matching cost lever (CLAUDE.md §5: on Opus 5, `low`/`medium` punch far above their weight), not `xhigh` by default. Sonnet 5 implementer + Opus 5 `medium` orchestrator.                                                                                                                                                   | Skip to BUILD→VERIFY→CLEAN (micro). No council, no fan-out, no Workflow, ≤1 grader dispatch. Declare the skip.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **2 · STANDARD**        | feature / fix / research with deliverable; anything producing a PR                                                                                          | **`xhigh`** — the coding/agentic sweet spot (CLAUDE.md §5).                                                                                                                                                                                                                                                                                                                                     | Full loop, solo-orchestrator. 1 adversarial spalla (independent reviewer, LLM ≠ author) at VERIFY. Subagents only for independent READS or ≥3 parallel well-specified units.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **3 · PROFONDO** (deep) | deep/wide audit (TAC), architectural decision, migration, cross-system investigation, pre-deploy critical path, client quotes, "vai da solo e non fermarti" | **`xhigh`** by default; **`max` is opt-in ONLY on a declared Gear-3 adjudication, never a blanket default** (RULED 2026-08-20/08-21, CLAUDE.md §5) — effort is the primary cost/latency lever on Opus 5 (~86% of output tokens measured as thinking, `research/operations/2026-08-21-token-ceremony-ci-system-audit.md`), rigor comes from the gate itself, not from spending `max` everywhere. | Full loop + Workflow-tool orchestration + the TAC patterns (ex opus-mythos): decompose by ANATOMY not to-do; hunt the SECOND-ORDER pattern (the malattia-delle-malattie — a MANDATORY "§Meta-pattern" section in the deliverable report: what repeats across the findings, which single defective belief generates them); cure-while-diagnosing (spawn fixers for clear+low-risk+in-perimeter findings — in their OWN worktrees, only after the evidence they touch is snapshotted in the report; never mutate a surface still under diagnosis); stop at the operator boundary (a "§Solo-operatore" section in the report: physical / strategic / operator-only actions). Council only if its gate fires (the anti-sperpero rules under TRIAGE). |
+
+**Anti-sperpero rules (BUDGET made a router):**
+
+- **Council is NOT automatic at Gear 3.** Convene it only if ALL THREE: divergent priors can change
+  the answer ∧ error costs >15× tokens ∧ genuinely parallel breadth. Else: solo + more reasoning
+  budget + 1 red-team spalla (evidence: 1 agent with 10× budget beats homogeneous debate at ⅓ cost).
+- Fan-out only when items ≥3 and independent. Fan-out for READS, funnel-in for WRITES.
+  Subagents can spawn their own subagents (v2.1.172, chains capped at 5 levels): at Gear 3 one
+  coordinator subagent per anatomical organ may fan out its own readers, keeping the orchestrator
+  context clean — but the declared budget shape counts DESCENDANTS, not just direct children
+  (`/agents` shows the tree).
+- Prefer one agent + more budget over N agents (coding barely parallelizes — Anthropic/Cognition).
+- Cache-aware waiting (session polling only — the cadence for an external system matches THAT
+  system's rate of change): ≤270s (inside the prompt-cache window) or commit to 1200s+; never ~300s.
+- Stop-loss: at Gear 3 declare the budget shape up front ("~N agents, ~1 council").
+- Escalate gear mid-flight if the terrain grows (RECONCILE); NEVER de-escalate silently — say it.
+- **The FLOOR is enforced by `harness-floor.yml`; the CEILING is enforced too** (`compute_ceiling()`
+  in `scripts/evidence_pack_lint.py`, PR #4474): a docs/ledger-only diff, or a ≤2-file/≤60-net-line
+  diff outside hot zones, is Gear-1-shaped by construction — declaring it Gear 3 with a council or
+  ≥3 grader dispatches FAILS the lint unless the dated `pack.yml` carries a `gear_override:` naming
+  the reason (then it's a NOTICE, not a fail). The ceiling never overrides the floor — a hot-zone
+  hit still floors at Gear 3 regardless of how small the diff looks.
+
+---
+
+## THE STAGES (1→9)
+
+| #   | Stage           | Goal                    | Driver                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | The PROBE (what proves it, not what claims it)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Scars killed          |
+| --- | --------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| 1   | **GROUND**      | Terrain before plan     | `/stadio-zero`: mem+scar query, hot-files verified ON DISK, PII scope, falsifiable acceptance. **Quote the applicable scar ANTIDOTE lines into your working notes** — a scar you only counted doesn't restrict you. Plus reuse-first (search existing code/world before building). **SIBLINGS, run and timestamped:** open PRs' changed paths (`gh pr list --state open --json files`), worktree leases (`python3 scripts/agent_start.py --list`), the native agent tree (`ListAgents`), and the fleet mailbox (`scripts/fleet_mail.sh <host> --list`). Another window already on your paths is a coordination act, not a race — comment there. The four outputs go in the evidence pack with their timestamp and ONE reference in `Bites:`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Every LOAD-BEARING file:line — one you are about to build on — re-executed THIS turn (current evidence for critical claims, not blanket re-reads of every citation). A path from memory/report/spec is a PHANTOM until re-grepped. A NotebookLM verdict on a number/threshold is a LEAD, not a fact, until its SOURCE DATE is compared against the date of the last official re-grounding of that layer (W90: NB-3 confirmed pre-resolution PMA caps with clean citations, indistinguishable in tone/format from a fresh verdict — the only defense is source-date vs resolution-date, never apparent answer quality). Before acting on an NLM numeric/threshold verdict, verify the NB source predates or postdates the relevant dataset provenance flag (e.g. `pma_cap_verified`/`pma_cap_note`).                                                                                                                                                                                                                                                   | #6 phantom            |
+| 2   | **DESIGN**      | Decide, adversarially   | `sota-architecture-loop` steps 0-4: frame → ground → reason → council-gate → decision. **Output = a durable spec artifact on disk** (scratchpad or `specs/` — BUILD consumes the file, not the chat memory). Operator GO for L2/L3 risk classes (AUTONOMOUS_OPS preflight). NLM is the ground-truth VERIFIER of facts here, not a reasoning seat.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | A falsifiable metric on the decision. Council verdicts are LEADS — re-verify what they attack AND what they bless (W65: even the refuter hallucinates).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | #3, groupthink        |
+| 3   | **BUILD**       | Execute, isolated       | Worktree via `scripts/agent_start.py` (main checkout read-only; hotfix-preemption gets its OWN lane — worktrees make stashing unnecessary). TDD where testable (code); for non-code deliverables the falsifiable acceptance criteria from GROUND play the test's role. `karpathy-discipline` (no silent assumptions, no collateral edits). Implementer routing → Arsenal. Leave-dirty toward siblings' files.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Tests written first fail→pass. Diff scoped to the mandate — every changed line traceable to it.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | #5 sibling            |
+| 4   | **VERIFY**      | Prove each increment    | CONTINUOUS, not close-loaded (context-anxiety makes CLOSE the worst first-verify point). Generator≠grader: `infra/workflows/verify-template.js`, `codex-second-opinion`, devils-advocate. Adversarial fixtures (edges, not happy path). Risk-proportional depth. **Pattern-fix = class-audit (W89/W70):** when the change cures one instance of a repeated pattern (auth call, hardcoded path, secret handling, env sourcing), grep ALL sibling call-sites THIS turn — fix the in-perimeter ones, write one PENDING-ARMS line per sibling left out; a cure applied to 1-of-N paths is a time bomb (#1825 cured `base_worker`, left `stream_tools` unauthed → 3 days blind); the sweep MUST include tests that ASSERT on the removed/migrated symbol (backend/tests or equivalent), not just prod call-sites — a symbol-removal that class-audits app code but skips test-source-asserts still dies in CI on a file the local subtree run never touches (AMENDMENTS 2026-07-05).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | The WORK by CONTENT (W88 blob-compare; never SHA-ancestor / timestamp / substring / exit-code). A FRESH session on the mission COLOUR's gate seat (army-map §1bis: Opus 5 xhigh in BLUE, Sol xhigh in ORANGE), outside the contribution chain, does the last grep (RULED 2026-09-06→08 and 2026-09-10; Fable 5.1 only as the owner-opened imperator window) — never delegable, never cascadable, never cross-colour; it SIGNS and never arms or alters the candidate, and its receipt carries mission id, colour, HEAD sha, gate thread id, commands with exit codes, verdict: the final gate is an EMPIRICAL disk/live check, not a quality opinion (quality already had its independent grader; empiricism needs execution, not heterogeneity). Before blessing any subagent's "done" — load `final-gate-discipline` skill and answer its 5 questions (who calls it, what else describes it, what will expire, does the probe know how to say yes, where does the work actually live) with a command run THIS turn, not the subagent's self-report. | #2, #6, #9, W89       |
+| 5   | **SHIP+ARM**    | Land it end-to-end      | **Re-run the SIBLING check before you push** (same four probes as GROUND — an hour of building is enough for another window to land on your paths). Atomic commits (conventional msg + co-author). The RELEASE OWNER is the mission's Dux on the colour's seat (army-map §1bis): the Dux Opus 5 in BLUE, the appointed Dux Sol in ORANGE (RULED 2026-09-10) — the gate never releases, in either colour. PR — opened only AFTER VERIFY passed, so **arming `gh pr merge --auto --squash` immediately** (standing rule 2026-06-25) never merges unreviewed work, by construction (exceptions → operator merges: guardrails, config-critical, migrations, force-push). Before arming, confirm the diff's author didn't exceed a review-only mandate (`final-gate-discipline` skill — scar 2026-08-03, a subagent dispatched to red-team a draft instead self-orchestrated a whole pipeline, committed, opened this class of PR, and armed it unsupervised): a subagent that committed/opened/armed on its own initiative is a governance finding to contain, not content to ship as-is. **Derived contracts travel IN the commit you arm on (W86):** if the diff moves a DOCSYNC-counted surface (backend tests/routers/services), run `python scripts/docs_sync.py` and fold the regen into the SAME commit BEFORE arming `--auto` — with `--auto` there is no 'later': merge fires at first green and any post-arm commit is orphaned. Bump already missing on a pushed PR → open a 1-line repair PR (like #1672), never re-push racing the merge. CI watch async — fire-and-sleep, never busy-wait; merge-train awareness on strict CI. **Deploy follows MERGE** — main is the only deployable ref (Vercel auto-deploys main; `fly deploy` runs from post-merge main via `nuzantara-deploy`; never deploy an unmerged branch). **Capture a pre-deploy baseline** (public health, key endpoints, log tail) so the post-deploy delta is attributable; **migrations get a post-deploy DB-state probe BEFORE public exposure** (upgrade applied? schema as expected?). Then the **ARMED reconciliation**: merged? deployed? installed? loaded? env propagated? cron armed? — anything built-but-not-armed = **SUSPENDED: write a line in `.claude/skills/modus/PENDING-ARMS.md`** (the W81 ledger — read back at every TRIAGE). | Each arming step probed by its own state (PR state=MERGED; `fly status`; `launchctl print` exit AND log content), not by "I ran the command".                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | W81, W86, #7          |
+| 6   | **PROVE-LIVE**  | Done = live in prod     | curl/smoke on the PUBLIC domain against the pre-deploy baseline; runtime state; READ THE OUTPUT/log, not the exit code. Post-deploy browser QA when frontend. **Probe FAILS → STOP-THE-LINE**: no CLEAN, no CAPTURE-as-done — rollback (`fly releases` / revert PR / flag off / migration backout), keep the branch alive, escalate to the operator if prod isn't restored; a broken prod outranks every downstream stage. What cannot be proven this turn (cron liveness, async jobs, propagation) → a DURABLE RECEPTOR + reconciliation at the next boundary — never a fake this-turn check.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | The feature observed working in production, by content. Green ≠ working. `✔ Connected` = TCP handshake, not auth — run `SELECT 1`. A producer's own log/counter is STILL a proxy (W89: '56 harvested' printed every cycle while the stream stayed frozen 69.5h) — prove by the DOWNSTREAM state-delta: stream length / row count / artifact content, before vs after.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | #2, 503-RAG, W87, W89 |
+| 7   | **ALIGN-FLEET** | 3 machines = 1 organism | M5/Pro/Mini — MAIN checkouts only (per-task worktrees are exempt; never disturb a sibling's live session: dirty main or active session on a node → skip + `PENDING-ALIGN:<machine>`, never stash/checkout someone else's state): `git pull --ff-only` on siblings (Pro first); restart consumers of changed code; skill/symlink liveness; HOME-fork lint (`cmp -s` repo-vs-live for anything executed from $HOME); plist/TCC liveness where launchd touched (W84: exit-code green can mask TCC death — read the log). Machine-aware paths (`balizero` on M5, `nuzantara` on Pro/Mini). **Partial fleet: if a sibling is unreachable, write `PENDING-ALIGN:<machine>` to PENDING-ARMS.md and PROCEED — never block the loop on a dead node.**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `git rev-parse HEAD` identical on all reachable MAIN checkouts; restarted consumers show a fresh heartbeat/log line, not just a PID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | #1, #10, W84          |
+| 8   | **CLEAN**       | Deep hygiene            | Worktree reap only at 3-AND (no live process ∧ no active lease ∧ content-on-main). **Branch delete only after BOTH: PROVE-LIVE passed AND content-on-main verified by BLOB-per-file** (W88 — the three-dot diff lies post-squash; a failed prod verification needs the branch alive for rollback). Scratchpad purged. Leases released. Background tasks stopped. `git status` clean OR leave-dirty declared with owner+reason.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `git worktree list` back to baseline; no zombie branch of this task; no orphaned process.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | #5, W62/W80, W88      |
+| 9   | **CAPTURE**     | Learn, then close       | `mem save` (decision 8-10, discovery 7-8 — don't ask, save). `scar` + superscar family if a trauma occurred. Research capture if ≥400 words + ≥3 sources. **AMENDMENTS entry if the LOOP ITSELF misfired** (wrong gear, wasted council, skipped probe that bit — see Self-refinement). Close line: `result:` / `needs input:` / `failed:` — self-contained.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | The memory/scar exists on disk after writing (re-`ls` it — Write can succeed and the file still vanish).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | memory-loss, W78      |
+
+---
+
+## STATE & RE-ENTRY (tasks outlive sessions)
+
+- **Durable state lives in files, not in the window:** the DESIGN spec artifact, PENDING-ARMS.md,
+  the worktree itself. If it matters past this turn, it is on disk.
+- **A "durable receptor" is one of three CONCRETE mechanisms, never an abstract intention:**
+  (1) a PENDING-ARMS.md line — reconciled at every TRIAGE; (2) a SessionStart hook injecting live
+  state at boot (escalations / organism receptors); (3) a harness background task — completion
+  re-invokes the loop — CAVEAT (v2.1.193): the harness auto-reaps IDLE background shells under
+  memory pressure, so receptor (3) is no longer guaranteed-durable on RAM-tight nodes (Mini 24GB);
+  for a load-bearing monitor set `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP=1` (Monitor-kind
+  tasks are exempt), or carry the proof on receptor (1) PENDING-ARMS instead. When you defer a proof, NAME which receptor carries it. A receptor whose HEALTHY output is silence must expose a self-probe that distinguishes healthy-silent from dead (a `--selftest` mode or synthetic-item injection), and a proof-of-armed may NEVER be 'silence observed' — a fail-open snapshot receptor is W84 green-but-dead by construction otherwise.
+- **On wake** (sleep, compaction, quota reset, session resume): emit a dense recap block
+  (done / verified-live / next) **and re-run a light GROUND** — re-verify the hot files on disk
+  before resuming the interrupted stage. The disk may have moved while you slept.
+- **Preemption** (a Gear-1 hotfix interrupts a Gear-3 task): park the current worktree as-is
+  (it is isolated by construction), run the hotfix in its own lane, return via the recap block. `/cd` (v2.1.169) can relocate THIS session into the hotfix worktree
+  and back without rebuilding the prompt cache (the new dir's CLAUDE.md is appended, not
+  substituted) — preemption no longer forces a fresh session or a cache rebuild.
+- **Quota exhaustion:** implementation seats may cascade (Arsenal). **The final gate may NOT** —
+  if the gate's window on the colour's seat dies mid-task (Opus 5 in BLUE, Sol in ORANGE), the task SUSPENDS (PENDING-ARMS line + wakeup after
+  reset), it does not hand the last grep to a weaker judge (nor to Fable — Fable 5.1 is the owner-opened imperator window, never a gate seat, RULED 2026-09-06→08). Availability-death >24h (regulatory, not
+  quota) → escalate to the operator instead of waiting on a receptor that may never fire.
+
+---
+
+## THE ARSENAL — routing v2 (the Fable-5 inversion)
+
+**The inversion.** opus-mythos dispatched external AIs to _surrogate the width Fable wasn't there
+to provide_ (~75% strategy / ~25% power, the 25% prosthetic). Fable is here. External AIs now
+serve what they are GENUINELY better for: **(a) heterogeneity** — adversarial gates need different
+training priors; a Claude judging Claude is self-approval in costume; **(b) quota economics** —
+MAX windows are finite, subscriptions are flat; **(c) specialized organs** — sandbox execution,
+1M-context ingestion, $0 local PII processing.
+
+| Role | Who | Invocation | When |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| **Architect · orchestrator · judge · final on-disk gate** | **The mission COLOUR's general seat — read the table in `docs/architecture/dual-consul/army-map.md` §1bis, never a copy of it: Opus 5 `xhigh` in BLUE, Sol `xhigh` in ORANGE (RULED 2026-09-10); no cross-colour fallback, a dead seat SUSPENDS.** In BLUE that is **Opus 5** (xhigh effort) as general/Dux and the mandatory seat of the final on-disk gate assignment (distinct from the independent review; no substitution without a ruling) — Fable 5.1 is an imperator window only (RULED 2026-09-06→08, `docs/rules/RULINGS.md`; owner-opened with `--model`, never auto-routed, never fan-out) | interactive session default | **All gears.** Gear 1-2 already closed on Opus 5 (ruling Zero 2026-08-19); Gear-3's final on-disk gate now does too, superseding that ruling's Fable-on-Gear-3 carve-out. NEVER delegate or cascade the last grep (W65). Window dead → SUSPEND, don't substitute. Gate-death can be regulatory, not just quota (precedent: Fable 5 was export-control-disabled 2026-06-12→30 while it held this role). Quota-death (hours) → SUSPEND per the standing rule; availability-death >24h → still no substitution, but escalate to the operator as §Solo-operatore (the organism must not freeze silently for weeks). |
+| **Implementer fan-out** | **Sonnet 5** (default in BLUE; in ORANGE the default is Terra `gpt-5.6-terra` and Sol implements small work directly — army-map §1bis) — task-shaped across the full roster since Zero's 2026-08-14 ruling; see `MODEL_ROSTER.md` for every model × strength × effort × door | `Agent`/`Workflow` `model:"sonnet"` (`claude-sonnet-5`) | BUILD: well-specified, parallel, testable units. Opus 5 designs, Sonnet builds, Opus 5 verifies. Sonnet is the sane default, not an obligation — grunt lanes may go Haiku/Codex-luna/Kimi-highspeed, hard lanes may go Opus-5-xhigh/Codex-sol, and a multi-PR campaign should route at least one lane through a non-Anthropic builder. |
+| **Grunt** | **Haiku 4.5** | `model:"haiku"` | Mechanical lanes inside workflows (format, extract, classify). |
+| **Red-team + empirical sandbox** | **Codex GPT-5.6** (codex-cli 0.144.6; slugs `sol`/`terra`/`luna` **DEAD 2026-07-21** — "not supported when using Codex with a ChatGPT account" after account rotation; the account's **default model** carries the seat) | `codex exec --sandbox read-only / workspace-write -c model_reasoning_effort=<level>` — **`< /dev/null` in scripts** (it blocks on open stdin); re-probe slug names before any `-m` use (PENDING-ARMS 2026-07-21) | **sol** xhigh/max = council red-team, migrations (upgrade+downgrade), high-stakes diffs · **terra** medium (its own model default) = standard second-opinion/sandbox · **luna** low/medium = mechanical/grunt lanes. `ultra` (sol/terra only) = max reasoning + auto task delegation. Legacy `gpt-5.5` (low→xhigh) still available. |
+| **Width / ingestion + costruttivo** | **Gemini via `agy`** | `agy -p` (3.5 Flash High default; 3.1 Pro for final architectural synthesis) | Corpus-scale reading; KBLI/visa/normativa search (Claude hallucinates regulations); pre-deploy red-team; council costruttivo. |
+| **Refuter (council 3rd seat + general Gear-3 ladder)** | **FLEET_TOPOLOGY v1.2 general Gear-3 chain: codex-sol → glm-5.2 → kimi-k3 → gemini-agy-redteam → deepseek-v4-pro (TP1 reserve).** GLM 5.2 is LIVE through Alibaba TP1 seat `tp1-glm-5.2`; use it for compact refutations when family-exclusion permits. | `no door: line in roster` — probe with `python3 scripts/arsenal_probe.py --seats tp1-glm-5.2`; OpenAI-compatible base `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`, key loaded by `load_tp1_settings_key()` from `~/.qwen/settings.json`. | **Family-exclusion (hard, spec §3.2):** a family that built OR counter-built on the task is excluded from ITS OWN refuter chain. Two refuters from two different families are required; probe every seat live first. GLM-as-refuter still requires GLM ≠ implementer on the same task. |
+| **Second brain (quota relief)** | **GLM 5.2 via Alibaba TP1 seat `tp1-glm-5.2` — ARMED** | `no door: line in roster`; direct OpenAI-compatible TP1 API, key loaded by `load_tp1_settings_key()` from `~/.qwen/settings.json` | When MAX OAuth windows are cap-exhausted mid-task. Implementation only — never the final gate. |
+| **Cross-family coding + width (flat sub)** | **Kimi K3 «Vivace» / kimi-for-coding 2.7** (Moonshot, Allegro subscription — Zero GO 2026-07-19; «Vivace» designation Zero 2026-07-21 after the 14h PR-queue run: 34 open → 2 drafts, 57 merged, 9 cured directly) | `kimi -p "..." -m kimi-code/k3` (reasoning/refuter) · `-m kimi-code/kimi-for-coding` (coding lanes) · `-m kimi-code/kimi-for-coding-highspeed` (grunt); bin `~/.kimi-code/bin/kimi`; probed by `arsenal_probe.py` (seat `kimi`) | Heterogeneity seat #4 for councils/second-opinion (training prior ≠ Claude/GPT/Gemini/GLM) and flat-quota implementation relief. Armed+PONG-proven on ALL THREE machines 2026-07-19 (Mini device-code authorized same day). Never the final gate. | |
+| **Third strategy voice + non-PII mass engine (TP1)** | **Qwen 3.8 Max** (Alibaba Token Plan, **ARMED 2026-08-14** — 459 calls / 74.1M tokens measured) | Qwen Code CLI (`qwen-cloud-code` seat, UNARMED pending Zero's ratification of the 2026-08-08 study) or direct OpenAI/Anthropic-compatible API against `~/.qwen/settings.json` (0600) | 3rd voice in `strategy_panel` (with Opus 5 + Gemini deepthink) and `normative_search` (the Qwen leg needs mandatory NotebookLM/Anthropic-seat verification — documented hallucination weakness on compliance-exact extraction, and our trade IS exact compliance); non-PII doc/video mass engine; fenced GUI-agent. **`eligible_for_quorum:true` since the 2026-08-14 ARMED promotion** — it IS one of the three `COUNCIL_REVIEW_SEATS` in `scripts/evidence_pack_lint.py` (R9). This row is the root cause of a contradiction that ran from 2026-08-14 to 2026-09-02: it stated the eligibility as a CONDITIONAL ("never counts ... until promoted ARMED"), the promotion then happened, and nothing walked the flipped condition back to `MODEL_ROSTER.md` or `seat_build_tp1.sh`, both of which went on asserting the pre-promotion answer as a flat fact while the lint counted the seat anyway. A conditional written where only a reader can evaluate it does not update itself — put it where a machine can, or the event that flips it must also edit every doc that restated it. |
+| **Counter-builder** | **GLM 5.2 via Alibaba TP1 seat `tp1-glm-5.2`** | `no door: line in roster`; OpenAI-compatible base `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`, key loaded by `load_tp1_settings_key()` from `~/.qwen/settings.json` | Counter-implementations for Gear-3 diffs, long-horizon refactors, and spikes. `clear_thinking:false` mandatory in agent use. Never architecture, client-facing output, final gate, or merge. |
+| **Second reasoner (refuter reserve, TP1)** | **DeepSeek v4-pro / v4-flash / v3.2** (Alibaba Token Plan, PROBATION — RE-ADMITTED 2026-08-10) | direct API via TP1 key (`~/.qwen/settings.json`, 0600) | Last hop of the refuter chain (see Refuter row above); reasoning second-opinion, math/logic chains. Re-admission is economics-only — the 2026-07-19 retirement was a dead standalone per-token balance, not a quality verdict; the Token Plan's flat credits remove the death cause. PII: vendor-parity (Zero ruling 2026-08-24: Chinese-cloud limit ABOLISHED system-wide — same common rules as Anthropic/OpenAI: Law 2 output boundary + Art. 56 basis for PROD transfers). `eligible_for_quorum:false` until promoted ARMED. |
+| **Grinder (throughput, post-PROBE-4)** | **MiniMax M2.5** (Alibaba Token Plan, PROBATION — gated on PROBE-4) | TP1 direct API | Repetitive tests/docs/mechanical batches; quality gate = a sample of every lot verified by an Anthropic seat. Not usable before PROBE-4 (MiniMax sample lot + Anthropic-seat verification) lands. |
+| **PII / offline / $0** | **Ollama** (Mini-first wrapper; local fallback) | `ollama run qwen3.5:9b`; vision `qwen2.5vl:7b`; embed `bge-m3` | Any transform whose PROMPT would carry client PII. If a cloud model must see the case: redact FIRST to `client_id`/placeholders — the gate is redaction-before-egress, not just model choice (Law 2 output boundary). |
+| **Ground truth** | **NotebookLM** (profile `default`) | `mcp__notebooklm-mcp__*` | Facts/normativa at GROUND and VERIFY: bipolar verifier — NLM verifies, it does not synthesize. Gemini = reasoning width; NLM = retrieval width. |
+
+**Kimi TP1 note:** the Token Plan also lists `kimi-k2.5`/`k2.6`/`k2.7-code` — OLDER than K3 and
+second-line redundancy only; the Allegro subscription (K3 + kimi-for-coding, row above) remains the
+load-bearing Kimi door, never displaced by the TP1 copies.
+
+**TP1 wing-wide hard NOs (spec §2.5, no exceptions):** client PII (Law 2 — PII intake is
+SEA-LION/local, never this wing), client-facing outputs (producing/certifying content that reaches
+a client — reading a diff for refutation is fine, provided real-client PII is redacted before
+egress), merge/deploy, final gates, NUZANTARA/infra credentials in the model-visible env (the
+seat's own TP1 token lives in the broker layer, outside the model's context).
+
+**Gate taxonomy (spec §4, 2026-08-10 — the drift-killer; four distinct organs called "gate",
+conflating them is the W86-class drift this table exists to prevent):**
+
+| Gate                                  | What it judges                                               | Who                                                                                                                                                                                                             | Fallback                                                                                                                                                            |
+| ------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Final on-disk gate** (modus VERIFY) | the last empirical grep/disk/live check of every task        | **Independent-verifier assignment on the Opus 5 `xhigh` seat, a Claude session outside the contribution chain — ALL gears** (RULED 2026-09-06→08: no permanent reviewer title; Fable 5.1 imperator window only) | **NONE. Never cascades to a weaker model.** All Anthropic accounts dead → task SUSPENDS (Gear-3 strictness). Gear 1-2: ordinary Opus-5 account rotation (unchanged) |
+| **WR2 content gate**                  | on-disk editorial content                                    | **Opus 5, xhigh effort** (RULED 2026-08-20 — was Fable 5, no fallback then either)                                                                                                                              | **NONE.** Window dead → SUSPEND                                                                                                                                     |
+| **Gear 2-3 harness verdict gate**     | PASS or BLOCK — the verdict a Gear 2 or 3 task ships (09-12) | **Opus 5, xhigh effort**, rotating AZ→A2→A3→A1 (RULED 2026-08-20 — was "Fable 5 first, degrade to Opus on exhaustion" per the 2026-08-09 ruling; that two-tier degradation is now moot, Opus 5 IS the seat)     | **NONE.** All Anthropic accounts dead → task QUEUES in PENDING-ARMS. Never pay                                                                                      |
+| **Gear-2 verdict**                    | standard feature PRs — gated since 2026-09-10                | Opus 5 + AI-review action + CI                                                                                                                                                                                  | ordinary cascade rules                                                                                                                                              |
+
+None of these rows route to Fable — Fable 5.1 is an owner-opened imperator window, never a gate seat (RULED 2026-09-06→08); the old "Fable-paid contingency" is moot for the same reason.
+
+**Sequencing note:** the final on-disk check (modus VERIFY) PRECEDES the harness verdict gate.
+Since RULED 2026-09-10 that gate is required from **Gear 2**, not only Gear 3 (`docs/rules/RULINGS.md`);
+the Evidence Pack it judges at Gear 3 is still a Gear-3-only demand, so a Gear-2 PR is gated on the
+verdict alone.
+Both now run on Opus 5 (RULED 2026-08-20), so there is no cross-model fallback to reason about: if
+Opus 5 is unavailable for either stage, the task suspends/queues rather than cascading to a weaker
+model. No contradiction, no bypass.
+
+**SAETTA rules (RULED 2026-09-12, `docs/rules/RULINGS.md` — the seven amendments, binding on every window from 2026-09-12):**
+
+1. Verdict binary, PASS or BLOCK; evidence-record defects are notices, never conditions; a surviving condition is discharged in the PR's own pack or the mission close row.
+2. One `PENDING-ARMS.md` row per MISSION, written by the imperator at close — no ledger PR per gated PR, healer at most daily.
+3. A window is a customer-visible slice; an infrastructure window opens only with its consumer in the same wave.
+4. The imperator opens, acks within 15 min, rules on BLOCK — nothing else; the gate is a fresh read-only subagent commissioned by the level above the Dux, 20-minute budget.
+5. Silence does not suspend: no ack in 15 min → the Dux proceeds on its declared default; the root deadline counts Dux active time only.
+6. A guarded window with a live successor is never re-enabled; first act on resume = `ListAgents`, stand down if a successor exists.
+7. A harness-caused red never rebuilds the branch: fix the harness in its own PR or waive with the reason in the pack.
+
+**Floor note:** gear classification is the DETERMINISTIC FLOOR computed from the diff (harness §1),
+recomputed by CI — never the conductor's choice. This table is not a downgrade lever: a task cannot
+be talked into Gear-2 when its diff says 3.
+
+**Merge-driver caveat (famiglia #9 pointer, discovered live on PR #3938):** GitHub's mergeability
+computation does not honor custom merge drivers (`merge=union`) — a union-file PR (e.g. two sibling
+PRs both editing `.claude/skills/modus/PENDING-ARMS.md`) can read DIRTY/CONFLICTING against a
+sibling that merged first even though local git resolves the union cleanly; cure = a LOCAL `git
+merge origin/main` (never `update-branch`, which uses GitHub's own merge and hits the same wall),
+inspect the union result, push. Since RULED 2026-09-12 (SAETTA rule 2) sibling ledger PRs do not exist by construction — one row per mission, at close.
+
+Full source: `research/operations/2026-08-10-fleet-order-spec.md` §4.
+
+**REVIEW-È-INVOCABILE (ruling Zero 2026-08-10):** "serve review" is a dispatch instruction, never a
+parking state — the conductor does not wait for graders, it CONVOKES them ("chi conduce non aspetta
+i grader: li convoca") per the role chains above the moment a diff exists to judge. Reference:
+memory `feedback_review_is_summonable_never_a_parking_reason_2026_08_10`, spec §3.2/§4.
+
+**Council composition (when the gate fires):** Phase 1 runs exactly three independent external
+seats: costruttivo = Gemini (_save it by improving it_) · red-team = Codex GPT-5.6 (_find the
+flaw; default to defective_) · refuter = Kimi K3 (_falsify the core claim_). GLM and DeepSeek do
+not sit on this fixed panel (deliberately closed by design, not because either is retired — see
+the Refuter row above for their current general-ladder status). After the orchestrator disposes
+every finding,
+Phase 2 is the sequential **final on-disk gate, an independent-verifier assignment on the Opus 5 xhigh seat** (RULED 2026-09-06→08 — was a permanent Fable, then Opus, seat)
+over the candidate bytes, all three reviews, and the disposition. The gate seat is never concurrent
+with or counted among the three external seats; gate-seat unavailable, a missing/duplicated
+external route, or an unresolved finding suspends the gate. Rounds are capped and NEVER
+consensus-seeking ("do you all agree?" generates conformity hallucinations). Verdicts are leads
+until the gate seat re-verifies them on disk.
+
+**Quota cascade (cron + subprocess):** Sonnet 5 → agy → Codex → Ollama, with a LIVE health-ping
+per tier before trusting it (grep for `out of extra usage|quota|429`, fall through on match).
+Reference: `~/scripts/regulatory-watcher-run.sh`. Cron tier-1: repo pins migrated to `claude-sonnet-5` 2026-07-03 (#1917, probed per-agent; the
+nb-agents slug micro-prompt stays 4-6); HOME wrappers armed 2026-07-03.
+
+**Claude Team org «Balizero» (2026-07-22):** new independent quota pool — `zero@balizero.com`
+premium seat is the M5 interactive default slot (≈6.25× Pro/session, TWO weekly caps: all-models +
+Sonnet-only — unlike MAX there IS a weekly ceiling, so sustained multi-day lanes exhaust it before a
+Max 20x would); Subhi + Krisna standard seats (Claude Code included, ≈1.25× Pro/session, one weekly
+cap). Per-member caps are independent. MAX slots on Pro/Mini and all cron OAuth tokens are UNCHANGED;
+decommission of ONE MAX x20 is PLANNED, not executed — remap cron/wrapper tokens first (PENDING-ARMS
+2026-07-22). Detail: memory `decision_claude_team_account_balizero_2026_07_22`.
+
+---
+
+## CROSS-CUTTING (every stage, no exceptions)
+
+- **BOUNDARY** — no secret in cleartext (0600, never `cat` a key — read var NAMES only), no
+  PII/OSINT transcribed into any output/memory/log/artifact (SYMBIOSIS Law 2 / UU PDP). Redact
+  before any cloud egress.
+- **BUDGET** — verification depth ∝ blast-radius; council ≈ 15×; declare stop-loss at TRIAGE.
+- **RECONCILE** — new operator input mid-run → restate it FIRST, re-derive acceptance, drop stale plans.
+- **SESSION CWD** — A worktree entered by a child (`EnterWorktree` / `agent_start`) becomes the cwd of the WHOLE session, parent included (measured 2026-09-10): a window that coordinates several Dux uses absolute paths and never writes into an inherited cwd.
+- **ASYNC** — any job >30s (CI, deploy, render, external LLM panel) → background + wakeup.
+  Busy-waiting a panel in foreground is a violation, not a nuance. A subagent/Workflow task marked
+  completed is UNVERIFIED until its report/artifact is actually read (AMENDMENTS 2026-07-05: a13
+  marked done with its report still in the mailbox) — for a Gear-3 read-lane that gates a downstream
+  cure, either run it synchronously (run_in_background:false) or poll/SendMessage at the stage
+  boundary BEFORE proceeding on its stated status.
+- **OPERATOR BOUNDARY** — physical actions, secret rotation, strategic calls, self-doctrine merges →
+  list them in the report's "§Solo-operatore" section and stop there. The operator's veto is not
+  the safety layer; the guardrails are.
+
+---
+
+## SELF-REFINEMENT (the organ that sharpens the loop)
+
+Honest name: self-**healing/refinement** — NOT recursive self-improvement (A4 terminology note
+2026-06-28: these rings raise reliability, not model capability; the operator gate is the point).
+
+1. **Per-run capture.** When the LOOP ITSELF misfires — wrong gear, council convened for a rubber
+   stamp, a probe skipped that later bit, a stage that proved dead weight — append one line to
+   `.claude/skills/modus/AMENDMENTS.md`: `date | what misfired | evidence | proposed change`.
+   The loop's own scar file, distinct from cicatrix (organism traumas). It is an EVIDENCE LOG,
+   not live doctrine: nothing in the loop executes from it; entries land on main through normal
+   PR review and become doctrine only via an operator-approved SKILL.md change.
+2. **`modus-bench` (on demand, ~monthly, or after a major harness/model release).**
+   `Workflow({scriptPath: "infra/workflows/modus-bench.js", args: {today: "<YYYY-MM-DD>"}})` —
+   parallel sweeps: INTERNAL (scars Δ30d + AMENDMENTS + PENDING-ARMS: _which recent traumas would
+   this loop NOT have prevented?_) × EXTERNAL (Claude Code changelog, Anthropic engineering,
+   frontier model releases: _which new capability should the loop exploit? which rule did the world
+   obsolete?_) → every proposal faces an adversarial refuter on fresh context → survivors become an
+   AMENDMENTS block. No new cron/daemon — 176 daemons exist and W84 proved launchd fragile; the
+   bench runs when invoked.
+3. **Operator gate, always.** modus NEVER merges changes to itself. Proposals land as AMENDMENTS
+   entries or a PR; Zero decides (Legge 5). Model-generation events (as Fable 5's return killed
+   opus-mythos's premise on 2026-07-02) are exactly what the bench exists to catch.
+
+---
+
+## ANTI-PATTERNS (the walking dead)
+
+- Busy-waiting an external LLM/CI in foreground → background it, close the turn.
+- "È benigno / si sblocca da solo" not falsified by a tool call THIS TURN → a stall in costume.
+  Read the log NOW. (Recorded: a 6h-stuck render closed as "quota, self-resolving" — the log held
+  a real crash loop.)
+- Chasing a merge-train on strict CI with update-branch loops → arm `--auto`, let the queue drain.
+- Council for a mechanical decision → 15× tokens for a rubber stamp.
+- Green exit / `✔ Connected` / `bash -n` / CI-green as proof → that's the PROXY. Probe the WORK:
+  real query, real render, real JSON out, real page in a real browser.
+- A subagent's (or refuter's) claim treated as a verdict → it's a LEAD; expect 30-40% false-sick.
+- Running all stages on a typo → sperpero. Say `GEAR 1` and go.
+- A file:line you didn't re-grep this turn → a phantom you're about to build on.
+
+---
+
+## REFERENCES
+
+- The LAW: `research/operations/2026-06-30-claude-code-perfect-session-doctrine.md` (4 axes, PR #1852)
+- The scar families: `.claude/rules/cicatrix-superscar.md` (10 superscar + orphans; `scar query`)
+- Battle-window spec, seven sections: `.claude/skills/modus/battle-window-spec.md` (PARABELLUM)
+- **Gate commission depth:** The independent gate is commissioned by the level ABOVE the Dux whenever the Dux runs as a subagent (delegation depth 1 — measured 2026-09-10: two subagent Duxes could not spawn their gate and the imperator window did); a top-level Dux commissions its own. In every colour.
+- **Gate gear threshold:** A brief declaring **Gear 2 or Gear 3** cannot merge without a `harness/fable-gate` success on its own head sha — `Harness floor recompute` reads it and stays red until then, so the queue never takes the PR (RULED 2026-09-10, `docs/rules/RULINGS.md`). Gear 1 stays advisory. Arm at PR-open as usual, then have the gate posted; the Evidence Pack is still a Gear-3-only demand.
+- The colour table (BLUE/ORANGE), single copy: `docs/architecture/dual-consul/army-map.md` §1bis
+- Entry gate detail: `.claude/commands/stadio-zero.md` · Architecture detail: `sota-architecture-loop`
+- Adversarial verify artifact: `infra/workflows/verify-template.js` (A4, generator≠grader)
+- Autonomy contract: `AUTONOMOUS_OPS.md` (L2) · Deploy: `nuzantara-deploy` skill
+- Superseded: `opus-mythos` (2026-06-13 → 2026-07-02, archaeology — the surrogate-era artifact)
+---
+name: differential-review
+description: "Performs security-focused differential review of code changes. Adapts analysis depth to codebase size, uses git blame for context, calculates blast radius by counting callers, checks test coverage of modified code, and generates a markdown report. Use when reviewing a PR, commit, or diff for security vulnerabilities, checking whether a change re-introduces a previously fixed bug, asking what else a change could break, or finding which modified code has no test covering it."
+allowed-tools: Read Write Grep Glob Bash
+---
+
+# Differential Security Review
+
+Security-focused code review for PRs, commits, and diffs.
+
+## Core Principles
+
+1. **Risk-First**: Focus on auth, crypto, value transfer, external calls
+2. **Evidence-Based**: Every finding backed by git history, line numbers, attack scenarios
+3. **Adaptive**: Scale to codebase size (SMALL/MEDIUM/LARGE)
+4. **Honest**: Explicitly state coverage limits and confidence level
+5. **Output-Driven**: Always generate comprehensive markdown report file
+
+---
+
+## Rationalizations (Do Not Skip)
+
+| Rationalization | Why It's Wrong | Required Action |
+|-----------------|----------------|-----------------|
+| "Small PR, quick review" | Heartbleed was 2 lines | Classify by RISK, not size |
+| "I know this codebase" | Familiarity breeds blind spots | Build explicit baseline context |
+| "Git history takes too long" | History reveals regressions | Never skip Phase 1 |
+| "Blast radius is obvious" | You'll miss transitive callers | Calculate quantitatively |
+| "No tests = not my problem" | Missing tests = elevated risk rating | Flag in report, elevate severity |
+| "Just a refactor, no security impact" | Refactors break invariants | Analyze as HIGH until proven LOW |
+| "I'll explain verbally" | No artifact = findings lost | Always write report |
+
+---
+
+## Quick Reference
+
+### Codebase Size Strategy
+
+| Codebase Size | Strategy | Approach |
+|---------------|----------|----------|
+| SMALL (<20 files) | DEEP | Read all deps, full git blame |
+| MEDIUM (20-200) | FOCUSED | 1-hop deps, priority files |
+| LARGE (200+) | SURGICAL | Critical paths only |
+
+### Risk Level Triggers
+
+| Risk Level | Triggers |
+|------------|----------|
+| HIGH | Auth, crypto, external calls, value transfer, validation removal |
+| MEDIUM | Business logic, state changes, new public APIs |
+| LOW | Comments, tests, UI, logging |
+
+---
+
+## Workflow Overview
+
+```
+Pre-Analysis → Phase 0: Triage → Phase 1: Code Analysis → Phase 2: Test Coverage
+    ↓              ↓                    ↓                        ↓
+Phase 3: Blast Radius → Phase 4: Deep Context → Phase 5: Adversarial → Phase 6: Report
+```
+
+---
+
+## Decision Tree
+
+**Starting a review?**
+
+```
+├─ Need detailed phase-by-phase methodology?
+│  └─ Read: methodology.md
+│     (Pre-Analysis + Phases 0-4: triage, code analysis, test coverage, blast radius)
+│
+├─ Analyzing HIGH RISK change?
+│  ├─ Read: adversarial.md
+│  │  (Phase 5: Attacker modeling, exploit scenarios, exploitability rating)
+│  └─ Or delegate to: differential-review:adversarial-modeler agent
+│     (Autonomous attacker modeling with concrete exploit scenarios)
+│
+├─ Writing the final report?
+│  └─ Read: reporting.md
+│     (Phase 6: Report structure, templates, formatting guidelines)
+│
+├─ Looking for specific vulnerability patterns?
+│  └─ Read: patterns.md
+│     (Regressions, reentrancy, access control, overflow, etc.)
+│
+└─ Quick triage only?
+   └─ Use Quick Reference above, skip detailed docs
+```
+
+---
+
+## Agents
+
+**`differential-review:adversarial-modeler`** — Models attacker perspectives and
+builds exploit scenarios for HIGH RISK code changes. Follows the 5-step
+adversarial methodology (attacker model, attack vectors, exploitability rating,
+exploit scenario, baseline cross-reference) and produces structured vulnerability
+reports. Delegate to this agent when Phase 5 analysis is needed on high-risk
+changes, passing that full namespaced name as `subagent_type` — a bare
+`adversarial-modeler` is unregistered and the dispatch fails at runtime.
+
+---
+
+## Quality Checklist
+
+Before delivering:
+
+- [ ] All changed files analyzed
+- [ ] Git blame on removed security code
+- [ ] Blast radius calculated for HIGH risk
+- [ ] Attack scenarios are concrete (not generic)
+- [ ] Findings reference specific line numbers + commits
+- [ ] Report file generated
+- [ ] User notified with summary
+
+---
+
+## Integration
+
+**audit-context-building skill:**
+- Pre-Analysis: Build baseline context
+- Phase 4: Deep context on HIGH RISK changes
+
+**issue-writer skill:**
+- Transform findings into formal audit reports
+- Command: `issue-writer --input DIFFERENTIAL_REVIEW_REPORT.md --format audit-report`
+
+---
+
+## Example Usage
+
+### Quick Triage (Small PR)
+```
+Input: 5 file PR, 2 HIGH RISK files
+Strategy: Use Quick Reference
+1. Classify risk level per file (2 HIGH, 3 LOW)
+2. Focus on 2 HIGH files only
+3. Git blame removed code
+4. Generate minimal report
+Time: ~30 minutes
+```
+
+### Standard Review (Medium Codebase)
+```
+Input: 80 files, 12 HIGH RISK changes
+Strategy: FOCUSED (see methodology.md)
+1. Full workflow on HIGH RISK files
+2. Surface scan on MEDIUM
+3. Skip LOW risk files
+4. Complete report with all sections
+Time: ~3-4 hours
+```
+
+### Deep Audit (Large, Critical Change)
+```
+Input: 450 files, auth system rewrite
+Strategy: SURGICAL + audit-context-building
+1. Baseline context with audit-context-building
+2. Deep analysis on auth changes only
+3. Blast radius analysis
+4. Adversarial modeling
+5. Comprehensive report
+Time: ~6-8 hours
+```
+
+---
+
+## When NOT to Use This Skill
+
+- **Greenfield code** (no baseline to compare)
+- **Documentation-only changes** (no security impact)
+- **Formatting/linting** (cosmetic changes)
+- **User explicitly requests quick summary only** (they accept risk)
+
+For these cases, use standard code review instead.
+
+---
+
+## Red Flags (Stop and Investigate)
+
+**Immediate escalation triggers:**
+- Removed code from "security", "CVE", or "fix" commits
+- Access control modifiers removed (onlyOwner, internal → external)
+- Validation removed without replacement
+- External calls added without checks
+- High blast radius (50+ callers) + HIGH risk change
+
+These patterns require adversarial analysis even in quick triage.
+
+---
+
+## Tips for Best Results
+
+**Do:**
+- Start with git blame for removed code
+- Calculate blast radius early to prioritize
+- Generate concrete attack scenarios
+- Reference specific line numbers and commits
+- Be honest about coverage limitations
+- Always generate the output file
+
+**Don't:**
+- Skip git history analysis
+- Make generic findings without evidence
+- Claim full analysis when time-limited
+- Forget to check test coverage
+- Miss high blast radius changes
+- Output report only to chat (file required)
+
+---
+
+## Supporting Documentation
+
+- **[methodology.md](methodology.md)** - Detailed phase-by-phase workflow (Phases 0-4)
+- **[adversarial.md](adversarial.md)** - Attacker modeling and exploit scenarios (Phase 5)
+- **[reporting.md](reporting.md)** - Report structure and formatting (Phase 6)
+- **[patterns.md](patterns.md)** - Common vulnerability patterns reference
+
+---
+
+**For first-time users:** Start with [methodology.md](methodology.md) to understand the complete workflow.
+
+**For experienced users:** Use this page's Quick Reference and Decision Tree to navigate directly to needed content.
+scope: 2026-06-25 later desktop windows that moved from KBLI Navigator source-of-truth checks into portal validation, WR2 publish strategy, model/tool fit, batch recovery, and report review.
+applies_to: cwd=/Users/balizero/Desktop/nuzantara; reuse_rule=use for the same checkout when later-day desktop windows mix KBLI Navigator content parity, portal/onboarding validation, WR2 publishing architecture, or recovery from overloaded batch/model runs; exact tabs and report paths are session-specific.
+
+## Task 1: KBLI Navigator translation overhaul and multiscope completion
+
+### rollout_summary_files
+
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T07-16-00-GPAR-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T07-16-00-GPAR-10min-memory-summary.md, updated_at=2026-06-25T07:16:00+00:00, thread_id=None, KBLI Navigator content parity / scope discussion [skysight memory])
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T07-18-00-hDZo-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T07-18-00-hDZo-10min-memory-summary.md, updated_at=2026-06-25T07:18:00+00:00, thread_id=None, KBLI Navigator content parity / WR2 rerender loop [skysight memory])
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T10-53-00-JLCS-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T10-53-00-JLCS-10min-memory-summary.md, updated_at=2026-06-25T10:53:00+00:00, thread_id=None, KBLI Navigator app validation and multiscope overhaul kickoff [skysight memory])
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T13-00-00-VZed-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T13-00-00-VZed-10min-memory-summary.md, updated_at=2026-06-25T13:00:00+00:00, thread_id=None, KBLI Navigator multiscope overhaul reached done state [skysight memory])
+
+### keywords
+
+- `kbli-2025.json`, `L4 Bali-status`, `schema-v2`, `kbli-l3-generate.py`, `KBLI_OPEN=<code>`, `balizero.com/kbli`, `slides.json`, `Migliora`, `rendered PNGs`, `0/328 collisions`
+
+## Task 2: Portal onboarding validation, first-client readiness, and Google Sheets export deployment
+
+### rollout_summary_files
+
+- /Users/balizero/.codex/memories/rollout_summaries/2026-06-25T04-34-03-gZzr-portal_client_ready_audit_and_deploy.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/sessions/2026/06/25/rollout-2026-06-25T12-34-03-019efd0e-7492-7213-b68e-9d826d73f3c9.jsonl, updated_at=2026-06-25T18:39:40+00:00, thread_id=019efd0e-7492-7213-b68e-9d826d73f3c9, portal readiness audit/fix/deploy and separate drive cron follow-up [rollout summary])
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T08-17-00-CXxX-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T08-17-00-CXxX-10min-memory-summary.md, updated_at=2026-06-25T08:17:00+00:00, thread_id=None, portal onboarding validation / sheet ops / mixed browsing [skysight memory])
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T13-00-00-VZed-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T13-00-00-VZed-10min-memory-summary.md, updated_at=2026-06-25T13:00:00+00:00, thread_id=None, portal validation and Google Sheets export deploy status [skysight memory])
+
+### keywords
+
+- `Prepara portale onboarding`, `my.balizero.com`, `Playwright`, `browser-live`, `two-step email then PIN`, `PortalNewsRail.tsx`, `gspread`, `List rups`, `GENERAL STATUS`, `fly status`, `PR #1731`, `PR #1730`, `drive_poll_service`, `cron-drive-poll`, `HTTP 502`
+
+## Task 3: WR2 Instagram publisher architecture and Fly dry-run gating
+
+### rollout_summary_files
+
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T10-53-00-JLCS-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T10-53-00-JLCS-10min-memory-summary.md, updated_at=2026-06-25T10:53:00+00:00, thread_id=None, WR2 Instagram publisher architecture discussion [skysight memory])
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T16-00-00-zdkP-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T16-00-00-zdkP-10min-memory-summary.md, updated_at=2026-06-25T16:00:00+00:00, thread_id=None, WR2 IG publish dry-run decision [skysight memory])
+
+### keywords
+
+- `publish-ig`, `graph.instagram.com/v22.0`, `Tigris`, `Fly`, `401 auth-gated`, `validate()`, `JWT admin token`, `backend endpoint`
+
+## Task 4: GLM quota fit, batch rerun recovery, Postgres cleanup, and local report review
+
+### rollout_summary_files
+
+- /Users/balizero/.codex/memories/rollout_summaries/2026-06-25T18-33-23-k5GN-glm_pro_quota_exhaustion_and_4_7_vs_5_2_comparison.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/sessions/2026/06/26/rollout-2026-06-26T02-33-23-019f000e-e2e8-7a21-b501-d014748af911.jsonl, updated_at=2026-06-25T18:56:07+00:00, thread_id=019f000e-e2e8-7a21-b501-d014748af911, GLM quota exhaustion and practical 4.7 vs 5.2 split [rollout summary])
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T16-00-00-zdkP-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T16-00-00-zdkP-10min-memory-summary.md, updated_at=2026-06-25T16:00:00+00:00, thread_id=None, GLM 5.2 fit and active Nuzantara dev work [skysight memory])
+- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T16-50-00-xtJP-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T16-50-00-xtJP-10min-memory-summary.md, updated_at=2026-06-25T16:50:00+00:00, thread_id=None, batch recovery / Postgres cleanup / consultation report review [skysight memory])
+
+### keywords
+
+- `GLM 5.2`, `GLM-4.7`, `Opus 4.8`, `Z.ai`, `429`, `quota`, `rate_limit`, `model-usage`, `usage endpoint`, `api/monitor/usage/quota/limit`, `api/monitor/usage/model-usage`, `z.ai/subscribe`, `API Error: 529`, `516 done`, `719 lost`, `3 sequential workflows`, `scripts/pg.sh`, `/Users/balizero/Desktop/bz-pdf-build/CONSULTATION-REPORT-wr2-wr3-sota.html`, `Direct DM`, `Ciclo chiuso`
+
+## User preferences
+
+- when later-day desktop work splits across KBLI, portal, WR2 publishing, and model/tooling chores, keep the active lane explicit instead of collapsing the windows [Task 1][Task 2][Task 3][Task 4] [skysight memory]
+- when comparing model/tool tiers, anchor the question to the actual workflow and say whether it is “come uso claude code in cli” before choosing a subscription or integration path [Task 4] [skysight memory]
+- when a deploy or publish flow is live, prefer the live runtime/status image or backend gate over CI-only conclusions [Task 2][Task 3] [skysight memory]
+- when the user says GLM 5.2 is "installato nella claude code" because Claude MAX is exhausted, answer in Claude Code workflow and quota terms rather than abstract model marketing [Task 4] [skysight memory]
+- when the user asks for GLM 4.7 vs 5.2, make the practical default/escalation split explicit instead of implying a single best model [Task 4] [skysight memory]
+- when the user says the portal must be "pronti a far accedere il primo cliente", require repeated live browser checks and HTTP smoke before saying ready [Task 2] [skysight memory]
+- when `cron - drive poll (every 5 min)` throws `HTTP 502`, keep it as a separate Drive-ops follow-up instead of folding it into the portal patch [Task 2] [skysight memory]
+
+## Reusable knowledge
+
+- `kbli-2025.json` is the March base dataset; the June `L4 Bali-status` layer from commit `#1575` adds richer Bali-specific content, so the visible KBLI gap is layered data plus rerender state rather than a simple app-vs-site mismatch. [Task 1] [skysight memory]
+- `apps/war-room/output/...` is runtime output, not source code; changing the worktree alone does not update the rendered PNGs, so the live render flow or `Migliora` has to rerun before visible output changes. [Task 1] [skysight memory]
+- `KBLI_OPEN=<code>` was used as the direct-open path in the KBLI app, and multiscope codes were the useful stress-test for the overhaul. [Task 1] [skysight memory]
+- Portal validation used a real two-step email-then-PIN flow; `Playwright` was available locally, and `PortalNewsRail.tsx` carried the local cross-domain fix. [Task 2] [skysight memory]
+- The Google Sheets export rollout was healthy server-side, but the decisive follow-up was the image reference in `fly status`, not CI alone. [Task 2] [skysight memory]
+- `my.balizero.com` readiness work treated browser-live verification as part of the prompt, and `/portal/process` plus the home redirect were the practical smoke checks. [Task 2] [skysight memory]
+- WR2 IG publishing needed a server-side Fly backend path because Tigris credentials and DB live there; the local Mini dry-run failed on missing creds, so the dry-run gate should stay backend-first. [Task 3] [skysight memory]
+- The live Z.ai quota endpoints (`api/monitor/usage/quota/limit` and `api/monitor/usage/model-usage`) were authoritative; the verified window showed Pro plan, 5-hour quota at 100% used, about `59,545,920` tokens, and `GLM-5.2` carrying almost all of it. [Task 4] [skysight memory]
+- `GLM-4.7` is the routine default for small/medium patches, file reading, local refactors, docs, and cleanup; `GLM-5.2` is for architecture, hard multi-file bugs, long-context sessions, serious review, and when 4.7 gets stuck. [Task 4] [skysight memory]
+- `GLM Pro = secondo cervello manuale, non worker autonomo`. [Task 4] [skysight memory]
+- `GLM 5.2` was being evaluated as a Claude Code-like CLI alternative to `Opus 4.8`, with subscription fit favored over a standalone API framing. [Task 4] [skysight memory]
+- The batch-rerun recovery plan after `146 agents` and `516 done, 719 lost` was to rerun in `3 sequential workflows` of about `20 batches` each. [Task 4] [skysight memory]
+- `scripts/pg.sh` was the working helper for Postgres proxy startup/pass-through when Fly exposed `:15432` and local/prod identities were mismatched. [Task 4] [skysight memory]
+
+## Failures and how to do differently
+
+- Do not treat KBLI drift as a one-layer bug; check the base dataset, the June Bali overlay, and the rerender state first. [Task 1] [skysight memory]
+- Do not rely on rendered PNGs or app output that has not been rerun through the live render flow. [Task 1] [skysight memory]
+- Do not let CI substitute for a live `fly status` / backend gate check when a deploy is already rolling. [Task 2] [skysight memory]
+- Do not declare the portal ready from static inspection alone; keep the live browser and HTTP smoke loop running until the first-client gate is satisfied. [Task 2] [skysight memory]
+- Do not conflate the portal patch with the `cron - drive poll (every 5 min)` 502; treat the drive poller as a separate follow-up lane. [Task 2] [skysight memory]
+-rw-r--r--@ 1 balizero  wheel  80201 13 set 06:38 /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+    1963 /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+diff --git a/apps/mouth/e2e/portal-prodlike-smoke.spec.ts b/apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+index 16c0d7f179..7eb4da21a9 100644
+--- a/apps/mouth/e2e/portal-prodlike-smoke.spec.ts
++++ b/apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+@@ -141,7 +141,7 @@ async function loginViaPortalUi(
+     waitUntil: "domcontentloaded",
+   });
+   const emailInput = page.getByRole("textbox", { name: "Corporate Email" });
+-  const emailSubmit = page.getByRole("button", { name: "Pass the Portal" });
++  const emailSubmit = page.getByRole("button", { name: "Continue" });
+   await expect(emailInput).toBeEnabled();
+   await emailInput.fill(email);
+   await expect(emailSubmit).toBeEnabled();
+@@ -186,7 +186,7 @@ async function loginPartnerViaPortalUi(
+     waitUntil: "domcontentloaded",
+   });
+   await page.getByRole("textbox", { name: "Corporate Email" }).fill(email);
+-  await page.getByRole("button", { name: "Pass the Portal" }).click();
++  await page.getByRole("button", { name: "Continue" }).click();
+   await page.getByLabel("Access PIN").fill(pin);
+   const loginResponsePromise = page.waitForResponse((response) => {
+     const url = new URL(response.url());
+@@ -363,7 +363,7 @@ test("@qa-be-003 portal-disabled PIN credentials fail closed without a session",
+   });
+   const emailInput = page.getByRole("textbox", { name: "Corporate Email" });
+   await emailInput.fill(environment.disabledClientEmail);
+-  await page.getByRole("button", { name: "Pass the Portal" }).click();
++  await page.getByRole("button", { name: "Continue" }).click();
+   await page.getByLabel("Access PIN").fill(environment.disabledClientPin);
+ 
+   const loginResponsePromise = page.waitForResponse((response) => {
+diff --git a/apps/mouth/src/app/portal/login-upgraded/error.tsx b/apps/mouth/src/app/portal/login-upgraded/error.tsx
+index 4a490648b9..8a8537ce00 100644
+--- a/apps/mouth/src/app/portal/login-upgraded/error.tsx
++++ b/apps/mouth/src/app/portal/login-upgraded/error.tsx
+@@ -18,17 +18,19 @@ export default function LoginError({
+ 
+   return (
+     <div className="flex min-h-[60vh] flex-col items-center justify-center p-6">
+-      {/* WS3 final slice: bg-destructive/text-destructive are dead classes in
+-          mouth (no such Tailwind token) → real --state-danger tokens with a
+-          color-mix tint of the same AA step. */}
++      {/* R19 concept F: red does not exist on the portal surface — a failed
++          load is copper ("needs you"), and the word carries the state. */}
+       <div
+         className="flex h-20 w-20 items-center justify-center rounded-full"
+         style={{
+           background:
+-            "color-mix(in srgb, var(--state-danger) 10%, transparent)",
++            "color-mix(in srgb, var(--bz-copper-text) 10%, transparent)",
+         }}
+       >
+-        <LogIn className="h-10 w-10" style={{ color: "var(--state-danger)" }} />
++        <LogIn
++          className="h-10 w-10"
++          style={{ color: "var(--bz-copper-text)" }}
++        />
+       </div>
+       <div className="mt-6 text-center space-y-2 max-w-md">
+         <h2 className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]">
+diff --git a/apps/mouth/src/app/portal/login-upgraded/page.test.tsx b/apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+index 2ce07f2ab5..e3dccd43a8 100644
+--- a/apps/mouth/src/app/portal/login-upgraded/page.test.tsx
++++ b/apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+@@ -5,7 +5,6 @@ import {
+   screen,
+   waitFor,
+ } from "@testing-library/react";
+-import type { ReactNode } from "react";
+ import { beforeEach, describe, expect, it, vi } from "vitest";
+ 
+ const { mockLogin, mockLoggerError, mockLoggerInfo, mockRouterReplace } =
+@@ -25,46 +24,6 @@ vi.mock("next/navigation", () => ({
+   }),
+ }));
+ 
+-// Login behaviour does not depend on animation timing. Keeping this unit test
+-// on semantic DOM elements also prevents motion's RAF loop from obscuring the
+-// submit and accessibility assertions.
+-vi.mock("framer-motion", async () => {
+-  const React = await vi.importActual<typeof import("react")>("react");
+-  const makeMotionElement = (tag: "button" | "div" | "form" | "p") =>
+-    React.forwardRef<
+-      HTMLElement,
+-      Record<string, unknown> & { children?: ReactNode }
+-    >(function MotionElement(
+-      {
+-        animate: _animate,
+-        exit: _exit,
+-        initial: _initial,
+-        transition: _transition,
+-        whileHover: _whileHover,
+-        whileTap: _whileTap,
+-        children,
+-        ...domProps
+-      },
+-      ref,
+-    ) {
+-      return React.createElement(
+-        tag,
+-        { ...domProps, ref },
+-        children as ReactNode,
+-      );
+-    });
+-
+-  return {
+-    AnimatePresence: ({ children }: { children?: ReactNode }) => children,
+-    motion: {
+-      button: makeMotionElement("button"),
+-      div: makeMotionElement("div"),
+-      form: makeMotionElement("form"),
+-      p: makeMotionElement("p"),
+-    },
+-  };
+-});
+-
+ vi.mock("@/lib/api/public-auth", () => ({
+   publicAuth: { login: mockLogin },
+ }));
+@@ -80,78 +39,79 @@ vi.mock("@/lib/logger", () => ({
+ 
+ import UpgradedLoginPage from "./page";
+ 
+-describe("UpgradedLoginPage (WS3 day pass)", () => {
++describe("UpgradedLoginPage (R19 concept F sign-in)", () => {
+   beforeEach(() => {
+     vi.clearAllMocks();
+     window.history.replaceState({}, "", "/portal/login-upgraded");
+   });
+ 
+-  it("shell reads --bz-base and the gate scene carries its re-light class", () => {
++  it("renders the split gate and no illustration survives", () => {
+     const { container } = render(<UpgradedLoginPage />);
+ 
+-    const shell = container.querySelector(".min-h-screen");
+-    expect(shell?.className).toContain("bg-[var(--bz-base)]");
+-    expect(shell?.className).not.toContain("bg-black");
+-
+-    // The day re-light is scoped to this class via attribute-selector CSS.
+-    expect(container.querySelector(".gate-scene")).not.toBeNull();
++    expect(container.querySelector(".r19-gate")).not.toBeNull();
++    expect(container.querySelector(".r19-hero")).not.toBeNull();
++    // The candi-bentar gate scene, its starfield and its re-light class are gone.
++    expect(container.querySelector(".gate-scene")).toBeNull();
++    expect(container.querySelector("svg circle")).toBeNull();
+   });
+ 
+-  it("masthead slogan reads day tokens (copper headline: AA on the gate passage)", () => {
+-    render(<UpgradedLoginPage />);
+-
+-    // The headline spans the sky AND the dark gate passage: copper-text
+-    // keeps ≥3:1 large-text contrast on both (3.28:1 on the passage,
+-    // 5.05:1 on paper) where ink would drop to ~1.2:1 on the passage.
+-    const h1 = screen.getByText("Your Bali Life.");
+-    expect(h1.className).toContain("text-[var(--bz-copper-text)]");
++  it("the forest panel carries the brand mark and the hero sentence", () => {
++    const { container } = render(<UpgradedLoginPage />);
+ 
+-    const kicker = screen.getByText("Turn On");
+-    expect(kicker.className).toContain("text-[var(--bz-copper-text)]");
++    const hero = container.querySelector(".r19-hero");
++    expect(hero).not.toBeNull();
++    // The logo asset carries the wordmark; the hero does not repeat it in text.
++    expect(hero?.textContent).not.toContain("Bali Zero");
++    expect(hero?.textContent).toContain("Client portal");
++    expect(hero?.querySelector("h2")?.textContent).toBe(
++      "Your Bali file,kept in order.",
++    );
++    // Zero's order: the real logo, never cropped into a circle.
++    const mark = hero?.querySelector("img");
++    expect(mark).not.toBeNull();
++    expect(mark?.getAttribute("alt")).toBe("Bali Zero");
++    expect(mark?.className ?? "").not.toContain("rounded-full");
+   });
+ 
+-  it("spotlight card is the token surface; inputs are warm paper with copper focus", () => {
+-    const { container } = render(<UpgradedLoginPage />);
+-
+-    const card = container.querySelector(".bg-\\[var\\(--bz-card\\)\\]\\/95");
+-    expect(card).not.toBeNull();
+-    expect(card?.className).toContain("border-[var(--bz-border)]");
++  it("the email field is the paper form control with a copper focus ring", () => {
++    render(<UpgradedLoginPage />);
+ 
+     const email = screen.getByPlaceholderText("client@company.com");
+-    expect(email.className).toContain("bg-[var(--bz-base)]");
+-    expect(email.className).toContain("border-[var(--bz-border)]");
+-    expect(email.className).toContain("text-[var(--tx-primary)]");
+-    expect(email.className).toContain("focus:border-[var(--bz-copper)]");
++    expect(email.className).toContain("r19-input");
++
++    const eyebrow = screen.getByText("Sign in · step 1 of 2");
++    expect(eyebrow.className).toContain("r19-eyebrow");
+   });
+ 
+-  it("CTA uses the darker copper step + --bz-on-warm (AA pair)", () => {
++  it("the primary CTA is filled forest — copper never fills a button", () => {
+     render(<UpgradedLoginPage />);
+ 
+-    const cta = screen.getByRole("button", { name: /Pass the Portal/ });
+-    expect(cta.style.background).toBe("var(--bz-copper-text)");
+-    expect(cta.style.color).toBe("var(--bz-on-warm)");
++    const cta = screen.getByRole("button", { name: /Continue/ });
++    expect(cta.style.background).toBe("var(--r19-forest)");
++    expect(cta.style.color).toBe("var(--r19-paper)");
+   });
+ 
+-  it("email step advances to the PIN step with token-styled controls", async () => {
++  it("email step advances to the PIN step with the R19 controls", async () => {
+     render(<UpgradedLoginPage />);
+ 
+     fireEvent.change(screen.getByPlaceholderText("client@company.com"), {
+       target: { value: "synthetic.user@example.test" },
+     });
+-    fireEvent.click(screen.getByRole("button", { name: /Pass the Portal/ }));
++    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
+ 
+     const pin = await screen.findByLabelText("Access PIN");
+-    expect(pin.className).toContain("bg-[var(--bz-base)]");
+-    expect(pin.className).toContain("border-[var(--bz-border)]");
++    expect(pin.className).toContain("r19-input");
++    expect(pin.className).toContain("r19-pin");
++    expect(screen.getByText("Sign in · step 2 of 2")).toBeTruthy();
+ 
+     const verify = screen.getByRole("button", { name: /Verify Identity/ });
+-    expect(verify.style.background).toBe("var(--bz-copper-text)");
+-    expect(verify.style.color).toBe("var(--bz-on-warm)");
++    expect(verify.style.background).toBe("var(--r19-forest)");
++    expect(verify.style.color).toBe("var(--r19-paper)");
+ 
+     const magicLink = screen.getByRole("link", {
+       name: /Sign in with an email link instead/,
+     });
+-    expect(magicLink.className).toContain("text-[var(--bz-accent-warm)]");
++    expect(magicLink.className).toContain("r19-link");
+   });
+ 
+   it("exposes durable labels and password-manager semantics", async () => {
+@@ -366,5 +326,7 @@ describe("UpgradedLoginPage (WS3 day pass)", () => {
+     expect(html).not.toContain("text-[#f0ece4]"); // token-lint-ok: drain-guard assertion string, not a color use
+     expect(html).not.toContain("text-[#f8e89a]"); // token-lint-ok: drain-guard assertion string, not a color use
+     expect(html).not.toContain("accent-gold-muted");
++    expect(html).not.toContain("starDrift");
++    expect(html).not.toContain("passageGlow");
+   });
+ });
+diff --git a/apps/mouth/src/app/portal/login-upgraded/page.tsx b/apps/mouth/src/app/portal/login-upgraded/page.tsx
+index a75e1b85b2..30f7206489 100644
+--- a/apps/mouth/src/app/portal/login-upgraded/page.tsx
++++ b/apps/mouth/src/app/portal/login-upgraded/page.tsx
+@@ -1,13 +1,11 @@
+ // apps/mouth/src/app/portal/login-upgraded/page.tsx
+ "use client";
+ 
+-import React, { useEffect, useState, useRef, MouseEvent } from "react";
++import React, { useEffect, useState, useRef } from "react";
+ import { useRouter } from "next/navigation";
+-import Image from "next/image";
+ import Link from "next/link";
+ import { Loader2 } from "lucide-react";
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+codex
+STADIO-0 completato: i file citati e il diff esistono; la memoria conferma che il portale usa storicamente il flusso email→PIN, ma la conclusione sarà basata esclusivamente sui byte correnti e sul diff di questo turno. Passo ora alla comparazione riga-per-riga e ai test mirati; non eseguirò browser live perché il mandato è una review pre-merge del refactor.
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "sed -n '240,620p' /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+sed -n '621,1000p' /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 221ms:
+     expect(html).not.toContain("text-[#f0ece4]"); // token-lint-ok: drain-guard assertion string, not a color use
+     expect(html).not.toContain("text-[#f8e89a]"); // token-lint-ok: drain-guard assertion string, not a color use
+     expect(html).not.toContain("accent-gold-muted");
++    expect(html).not.toContain("starDrift");
++    expect(html).not.toContain("passageGlow");
+   });
+ });
+diff --git a/apps/mouth/src/app/portal/login-upgraded/page.tsx b/apps/mouth/src/app/portal/login-upgraded/page.tsx
+index a75e1b85b2..30f7206489 100644
+--- a/apps/mouth/src/app/portal/login-upgraded/page.tsx
++++ b/apps/mouth/src/app/portal/login-upgraded/page.tsx
+@@ -1,13 +1,11 @@
+ // apps/mouth/src/app/portal/login-upgraded/page.tsx
+ "use client";
+ 
+-import React, { useEffect, useState, useRef, MouseEvent } from "react";
++import React, { useEffect, useState, useRef } from "react";
+ import { useRouter } from "next/navigation";
+-import Image from "next/image";
+ import Link from "next/link";
+ import { Loader2 } from "lucide-react";
+-import { motion, AnimatePresence } from "framer-motion";
+-import { cormorant } from "@balizero/core/fonts/cormorant";
++import { BZLogo } from "@balizero/core/components/BZLogo";
+ import { useSystemSound } from "@/hooks/useSystemSound";
+ import { publicAuth } from "@/lib/api/public-auth";
+ import { sanitizeRedirect } from "@/lib/auth/sanitizeRedirect";
+@@ -18,17 +16,92 @@ import { I18nProvider, useTranslation } from "@/i18n";
+ const REDIRECT_DELAY_MS = 1500;
+ const ERROR_RESET_DELAY_MS = 2000;
+ 
+-// WS3 final slice (GARUDA Day Edition): CTA = darker copper step
+-// --bz-copper-text with theme-aware --bz-on-warm fg (white on #9d5230 =
+-// 5.70:1 light; ink #0c0c0e on #d4845a = 6.74:1 dark — the #b5633a copper
+-// step with white would be 4.37:1, below the 4.5:1 AA floor). Was a
+-// #d9bd7a→#a07838 gradient with black text.
++// R19 concept F ("RAPI"): forest is the ONLY primary-button fill. Copper
++// carries "needs you" as text, numerals and outline — never as a filled
++// surface — and red does not exist on this surface at all.
+ const LOGIN_CTA_STYLE = {
+-  background: "var(--bz-copper-text)",
+-  color: "var(--bz-on-warm)",
+-  boxShadow: "0 4px 24px color-mix(in srgb, var(--bz-copper) 30%, transparent)",
++  background: "var(--r19-forest)",
++  color: "var(--r19-paper)",
+ } as const;
+ 
++// Page-local presentation layer. Scoped under .r19-gate so nothing here can
++// reach kita/prime; the palette lives as page-local custom properties until
++// the my-product token seam carries the R19 values.
++const R19_STYLES = `
++.r19-gate{
++  --r19-paper:#f7f4ee;--r19-surface:#fffcf7;--r19-ink:#1d2c3b;--r19-muted:#58626b; /* token-lint-ok: concept-F paper/ink scale, page-local until the my-product token seam lands */
++  --r19-line:#dad8d1;--r19-line-strong:#a8aca9; /* token-lint-ok: concept-F hairlines */
++  --r19-copper:#a44b36;--r19-forest:#253e33; /* token-lint-ok: concept-F copper (needs-you) and forest (done) meanings */
++  position:relative;display:grid;grid-template-columns:minmax(0,5fr) minmax(0,6fr);
++  min-height:100vh;background:var(--r19-paper);color:var(--r19-ink);
++  font-size:15px;line-height:1.75;
++}
++.r19-serif{font-family:var(--font-serif),Georgia,serif;font-weight:450;letter-spacing:-0.03em}
++.r19-eyebrow{font-size:10px;line-height:1.4;font-weight:650;letter-spacing:0.14em;text-transform:uppercase;color:var(--r19-muted)}
++.r19-gate button{cursor:pointer;border:0;background:none;color:inherit;font:inherit}
++.r19-gate a{color:inherit;text-decoration:none}
++
++.r19-hero{background:var(--r19-forest);color:var(--r19-paper);display:flex;flex-direction:column;justify-content:space-between;gap:32px;padding:40px 48px}
++.r19-brand{display:flex;align-items:center;gap:10px}
++.r19-brand-text{display:flex;flex-direction:column}
++.r19-brand-role{color:rgba(247,244,238,0.72)}
++.r19-hero-rule{width:56px;height:3px;border-radius:2px;background:var(--r19-copper);margin-bottom:22px}
++.r19-hero h2{margin:0;font-size:clamp(40px,4vw,56px);line-height:1.04}
++.r19-hero-lede{margin:20px 0 0;max-width:34ch;font-size:15px;color:rgba(247,244,238,0.78)}
++.r19-hero-foot{display:flex;justify-content:space-between;gap:16px;color:rgba(247,244,238,0.72)}
++
++.r19-form{display:flex;flex-direction:column;justify-content:center;align-items:center;padding:48px 32px}
++.r19-box{width:100%;max-width:400px}
++.r19-steps{display:flex;align-items:center;gap:6px;margin-bottom:18px}
++.r19-steps i{display:block;width:28px;height:3px;border-radius:2px;background:var(--r19-line)}
++.r19-steps i.on{background:var(--r19-forest)}
++.r19-form h1{margin:10px 0 8px;font-size:40px;line-height:1.06}
++.r19-hint{margin:0 0 26px;color:var(--r19-muted)}
++.r19-field{margin-bottom:16px}
++.r19-field-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:8px}
++.r19-input{display:block;width:100%;height:52px;padding:0 16px;font-size:15px;color:var(--r19-ink);background:var(--r19-surface);border:1px solid var(--r19-line-strong);border-radius:0.25rem;outline:none}
++.r19-input::placeholder{color:var(--r19-muted)}
++.r19-input:focus{border-color:var(--r19-copper);box-shadow:0 0 0 3px rgba(164,75,54,0.18)}
++.r19-input:disabled{opacity:0.55;cursor:not-allowed}
++.r19-pin{font-size:22px;text-align:center;letter-spacing:14px;font-variant-numeric:tabular-nums}
++.r19-gate .r19-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;width:100%;height:48px;margin-top:6px;padding:0 22px;border-radius:0.25rem;font-size:13px;font-weight:650;letter-spacing:0.02em}
++.r19-gate .r19-btn:disabled{opacity:0.5;cursor:not-allowed}
++.r19-gate .r19-back{font-size:12px;font-weight:650;color:var(--r19-copper)}
++.r19-alt{margin-top:22px;display:flex;flex-direction:column;gap:10px;font-size:13px}
++.r19-gate .r19-link{color:var(--r19-copper);font-weight:650}
++.r19-gate .r19-link:hover{text-decoration:underline}
++.r19-alt-sep{border-top:1px solid var(--r19-line);margin:6px 0}
++.r19-quiet{color:var(--r19-muted)}
++.r19-formfoot{margin-top:40px;display:flex;gap:16px;font-size:12px;color:var(--r19-muted);font-variant-numeric:tabular-nums}
++.r19-formfoot a{display:inline-flex;align-items:center;min-height:24px}
++.r19-formfoot a:hover{text-decoration:underline}
++
++.r19-overlay{position:absolute;inset:0;z-index:50;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:24px;text-align:center;background:color-mix(in srgb, var(--r19-paper) 92%, transparent);backdrop-filter:blur(8px)}
++.r19-overlay h1{margin:0;font-size:clamp(34px,5vw,56px);line-height:1.05}
++.r19-overlay-ok h1{color:var(--r19-forest)}
++.r19-overlay-denied h1{color:var(--r19-copper)}
++.r19-overlay p{margin:0;max-width:34rem;font-size:15px;color:var(--r19-ink)}
++
++.r19-input:-webkit-autofill,
++.r19-input:-webkit-autofill:hover,
++.r19-input:-webkit-autofill:focus,
++.r19-input:-webkit-autofill:active{
++  -webkit-box-shadow:0 0 0 30px var(--r19-surface) inset !important;
++  -webkit-text-fill-color:var(--r19-ink) !important;
++  caret-color:var(--r19-copper) !important;
++}
++
++@media (max-width:767px){
++  .r19-gate{grid-template-columns:1fr}
++  .r19-hero{padding:28px 22px 30px;gap:28px}
++  .r19-hero h2{font-size:34px}
++  .r19-hero-lede{margin-top:12px;font-size:14px}
++  .r19-hero-foot{display:none}
++  .r19-form{padding:32px 22px 40px;align-items:stretch}
++  .r19-form h1{font-size:34px}
++}
++`;
++
+ // Map HTTP status code → i18n error key. Unknown → server_error (5xx) or
+ // network_error (anything else, including status=0 from opaque fetch failures).
+ function errorKeyFor(status: number): string {
+@@ -85,18 +158,23 @@ function UpgradedLoginPageInner() {
+     setIsHydrated(true);
+   }, []);
+ 
+-  // Spotlight mouse tracking state
+-  const cardRef = useRef<HTMLDivElement>(null);
+-  const [{ mouseX, mouseY }, setMousePos] = useState({ mouseX: 0, mouseY: 0 });
+-
+-  const handleMouseMove = (e: MouseEvent<HTMLDivElement>) => {
+-    if (!cardRef.current) return;
+-    const { left, top } = cardRef.current.getBoundingClientRect();
+-    setMousePos({
+-      mouseX: e.clientX - left,
+-      mouseY: e.clientY - top,
+-    });
+-  };
++  // Same persona declaration the authenticated portal layout makes at mount
++  // (portal/(authenticated)/layout.tsx): the sign-in page is part of My, so
++  // the product token seam has to apply here too. No cleanup — the layout
++  // does not remove the attribute either, and a removal on unmount would
++  // strip the persona during the redirect into the portal itself.
++  useEffect(() => {
++    const root = document.documentElement;
++    root.dataset.product = "my";
++    if (root.dataset.theme === "light") root.dataset.theme = "operative-light";
++    if (root.dataset.theme === "dark") root.dataset.theme = "operative-dark";
++    if (
++      root.dataset.theme !== "operative-light" &&
++      root.dataset.theme !== "operative-dark"
++    ) {
++      root.dataset.theme = "operative-light";
++    }
++  }, []);
+ 
+   const playClickSound = () => {
+     play("focus");
+@@ -206,1370 +284,214 @@ function UpgradedLoginPageInner() {
+     }
+   };
+ 
++  // The two existing alternative paths, equal and visible on both steps.
++  const alternatives = (
++    <div className="r19-alt">
++      <Link href="/portal/magic-link" className="r19-link">
++        Sign in with an email link instead
++      </Link>
++      <Link href="/portal/forgot-password" className="r19-link">
++        {t("portal.login.forgot_password")}
++      </Link>
++      <div className="r19-alt-sep" aria-hidden="true" />
++      <span className="r19-quiet">
++        New here? Your Bali Zero contact sends the invitation — there is nothing
++        to register.
++      </span>
++    </div>
++  );
++
++  const formFooter = (
++    <div className="r19-formfoot">
++      <span>© 2026 Bali Zero</span>
++      <Link href="/privacy">Privacy</Link>
++      <Link href="/terms">Terms</Link>
++    </div>
++  );
++
+   return (
+-    // WS3 final slice (GARUDA Day Edition, 2026-07-26): the shell reads
+-    // --bz-base (paper on operative-light, near-black navy on
+-    // operative-dark) instead of a forced bg-black. The SVG gate scene JSX
+-    // is untouched — the day re-light lives in the <style> block below as
+-    // [data-theme="operative-light"] attribute-selector overrides (CSS
+-    // beats SVG presentation attributes), so the dark theme renders the
+-    // original night scene pixel-identically. The UI layer (card, forms,
+-    // CTAs, overlays) reads day tokens throughout.
+-    <div className="min-h-screen relative overflow-hidden flex flex-col bg-[var(--bz-base)]">
++    <div className="r19-gate">
++      {/* Safe: static presentation CSS, no external input. */}
++      <style dangerouslySetInnerHTML={{ __html: R19_STYLES }} />
++
+       {/* ACCESS GRANTED OVERLAY */}
+       {loginStage === "success" && (
+-        <motion.div
+-          initial={{ opacity: 0 }}
+-          animate={{ opacity: 1 }}
+-          transition={{ duration: 0.1 }}
+-          className="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md"
++        <div
++          className="r19-overlay r19-overlay-ok"
+           role="status"
+           aria-live="polite"
+-          style={{
+-            background: "color-mix(in srgb, var(--bz-base) 80%, transparent)",
+-          }}
+         >
+-          <div className="text-center group">
+-            <h1
+-              className={`${cormorant.className} text-4xl md:text-6xl text-[var(--bz-copper-text)] tracking-[0.2em] font-light shadow-[0_0_40px_rgba(201,169,110,0.4)]`}
+-            >
+-              Portal Unlocked
+-            </h1>
+-          </div>
+-        </motion.div>
++          <h1 className="r19-serif">Portal Unlocked</h1>
++        </div>
+       )}
+ 
+-      {/* ACCESS DENIED OVERLAY */}
++      {/* ACCESS DENIED OVERLAY — copper, never red: the state carries a word. */}
+       {loginStage === "denied" && (
+-        <motion.div
+-          initial={{ opacity: 0 }}
+-          animate={{ opacity: 1 }}
+-          exit={{ opacity: 0 }}
+-          transition={{ duration: 0.1 }}
+-          className="absolute inset-0 z-50 flex flex-col items-center justify-center backdrop-blur-md"
++        <div
++          className="r19-overlay r19-overlay-denied"
+           role="alert"
+           aria-live="assertive"
+-          style={{
+-            background: "color-mix(in srgb, var(--bz-base) 92%, transparent)",
+-          }}
+         >
+-          <h1
+-            className={`${cormorant.className} text-4xl md:text-6xl tracking-[0.2em] font-light uppercase`}
+-            style={{ color: "var(--state-danger)" }}
+-          >
+-            Access Denied
+-          </h1>
+-          {errorMessage && (
+-            <p
+-              id="portal-login-error"
+-              className="mt-4 text-sm tracking-wide max-w-md text-center px-4"
+-              style={{ color: "var(--state-danger)" }}
+-            >
+-              {errorMessage}
+-            </p>
+-          )}
+-        </motion.div>
++          <h1 className="r19-serif">Access Denied</h1>
++          {errorMessage && <p id="portal-login-error">{errorMessage}</p>}
++        </div>
+       )}
+ 
+-      {/* Safe: hardcoded CSS for autofill styling, no external input.
+-          WS3: tokenized — card inset + theme text + copper caret (was a
+-          dark inset with hardcoded cream text and gold caret). */}
+-      <style
+-        dangerouslySetInnerHTML={{
+-          __html: `
+-        input:-webkit-autofill,
+-        input:-webkit-autofill:hover,
+-        input:-webkit-autofill:focus,
+-        input:-webkit-autofill:active {
+-            -webkit-box-shadow: 0 0 0 30px var(--bz-card) inset !important;
+-            -webkit-text-fill-color: var(--tx-primary) !important;
+-            caret-color: var(--bz-copper) !important;
+-        }
+-      `,
+-        }}
+-      />
+-      <style>{`
+-        @keyframes twinkle {
+-          0%, 100% { opacity: var(--op-base); transform: scale(1); }
+-          50%       { opacity: var(--op-peak); transform: scale(1.5); }
+-        }
+-        @keyframes starDriftFast {
+-          0%, 100% { transform: translate(0px, 0px); }
+-          50%      { transform: translate(15px, -5px); }
+-        }
+-        @keyframes starDriftMid {
+-          0%, 100% { transform: translate(0px, 0px); }
+-          50%      { transform: translate(10px, -3px); }
+-        }
+-        @keyframes starDriftSlow {
+-          0%, 100% { transform: translate(0px, 0px); }
+-          50%      { transform: translate(5px, -1.5px); }
+-        }
+-
+-        /* ── WS3 Day re-light (operative-light only) ────────────────────
+-           The gate SVG keeps its single-source night palette in JSX; these
+-           attribute-selector overrides re-light it for the Day Edition
+-           (CSS beats SVG presentation attributes). Decorative illustration
+-           colors, not UI colors. Dark theme: zero rules match → the night
+-           scene renders unchanged. */
+-        [data-theme="operative-light"] .gate-scene #skyGrad stop[stop-color="#000000"] { stop-color: #f7f3ea; } /* token-lint-ok: decorative illustration day sky */
+-        [data-theme="operative-light"] .gate-scene #skyGrad stop[stop-color="#030306"] { stop-color: #e6dcc8; } /* token-lint-ok: decorative illustration day sky depth */
+-        [data-theme="operative-light"] .gate-scene #goldEdge stop[stop-color="#f8e89a"] { stop-color: #8a6d3b; } /* token-lint-ok: decorative illustration daylight gold edge */
+-        [data-theme="operative-light"] .gate-scene #goldEdge stop[stop-color="#e8c96a"] { stop-color: #b5633a; } /* token-lint-ok: decorative illustration copper edge */
+-        [data-theme="operative-light"] .gate-scene #goldEdge stop[stop-color="#c9a96e"] { stop-color: #c07a48; } /* token-lint-ok: decorative illustration copper edge fade */
+-        [data-theme="operative-light"] .gate-scene #goldEdge stop[stop-color="#7a5020"] { stop-color: #d4b483; } /* token-lint-ok: decorative illustration sand edge end */
+-        [data-theme="operative-light"] .gate-scene [fill="#0a0804"] { fill: #4a3b26; } /* token-lint-ok: decorative illustration umber stone */
+-        [data-theme="operative-light"] .gate-scene [fill="#0c0a05"] { fill: #55452e; } /* token-lint-ok: decorative illustration umber stone tier */
+-        [data-theme="operative-light"] .gate-scene [fill="#080602"] { fill: #5f4e36; } /* token-lint-ok: decorative illustration umber step */
+-        [data-theme="operative-light"] .gate-scene [fill="#060401"] { fill: #6a5840; } /* token-lint-ok: decorative illustration umber step light */
+-        [data-theme="operative-light"] .gate-scene [stroke="#f8e89a"] { stroke: #8a6d3b; } /* token-lint-ok: decorative illustration daylight gold stroke */
+-        [data-theme="operative-light"] .gate-scene [stroke="#e8c96a"] { stroke: #b5633a; } /* token-lint-ok: decorative illustration copper stroke */
+-        [data-theme="operative-light"] .gate-scene [fill="#c9a96e"] { fill: #b08a5a; } /* token-lint-ok: decorative illustration warm carving fill */
+-        [data-theme="operative-light"] .gate-scene [stroke="#c9a96e"] { stroke: #a08050; } /* token-lint-ok: decorative illustration warm carving stroke */
+-        [data-theme="operative-light"] .gate-scene [stroke="#8a6030"] { stroke: #9c7c4e; } /* token-lint-ok: decorative illustration dim gold stroke */
+-        [data-theme="operative-light"] .gate-scene [fill="#000000"] { fill: #d8cdb6; } /* token-lint-ok: decorative illustration sand silhouette (moon cover, ground, foliage) */
+-        [data-theme="operative-light"] .gate-scene [fill="#0a0a0a"] { fill: #d9a441; } /* token-lint-ok: decorative illustration sun disc */
+-        /* #passageGlow was still the night-only ember (#1a1008 → #000000,
+-           opaque both stops), so in daylight the central passage rendered
+-           as a near-black slab instead of a glimpse of sky through the
+-           gate. Re-lit with the same two skyGrad tones so the passage
+-           reads as daylight, not a void — both stops clear WCAG 3:1
+-           against the copper title text that overlaps this rect. */
+-        [data-theme="operative-light"] .gate-scene #passageGlow stop[stop-color="#1a1008"] { stop-color: #f7f3ea; } /* token-lint-ok: decorative illustration daylight passage glow (reuses day sky) */
+-        [data-theme="operative-light"] .gate-scene #passageGlow stop[stop-color="#000000"] { stop-color: #e6dcc8; } /* token-lint-ok: decorative illustration daylight passage glow depth (reuses day sky depth) */
+-      `}</style>
+-
+-      {/* ═══════════════════════════════════════
+-          LAYER 0 — STARFIELD + VOLUMETRIC GATE
+-      ═══════════════════════════════════════ */}
+-      <motion.div
+-        initial={{ opacity: 0, scale: 1.05 }}
+-        animate={{ opacity: 1, scale: 1 }}
+-        transition={{ duration: 2, ease: "easeOut" }}
+-        className="absolute inset-0 gate-scene"
+-      >
+-        <svg
+-          className="absolute inset-0 w-full h-full"
+-          viewBox="0 0 1440 900"
+-          preserveAspectRatio="xMidYMid slice"
+-        >
+-          <defs>
+-            <linearGradient id="skyGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+-              <stop offset="0%" stopColor="#000000" />
+-              <stop offset="100%" stopColor="#030306" />
+-            </linearGradient>
+-
+-            <linearGradient id="goldEdge" x1="0%" y1="0%" x2="0%" y2="100%">
+-              <stop offset="0%" stopColor="#f8e89a" stopOpacity="1" />
+-              <stop offset="25%" stopColor="#e8c96a" stopOpacity="0.95" />
+-              <stop offset="65%" stopColor="#c9a96e" stopOpacity="0.7" />
+-              <stop offset="100%" stopColor="#7a5020" stopOpacity="0.3" />
+-            </linearGradient>
+-
+-            <radialGradient id="gateGlow" cx="50%" cy="85%" r="40%">
+-              <stop offset="0%" stopColor="#c9a96e" stopOpacity="0.3" />
+-              <stop offset="60%" stopColor="#c9a96e" stopOpacity="0.08" />
+-              <stop offset="100%" stopColor="#c9a96e" stopOpacity="0" />
+-            </radialGradient>
+-
+-            <radialGradient id="passageGlow" cx="50%" cy="40%" r="50%">
+-              <stop offset="0%" stopColor="#1a1008" stopOpacity="1" />
+-              <stop offset="100%" stopColor="#000000" stopOpacity="1" />
+-            </radialGradient>
+-
+-            <filter id="displacement" x="0%" y="0%" width="100%" height="100%">
+-              <feTurbulence
+-                type="fractalNoise"
+-                baseFrequency="0.02"
+-                numOctaves="3"
+-                result="noise"
+-              />
+-              <feDisplacementMap
+-                in="SourceGraphic"
+-                in2="noise"
+-                scale="5"
+-                xChannelSelector="R"
+-                yChannelSelector="G"
+-              />
+-            </filter>
+-          </defs>
+-
+-          <rect width="1440" height="900" fill="url(#skyGrad)" />
+-
+-          {/* ── ANIMATED STARFIELD ── */}
+-          <g style={{ animation: "starDriftSlow 300s ease-in-out infinite" }}>
+-            {[
+-              [88, 45, 0.18, 4.2],
+-              [144, 72, 0.22, 6.1],
+-              [201, 28, 0.16, 8.3],
+-              [267, 91, 0.25, 5.0],
+-              [312, 55, 0.19, 7.2],
+-              [389, 38, 0.14, 3.8],
+-              [445, 82, 0.23, 9.1],
+-              [501, 19, 0.17, 6.7],
+-              [563, 66, 0.21, 4.5],
+-              [618, 33, 0.15, 7.9],
+-              [674, 77, 0.26, 5.5],
+-              [785, 88, 0.18, 8.8],
+-              [841, 22, 0.13, 3.2],
+-              [897, 67, 0.22, 6.4],
+-              [953, 41, 0.19, 4.8],
+-              [1009, 79, 0.24, 7.3],
+-              [1065, 31, 0.16, 9.5],
+-              [1121, 58, 0.2, 5.1],
+-              [1177, 84, 0.17, 6.8],
+-              [1289, 73, 0.23, 4.1],
+-              [1345, 26, 0.14, 7.6],
+-              [1401, 62, 0.21, 3.5],
+-              [1430, 89, 0.18, 8.2],
+-              [110, 140, 0.16, 5.4],
+-              [178, 163, 0.2, 7.1],
+-              [244, 128, 0.13, 4.0],
+-              [310, 157, 0.24, 6.3],
+-              [376, 134, 0.17, 8.9],
+-              [442, 169, 0.22, 3.7],
+-              [508, 142, 0.15, 5.8],
+-              [574, 118, 0.19, 7.4],
+-              [640, 155, 0.23, 4.6],
+-              [706, 131, 0.16, 6.0],
+-              [772, 148, 0.2, 8.5],
+-              [838, 122, 0.14, 3.9],
+-              [904, 159, 0.25, 5.2],
+-              [970, 136, 0.18, 7.8],
+-              [1036, 152, 0.22, 4.3],
+-              [1102, 127, 0.15, 6.6],
+-              [1168, 144, 0.19, 8.1],
+-              [1234, 161, 0.23, 5.7],
+-              [1300, 129, 0.16, 3.4],
+-              [1366, 156, 0.21, 7.0],
+-            ].map(([x, y, op, dur], i) => (
+-              <circle
+-                key={`sa-${i}`}
+-                cx={x}
+-                cy={y}
+-                r={0.5 + (i % 3) * 0.2}
+-                fill="#ffffff"
+-                style={
+-                  {
+-                    "--op-base": String(op),
+-                    "--op-peak": String(Math.min(1, (op as number) * 2.5)),
+-                    opacity: op as number,
+-                    animation: `twinkle ${dur}s ease-in-out infinite`,
+-                    animationDelay: `${(i * 0.37) % dur}s`,
+-                  } as React.CSSProperties
+-                }
+-              />
+-            ))}
+-          </g>
+-
+-          <g style={{ animation: "starDriftMid 200s ease-in-out infinite" }}>
+-            {[
+-              [55, 220, 0.15, 5.9],
+-              [123, 248, 0.19, 7.2],
+-              [191, 235, 0.22, 4.4],
+-              [259, 212, 0.13, 8.6],
+-              [327, 244, 0.17, 6.1],
+-              [395, 228, 0.24, 3.8],
+-              [463, 241, 0.16, 5.5],
+-              [531, 217, 0.2, 7.7],
+-              [599, 238, 0.14, 9.2],
+-              [667, 223, 0.23, 4.9],
+-              [735, 245, 0.18, 6.3],
+-              [803, 219, 0.21, 8.0],
+-              [871, 236, 0.15, 5.1],
+-              [939, 251, 0.25, 7.4],
+-              [1007, 224, 0.17, 3.6],
+-              [1075, 242, 0.22, 6.8],
+-              [1143, 229, 0.19, 8.4],
+-              [1211, 246, 0.14, 4.7],
+-              [1279, 213, 0.23, 5.9],
+-              [1347, 240, 0.16, 7.1],
+-              [170, 52, 0.22, 6.5],
+-              [320, 38, 0.18, 8.3],
+-              [470, 62, 0.25, 4.0],
+-              [620, 29, 0.19, 7.6],
+-              [820, 51, 0.16, 5.2],
+-              [970, 35, 0.23, 3.7],
+-              [1120, 58, 0.2, 8.9],
+-              [1290, 42, 0.17, 6.1],
+-              [245, 155, 0.24, 7.3],
+-              [415, 131, 0.15, 4.8],
+-              [565, 168, 0.21, 6.0],
+-              [715, 144, 0.18, 8.5],
+-              [915, 162, 0.25, 5.4],
+-              [1065, 138, 0.13, 7.0],
+-              [1215, 155, 0.22, 4.2],
+-              [1385, 169, 0.19, 6.7],
+-            ].map(([x, y, op, dur], i) => (
+-              <circle
+-                key={`sb-${i}`}
+-                cx={x}
+-                cy={y}
+-                r={0.6 + (i % 2) * 0.3}
+-                fill="#f5e8c0"
+-                style={
+-                  {
+-                    "--op-base": String(op),
+-                    "--op-peak": String(Math.min(1, (op as number) * 2.8)),
+-                    opacity: op as number,
+-                    animation: `twinkle ${dur}s ease-in-out infinite`,
+-                    animationDelay: `${(i * 0.53) % dur}s`,
+-                  } as React.CSSProperties
+-                }
+-              />
+-            ))}
+-          </g>
+-
+-          <g style={{ animation: "starDriftFast 120s ease-in-out infinite" }}>
+-            {[
+-              [180, 88, 0.65, 3.8],
+-              [520, 45, 0.7, 5.1],
+-              [860, 72, 0.6, 4.4],
+-              [1200, 55, 0.72, 3.2],
+-              [350, 195, 0.58, 6.2],
+-              [750, 168, 0.68, 4.7],
+-              [1100, 182, 0.62, 5.5],
+-              [140, 285, 0.55, 7.1],
+-              [580, 294, 0.7, 3.9],
+-              [980, 289, 0.63, 5.8],
+-              [1380, 292, 0.67, 4.3],
+-            ].map(([x, y, op, dur], i) => (
+-              <g
+-                key={`sc-${i}`}
+-                style={
+-                  {
+-                    "--op-base": String((op as number) * 0.7),
+-                    "--op-peak": String(op),
+-                    animation: `twinkle ${dur}s ease-in-out infinite`,
+-                    animationDelay: `${(i * 0.7) % dur}s`,
+-                  } as React.CSSProperties
+-                }
+-              >
+-                <circle cx={x} cy={y} r={1.4} fill="#fffbe8" />
+-                <line
+-                  x1={(x as number) - 5}
+-                  y1={y as number}
+-                  x2={(x as number) + 5}
+-                  y2={y as number}
+-                  stroke="#fffbe8"
+-                  strokeWidth="0.4"
+-                  opacity="0.4"
+-                />
+-                <line
+-                  x1={x as number}
+-                  y1={(y as number) - 5}
+-                  x2={x as number}
+-                  y2={(y as number) + 5}
+-                  stroke="#fffbe8"
+-                  strokeWidth="0.4"
+-                  opacity="0.4"
+-                />
+-              </g>
+-            ))}
+-          </g>
+-
+-          {/* Moon — crescent upper left */}
+-          <circle cx="200" cy="110" r="48" fill="#0a0a0a" />
+-          <circle cx="218" cy="96" r="48" fill="#000000" />
+-          <circle
+-            cx="200"
+-            cy="110"
+-            r="47"
+-            fill="none"
+-            stroke="#c9a96e"
+-            strokeWidth="0.6"
+-            opacity="0.25"
+-          />
+-
+-          {/* Ambient gate glow */}
+-          <ellipse cx="720" cy="830" rx="360" ry="150" fill="url(#gateGlow)" />
+-
+-          <g filter="url(#displacement)" className="opacity-90">
+-            {/* ═══════════════════════════════════════
+-              AUTHENTIC CANDI BENTAR
+-          ═══════════════════════════════════════ */}
+-
+-            {/* ── LEFT HALF ── */}
+-            <g filter="url(#pillarGlow)">
+-              {/* Tower body */}
+-              <path
+-                d="M510 780 L510 430 L535 410 L535 390 L545 375 L560 365 L620 365 L640 380 L640 780 Z"
+-                fill="#0a0804"
+-                stroke="url(#goldEdge)"
+-                strokeWidth="1.5"
+-              />
+-              <line
+-                x1="510"
+-                y1="430"
+-                x2="510"
+-                y2="780"
+-                stroke="#f8e89a"
+-                strokeWidth="2"
+-                opacity="0.88"
+-              />
+-              <line
+-                x1="640"
+-                y1="380"
+-                x2="640"
+-                y2="780"
+-                stroke="#e8c96a"
+-                strokeWidth="1.5"
+-                opacity="0.7"
+-              />
+-              {/* Stone bands */}
+-              {[410, 445, 480, 515, 550, 585, 620, 655, 690, 725, 760].map(
+-                (y, i) => (
+-                  <g key={`lb-${i}`}>
+-                    <rect
+-                      x="510"
+-                      y={y}
+-                      width="130"
+-                      height="2"
+-                      fill="#c9a96e"
+-                      opacity={0.16 + (i % 3) * 0.06}
+-                    />
+-                    <line
+-                      x1="510"
+-                      y1={y}
+-                      x2="640"
+-                      y2={y}
+-                      stroke="#e8c96a"
+-                      strokeWidth="0.5"
+-                      opacity={0.1}
+-                    />
+-                  </g>
+-                ),
+-              )}
+-              {/* Carved panels */}
+-              <rect
+-                x="518"
+-                y="440"
+-                width="114"
+-                height="90"
+-                rx="1"
+-                fill="none"
+-                stroke="#c9a96e"
+-                strokeWidth="0.6"
+-                opacity="0.22"
+-              />
+-              <rect
+-                x="518"
+-                y="545"
+-                width="114"
+-                height="90"
+-                rx="1"
+-                fill="none"
+-                stroke="#c9a96e"
+-                strokeWidth="0.6"
+-                opacity="0.22"
+-              />
+-              <rect
+-                x="518"
+-                y="650"
+-                width="114"
+-                height="90"
+-                rx="1"
+-                fill="none"
+-                stroke="#c9a96e"
+-                strokeWidth="0.6"
+-                opacity="0.22"
+-              />
+-              <path
+-                d="M575 465 Q565 480 575 495 Q585 480 575 465Z"
+-                fill="#c9a96e"
+-                opacity="0.18"
+-              />
+-              <path
+-                d="M575 570 Q565 585 575 600 Q585 585 575 570Z"
+-                fill="#c9a96e"
+-                opacity="0.18"
+-              />
+-              <path
+-                d="M575 675 Q565 690 575 700 Q585 690 575 675Z"
+-                fill="#c9a96e"
+-                opacity="0.18"
+-              />
+-              {/* Meru stepped arch tiers */}
+-              <path
+-                d="M500 390 L640 390 L640 375 L555 375 L545 360 L500 360Z"
+-                fill="#0c0a05"
+-                stroke="#e8c96a"
+-                strokeWidth="1.2"
+-                opacity="0.92"
+-              />
+-              <line
+-                x1="500"
+-                y1="360"
+-                x2="500"
+-                y2="390"
+-                stroke="#f8e89a"
+-                strokeWidth="2.2"
+-                opacity="0.92"
+-              />
+-              <path
+-                d="M508 360 L640 360 L640 346 L562 346 L552 332 L508 332Z"
+-                fill="#0c0a05"
+-                stroke="#e8c96a"
+-                strokeWidth="1.1"
+-                opacity="0.87"
+-              />
+-              <line
+-                x1="508"
+-                y1="332"
+-                x2="508"
+-                y2="360"
+-                stroke="#f8e89a"
+-                strokeWidth="2"
+-                opacity="0.87"
+-              />
+-              <path
+-                d="M516 332 L640 332 L640 319 L569 319 L559 306 L516 306Z"
+-                fill="#0c0a05"
+-                stroke="#c9a96e"
+-                strokeWidth="1"
+-                opacity="0.82"
+-              />
+-              <line
+-                x1="516"
+-                y1="306"
+-                x2="516"
+-                y2="332"
+-                stroke="#f8e89a"
+-                strokeWidth="1.7"
+-                opacity="0.82"
+-              />
+-              <path
+-                d="M524 306 L638 306 L638 294 L575 294 L566 282 L524 282Z"
+-                fill="#0c0a05"
+-                stroke="#c9a96e"
+-                strokeWidth="0.9"
+-                opacity="0.77"
+-              />
+-              <line
+-                x1="524"
+-                y1="282"
+-                x2="524"
+-                y2="306"
+-                stroke="#e8c96a"
+-                strokeWidth="1.5"
+-                opacity="0.77"
+-              />
+-              <path
+-                d="M531 282 L636 282 L636 270 L581 270 L573 259 L531 259Z"
+-                fill="#0c0a05"
+-                stroke="#c9a96e"
+-                strokeWidth="0.8"
+-                opacity="0.72"
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "wc -l apps/mouth/src/app/portal/login-upgraded/page.tsx apps/mouth/src/app/portal/login-upgraded/page.test.tsx apps/mouth/src/app/portal/login-upgraded/error.tsx apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+nl -ba apps/mouth/src/app/portal/login-upgraded/page.tsx | sed -n '1,560p'
+nl -ba apps/mouth/src/app/portal/login-upgraded/error.tsx
+nl -ba apps/mouth/src/app/portal/login-upgraded/page.test.tsx | sed -n '1,420p'" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 301ms:
+     497 apps/mouth/src/app/portal/login-upgraded/page.tsx
+     332 apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+      52 apps/mouth/src/app/portal/login-upgraded/error.tsx
+    2599 apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+    3480 total
+     1	// apps/mouth/src/app/portal/login-upgraded/page.tsx
+     2	"use client";
+     3	
+     4	import React, { useEffect, useState, useRef } from "react";
+     5	import { useRouter } from "next/navigation";
+     6	import Link from "next/link";
+     7	import { Loader2 } from "lucide-react";
+     8	import { BZLogo } from "@balizero/core/components/BZLogo";
+     9	import { useSystemSound } from "@/hooks/useSystemSound";
+    10	import { publicAuth } from "@/lib/api/public-auth";
+    11	import { sanitizeRedirect } from "@/lib/auth/sanitizeRedirect";
+    12	import { logger } from "@/lib/logger";
+    13	import { I18nProvider, useTranslation } from "@/i18n";
+    14	
+    15	// Configuration
+    16	const REDIRECT_DELAY_MS = 1500;
+    17	const ERROR_RESET_DELAY_MS = 2000;
+    18	
+    19	// R19 concept F ("RAPI"): forest is the ONLY primary-button fill. Copper
+    20	// carries "needs you" as text, numerals and outline — never as a filled
+    21	// surface — and red does not exist on this surface at all.
+    22	const LOGIN_CTA_STYLE = {
+    23	  background: "var(--r19-forest)",
+    24	  color: "var(--r19-paper)",
+    25	} as const;
+    26	
+    27	// Page-local presentation layer. Scoped under .r19-gate so nothing here can
+    28	// reach kita/prime; the palette lives as page-local custom properties until
+    29	// the my-product token seam carries the R19 values.
+    30	const R19_STYLES = `
+    31	.r19-gate{
+    32	  --r19-paper:#f7f4ee;--r19-surface:#fffcf7;--r19-ink:#1d2c3b;--r19-muted:#58626b; /* token-lint-ok: concept-F paper/ink scale, page-local until the my-product token seam lands */
+    33	  --r19-line:#dad8d1;--r19-line-strong:#a8aca9; /* token-lint-ok: concept-F hairlines */
+    34	  --r19-copper:#a44b36;--r19-forest:#253e33; /* token-lint-ok: concept-F copper (needs-you) and forest (done) meanings */
+    35	  position:relative;display:grid;grid-template-columns:minmax(0,5fr) minmax(0,6fr);
+    36	  min-height:100vh;background:var(--r19-paper);color:var(--r19-ink);
+    37	  font-size:15px;line-height:1.75;
+    38	}
+    39	.r19-serif{font-family:var(--font-serif),Georgia,serif;font-weight:450;letter-spacing:-0.03em}
+    40	.r19-eyebrow{font-size:10px;line-height:1.4;font-weight:650;letter-spacing:0.14em;text-transform:uppercase;color:var(--r19-muted)}
+    41	.r19-gate button{cursor:pointer;border:0;background:none;color:inherit;font:inherit}
+    42	.r19-gate a{color:inherit;text-decoration:none}
+    43	
+    44	.r19-hero{background:var(--r19-forest);color:var(--r19-paper);display:flex;flex-direction:column;justify-content:space-between;gap:32px;padding:40px 48px}
+    45	.r19-brand{display:flex;align-items:center;gap:10px}
+    46	.r19-brand-text{display:flex;flex-direction:column}
+    47	.r19-brand-role{color:rgba(247,244,238,0.72)}
+    48	.r19-hero-rule{width:56px;height:3px;border-radius:2px;background:var(--r19-copper);margin-bottom:22px}
+    49	.r19-hero h2{margin:0;font-size:clamp(40px,4vw,56px);line-height:1.04}
+    50	.r19-hero-lede{margin:20px 0 0;max-width:34ch;font-size:15px;color:rgba(247,244,238,0.78)}
+    51	.r19-hero-foot{display:flex;justify-content:space-between;gap:16px;color:rgba(247,244,238,0.72)}
+    52	
+    53	.r19-form{display:flex;flex-direction:column;justify-content:center;align-items:center;padding:48px 32px}
+    54	.r19-box{width:100%;max-width:400px}
+    55	.r19-steps{display:flex;align-items:center;gap:6px;margin-bottom:18px}
+    56	.r19-steps i{display:block;width:28px;height:3px;border-radius:2px;background:var(--r19-line)}
+    57	.r19-steps i.on{background:var(--r19-forest)}
+    58	.r19-form h1{margin:10px 0 8px;font-size:40px;line-height:1.06}
+    59	.r19-hint{margin:0 0 26px;color:var(--r19-muted)}
+    60	.r19-field{margin-bottom:16px}
+    61	.r19-field-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:8px}
+    62	.r19-input{display:block;width:100%;height:52px;padding:0 16px;font-size:15px;color:var(--r19-ink);background:var(--r19-surface);border:1px solid var(--r19-line-strong);border-radius:0.25rem;outline:none}
+    63	.r19-input::placeholder{color:var(--r19-muted)}
+    64	.r19-input:focus{border-color:var(--r19-copper);box-shadow:0 0 0 3px rgba(164,75,54,0.18)}
+    65	.r19-input:disabled{opacity:0.55;cursor:not-allowed}
+    66	.r19-pin{font-size:22px;text-align:center;letter-spacing:14px;font-variant-numeric:tabular-nums}
+    67	.r19-gate .r19-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;width:100%;height:48px;margin-top:6px;padding:0 22px;border-radius:0.25rem;font-size:13px;font-weight:650;letter-spacing:0.02em}
+    68	.r19-gate .r19-btn:disabled{opacity:0.5;cursor:not-allowed}
+    69	.r19-gate .r19-back{font-size:12px;font-weight:650;color:var(--r19-copper)}
+    70	.r19-alt{margin-top:22px;display:flex;flex-direction:column;gap:10px;font-size:13px}
+    71	.r19-gate .r19-link{color:var(--r19-copper);font-weight:650}
+    72	.r19-gate .r19-link:hover{text-decoration:underline}
+    73	.r19-alt-sep{border-top:1px solid var(--r19-line);margin:6px 0}
+    74	.r19-quiet{color:var(--r19-muted)}
+    75	.r19-formfoot{margin-top:40px;display:flex;gap:16px;font-size:12px;color:var(--r19-muted);font-variant-numeric:tabular-nums}
+    76	.r19-formfoot a{display:inline-flex;align-items:center;min-height:24px}
+    77	.r19-formfoot a:hover{text-decoration:underline}
+    78	
+    79	.r19-overlay{position:absolute;inset:0;z-index:50;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:24px;text-align:center;background:color-mix(in srgb, var(--r19-paper) 92%, transparent);backdrop-filter:blur(8px)}
+    80	.r19-overlay h1{margin:0;font-size:clamp(34px,5vw,56px);line-height:1.05}
+    81	.r19-overlay-ok h1{color:var(--r19-forest)}
+    82	.r19-overlay-denied h1{color:var(--r19-copper)}
+    83	.r19-overlay p{margin:0;max-width:34rem;font-size:15px;color:var(--r19-ink)}
+    84	
+    85	.r19-input:-webkit-autofill,
+    86	.r19-input:-webkit-autofill:hover,
+    87	.r19-input:-webkit-autofill:focus,
+    88	.r19-input:-webkit-autofill:active{
+    89	  -webkit-box-shadow:0 0 0 30px var(--r19-surface) inset !important;
+    90	  -webkit-text-fill-color:var(--r19-ink) !important;
+    91	  caret-color:var(--r19-copper) !important;
+    92	}
+    93	
+    94	@media (max-width:767px){
+    95	  .r19-gate{grid-template-columns:1fr}
+    96	  .r19-hero{padding:28px 22px 30px;gap:28px}
+    97	  .r19-hero h2{font-size:34px}
+    98	  .r19-hero-lede{margin-top:12px;font-size:14px}
+    99	  .r19-hero-foot{display:none}
+   100	  .r19-form{padding:32px 22px 40px;align-items:stretch}
+   101	  .r19-form h1{font-size:34px}
+   102	}
+   103	`;
+   104	
+   105	// Map HTTP status code → i18n error key. Unknown → server_error (5xx) or
+   106	// network_error (anything else, including status=0 from opaque fetch failures).
+   107	function errorKeyFor(status: number): string {
+   108	  switch (status) {
+   109	    case 401:
+   110	      return "portal.login.errors.invalid_credentials";
+   111	    case 403:
+   112	      return "portal.login.errors.portal_unavailable";
+   113	    case 404:
+   114	      return "portal.login.errors.email_not_found";
+   115	    case 422:
+   116	      return "portal.login.errors.invalid_2fa";
+   117	    case 429:
+   118	      return "portal.login.errors.rate_limited";
+   119	    case 503:
+   120	      return "portal.login.errors.maintenance";
+   121	    default:
+   122	      return status >= 500
+   123	        ? "portal.login.errors.server_error"
+   124	        : "portal.login.errors.network_error";
+   125	  }
+   126	}
+   127	
+   128	export default function UpgradedLoginPage() {
+   129	  // `useTranslation` requires an I18nProvider ancestor; the root layout does
+   130	  // not wrap one (only (blog) does). Wrap locally so /portal/login-upgraded
+   131	  // can consume the shared locale JSON without touching global providers.
+   132	  return (
+   133	    <I18nProvider>
+   134	      <UpgradedLoginPageInner />
+   135	    </I18nProvider>
+   136	  );
+   137	}
+   138	
+   139	function UpgradedLoginPageInner() {
+   140	  const router = useRouter();
+   141	  const { t } = useTranslation();
+   142	  const [isHydrated, setIsHydrated] = useState(false);
+   143	  const [email, setEmail] = useState("");
+   144	  const [pin, setPin] = useState("");
+   145	  const [step, setStep] = useState<"email" | "pin">("email");
+   146	  const [loginStage, setLoginStage] = useState<
+   147	    "idle" | "authenticating" | "success" | "denied"
+   148	  >("idle");
+   149	  const [errorMessage, setErrorMessage] = useState<string>("");
+   150	  const { play } = useSystemSound();
+   151	  const loginInFlightRef = useRef(false);
+   152	
+   153	  // Keep the controlled fields inert until React owns them. Without this
+   154	  // guard, a fast user (or WebKit restoring form state) can update the native
+   155	  // input before hydration while React still holds an empty email, leaving the
+   156	  // visible value and the disabled CTA out of sync.
+   157	  useEffect(() => {
+   158	    setIsHydrated(true);
+   159	  }, []);
+   160	
+   161	  // Same persona declaration the authenticated portal layout makes at mount
+   162	  // (portal/(authenticated)/layout.tsx): the sign-in page is part of My, so
+   163	  // the product token seam has to apply here too. No cleanup — the layout
+   164	  // does not remove the attribute either, and a removal on unmount would
+   165	  // strip the persona during the redirect into the portal itself.
+   166	  useEffect(() => {
+   167	    const root = document.documentElement;
+   168	    root.dataset.product = "my";
+   169	    if (root.dataset.theme === "light") root.dataset.theme = "operative-light";
+   170	    if (root.dataset.theme === "dark") root.dataset.theme = "operative-dark";
+   171	    if (
+   172	      root.dataset.theme !== "operative-light" &&
+   173	      root.dataset.theme !== "operative-dark"
+   174	    ) {
+   175	      root.dataset.theme = "operative-light";
+   176	    }
+   177	  }, []);
+   178	
+   179	  const playClickSound = () => {
+   180	    play("focus");
+   181	    if (typeof window !== "undefined" && "vibrate" in navigator) {
+   182	      navigator.vibrate(10);
+   183	    }
+   184	  };
+   185	
+   186	  const handleSubmitEmail = (e: React.FormEvent) => {
+   187	    e.preventDefault();
+   188	    const normalizedEmail = email.trim();
+   189	    if (normalizedEmail) {
+   190	      playClickSound();
+   191	      setEmail(normalizedEmail);
+   192	      setStep("pin");
+   193	    }
+   194	  };
+   195	
+   196	  const handleLogin = async (e: React.FormEvent) => {
+   197	    e.preventDefault();
+   198	    const normalizedEmail = email.trim();
+   199	    if (
+   200	      loginStage !== "idle" ||
+   201	      loginInFlightRef.current ||
+   202	      !normalizedEmail ||
+   203	      pin.length < 4 ||
+   204	      pin.length > 8
+   205	    ) {
+   206	      return;
+   207	    }
+   208	    loginInFlightRef.current = true;
+   209	
+   210	    logger.info("Login process started", {
+   211	      component: "UpgradedLoginPage",
+   212	      action: "handleLogin",
+   213	    });
+   214	
+   215	    play("auth_start");
+   216	    setLoginStage("authenticating");
+   217	
+   218	    try {
+   219	      const loginResult = await publicAuth.login(normalizedEmail, pin);
+   220	      setLoginStage("success");
+   221	      play("access_granted");
+   222	
+   223	      const urlParams = new URLSearchParams(globalThis.location.search);
+   224	      const requestedRedirect = sanitizeRedirect(urlParams.get("redirect"));
+   225	      const backendRedirect = sanitizeRedirect(loginResult.redirectTo ?? null);
+   226	      const role = loginResult.user.role;
+   227	      const redirectTo =
+   228	        role === "partner"
+   229	          ? requestedRedirect?.startsWith("/portal/partner/")
+   230	            ? requestedRedirect
+   231	            : "/portal/partner/dashboard"
+   232	          : role === "client"
+   233	            ? requestedRedirect?.startsWith("/portal/partner/")
+   234	              ? "/portal"
+   235	              : (requestedRedirect ?? "/portal")
+   236	            : (backendRedirect ?? "/dashboard");
+   237	
+   238	      setTimeout(() => {
+   239	        router.replace(redirectTo);
+   240	      }, REDIRECT_DELAY_MS);
+   241	    } catch (error) {
+   242	      // Extract HTTP status from error shape (best-effort — covers both
+   243	      // fetch Response-shaped errors and axios-style { response: { status } }).
+   244	      const status =
+   245	        (error as { response?: { status?: number } })?.response?.status ??
+   246	        (error as { status?: number })?.status ??
+   247	        0;
+   248	
+   249	      // Auth telemetry is deliberately limited to non-sensitive diagnostics.
+   250	      // Never pass credentials, addresses, the current URL, or the raw HTTP
+   251	      // error (which may embed a request body) to the logger/Sentry pipeline.
+   252	      const telemetryContext = {
+   253	        component: "UpgradedLoginPage",
+   254	        action: "handleLogin",
+   255	        code: status,
+   256	        reason: errorKeyFor(status),
+   257	      } as const;
+   258	      if (status >= 400 && status < 500) {
+   259	        logger.info("Login denied", telemetryContext);
+   260	      } else {
+   261	        logger.error("Login failed", telemetryContext);
+   262	      }
+   263	
+   264	      let msg = t(errorKeyFor(status));
+   265	      if (status === 429) {
+   266	        const retryAfter = (
+   267	          error as {
+   268	            response?: { headers?: { get?: (k: string) => string | null } };
+   269	          }
+   270	        )?.response?.headers?.get?.("retry-after");
+   271	        const seconds = retryAfter ? parseInt(retryAfter, 10) : 60;
+   272	        msg = t("portal.login.errors.rate_limited", {
+   273	          seconds: String(Number.isFinite(seconds) ? seconds : 60),
+   274	        });
+   275	      }
+   276	      setErrorMessage(msg);
+   277	      setLoginStage("denied");
+   278	      play("access_denied");
+   279	
+   280	      setTimeout(() => {
+   281	        loginInFlightRef.current = false;
+   282	        setLoginStage("idle");
+   283	      }, ERROR_RESET_DELAY_MS);
+   284	    }
+   285	  };
+   286	
+   287	  // The two existing alternative paths, equal and visible on both steps.
+   288	  const alternatives = (
+   289	    <div className="r19-alt">
+   290	      <Link href="/portal/magic-link" className="r19-link">
+   291	        Sign in with an email link instead
+   292	      </Link>
+   293	      <Link href="/portal/forgot-password" className="r19-link">
+   294	        {t("portal.login.forgot_password")}
+   295	      </Link>
+   296	      <div className="r19-alt-sep" aria-hidden="true" />
+   297	      <span className="r19-quiet">
+   298	        New here? Your Bali Zero contact sends the invitation — there is nothing
+   299	        to register.
+   300	      </span>
+   301	    </div>
+   302	  );
+   303	
+   304	  const formFooter = (
+   305	    <div className="r19-formfoot">
+   306	      <span>© 2026 Bali Zero</span>
+   307	      <Link href="/privacy">Privacy</Link>
+   308	      <Link href="/terms">Terms</Link>
+   309	    </div>
+   310	  );
+   311	
+   312	  return (
+   313	    <div className="r19-gate">
+   314	      {/* Safe: static presentation CSS, no external input. */}
+   315	      <style dangerouslySetInnerHTML={{ __html: R19_STYLES }} />
+   316	
+   317	      {/* ACCESS GRANTED OVERLAY */}
+   318	      {loginStage === "success" && (
+   319	        <div
+   320	          className="r19-overlay r19-overlay-ok"
+   321	          role="status"
+   322	          aria-live="polite"
+   323	        >
+   324	          <h1 className="r19-serif">Portal Unlocked</h1>
+   325	        </div>
+   326	      )}
+   327	
+   328	      {/* ACCESS DENIED OVERLAY — copper, never red: the state carries a word. */}
+   329	      {loginStage === "denied" && (
+   330	        <div
+   331	          className="r19-overlay r19-overlay-denied"
+   332	          role="alert"
+   333	          aria-live="assertive"
+   334	        >
+   335	          <h1 className="r19-serif">Access Denied</h1>
+   336	          {errorMessage && <p id="portal-login-error">{errorMessage}</p>}
+   337	        </div>
+   338	      )}
+   339	
+   340	      {/* The one forest surface of the portal. No personal data before auth. */}
+   341	      <aside className="r19-hero" aria-label="Bali Zero">
+   342	        <span className="r19-brand">
+   343	          <BZLogo variant="full" size={36} priority />
+   344	          <span className="r19-brand-text">
+   345	            <span className="r19-brand-role r19-eyebrow">Client portal</span>
+   346	          </span>
+   347	        </span>
+   348	        <div>
+   349	          <div className="r19-hero-rule" aria-hidden="true" />
+   350	          <h2 className="r19-serif">
+   351	            Your Bali file,
+   352	            <br />
+   353	            kept in order.
+   354	          </h2>
+   355	          <p className="r19-hero-lede">
+   356	            Visas, company, taxes and documents — one place, one team, and
+   357	            always a clear next step.
+   358	          </p>
+   359	        </div>
+   360	        <div className="r19-hero-foot r19-eyebrow">
+   361	          <span>my.balizero.com</span>
+   362	          <span>Denpasar · Bali</span>
+   363	        </div>
+   364	      </aside>
+   365	
+   366	      {/* The existing two-step flow: email, then the PIN. */}
+   367	      <section className="r19-form" aria-label="Sign in">
+   368	        {step === "email" ? (
+   369	          <form className="r19-box" onSubmit={handleSubmitEmail}>
+   370	            <div className="r19-steps" aria-hidden="true">
+   371	              <i className="on" />
+   372	              <i />
+   373	            </div>
+   374	            <p className="r19-eyebrow">Sign in · step 1 of 2</p>
+   375	            <h1 className="r19-serif">Welcome back.</h1>
+   376	            <p className="r19-hint">
+   377	              Enter the email registered with Bali Zero. We will ask for your
+   378	              PIN next.
+   379	            </p>
+   380	            <div className="r19-field">
+   381	              <div className="r19-field-head">
+   382	                <label className="r19-eyebrow" htmlFor="portal-email">
+   383	                  Corporate Email
+   384	                </label>
+   385	              </div>
+   386	              <input
+   387	                id="portal-email"
+   388	                type="email"
+   389	                name="email"
+   390	                autoComplete="username"
+   391	                autoCapitalize="none"
+   392	                spellCheck={false}
+   393	                value={email}
+   394	                onChange={(e) => setEmail(e.target.value)}
+   395	                onFocus={() => play("focus")}
+   396	                disabled={!isHydrated || loginStage !== "idle"}
+   397	                placeholder="client@company.com"
+   398	                required
+   399	                autoFocus
+   400	                className="r19-input"
+   401	              />
+   402	            </div>
+   403	            <button
+   404	              type="submit"
+   405	              disabled={!isHydrated || loginStage !== "idle" || !email.trim()}
+   406	              className="r19-btn"
+   407	              style={LOGIN_CTA_STYLE}
+   408	            >
+   409	              Continue
+   410	            </button>
+   411	            {alternatives}
+   412	            {formFooter}
+   413	          </form>
+   414	        ) : (
+   415	          <form className="r19-box" onSubmit={handleLogin}>
+   416	            <div className="r19-steps" aria-hidden="true">
+   417	              <i className="on" />
+   418	              <i className="on" />
+   419	            </div>
+   420	            <p className="r19-eyebrow">Sign in · step 2 of 2</p>
+   421	            <h1 className="r19-serif">Welcome back.</h1>
+   422	            <p className="r19-hint">
+   423	              Enter the PIN from your invitation email.
+   424	            </p>
+   425	            <div className="r19-field">
+   426	              <div className="r19-field-head">
+   427	                <label className="r19-eyebrow" htmlFor="portal-pin">
+   428	                  Access PIN
+   429	                </label>
+   430	                <button
+   431	                  type="button"
+   432	                  onClick={() => {
+   433	                    playClickSound();
+   434	                    setStep("email");
+   435	                  }}
+   436	                  className="r19-back"
+   437	                >
+   438	                  ← {email.split("@")[0]}
+   439	                </button>
+   440	              </div>
+   441	              <input
+   442	                id="portal-pin"
+   443	                type="password"
+   444	                name="password"
+   445	                autoComplete="current-password"
+   446	                inputMode="numeric"
+   447	                aria-describedby={
+   448	                  errorMessage ? "portal-login-error" : undefined
+   449	                }
+   450	                aria-invalid={loginStage === "denied"}
+   451	                value={pin}
+   452	                onChange={(e) => {
+   453	                  setPin(e.target.value);
+   454	                  if (
+   455	                    e.target.value.length === 6 &&
+   456	                    typeof window !== "undefined" &&
+   457	                    "vibrate" in navigator
+   458	                  )
+   459	                    navigator.vibrate(20);
+   460	                }}
+   461	                onFocus={() => play("focus")}
+   462	                disabled={loginStage !== "idle"}
+   463	                placeholder="••••••"
+   464	                required
+   465	                autoFocus
+   466	                minLength={4}
+   467	                maxLength={8}
+   468	                className="r19-input r19-pin"
+   469	              />
+   470	            </div>
+   471	            <button
+   472	              type="submit"
+   473	              disabled={
+   474	                loginStage !== "idle" || pin.length < 4 || pin.length > 8
+   475	              }
+   476	              aria-label={
+   477	                loginStage === "authenticating"
+   478	                  ? "Verifying identity"
+   479	                  : "Verify Identity"
+   480	              }
+   481	              className="r19-btn"
+   482	              style={LOGIN_CTA_STYLE}
+   483	            >
+   484	              {loginStage === "authenticating" ? (
+   485	                <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+   486	              ) : (
+   487	                "Verify Identity"
+   488	              )}
+   489	            </button>
+   490	            {alternatives}
+   491	            {formFooter}
+   492	          </form>
+   493	        )}
+   494	      </section>
+   495	    </div>
+   496	  );
+   497	}
+     1	"use client";
+     2	
+     3	import { useEffect } from "react";
+     4	import { Button } from "@/components/ui/button";
+     5	import { RefreshCw, LogIn } from "lucide-react";
+     6	import { logger } from "@/lib/logger";
+     7	
+     8	export default function LoginError({
+     9	  error,
+    10	  reset,
+    11	}: {
+    12	  error: Error & { digest?: string };
+    13	  reset: () => void;
+    14	}) {
+    15	  useEffect(() => {
+    16	    logger.error("Login Error", {}, error);
+    17	  }, [error]);
+    18	
+    19	  return (
+    20	    <div className="flex min-h-[60vh] flex-col items-center justify-center p-6">
+    21	      {/* R19 concept F: red does not exist on the portal surface — a failed
+    22	          load is copper ("needs you"), and the word carries the state. */}
+    23	      <div
+    24	        className="flex h-20 w-20 items-center justify-center rounded-full"
+    25	        style={{
+    26	          background:
+    27	            "color-mix(in srgb, var(--bz-copper-text) 10%, transparent)",
+    28	        }}
+    29	      >
+    30	        <LogIn
+    31	          className="h-10 w-10"
+    32	          style={{ color: "var(--bz-copper-text)" }}
+    33	        />
+    34	      </div>
+    35	      <div className="mt-6 text-center space-y-2 max-w-md">
+    36	        <h2 className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]">
+    37	          Couldn&apos;t Load Login
+    38	        </h2>
+    39	        <p className="text-[var(--tx-secondary)]">
+    40	          There was an error loading this page. Please try again or contact
+    41	          support if the problem persists.
+    42	        </p>
+    43	      </div>
+    44	      <div className="mt-8 flex gap-3">
+    45	        <Button onClick={() => reset()} variant="default">
+    46	          <RefreshCw className="mr-2 h-4 w-4" />
+    47	          Try Again
+    48	        </Button>
+    49	      </div>
+    50	    </div>
+    51	  );
+    52	}
+     1	import {
+     2	  act,
+     3	  fireEvent,
+     4	  render,
+     5	  screen,
+     6	  waitFor,
+     7	} from "@testing-library/react";
+     8	import { beforeEach, describe, expect, it, vi } from "vitest";
+     9	
+    10	const { mockLogin, mockLoggerError, mockLoggerInfo, mockRouterReplace } =
+    11	  vi.hoisted(() => ({
+    12	    mockLogin: vi.fn(),
+    13	    mockLoggerError: vi.fn(),
+    14	    mockLoggerInfo: vi.fn(),
+    15	    mockRouterReplace: vi.fn(),
+    16	  }));
+    17	
+    18	vi.mock("next/navigation", () => ({
+    19	  useRouter: () => ({
+    20	    push: vi.fn(),
+    21	    replace: mockRouterReplace,
+    22	    prefetch: vi.fn(),
+    23	    back: vi.fn(),
+    24	  }),
+    25	}));
+    26	
+    27	vi.mock("@/lib/api/public-auth", () => ({
+    28	  publicAuth: { login: mockLogin },
+    29	}));
+    30	
+    31	vi.mock("@/lib/logger", () => ({
+    32	  logger: {
+    33	    error: mockLoggerError,
+    34	    info: mockLoggerInfo,
+    35	    warn: vi.fn(),
+    36	    debug: vi.fn(),
+    37	  },
+    38	}));
+    39	
+    40	import UpgradedLoginPage from "./page";
+    41	
+    42	describe("UpgradedLoginPage (R19 concept F sign-in)", () => {
+    43	  beforeEach(() => {
+    44	    vi.clearAllMocks();
+    45	    window.history.replaceState({}, "", "/portal/login-upgraded");
+    46	  });
+    47	
+    48	  it("renders the split gate and no illustration survives", () => {
+    49	    const { container } = render(<UpgradedLoginPage />);
+    50	
+    51	    expect(container.querySelector(".r19-gate")).not.toBeNull();
+    52	    expect(container.querySelector(".r19-hero")).not.toBeNull();
+    53	    // The candi-bentar gate scene, its starfield and its re-light class are gone.
+    54	    expect(container.querySelector(".gate-scene")).toBeNull();
+    55	    expect(container.querySelector("svg circle")).toBeNull();
+    56	  });
+    57	
+    58	  it("the forest panel carries the brand mark and the hero sentence", () => {
+    59	    const { container } = render(<UpgradedLoginPage />);
+    60	
+    61	    const hero = container.querySelector(".r19-hero");
+    62	    expect(hero).not.toBeNull();
+    63	    // The logo asset carries the wordmark; the hero does not repeat it in text.
+    64	    expect(hero?.textContent).not.toContain("Bali Zero");
+    65	    expect(hero?.textContent).toContain("Client portal");
+    66	    expect(hero?.querySelector("h2")?.textContent).toBe(
+    67	      "Your Bali file,kept in order.",
+    68	    );
+    69	    // Zero's order: the real logo, never cropped into a circle.
+    70	    const mark = hero?.querySelector("img");
+    71	    expect(mark).not.toBeNull();
+    72	    expect(mark?.getAttribute("alt")).toBe("Bali Zero");
+    73	    expect(mark?.className ?? "").not.toContain("rounded-full");
+    74	  });
+    75	
+    76	  it("the email field is the paper form control with a copper focus ring", () => {
+    77	    render(<UpgradedLoginPage />);
+    78	
+    79	    const email = screen.getByPlaceholderText("client@company.com");
+    80	    expect(email.className).toContain("r19-input");
+    81	
+    82	    const eyebrow = screen.getByText("Sign in · step 1 of 2");
+    83	    expect(eyebrow.className).toContain("r19-eyebrow");
+    84	  });
+    85	
+    86	  it("the primary CTA is filled forest — copper never fills a button", () => {
+    87	    render(<UpgradedLoginPage />);
+    88	
+    89	    const cta = screen.getByRole("button", { name: /Continue/ });
+    90	    expect(cta.style.background).toBe("var(--r19-forest)");
+    91	    expect(cta.style.color).toBe("var(--r19-paper)");
+    92	  });
+    93	
+    94	  it("email step advances to the PIN step with the R19 controls", async () => {
+    95	    render(<UpgradedLoginPage />);
+    96	
+    97	    fireEvent.change(screen.getByPlaceholderText("client@company.com"), {
+    98	      target: { value: "synthetic.user@example.test" },
+    99	    });
+   100	    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
+   101	
+   102	    const pin = await screen.findByLabelText("Access PIN");
+   103	    expect(pin.className).toContain("r19-input");
+   104	    expect(pin.className).toContain("r19-pin");
+   105	    expect(screen.getByText("Sign in · step 2 of 2")).toBeTruthy();
+   106	
+   107	    const verify = screen.getByRole("button", { name: /Verify Identity/ });
+   108	    expect(verify.style.background).toBe("var(--r19-forest)");
+   109	    expect(verify.style.color).toBe("var(--r19-paper)");
+   110	
+   111	    const magicLink = screen.getByRole("link", {
+   112	      name: /Sign in with an email link instead/,
+   113	    });
+   114	    expect(magicLink.className).toContain("r19-link");
+   115	  });
+   116	
+   117	  it("exposes durable labels and password-manager semantics", async () => {
+   118	    render(<UpgradedLoginPage />);
+   119	
+   120	    const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   121	    expect(email).toHaveAttribute("name", "email");
+   122	    expect(email).toHaveAttribute("autocomplete", "username");
+   123	
+   124	    fireEvent.change(email, {
+   125	      target: { value: "  synthetic.user@example.test  " },
+   126	    });
+   127	    fireEvent.submit(email.closest("form")!);
+   128	
+   129	    const pin = await screen.findByLabelText("Access PIN");
+   130	    expect(pin).toHaveAttribute("name", "password");
+   131	    expect(pin).toHaveAttribute("autocomplete", "current-password");
+   132	    expect(pin).toHaveAttribute("minlength", "4");
+   133	    expect(pin).toHaveAttribute("maxlength", "8");
+   134	  });
+   135	
+   136	  it.each([
+   137	    ["/portal/matters?tab=open", "/portal/matters?tab=open"],
+   138	    ["https://attacker.example/collect", "/portal"],
+   139	    ["//attacker.example/collect", "/portal"],
+   140	  ])(
+   141	    "routes redirect %s only through the allowlisted same-origin sanitizer",
+   142	    async (redirect, expected) => {
+   143	      window.history.replaceState(
+   144	        {},
+   145	        "",
+   146	        `/portal/login-upgraded?redirect=${encodeURIComponent(redirect)}`,
+   147	      );
+   148	      mockLogin.mockResolvedValue({
+   149	        access_token: "synthetic-token",
+   150	        token_type: "Bearer",
+   151	        user: {
+   152	          id: "client-1",
+   153	          email: "synthetic.user@example.test",
+   154	          name: "Synthetic Client",
+   155	          role: "client",
+   156	        },
+   157	        redirectTo: "/portal",
+   158	      });
+   159	      render(<UpgradedLoginPage />);
+   160	
+   161	      const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   162	      fireEvent.change(email, {
+   163	        target: { value: "synthetic.user@example.test" },
+   164	      });
+   165	      fireEvent.submit(email.closest("form")!);
+   166	
+   167	      const pin = await screen.findByLabelText("Access PIN");
+   168	      fireEvent.change(pin, { target: { value: "1234" } });
+   169	
+   170	      vi.useFakeTimers();
+   171	      try {
+   172	        await act(async () => {
+   173	          const form = pin.closest("form")!;
+   174	          fireEvent.submit(form);
+   175	          fireEvent.submit(form);
+   176	          await Promise.resolve();
+   177	        });
+   178	
+   179	        expect(mockLogin).toHaveBeenCalledTimes(1);
+   180	        expect(mockLogin).toHaveBeenCalledWith(
+   181	          "synthetic.user@example.test",
+   182	          "1234",
+   183	        );
+   184	
+   185	        act(() => {
+   186	          vi.advanceTimersByTime(1500);
+   187	        });
+   188	        expect(mockRouterReplace).toHaveBeenCalledWith(expected);
+   189	      } finally {
+   190	        vi.useRealTimers();
+   191	      }
+   192	    },
+   193	  );
+   194	
+   195	  it("routes a partner to the dedicated portal and rejects a client-only redirect", async () => {
+   196	    window.history.replaceState(
+   197	      {},
+   198	      "",
+   199	      "/portal/login-upgraded?redirect=%2Fportal%2Fbilling",
+   200	    );
+   201	    mockLogin.mockResolvedValue({
+   202	      access_token: "synthetic-token",
+   203	      token_type: "Bearer",
+   204	      user: {
+   205	        id: "partner-user-1",
+   206	        email: "synthetic.partner@example.test",
+   207	        name: "Synthetic Partner",
+   208	        role: "partner",
+   209	      },
+   210	      redirectTo: "/portal/partner/dashboard",
+   211	    });
+   212	    render(<UpgradedLoginPage />);
+   213	
+   214	    const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   215	    fireEvent.change(email, {
+   216	      target: { value: "synthetic.partner@example.test" },
+   217	    });
+   218	    fireEvent.submit(email.closest("form")!);
+   219	    const pin = await screen.findByLabelText("Access PIN");
+   220	    fireEvent.change(pin, { target: { value: "1234" } });
+   221	
+   222	    vi.useFakeTimers();
+   223	    try {
+   224	      await act(async () => {
+   225	        fireEvent.submit(pin.closest("form")!);
+   226	        await Promise.resolve();
+   227	      });
+   228	      act(() => vi.advanceTimersByTime(1500));
+   229	      expect(mockRouterReplace).toHaveBeenCalledWith(
+   230	        "/portal/partner/dashboard",
+   231	      );
+   232	    } finally {
+   233	      vi.useRealTimers();
+   234	    }
+   235	  });
+   236	
+   237	  it("never forwards credentials, email, current URL, or raw auth errors to telemetry", async () => {
+   238	    const rawError = Object.assign(new Error("synthetic auth failure"), {
+   239	      response: {
+   240	        status: 401,
+   241	        config: {
+   242	          data: {
+   243	            email: "synthetic.user@example.test",
+   244	            pin: "1234",
+   245	          },
+   246	        },
+   247	      },
+   248	    });
+   249	    mockLogin.mockRejectedValue(rawError);
+   250	    render(<UpgradedLoginPage />);
+   251	
+   252	    const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   253	    fireEvent.change(email, {
+   254	      target: { value: "synthetic.user@example.test" },
+   255	    });
+   256	    fireEvent.submit(email.closest("form")!);
+   257	
+   258	    const pin = await screen.findByLabelText("Access PIN");
+   259	    fireEvent.change(pin, { target: { value: "1234" } });
+   260	    fireEvent.submit(pin.closest("form")!);
+   261	
+   262	    await waitFor(() => {
+   263	      expect(mockLoggerInfo).toHaveBeenCalledWith("Login denied", {
+   264	        component: "UpgradedLoginPage",
+   265	        action: "handleLogin",
+   266	        code: 401,
+   267	        reason: "portal.login.errors.invalid_credentials",
+   268	      });
+   269	    });
+   270	    expect(mockLoggerInfo).toHaveBeenCalledWith("Login process started", {
+   271	      component: "UpgradedLoginPage",
+   272	      action: "handleLogin",
+   273	    });
+   274	
+   275	    const telemetryPayload = JSON.stringify([
+   276	      mockLoggerInfo.mock.calls,
+   277	      mockLoggerError.mock.calls,
+   278	    ]);
+   279	    expect(telemetryPayload).not.toContain("synthetic.user@example.test");
+   280	    expect(telemetryPayload).not.toContain("1234");
+   281	    expect(telemetryPayload).not.toContain("currentUrl");
+   282	    expect(telemetryPayload).not.toContain("config");
+   283	  });
+   284	
+   285	  it("renders a generic portal-unavailable denial for an eligible-credential 403", async () => {
+   286	    const rawError = Object.assign(
+   287	      new Error("private portal eligibility state"),
+   288	      { status: 403 },
+   289	    );
+   290	    mockLogin.mockRejectedValue(rawError);
+   291	    render(<UpgradedLoginPage />);
+   292	
+   293	    const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   294	    fireEvent.change(email, {
+   295	      target: { value: "synthetic.disabled@example.test" },
+   296	    });
+   297	    fireEvent.submit(email.closest("form")!);
+   298	
+   299	    const pin = await screen.findByLabelText("Access PIN");
+   300	    fireEvent.change(pin, { target: { value: "1234" } });
+   301	    fireEvent.submit(pin.closest("form")!);
+   302	
+   303	    const denial = await screen.findByRole("alert");
+   304	    expect(denial).toHaveTextContent(
+   305	      "Portal access is not available for this account. Contact team@balizero.com.",
+   306	    );
+   307	    expect(denial).not.toHaveTextContent("private portal eligibility state");
+   308	    expect(mockRouterReplace).not.toHaveBeenCalled();
+   309	    expect(mockLoggerInfo).toHaveBeenCalledWith("Login denied", {
+   310	      component: "UpgradedLoginPage",
+   311	      action: "handleLogin",
+   312	      code: 403,
+   313	      reason: "portal.login.errors.portal_unavailable",
+   314	    });
+   315	  });
+   316	
+   317	  it("drain guard: no forced-dark UI utilities or gold hexes outside the scene", () => {
+   318	    const { container } = render(<UpgradedLoginPage />);
+   319	    const html = container.innerHTML;
+   320	
+   321	    expect(html).not.toContain("text-white");
+   322	    expect(html).not.toContain("bg-white/5");
+   323	    expect(html).not.toContain("bg-white/10");
+   324	    expect(html).not.toContain("from-[#d9bd7a]"); // token-lint-ok: drain-guard assertion string, not a color use
+   325	    expect(html).not.toContain("to-[#a07838]"); // token-lint-ok: drain-guard assertion string, not a color use
+   326	    expect(html).not.toContain("text-[#f0ece4]"); // token-lint-ok: drain-guard assertion string, not a color use
+   327	    expect(html).not.toContain("text-[#f8e89a]"); // token-lint-ok: drain-guard assertion string, not a color use
+   328	    expect(html).not.toContain("accent-gold-muted");
+   329	    expect(html).not.toContain("starDrift");
+   330	    expect(html).not.toContain("passageGlow");
+   331	  });
+   332	});
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "git show a75e1b85b2 | nl -ba | sed -n '1,300p'
+git show a75e1b85b2 | rg -n \"data-testid|role=\\\"status\\\"|role=\\\"alert\\\"|publicAuth\\.login|errorKeyFor|retry-after|isHydrated|setStep|onSubmit|portal-email|portal-pin|magic-link|forgot-password|Verify Identity|Pass the Portal|aria-describedby|aria-invalid\"
+rg -n \"data-testid|getByTestId|locator\\(.*data-testid|role=\\\"status\\\"|role=\\\"alert\\\"|publicAuth\\.login|errorKeyFor|retry-after|isHydrated|setStep|onSubmit|portal-email|portal-pin|magic-link|forgot-password|Verify Identity|Continue|aria-describedby|aria-invalid\" apps/mouth/src/app/portal/login-upgraded/page.tsx apps/mouth/src/app/portal/login-upgraded/page.test.tsx apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+rg -n '"'^[-+].*(data-testid|publicAuth'"\\.login|errorKeyFor|retry-after|isHydrated|setStep|role=\"status\"|role=\"alert\"|aria-live|onSubmit|href=\"/portal|href=\"/privacy|href=\"/terms|disabled=|autoFocus|aria-describedby|aria-invalid)' /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 367ms:
+     1	// apps/mouth/src/app/portal/login-upgraded/page.tsx
+     2	"use client";
+     3	
+     4	import React, { useEffect, useState, useRef, MouseEvent } from "react";
+     5	import { useRouter } from "next/navigation";
+     6	import Image from "next/image";
+     7	import Link from "next/link";
+     8	import { Loader2 } from "lucide-react";
+     9	import { motion, AnimatePresence } from "framer-motion";
+    10	import { cormorant } from "@balizero/core/fonts/cormorant";
+    11	import { useSystemSound } from "@/hooks/useSystemSound";
+    12	import { publicAuth } from "@/lib/api/public-auth";
+    13	import { sanitizeRedirect } from "@/lib/auth/sanitizeRedirect";
+    14	import { logger } from "@/lib/logger";
+    15	import { I18nProvider, useTranslation } from "@/i18n";
+    16	
+    17	// Configuration
+    18	const REDIRECT_DELAY_MS = 1500;
+    19	const ERROR_RESET_DELAY_MS = 2000;
+    20	
+    21	// WS3 final slice (GARUDA Day Edition): CTA = darker copper step
+    22	// --bz-copper-text with theme-aware --bz-on-warm fg (white on #9d5230 =
+    23	// 5.70:1 light; ink #0c0c0e on #d4845a = 6.74:1 dark — the #b5633a copper
+    24	// step with white would be 4.37:1, below the 4.5:1 AA floor). Was a
+    25	// #d9bd7a→#a07838 gradient with black text.
+    26	const LOGIN_CTA_STYLE = {
+    27	  background: "var(--bz-copper-text)",
+    28	  color: "var(--bz-on-warm)",
+    29	  boxShadow: "0 4px 24px color-mix(in srgb, var(--bz-copper) 30%, transparent)",
+    30	} as const;
+    31	
+    32	// Map HTTP status code → i18n error key. Unknown → server_error (5xx) or
+    33	// network_error (anything else, including status=0 from opaque fetch failures).
+    34	function errorKeyFor(status: number): string {
+    35	  switch (status) {
+    36	    case 401:
+    37	      return "portal.login.errors.invalid_credentials";
+    38	    case 403:
+    39	      return "portal.login.errors.portal_unavailable";
+    40	    case 404:
+    41	      return "portal.login.errors.email_not_found";
+    42	    case 422:
+    43	      return "portal.login.errors.invalid_2fa";
+    44	    case 429:
+    45	      return "portal.login.errors.rate_limited";
+    46	    case 503:
+    47	      return "portal.login.errors.maintenance";
+    48	    default:
+    49	      return status >= 500
+    50	        ? "portal.login.errors.server_error"
+    51	        : "portal.login.errors.network_error";
+    52	  }
+    53	}
+    54	
+    55	export default function UpgradedLoginPage() {
+    56	  // `useTranslation` requires an I18nProvider ancestor; the root layout does
+    57	  // not wrap one (only (blog) does). Wrap locally so /portal/login-upgraded
+    58	  // can consume the shared locale JSON without touching global providers.
+    59	  return (
+    60	    <I18nProvider>
+    61	      <UpgradedLoginPageInner />
+    62	    </I18nProvider>
+    63	  );
+    64	}
+    65	
+    66	function UpgradedLoginPageInner() {
+    67	  const router = useRouter();
+    68	  const { t } = useTranslation();
+    69	  const [isHydrated, setIsHydrated] = useState(false);
+    70	  const [email, setEmail] = useState("");
+    71	  const [pin, setPin] = useState("");
+    72	  const [step, setStep] = useState<"email" | "pin">("email");
+    73	  const [loginStage, setLoginStage] = useState<
+    74	    "idle" | "authenticating" | "success" | "denied"
+    75	  >("idle");
+    76	  const [errorMessage, setErrorMessage] = useState<string>("");
+    77	  const { play } = useSystemSound();
+    78	  const loginInFlightRef = useRef(false);
+    79	
+    80	  // Keep the controlled fields inert until React owns them. Without this
+    81	  // guard, a fast user (or WebKit restoring form state) can update the native
+    82	  // input before hydration while React still holds an empty email, leaving the
+    83	  // visible value and the disabled CTA out of sync.
+    84	  useEffect(() => {
+    85	    setIsHydrated(true);
+    86	  }, []);
+    87	
+    88	  // Spotlight mouse tracking state
+    89	  const cardRef = useRef<HTMLDivElement>(null);
+    90	  const [{ mouseX, mouseY }, setMousePos] = useState({ mouseX: 0, mouseY: 0 });
+    91	
+    92	  const handleMouseMove = (e: MouseEvent<HTMLDivElement>) => {
+    93	    if (!cardRef.current) return;
+    94	    const { left, top } = cardRef.current.getBoundingClientRect();
+    95	    setMousePos({
+    96	      mouseX: e.clientX - left,
+    97	      mouseY: e.clientY - top,
+    98	    });
+    99	  };
+   100	
+   101	  const playClickSound = () => {
+   102	    play("focus");
+   103	    if (typeof window !== "undefined" && "vibrate" in navigator) {
+   104	      navigator.vibrate(10);
+   105	    }
+   106	  };
+   107	
+   108	  const handleSubmitEmail = (e: React.FormEvent) => {
+   109	    e.preventDefault();
+   110	    const normalizedEmail = email.trim();
+   111	    if (normalizedEmail) {
+   112	      playClickSound();
+   113	      setEmail(normalizedEmail);
+   114	      setStep("pin");
+   115	    }
+   116	  };
+   117	
+   118	  const handleLogin = async (e: React.FormEvent) => {
+   119	    e.preventDefault();
+   120	    const normalizedEmail = email.trim();
+   121	    if (
+   122	      loginStage !== "idle" ||
+   123	      loginInFlightRef.current ||
+   124	      !normalizedEmail ||
+   125	      pin.length < 4 ||
+   126	      pin.length > 8
+   127	    ) {
+   128	      return;
+   129	    }
+   130	    loginInFlightRef.current = true;
+   131	
+   132	    logger.info("Login process started", {
+   133	      component: "UpgradedLoginPage",
+   134	      action: "handleLogin",
+   135	    });
+   136	
+   137	    play("auth_start");
+   138	    setLoginStage("authenticating");
+   139	
+   140	    try {
+   141	      const loginResult = await publicAuth.login(normalizedEmail, pin);
+   142	      setLoginStage("success");
+   143	      play("access_granted");
+   144	
+   145	      const urlParams = new URLSearchParams(globalThis.location.search);
+   146	      const requestedRedirect = sanitizeRedirect(urlParams.get("redirect"));
+   147	      const backendRedirect = sanitizeRedirect(loginResult.redirectTo ?? null);
+   148	      const role = loginResult.user.role;
+   149	      const redirectTo =
+   150	        role === "partner"
+   151	          ? requestedRedirect?.startsWith("/portal/partner/")
+   152	            ? requestedRedirect
+   153	            : "/portal/partner/dashboard"
+   154	          : role === "client"
+   155	            ? requestedRedirect?.startsWith("/portal/partner/")
+   156	              ? "/portal"
+   157	              : (requestedRedirect ?? "/portal")
+   158	            : (backendRedirect ?? "/dashboard");
+   159	
+   160	      setTimeout(() => {
+   161	        router.replace(redirectTo);
+   162	      }, REDIRECT_DELAY_MS);
+   163	    } catch (error) {
+   164	      // Extract HTTP status from error shape (best-effort — covers both
+   165	      // fetch Response-shaped errors and axios-style { response: { status } }).
+   166	      const status =
+   167	        (error as { response?: { status?: number } })?.response?.status ??
+   168	        (error as { status?: number })?.status ??
+   169	        0;
+   170	
+   171	      // Auth telemetry is deliberately limited to non-sensitive diagnostics.
+   172	      // Never pass credentials, addresses, the current URL, or the raw HTTP
+   173	      // error (which may embed a request body) to the logger/Sentry pipeline.
+   174	      const telemetryContext = {
+   175	        component: "UpgradedLoginPage",
+   176	        action: "handleLogin",
+   177	        code: status,
+   178	        reason: errorKeyFor(status),
+   179	      } as const;
+   180	      if (status >= 400 && status < 500) {
+   181	        logger.info("Login denied", telemetryContext);
+   182	      } else {
+   183	        logger.error("Login failed", telemetryContext);
+   184	      }
+   185	
+   186	      let msg = t(errorKeyFor(status));
+   187	      if (status === 429) {
+   188	        const retryAfter = (
+   189	          error as {
+   190	            response?: { headers?: { get?: (k: string) => string | null } };
+   191	          }
+   192	        )?.response?.headers?.get?.("retry-after");
+   193	        const seconds = retryAfter ? parseInt(retryAfter, 10) : 60;
+   194	        msg = t("portal.login.errors.rate_limited", {
+   195	          seconds: String(Number.isFinite(seconds) ? seconds : 60),
+   196	        });
+   197	      }
+   198	      setErrorMessage(msg);
+   199	      setLoginStage("denied");
+   200	      play("access_denied");
+   201	
+   202	      setTimeout(() => {
+   203	        loginInFlightRef.current = false;
+   204	        setLoginStage("idle");
+   205	      }, ERROR_RESET_DELAY_MS);
+   206	    }
+   207	  };
+   208	
+   209	  return (
+   210	    // WS3 final slice (GARUDA Day Edition, 2026-07-26): the shell reads
+   211	    // --bz-base (paper on operative-light, near-black navy on
+   212	    // operative-dark) instead of a forced bg-black. The SVG gate scene JSX
+   213	    // is untouched — the day re-light lives in the <style> block below as
+   214	    // [data-theme="operative-light"] attribute-selector overrides (CSS
+   215	    // beats SVG presentation attributes), so the dark theme renders the
+   216	    // original night scene pixel-identically. The UI layer (card, forms,
+   217	    // CTAs, overlays) reads day tokens throughout.
+   218	    <div className="min-h-screen relative overflow-hidden flex flex-col bg-[var(--bz-base)]">
+   219	      {/* ACCESS GRANTED OVERLAY */}
+   220	      {loginStage === "success" && (
+   221	        <motion.div
+   222	          initial={{ opacity: 0 }}
+   223	          animate={{ opacity: 1 }}
+   224	          transition={{ duration: 0.1 }}
+   225	          className="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md"
+   226	          role="status"
+   227	          aria-live="polite"
+   228	          style={{
+   229	            background: "color-mix(in srgb, var(--bz-base) 80%, transparent)",
+   230	          }}
+   231	        >
+   232	          <div className="text-center group">
+   233	            <h1
+   234	              className={`${cormorant.className} text-4xl md:text-6xl text-[var(--bz-copper-text)] tracking-[0.2em] font-light shadow-[0_0_40px_rgba(201,169,110,0.4)]`}
+   235	            >
+   236	              Portal Unlocked
+   237	            </h1>
+   238	          </div>
+   239	        </motion.div>
+   240	      )}
+   241	
+   242	      {/* ACCESS DENIED OVERLAY */}
+   243	      {loginStage === "denied" && (
+   244	        <motion.div
+   245	          initial={{ opacity: 0 }}
+   246	          animate={{ opacity: 1 }}
+   247	          exit={{ opacity: 0 }}
+   248	          transition={{ duration: 0.1 }}
+   249	          className="absolute inset-0 z-50 flex flex-col items-center justify-center backdrop-blur-md"
+   250	          role="alert"
+   251	          aria-live="assertive"
+   252	          style={{
+   253	            background: "color-mix(in srgb, var(--bz-base) 92%, transparent)",
+   254	          }}
+   255	        >
+   256	          <h1
+   257	            className={`${cormorant.className} text-4xl md:text-6xl tracking-[0.2em] font-light uppercase`}
+   258	            style={{ color: "var(--state-danger)" }}
+   259	          >
+   260	            Access Denied
+   261	          </h1>
+   262	          {errorMessage && (
+   263	            <p
+   264	              id="portal-login-error"
+   265	              className="mt-4 text-sm tracking-wide max-w-md text-center px-4"
+   266	              style={{ color: "var(--state-danger)" }}
+   267	            >
+   268	              {errorMessage}
+   269	            </p>
+   270	          )}
+   271	        </motion.div>
+   272	      )}
+   273	
+   274	      {/* Safe: hardcoded CSS for autofill styling, no external input.
+   275	          WS3: tokenized — card inset + theme text + copper caret (was a
+   276	          dark inset with hardcoded cream text and gold caret). */}
+   277	      <style
+   278	        dangerouslySetInnerHTML={{
+   279	          __html: `
+   280	        input:-webkit-autofill,
+   281	        input:-webkit-autofill:hover,
+   282	        input:-webkit-autofill:focus,
+   283	        input:-webkit-autofill:active {
+   284	            -webkit-box-shadow: 0 0 0 30px var(--bz-card) inset !important;
+   285	            -webkit-text-fill-color: var(--tx-primary) !important;
+   286	            caret-color: var(--bz-copper) !important;
+   287	        }
+   288	      `,
+   289	        }}
+   290	      />
+   291	      <style>{`
+   292	        @keyframes twinkle {
+   293	          0%, 100% { opacity: var(--op-base); transform: scale(1); }
+   294	          50%       { opacity: var(--op-peak); transform: scale(1.5); }
+   295	        }
+   296	        @keyframes starDriftFast {
+   297	          0%, 100% { transform: translate(0px, 0px); }
+   298	          50%      { transform: translate(15px, -5px); }
+   299	        }
+   300	        @keyframes starDriftMid {
+34:function errorKeyFor(status: number): string {
+69:  const [isHydrated, setIsHydrated] = useState(false);
+72:  const [step, setStep] = useState<"email" | "pin">("email");
+114:      setStep("pin");
+141:      const loginResult = await publicAuth.login(normalizedEmail, pin);
+178:        reason: errorKeyFor(status),
+186:      let msg = t(errorKeyFor(status));
+192:        )?.response?.headers?.get?.("retry-after");
+226:          role="status"
+250:          role="alert"
+1405:                      onSubmit={handleSubmitEmail}
+1410:                          htmlFor="portal-email"
+1416:                          id="portal-email"
+1425:                          disabled={!isHydrated || loginStage !== "idle"}
+1438:                          !isHydrated || loginStage !== "idle" || !email.trim()
+1443:                        Pass the Portal →
+1457:                      onSubmit={handleLogin}
+1463:                            htmlFor="portal-pin"
+1472:                              setStep("email");
+1480:                          id="portal-pin"
+1485:                          aria-describedby={
+1488:                          aria-invalid={loginStage === "denied"}
+1510:                            href="/portal/forgot-password"
+1529:                            : "Verify Identity"
+1540:                          "Verify Identity"
+1546:                          href="/portal/magic-link"
+apps/mouth/src/app/portal/login-upgraded/page.test.tsx:89:    const cta = screen.getByRole("button", { name: /Continue/ });
+apps/mouth/src/app/portal/login-upgraded/page.test.tsx:100:    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
+apps/mouth/src/app/portal/login-upgraded/page.test.tsx:107:    const verify = screen.getByRole("button", { name: /Verify Identity/ });
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:144:  const emailSubmit = page.getByRole("button", { name: "Continue" });
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:157:  await page.getByRole("button", { name: "Verify Identity" }).click();
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:189:  await page.getByRole("button", { name: "Continue" }).click();
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:198:  await page.getByRole("button", { name: "Verify Identity" }).click();
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:251:      throw new Error("Synthetic magic-link sink returned an invalid status");
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:255:      throw new Error("Synthetic magic-link sink returned an invalid contract");
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:259:  throw new Error("Synthetic magic-link sink did not receive the notification");
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:366:  await page.getByRole("button", { name: "Continue" }).click();
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:376:  await page.getByRole("button", { name: "Verify Identity" }).click();
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:1925:test("@qa-be-003 real magic-link login is tenant-bound and single-use", async ({
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:1949:  await page.goto("/portal/magic-link", { waitUntil: "domcontentloaded" });
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:1958:      url.pathname === "/api/auth/request-magic-link" &&
+apps/mouth/e2e/portal-prodlike-smoke.spec.ts:1977:    throw new Error("Synthetic sink returned an unsafe magic-link target");
+apps/mouth/src/app/portal/login-upgraded/page.tsx:107:function errorKeyFor(status: number): string {
+apps/mouth/src/app/portal/login-upgraded/page.tsx:142:  const [isHydrated, setIsHydrated] = useState(false);
+apps/mouth/src/app/portal/login-upgraded/page.tsx:145:  const [step, setStep] = useState<"email" | "pin">("email");
+apps/mouth/src/app/portal/login-upgraded/page.tsx:192:      setStep("pin");
+apps/mouth/src/app/portal/login-upgraded/page.tsx:219:      const loginResult = await publicAuth.login(normalizedEmail, pin);
+apps/mouth/src/app/portal/login-upgraded/page.tsx:256:        reason: errorKeyFor(status),
+apps/mouth/src/app/portal/login-upgraded/page.tsx:264:      let msg = t(errorKeyFor(status));
+apps/mouth/src/app/portal/login-upgraded/page.tsx:270:        )?.response?.headers?.get?.("retry-after");
+apps/mouth/src/app/portal/login-upgraded/page.tsx:290:      <Link href="/portal/magic-link" className="r19-link">
+apps/mouth/src/app/portal/login-upgraded/page.tsx:293:      <Link href="/portal/forgot-password" className="r19-link">
+apps/mouth/src/app/portal/login-upgraded/page.tsx:321:          role="status"
+apps/mouth/src/app/portal/login-upgraded/page.tsx:332:          role="alert"
+apps/mouth/src/app/portal/login-upgraded/page.tsx:369:          <form className="r19-box" onSubmit={handleSubmitEmail}>
+apps/mouth/src/app/portal/login-upgraded/page.tsx:382:                <label className="r19-eyebrow" htmlFor="portal-email">
+apps/mouth/src/app/portal/login-upgraded/page.tsx:387:                id="portal-email"
+apps/mouth/src/app/portal/login-upgraded/page.tsx:396:                disabled={!isHydrated || loginStage !== "idle"}
+apps/mouth/src/app/portal/login-upgraded/page.tsx:405:              disabled={!isHydrated || loginStage !== "idle" || !email.trim()}
+apps/mouth/src/app/portal/login-upgraded/page.tsx:409:              Continue
+apps/mouth/src/app/portal/login-upgraded/page.tsx:415:          <form className="r19-box" onSubmit={handleLogin}>
+apps/mouth/src/app/portal/login-upgraded/page.tsx:427:                <label className="r19-eyebrow" htmlFor="portal-pin">
+apps/mouth/src/app/portal/login-upgraded/page.tsx:434:                    setStep("email");
+apps/mouth/src/app/portal/login-upgraded/page.tsx:442:                id="portal-pin"
+apps/mouth/src/app/portal/login-upgraded/page.tsx:447:                aria-describedby={
+apps/mouth/src/app/portal/login-upgraded/page.tsx:450:                aria-invalid={loginStage === "denied"}
+apps/mouth/src/app/portal/login-upgraded/page.tsx:479:                  : "Verify Identity"
+apps/mouth/src/app/portal/login-upgraded/page.tsx:487:                "Verify Identity"
+411:+      <Link href="/portal/magic-link" className="r19-link">
+414:+      <Link href="/portal/forgot-password" className="r19-link">
+428:+      <Link href="/privacy">Privacy</Link>
+429:+      <Link href="/terms">Terms</Link>
+1429:+          <form className="r19-box" onSubmit={handleSubmitEmail}>
+1456:+                disabled={!isHydrated || loginStage !== "idle"}
+1459:+                autoFocus
+1653:+              disabled={!isHydrated || loginStage !== "idle" || !email.trim()}
+1664:+          <form className="r19-box" onSubmit={handleLogin}>
+1725:-                      onSubmit={handleSubmitEmail}
+1745:-                          disabled={!isHydrated || loginStage !== "idle"}
+1748:-                          autoFocus
+1757:-                        disabled={
+1758:-                          !isHydrated || loginStage !== "idle" || !email.trim()
+1777:-                      onSubmit={handleLogin}
+1792:-                              setStep("email");
+1805:-                          aria-describedby={
+1808:-                          aria-invalid={loginStage === "denied"}
+1820:-                          disabled={loginStage !== "idle"}
+1823:-                          autoFocus
+1830:-                            href="/portal/forgot-password"
+1841:-                        disabled={
+1866:-                          href="/portal/magic-link"
+1888:+                    setStep("email");
+1901:+                aria-describedby={
+1904:+                aria-invalid={loginStage === "denied"}
+1916:+                disabled={loginStage !== "idle"}
+1919:+                autoFocus
+1939:+              disabled={
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "git show a75e1b85b2 | nl -ba | sed -n '1380,1575p'
+rg -ni \"testid\" apps/mouth/e2e/portal-prodlike-smoke.spec.ts apps/mouth/src/app/portal/login-upgraded/page.test.tsx /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+rg -n \"BZLogo\" packages apps/mouth/src | head -40
+rg --files | rg 'BZLogo\\.(tsx|ts|jsx|js)"'$|package(-lock)?'"\\.json"'$|pnpm-lock.yaml$|yarn.lock$'"' | head -80
+rg -n \"portal\\.login\\.(forgot_password|errors\\.(invalid_credentials|portal_unavailable|email_not_found|invalid_2fa|rate_limited|maintenance|server_error|network_error))\" apps/mouth/src | head -120" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 746ms:
+  1380	            {/* Mouse Spotlight Effect - The Magic */}
+  1381	            <div
+  1382	              className="pointer-events-none absolute -inset-px rounded-2xl opacity-0 transition duration-300 group-hover:opacity-100 z-30"
+  1383	              style={{
+  1384	                background: `radial-gradient(400px circle at ${mouseX}px ${mouseY}px, color-mix(in srgb, var(--bz-copper) 15%, transparent), transparent 40%)`,
+  1385	              }}
+  1386	            />
+  1387	
+  1388	            {/* Card surface — WS3: token card + hairline (was a forced-dark
+  1389	                glass gradient with gold inset shadows). */}
+  1390	            <div className="bg-[var(--bz-card)]/95 backdrop-blur-[40px] saturate-150 p-1 rounded-2xl border border-[var(--bz-border)]">
+  1391	              <div className="relative z-40 h-[240px]">
+  1392	                {/* ANIMATED FORM TRANSITIONS */}
+  1393	                <AnimatePresence mode="popLayout">
+  1394	                  {step === "email" ? (
+  1395	                    <motion.form
+  1396	                      key="email-step"
+  1397	                      initial={{ opacity: 0, x: -30 }}
+  1398	                      animate={{ opacity: 1, x: 0 }}
+  1399	                      exit={{ opacity: 0, x: -30, filter: "blur(5px)" }}
+  1400	                      transition={{
+  1401	                        type: "spring",
+  1402	                        stiffness: 200,
+  1403	                        damping: 25,
+  1404	                      }}
+  1405	                      onSubmit={handleSubmitEmail}
+  1406	                      className="p-6 space-y-6 h-full flex flex-col justify-center"
+  1407	                    >
+  1408	                      <div className="space-y-2">
+  1409	                        <label
+  1410	                          htmlFor="portal-email"
+  1411	                          className={`${cormorant.className} block text-[10px] uppercase tracking-[2.5px] text-[var(--bz-accent-warm)] font-bold`}
+  1412	                        >
+  1413	                          Corporate Email
+  1414	                        </label>
+  1415	                        <input
+  1416	                          id="portal-email"
+  1417	                          type="email"
+  1418	                          name="email"
+  1419	                          autoComplete="username"
+  1420	                          autoCapitalize="none"
+  1421	                          spellCheck={false}
+  1422	                          value={email}
+  1423	                          onChange={(e) => setEmail(e.target.value)}
+  1424	                          onFocus={() => play("focus")}
+  1425	                          disabled={!isHydrated || loginStage !== "idle"}
+  1426	                          placeholder="client@company.com"
+  1427	                          required
+  1428	                          autoFocus
+  1429	                          className="w-full rounded-xl px-4 py-4 text-[13px] outline-none transition-all bg-[var(--bz-base)] border border-[var(--bz-border)] text-[var(--tx-primary)] placeholder:text-[var(--tx-tertiary)] focus:border-[var(--bz-copper)] focus:ring-2 focus:ring-[color-mix(in_srgb,var(--bz-copper)_25%,transparent)] disabled:opacity-50 disabled:cursor-not-allowed"
+  1430	                        />
+  1431	                      </div>
+  1432	
+  1433	                      <motion.button
+  1434	                        whileHover={{ scale: 1.01 }}
+  1435	                        whileTap={{ scale: 0.98 }}
+  1436	                        type="submit"
+  1437	                        disabled={
+  1438	                          !isHydrated || loginStage !== "idle" || !email.trim()
+  1439	                        }
+  1440	                        className="w-full py-4 rounded-xl text-[13px] tracking-[0.08em] uppercase font-bold relative overflow-hidden"
+  1441	                        style={LOGIN_CTA_STYLE}
+  1442	                      >
+  1443	                        Pass the Portal →
+  1444	                      </motion.button>
+  1445	                    </motion.form>
+  1446	                  ) : (
+  1447	                    <motion.form
+  1448	                      key="pin-step"
+  1449	                      initial={{ opacity: 0, x: 30 }}
+  1450	                      animate={{ opacity: 1, x: 0 }}
+  1451	                      exit={{ opacity: 0, x: 30 }}
+  1452	                      transition={{
+  1453	                        type: "spring",
+  1454	                        stiffness: 200,
+  1455	                        damping: 25,
+  1456	                      }}
+  1457	                      onSubmit={handleLogin}
+  1458	                      className="p-6 space-y-6 h-full flex flex-col justify-center"
+  1459	                    >
+  1460	                      <div className="space-y-2">
+  1461	                        <div className="flex justify-between items-center">
+  1462	                          <label
+  1463	                            htmlFor="portal-pin"
+  1464	                            className={`${cormorant.className} block text-[10px] uppercase tracking-[2.5px] text-[var(--bz-accent-warm)] font-bold`}
+  1465	                          >
+  1466	                            Access PIN
+  1467	                          </label>
+  1468	                          <button
+  1469	                            type="button"
+  1470	                            onClick={() => {
+  1471	                              playClickSound();
+  1472	                              setStep("email");
+  1473	                            }}
+  1474	                            className="text-[11px] text-[var(--bz-accent-warm)] hover:underline transition-colors"
+  1475	                          >
+  1476	                            ← {email.split("@")[0]}
+  1477	                          </button>
+  1478	                        </div>
+  1479	                        <input
+  1480	                          id="portal-pin"
+  1481	                          type="password"
+  1482	                          name="password"
+  1483	                          autoComplete="current-password"
+  1484	                          inputMode="numeric"
+  1485	                          aria-describedby={
+  1486	                            errorMessage ? "portal-login-error" : undefined
+  1487	                          }
+  1488	                          aria-invalid={loginStage === "denied"}
+  1489	                          value={pin}
+  1490	                          onChange={(e) => {
+  1491	                            setPin(e.target.value);
+  1492	                            if (
+  1493	                              e.target.value.length === 6 &&
+  1494	                              typeof window !== "undefined" &&
+  1495	                              "vibrate" in navigator
+  1496	                            )
+  1497	                              navigator.vibrate(20);
+  1498	                          }}
+  1499	                          onFocus={() => play("focus")}
+  1500	                          disabled={loginStage !== "idle"}
+  1501	                          placeholder="••••••"
+  1502	                          required
+  1503	                          autoFocus
+  1504	                          minLength={4}
+  1505	                          maxLength={8}
+  1506	                          className="w-full rounded-xl px-4 py-4 text-[22px] text-center tracking-[14px] outline-none transition-all bg-[var(--bz-base)] border border-[var(--bz-border)] text-[var(--tx-primary)] placeholder:text-[var(--tx-tertiary)] focus:border-[var(--bz-copper)] focus:ring-2 focus:ring-[color-mix(in_srgb,var(--bz-copper)_25%,transparent)] disabled:opacity-50 disabled:cursor-not-allowed"
+  1507	                        />
+  1508	                        <div className="flex justify-end pt-1">
+  1509	                          <Link
+  1510	                            href="/portal/forgot-password"
+  1511	                            className="text-[11px] text-[var(--bz-accent-warm)] hover:underline transition-colors"
+  1512	                          >
+  1513	                            {t("portal.login.forgot_password")}
+  1514	                          </Link>
+  1515	                        </div>
+  1516	                      </div>
+  1517	
+  1518	                      <motion.button
+  1519	                        whileTap={{ scale: 0.98 }}
+  1520	                        type="submit"
+  1521	                        disabled={
+  1522	                          loginStage !== "idle" ||
+  1523	                          pin.length < 4 ||
+  1524	                          pin.length > 8
+  1525	                        }
+  1526	                        aria-label={
+  1527	                          loginStage === "authenticating"
+  1528	                            ? "Verifying identity"
+  1529	                            : "Verify Identity"
+  1530	                        }
+  1531	                        className={`w-full py-4 rounded-xl text-[13px] tracking-[0.08em] uppercase flex items-center justify-center gap-2 font-bold transition-all ${loginStage !== "idle" ? "opacity-70 cursor-not-allowed" : ""}`}
+  1532	                        style={LOGIN_CTA_STYLE}
+  1533	                      >
+  1534	                        {loginStage === "authenticating" ? (
+  1535	                          <Loader2
+  1536	                            className="w-5 h-5 animate-spin"
+  1537	                            aria-hidden="true"
+  1538	                          />
+  1539	                        ) : (
+  1540	                          "Verify Identity"
+  1541	                        )}
+  1542	                      </motion.button>
+  1543	
+  1544	                      <div className="pt-3 text-center">
+  1545	                        <Link
+  1546	                          href="/portal/magic-link"
+  1547	                          className="text-[11px] uppercase tracking-[2px] text-[var(--bz-accent-warm)] hover:underline transition-colors"
+  1548	                        >
+  1549	                          Sign in with an email link instead
+  1550	                        </Link>
+  1551	                      </div>
+  1552	                    </motion.form>
+  1553	                  )}
+  1554	                </AnimatePresence>
+  1555	              </div>
+  1556	
+  1557	              <div className="px-6 pb-6 text-center text-[10px] leading-relaxed text-[var(--tx-secondary)]">
+  1558	                No PIN? Check your invitation email or contact support.
+  1559	              </div>
+  1560	            </div>
+  1561	          </motion.div>
+  1562	
+  1563	          <motion.p
+  1564	            initial={{ opacity: 0 }}
+  1565	            animate={{ opacity: 1 }}
+  1566	            transition={{ delay: 1.5, duration: 2 }}
+  1567	            className={`${cormorant.className} text-center mt-6 text-[9px] tracking-[3px] uppercase text-[var(--tx-secondary)] font-bold`}
+  1568	          >
+  1569	            Bali Zero · Private Client Portal
+  1570	          </motion.p>
+  1571	        </div>
+  1572	      </div>
+  1573	    </div>
+  1574	  );
+  1575	}
+packages/design-system/brand-api/components.json:198:      "name": "BZLogo",
+packages/design-system/brand-api/components.json:199:      "import": "@balizero/core/components/BZLogo",
+packages/design-system/brand-api/components.json:200:      "source": "packages/core/components/BZLogo.tsx",
+packages/design-system/brand-api/components.json:202:        "variant": "BZLogoVariant",
+packages/design-system/brand-api/components.json:211:      "example": "<BZLogo variant={/* BZLogoVariant */} />"
+packages/core/index.ts:2:export { BZLogo, type BZLogoVariant } from "./components/BZLogo";
+packages/core/package.json:25:    "./components/BZLogo": "./components/BZLogo.tsx",
+packages/core/components/BZLogo.tsx:3:export type BZLogoVariant = "full" | "mark" | "round" | "zantara";
+packages/core/components/BZLogo.tsx:5:interface BZLogoProps {
+packages/core/components/BZLogo.tsx:6:  variant: BZLogoVariant;
+packages/core/components/BZLogo.tsx:14:  BZLogoVariant,
+packages/core/components/BZLogo.tsx:39:export function BZLogo({ variant, size, className, priority }: BZLogoProps) {
+packages/core/README.md:8:import { BZLogo, ThemeProvider, useTheme } from "@balizero/core";
+packages/core/README.md:23:      <BZLogo variant="mark" />
+packages/core/README.md:38:components/             → BZLogo, NavShell, ThemeProvider
+packages/core/README.md:55:4. Shared components require a Phase 4 waiver to be promoted here. Current count: 21 (`BZLogo`, `NavShell`, `ThemeProvider`, `ProgressRing`, `DeadlineBadge`, `TrustBand`, `CTAHandoff`, `FunnelFrame`, `MatterCard`, `CommandPalette`, `Money`, `ListPageHeader`, `SearchBox`, `FilterBar`, `StatChips`, `SubNav`, `ContextPanel`, `WhatsAppFAB`, `FactBadge`, `SystemPulse`, `ComplianceRadar`). FactBadge (WS1, 2026-07-21): promoted under the Phase 4 waiver — rationale: one verifiable-facts badge (KBLI codes, citations, regulation codes) shared by every surface; semantic tokens only, funnel-agnostic. Granted with the WS1 merge. SystemPulse (WS2, 2026-07-22): promotion requested under Phase 4 (rationale: one live-stack service panel of status/latency rows shared by every workspace surface; semantic state tokens only, funnel-agnostic); waiver effective on operator merge (WS1/FactBadge precedent). ComplianceRadar (WS2, 2026-07-22): promotion requested under Phase 4 (rationale: one severity-ranked compliance alert panel shared by every workspace surface; semantic state tokens only, funnel-agnostic); waiver effective on operator merge (WS1/FactBadge precedent).
+packages/core/components/BZLogo.test.tsx:3:import { BZLogo } from "./BZLogo";
+packages/core/components/BZLogo.test.tsx:5:describe("BZLogo", () => {
+packages/core/components/BZLogo.test.tsx:7:    const { getByRole } = render(<BZLogo variant="full" />);
+packages/core/components/BZLogo.test.tsx:14:    const { getByRole } = render(<BZLogo variant="mark" />);
+packages/core/components/BZLogo.test.tsx:20:    const { getByRole } = render(<BZLogo variant="zantara" />);
+packages/core/components/BZLogo.test.tsx:27:    const { getByRole } = render(<BZLogo variant="mark" size={32} />);
+packages/core/components/BZLogo.test.tsx:34:      const { getByRole, unmount } = render(<BZLogo variant={variant} />);
+apps/mouth/src/app/kbli/layout.tsx:2:import { NavShell, BZLogo } from "@balizero/core";
+apps/mouth/src/app/kbli/layout.tsx:25:        logo={<BZLogo variant="full" />}
+apps/mouth/src/app/property/eligibility/layout.tsx:2:import { NavShell, BZLogo } from "@balizero/core";
+apps/mouth/src/app/property/eligibility/layout.tsx:26:        logo={<BZLogo variant="full" />}
+apps/mouth/src/app/v2/company/careers/page.tsx:3:import { BZLogo } from "@balizero/core/components/BZLogo";
+apps/mouth/src/app/v2/company/careers/page.tsx:23:        logo={<BZLogo variant="full" size={36} />}
+apps/mouth/src/app/v2/company/about/page.tsx:4:import { BZLogo } from "@balizero/core/components/BZLogo";
+apps/mouth/src/app/v2/company/about/page.tsx:52:        logo={<BZLogo variant="full" size={36} />}
+apps/mouth/src/app/v2/company/press/page.tsx:3:import { BZLogo } from "@balizero/core/components/BZLogo";
+apps/mouth/src/app/v2/company/press/page.tsx:23:        logo={<BZLogo variant="full" size={36} />}
+apps/mouth/src/app/v2/cookies/page.tsx:3:import { BZLogo } from "@balizero/core/components/BZLogo";
+apps/mouth/src/app/v2/cookies/page.tsx:21:        logo={<BZLogo variant="full" size={36} />}
+apps/mouth/src/app/v2/page.tsx:3:import { BZLogo } from "@balizero/core/components/BZLogo";
+apps/mouth/src/app/v2/page.tsx:69:        logo={<BZLogo variant="full" size={36} priority />}
+apps/mouth/src/app/v2/_components/HeroCarousel.tsx:6:import { BZLogo } from "@balizero/core/components/BZLogo";
+apps/mouth/src/app/v2/_components/HeroCarousel.tsx:122:              <BZLogo variant="round" size={72} />
+apps/mouth/src/app/v2/_components/HeroBlueprint.tsx:2:import { BZLogo } from "@balizero/core/components/BZLogo";
+packages/design-system/package.json
+packages/core/package.json
+packages/core/components/BZLogo.tsx
+packages/ts-schemas/package.json
+apps/wa-mirror/package.json
+apps/wa-mirror/package-lock.json
+apps/wa-dashboard-m1/package.json
+apps/team-agent/bridge/package.json
+apps/admin-dashboard/package.json
+package.json
+package-lock.json
+apps/web/package.json
+apps/autonomous-lab/package.json
+apps/backend-rag/package.json
+apps/kbli-navigator/package.json
+apps/bali-zero-magazine/package.json
+evidence/dual-consul-astra/package.json
+apps/wa-meta-inbox/package.json
+apps/admin-dashboard-local/package.json
+apps/osint-nexus-ui/package.json
+apps/mouth/package.json
+apps/mouth/src/app/portal/login-upgraded/page.tsx:110:      return "portal.login.errors.invalid_credentials";
+apps/mouth/src/app/portal/login-upgraded/page.tsx:112:      return "portal.login.errors.portal_unavailable";
+apps/mouth/src/app/portal/login-upgraded/page.tsx:114:      return "portal.login.errors.email_not_found";
+apps/mouth/src/app/portal/login-upgraded/page.tsx:116:      return "portal.login.errors.invalid_2fa";
+apps/mouth/src/app/portal/login-upgraded/page.tsx:118:      return "portal.login.errors.rate_limited";
+apps/mouth/src/app/portal/login-upgraded/page.tsx:120:      return "portal.login.errors.maintenance";
+apps/mouth/src/app/portal/login-upgraded/page.tsx:123:        ? "portal.login.errors.server_error"
+apps/mouth/src/app/portal/login-upgraded/page.tsx:124:        : "portal.login.errors.network_error";
+apps/mouth/src/app/portal/login-upgraded/page.tsx:272:        msg = t("portal.login.errors.rate_limited", {
+apps/mouth/src/app/portal/login-upgraded/page.tsx:294:        {t("portal.login.forgot_password")}
+apps/mouth/src/app/portal/login-upgraded/page.test.tsx:267:        reason: "portal.login.errors.invalid_credentials",
+apps/mouth/src/app/portal/login-upgraded/page.test.tsx:313:      reason: "portal.login.errors.portal_unavailable",
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "nl -ba packages/core/components/BZLogo.tsx | sed -n '1,160p'
+rg -n -- '--bz-copper-text|--bz-copper:|--state-danger|--tx-pure|--tx-secondary' apps/mouth/src packages/core | head -120
+rg -n '"'^diff --git|''^index |''^@@'"' /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+rg -n '"'^[-+].*t'"\\(' /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+rg -n '"'^'"\\s*\"@balizero/core\"|framer-motion|lucide-react' apps/mouth/package.json package.json
+rg -n '"'^[-+].*(red|#[fF][0-9a-fA-F]{5}|#[eE][0-9a-fA-F]{5}|#[dD][0-9a-fA-F]{5}|#[cC][0-9a-fA-F]{5}|#[bB][0-9a-fA-F]{5}|#[aA][0-9a-fA-F]{5}|state-danger)'"' /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff | tail -100
+git status --short
+git diff --stat
+git log -5 --oneline -- apps/mouth/src/app/portal/login-upgraded/page.tsx" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 778ms:
+     1	import Image from "next/image";
+     2	
+     3	export type BZLogoVariant = "full" | "mark" | "round" | "zantara";
+     4	
+     5	interface BZLogoProps {
+     6	  variant: BZLogoVariant;
+     7	  size?: number;
+     8	  className?: string;
+     9	  priority?: boolean;
+    10	}
+    11	
+    12	// Square intrinsic aspect for all variants (all assets are n×n).
+    13	const SOURCES: Record<
+    14	  BZLogoVariant,
+    15	  { src: string; alt: string; defaultSize: number }
+    16	> = {
+    17	  full: {
+    18	    src: "/assets/logo/balizero-logo-clean.png",
+    19	    alt: "Bali Zero",
+    20	    defaultSize: 44,
+    21	  },
+    22	  mark: {
+    23	    src: "/assets/logo/balizero-3-red.png",
+    24	    alt: "Bali Zero",
+    25	    defaultSize: 24,
+    26	  },
+    27	  round: {
+    28	    src: "/assets/logo/balizero-logo-circle.png",
+    29	    alt: "Bali Zero",
+    30	    defaultSize: 56,
+    31	  },
+    32	  zantara: {
+    33	    src: "/static/zantara-lotus.png",
+    34	    alt: "Zantara",
+    35	    defaultSize: 32,
+    36	  },
+    37	};
+    38	
+    39	export function BZLogo({ variant, size, className, priority }: BZLogoProps) {
+    40	  const entry = SOURCES[variant];
+    41	  const dim = size ?? entry.defaultSize;
+    42	  return (
+    43	    <Image
+    44	      src={entry.src}
+    45	      alt={entry.alt}
+    46	      width={dim}
+    47	      height={dim}
+    48	      priority={priority}
+    49	      className={className}
+    50	      style={{ height: `${dim}px`, width: "auto" }}
+    51	    />
+    52	  );
+    53	}
+packages/core/components/DeadlineBadge.test.tsx:22:    expect(fill?.getAttribute("stroke")).toBe("var(--state-danger)");
+packages/core/tokens/semantic.css:83:  --state-danger: var(--color-state-danger);
+packages/core/tokens/semantic.css:88:     never use it for text on dark surfaces (use --state-danger there). */
+packages/core/tokens/semantic.css:131:  --color-error: var(--state-danger, #ff5a5a);
+packages/core/tokens/semantic.css:175: *   --state-danger    #b91c1c              5.74:1  (was 3.34:1)
+packages/core/tokens/semantic.css:191:  --state-danger: #b91c1c;
+packages/core/tokens/operative.css:31:  --bz-copper: #d4845a;
+apps/mouth/src/app/globals.css:282:  --tx-pure: #ffffff;
+apps/mouth/src/app/globals.css:284:  --tx-secondary: #94a3b8;
+apps/mouth/src/app/globals.css:294:  --bz-copper: #d4845a;
+apps/mouth/src/app/globals.css:297:  --bz-copper-text: var(--bz-copper);
+apps/mouth/src/app/globals.css:310:  --bz-text-2: var(--tx-secondary);
+apps/mouth/src/app/globals.css:361:  --foreground-muted: var(--tx-secondary);
+apps/mouth/src/app/globals.css:366:  --accent-foreground: var(--tx-pure);
+apps/mouth/src/app/globals.css:369:  --tx-pure: #16213a;
+apps/mouth/src/app/globals.css:371:  --tx-secondary: #475372;
+apps/mouth/src/app/globals.css:372:  --tx-tertiary: var(--tx-secondary);
+apps/mouth/src/app/globals.css:375:  --bz-text-3: var(--tx-secondary);
+apps/mouth/src/app/globals.css:393:  --bz-copper: #b5633a;
+apps/mouth/src/app/globals.css:394:  --bz-copper-text: #9d5230;
+apps/mouth/src/app/globals.css:592:    var(--tx-pure) 0%,
+apps/mouth/src/app/globals.css:593:    var(--tx-secondary) 100%
+packages/core/components/ProgressRing.test.tsx:25:    expect(circle?.getAttribute("stroke")).toBe("var(--state-danger)");
+packages/core/components/ProgressRing.test.tsx:32:      danger: "var(--state-danger)",
+packages/core/components/ComplianceRadar.tsx:22: *   documented fill usage); the matching time-left TEXT reads --state-danger
+packages/core/components/ComplianceRadar.tsx:24: *   surfaces (~2.54:1) and names --state-danger as the dark-surface text tone.
+packages/core/components/ComplianceRadar.tsx:57:/** Text color for the visible severity label. `critical` reads --state-danger
+packages/core/components/ComplianceRadar.tsx:61:  critical: "var(--state-danger)",
+packages/core/components/ComplianceRadar.tsx:116:  color: "var(--state-danger)",
+packages/core/components/SystemPulse.test.tsx:57:    expect(valueOf(rows[1]).style.color).toBe("var(--state-danger)");
+packages/core/components/SystemPulse.test.tsx:58:    expect(fillOf(rows[1]).style.background).toBe("var(--state-danger)");
+packages/core/components/ProgressRing.tsx:18:  danger: "var(--state-danger)",
+packages/core/components/ComplianceRadar.test.tsx:71:    // dark-surface-safe --state-danger, never --status-critical as text)
+packages/core/components/ComplianceRadar.test.tsx:72:    expect(labels[0].style.color).toBe("var(--state-danger)");
+packages/core/components/ComplianceRadar.test.tsx:116:    expect(crit.style.color).toBe("var(--state-danger)");
+packages/core/components/SystemPulse.tsx:28:  down: "var(--state-danger)",
+apps/mouth/src/components/process/kanban-colors.ts:48:    gradientStart: "var(--bz-copper-text)",
+apps/mouth/src/components/process/kanban-colors.ts:49:    gradientEnd: "var(--bz-copper-text)",
+apps/mouth/src/components/process/kanban-colors.ts:50:    tintBg: "color-mix(in srgb, var(--bz-copper-text) 5%, transparent)",
+apps/mouth/src/components/process/kanban-colors.ts:51:    tintBorder: "color-mix(in srgb, var(--bz-copper-text) 22%, transparent)",
+apps/mouth/src/components/process/kanban-colors.ts:52:    badgeBg: "color-mix(in srgb, var(--bz-copper-text) 12%, transparent)",
+apps/mouth/src/components/process/kanban-colors.ts:53:    textColor: "var(--bz-copper-text)",
+apps/mouth/src/components/process/kanban-colors.ts:54:    dotColor: "bg-[var(--bz-copper-text)]",
+apps/mouth/src/components/process/kanban-colors.ts:80:    gradientStart: "var(--state-danger)",
+apps/mouth/src/components/process/kanban-colors.ts:82:    tintBg: "color-mix(in srgb, var(--state-danger) 5%, transparent)",
+apps/mouth/src/components/process/kanban-colors.ts:83:    tintBorder: "color-mix(in srgb, var(--state-danger) 22%, transparent)",
+apps/mouth/src/components/process/kanban-colors.ts:84:    badgeBg: "color-mix(in srgb, var(--state-danger) 12%, transparent)",
+apps/mouth/src/components/process/kanban-colors.ts:85:    textColor: "var(--state-danger)",
+apps/mouth/src/components/process/kanban-colors.ts:86:    dotColor: "bg-[var(--state-danger)]",
+apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx:346:  // not_eligible deliberately neutral rather than --state-danger), never
+apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.tsx:112:    // Deliberately neutral rather than --state-danger: a clear, respectful
+apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx:233:     not_eligible deliberately neutral rather than --state-danger.
+apps/mouth/src/app/visa/terms/page.tsx:22:      <p className="text-sm mb-10" style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/terms/page.tsx:33:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/terms/page.tsx:48:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/terms/page.tsx:63:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/terms/page.tsx:78:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/terms/page.tsx:92:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/terms/page.tsx:107:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/terms/page.tsx:120:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/privacy/page.tsx:22:      <p className="text-sm mb-10" style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/privacy/page.tsx:33:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/privacy/page.tsx:38:          style={{ color: "var(--tx-secondary)" }}
+apps/mouth/src/app/visa/privacy/page.tsx:59:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/privacy/page.tsx:64:          style={{ color: "var(--tx-secondary)" }}
+apps/mouth/src/app/visa/privacy/page.tsx:83:          style={{ color: "var(--tx-secondary)" }}
+apps/mouth/src/app/visa/privacy/page.tsx:104:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/privacy/page.tsx:118:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/app/visa/privacy/page.tsx:133:        <p style={{ color: "var(--tx-secondary)" }}>
+apps/mouth/src/lib/theme/merahPutihDayVars.ts:101:  // "Warm Depth" token family — NOT the funnel's. `--tx-secondary` and
+apps/mouth/src/lib/theme/merahPutihDayVars.ts:132:  "--tx-secondary": "#475372", // 7.64:1 on the banner's white ground
+apps/mouth/src/lib/theme/merahPutihDayVars.ts:150:  "--state-danger": "#a83a44",
+apps/mouth/src/components/visa/ConsentBanner.tsx:63:          style={{ color: "var(--tx-secondary)" }}
+apps/mouth/src/components/visa/WhatsAppCTA.tsx:43:          style={{ color: "var(--tx-secondary)" }}
+apps/mouth/src/components/visa/WhatsAppCTA.tsx:74:            style={{ color: "var(--tx-secondary)" }}
+apps/mouth/src/components/visa/QuestionCounter.tsx:15:      style={{ color: "var(--tx-secondary)" }}
+apps/mouth/src/components/visa/VisaChat.tsx:192:                    color: "var(--tx-secondary)",
+apps/mouth/src/components/visa/VisaChat.tsx:237:                    style={{ color: "var(--tx-secondary)" }}
+apps/mouth/src/components/visa/VisaChat.tsx:272:                    backgroundColor: "var(--tx-secondary)",
+apps/mouth/src/app/(workspace)/process/page.tsx:970:                  ? "bg-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] text-[var(--state-danger)] border-[color-mix(in_srgb,var(--state-danger)_40%,transparent)]"
+apps/mouth/src/app/(workspace)/process/page.tsx:971:                  : "bg-[var(--surface-raised)] text-[var(--bz-text-2)] border-[var(--bz-border)] hover:border-[color-mix(in_srgb,var(--state-danger)_30%,transparent)] hover:text-[var(--state-danger)]",
+apps/mouth/src/app/(workspace)/process/page.tsx:988:                  ? "bg-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] text-[var(--state-danger)] border-[color-mix(in_srgb,var(--state-danger)_40%,transparent)]"
+apps/mouth/src/app/(workspace)/process/page.tsx:989:                  : "bg-[var(--surface-raised)] text-[var(--bz-text-2)] border-[var(--bz-border)] hover:border-[color-mix(in_srgb,var(--state-danger)_30%,transparent)] hover:text-[var(--state-danger)]",
+apps/mouth/src/app/(workspace)/process/page.tsx:1330:                                      <span className="text-[9px] font-bold px-1.5 py-0.5 rounded bg-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] text-[var(--state-danger)] uppercase tracking-wide">
+apps/mouth/src/app/(workspace)/process/page.tsx:1347:                                              ? "bg-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] text-[var(--state-danger)]"
+apps/mouth/src/app/(workspace)/process/page.tsx:1417:                                        ? "text-[var(--state-danger)]"
+apps/mouth/src/app/(workspace)/process/page.tsx:1484:                                              className="text-[9px] px-1.5 py-0.5 rounded bg-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] text-[var(--state-danger)] tabular-nums"
+apps/mouth/src/app/(workspace)/process/page.tsx:1519:                                                ? "bg-[color-mix(in_srgb,var(--state-danger)_15%,transparent)] text-[var(--state-danger)]"
+apps/mouth/src/app/(workspace)/process/page.tsx:1772:                          <span className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full font-semibold bg-[color-mix(in_srgb,var(--state-danger)_15%,transparent)] text-[var(--state-danger)]">
+apps/mouth/src/app/(workspace)/process/page.tsx:1797:                                  : "bg-[color-mix(in_srgb,var(--state-danger)_15%,transparent)] text-[var(--state-danger)]"
+apps/mouth/src/app/(workspace)/process/page.tsx:1853:                                      ? "color-mix(in srgb, var(--state-danger) 12%, transparent)"
+apps/mouth/src/app/(workspace)/process/page.tsx:1859:                                      ? "var(--state-danger)"
+apps/mouth/src/app/(workspace)/process/page.tsx:2072:                            : "color-mix(in srgb, var(--state-danger) 25%, transparent)"
+apps/mouth/src/app/(workspace)/process/page.tsx:2080:                            : "var(--state-danger)"
+apps/mouth/src/app/(workspace)/process/page.tsx:2088:                            : "1px solid color-mix(in srgb, var(--state-danger) 40%, transparent)"
+apps/mouth/src/app/(workspace)/process/page.tsx:2126:                    color: "var(--state-danger)",
+apps/mouth/src/app/(workspace)/process/page.tsx:2128:                      "color-mix(in srgb, var(--state-danger) 25%, transparent)",
+apps/mouth/src/app/(workspace)/process/page.tsx:2130:                      "color-mix(in srgb, var(--state-danger) 40%, transparent)",
+apps/mouth/src/app/(workspace)/process/[id]/RequiredDocumentsCard.tsx:72:        "bg-[color-mix(in_srgb,var(--state-danger)_10%,transparent)] text-[var(--state-danger)]",
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:56:// board. "cancelled" is outside the 5-step workflow and reads --state-danger.
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:60:      background: "color-mix(in srgb, var(--state-danger) 10%, transparent)",
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:61:      color: "var(--state-danger)",
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:630:          <AlertCircle className="w-16 h-16 text-[var(--state-danger)] mx-auto mb-4" />
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:728:                        ? "color-mix(in srgb, var(--state-danger) 15%, transparent)"
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:733:                        ? "var(--state-danger)"
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:811:                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--state-danger)] hover:bg-[color-mix(in_srgb,var(--state-danger)_10%,transparent)] transition-colors"
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:1215:                      ? "bg-[color-mix(in_srgb,var(--state-danger)_15%,transparent)] text-[var(--state-danger)] hover:bg-[color-mix(in_srgb,var(--state-danger)_25%,transparent)]"
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:1249:                        : "bg-[color-mix(in_srgb,var(--state-danger)_15%,transparent)] text-[var(--state-danger)] hover:bg-[color-mix(in_srgb,var(--state-danger)_25%,transparent)]"
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:1410:                              ? "color-mix(in srgb, var(--state-danger) 8%, transparent)"
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:1414:                              ? "var(--state-danger)"
+apps/mouth/src/app/(workspace)/process/[id]/page.tsx:1530:                        ? "var(--state-danger)"
+apps/mouth/src/components/dashboard/role-widgets/AccountingRoleWidget.tsx:18:      <span className="text-2xl font-black text-[var(--state-danger)] leading-none">
+apps/mouth/src/components/dashboard/role-widgets/AccountingRoleWidget.tsx:25:      <div className="px-2 py-1.5 rounded-lg bg-[color-mix(in_srgb,var(--state-danger)_9%,transparent)] border border-[color-mix(in_srgb,var(--state-danger)_22%,transparent)] text-[9px] font-semibold text-[var(--state-danger)]">
+apps/mouth/src/components/admin/ServiceHealthCard.tsx:36:        return "text-[var(--state-danger)] bg-[var(--state-danger)]/10 border-[var(--state-danger)]/30";
+apps/mouth/src/app/(workspace)/process/new/page.tsx:576:            <div className="rounded-lg border border-[color-mix(in_srgb,var(--state-danger)_30%,transparent)] bg-[color-mix(in_srgb,var(--state-danger)_10%,transparent)] p-4 text-sm text-[var(--state-danger)]">
+apps/mouth/src/app/(workspace)/process/new/page.tsx:584:              Client <span className="text-[var(--state-danger)]">*</span>
+apps/mouth/src/app/(workspace)/process/new/page.tsx:683:              <p className="text-xs text-[var(--state-danger)] mt-1">
+apps/mouth/src/app/(workspace)/process/new/page.tsx:786:              <p className="text-xs text-[var(--state-danger)]">
+apps/mouth/src/app/(workspace)/process/new/page.tsx:937:                <p className="text-xs text-[var(--state-danger)]">
+apps/mouth/src/app/(workspace)/process/new/page.tsx:989:                  color: "text-[var(--state-danger)]",
+1:diff --git a/apps/mouth/e2e/portal-prodlike-smoke.spec.ts b/apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+2:index 16c0d7f179..7eb4da21a9 100644
+5:@@ -141,7 +141,7 @@ async function loginViaPortalUi(
+14:@@ -186,7 +186,7 @@ async function loginPartnerViaPortalUi(
+23:@@ -363,7 +363,7 @@ test("@qa-be-003 portal-disabled PIN credentials fail closed without a session",
+32:diff --git a/apps/mouth/src/app/portal/login-upgraded/error.tsx b/apps/mouth/src/app/portal/login-upgraded/error.tsx
+33:index 4a490648b9..8a8537ce00 100644
+36:@@ -18,17 +18,19 @@ export default function LoginError({
+61:diff --git a/apps/mouth/src/app/portal/login-upgraded/page.test.tsx b/apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+62:index 2ce07f2ab5..e3dccd43a8 100644
+65:@@ -5,7 +5,6 @@ import {
+73:@@ -25,46 +24,6 @@ vi.mock("next/navigation", () => ({
+120:@@ -80,78 +39,79 @@ vi.mock("@/lib/logger", () => ({
+239:@@ -366,5 +326,7 @@ describe("UpgradedLoginPage (WS3 day pass)", () => {
+247:diff --git a/apps/mouth/src/app/portal/login-upgraded/page.tsx b/apps/mouth/src/app/portal/login-upgraded/page.tsx
+248:index a75e1b85b2..30f7206489 100644
+251:@@ -1,13 +1,11 @@
+267:@@ -18,17 +16,92 @@ import { I18nProvider, useTranslation } from "@/i18n";
+368:@@ -85,18 +158,23 @@ function UpgradedLoginPageInner() {
+404:@@ -206,1370 +284,214 @@ function UpgradedLoginPageInner() {
+81:-  const React = await vi.importActual<typeof import("react")>("react");
+86:-    >(function MotionElement(
+99:-      return React.createElement(
+109:-      button: makeMotionElement("button"),
+110:-      div: makeMotionElement("div"),
+111:-      form: makeMotionElement("form"),
+112:-      p: makeMotionElement("p"),
+131:-  it("shell reads --bz-base and the gate scene carries its re-light class", () => {
+132:+  it("renders the split gate and no illustration survives", () => {
+136:-    expect(shell?.className).toContain("bg-[var(--bz-base)]");
+137:-    expect(shell?.className).not.toContain("bg-black");
+140:-    expect(container.querySelector(".gate-scene")).not.toBeNull();
+141:+    expect(container.querySelector(".r19-gate")).not.toBeNull();
+142:+    expect(container.querySelector(".r19-hero")).not.toBeNull();
+144:+    expect(container.querySelector(".gate-scene")).toBeNull();
+145:+    expect(container.querySelector("svg circle")).toBeNull();
+148:-  it("masthead slogan reads day tokens (copper headline: AA on the gate passage)", () => {
+154:-    const h1 = screen.getByText("Your Bali Life.");
+155:-    expect(h1.className).toContain("text-[var(--bz-copper-text)]");
+156:+  it("the forest panel carries the brand mark and the hero sentence", () => {
+159:-    const kicker = screen.getByText("Turn On");
+160:-    expect(kicker.className).toContain("text-[var(--bz-copper-text)]");
+162:+    expect(hero).not.toBeNull();
+164:+    expect(hero?.textContent).not.toContain("Bali Zero");
+165:+    expect(hero?.textContent).toContain("Client portal");
+166:+    expect(hero?.querySelector("h2")?.textContent).toBe(
+171:+    expect(mark).not.toBeNull();
+172:+    expect(mark?.getAttribute("alt")).toBe("Bali Zero");
+173:+    expect(mark?.className ?? "").not.toContain("rounded-full");
+176:-  it("spotlight card is the token surface; inputs are warm paper with copper focus", () => {
+180:-    expect(card).not.toBeNull();
+181:-    expect(card?.className).toContain("border-[var(--bz-border)]");
+182:+  it("the email field is the paper form control with a copper focus ring", () => {
+186:-    expect(email.className).toContain("bg-[var(--bz-base)]");
+187:-    expect(email.className).toContain("border-[var(--bz-border)]");
+188:-    expect(email.className).toContain("text-[var(--tx-primary)]");
+189:-    expect(email.className).toContain("focus:border-[var(--bz-copper)]");
+190:+    expect(email.className).toContain("r19-input");
+192:+    const eyebrow = screen.getByText("Sign in · step 1 of 2");
+193:+    expect(eyebrow.className).toContain("r19-eyebrow");
+196:-  it("CTA uses the darker copper step + --bz-on-warm (AA pair)", () => {
+197:+  it("the primary CTA is filled forest — copper never fills a button", () => {
+201:-    expect(cta.style.background).toBe("var(--bz-copper-text)");
+202:-    expect(cta.style.color).toBe("var(--bz-on-warm)");
+204:+    expect(cta.style.background).toBe("var(--r19-forest)");
+205:+    expect(cta.style.color).toBe("var(--r19-paper)");
+208:-  it("email step advances to the PIN step with token-styled controls", async () => {
+209:+  it("email step advances to the PIN step with the R19 controls", async () => {
+219:-    expect(pin.className).toContain("bg-[var(--bz-base)]");
+220:-    expect(pin.className).toContain("border-[var(--bz-border)]");
+221:+    expect(pin.className).toContain("r19-input");
+222:+    expect(pin.className).toContain("r19-pin");
+223:+    expect(screen.getByText("Sign in · step 2 of 2")).toBeTruthy();
+226:-    expect(verify.style.background).toBe("var(--bz-copper-text)");
+227:-    expect(verify.style.color).toBe("var(--bz-on-warm)");
+228:+    expect(verify.style.background).toBe("var(--r19-forest)");
+229:+    expect(verify.style.color).toBe("var(--r19-paper)");
+234:-    expect(magicLink.className).toContain("text-[var(--bz-accent-warm)]");
+235:+    expect(magicLink.className).toContain("r19-link");
+243:+    expect(html).not.toContain("starDrift");
+244:+    expect(html).not.toContain("passageGlow");
+378:-    const { left, top } = cardRef.current.getBoundingClientRect();
+389:+  useEffect(() => {
+415:+        {t("portal.login.forgot_password")}
+1704:-                background: `radial-gradient(400px circle at ${mouseX}px ${mouseY}px, color-mix(in srgb, var(--bz-copper) 15%, transparent), transparent 40%)`,
+1796:-                            ← {email.split("@")[0]}
+1833:-                            {t("portal.login.forgot_password")}
+1892:+                  ← {email.split("@")[0]}
+apps/mouth/package.json:55:    "framer-motion": "^13.1.0",
+apps/mouth/package.json:58:    "lucide-react": "^1.17.0",
+565:-        [data-theme="operative-light"] .gate-scene [fill="#c9a96e"] { fill: #b08a5a; } /* token-lint-ok: decorative illustration warm carving fill */
+566:-        [data-theme="operative-light"] .gate-scene [stroke="#c9a96e"] { stroke: #a08050; } /* token-lint-ok: decorative illustration warm carving stroke */
+568:-        [data-theme="operative-light"] .gate-scene [fill="#000000"] { fill: #d8cdb6; } /* token-lint-ok: decorative illustration sand silhouette (moon cover, ground, foliage) */
+569:-        [data-theme="operative-light"] .gate-scene [fill="#0a0a0a"] { fill: #d9a441; } /* token-lint-ok: decorative illustration sun disc */
+571:-           opaque both stops), so in daylight the central passage rendered
+576:-        [data-theme="operative-light"] .gate-scene #passageGlow stop[stop-color="#1a1008"] { stop-color: #f7f3ea; } /* token-lint-ok: decorative illustration daylight passage glow (reuses day sky) */
+577:-        [data-theme="operative-light"] .gate-scene #passageGlow stop[stop-color="#000000"] { stop-color: #e6dcc8; } /* token-lint-ok: decorative illustration daylight passage glow depth (reuses day sky depth) */
+601:-              <stop offset="0%" stopColor="#f8e89a" stopOpacity="1" />
+602:-              <stop offset="25%" stopColor="#e8c96a" stopOpacity="0.95" />
+603:-              <stop offset="65%" stopColor="#c9a96e" stopOpacity="0.7" />
+608:-              <stop offset="0%" stopColor="#c9a96e" stopOpacity="0.3" />
+609:-              <stop offset="60%" stopColor="#c9a96e" stopOpacity="0.08" />
+610:-              <stop offset="100%" stopColor="#c9a96e" stopOpacity="0" />
+689:-                fill="#ffffff"
+747:-                fill="#f5e8c0"
+786:-                <circle cx={x} cy={y} r={1.4} fill="#fffbe8" />
+792:-                  stroke="#fffbe8"
+801:-                  stroke="#fffbe8"
+817:-            stroke="#c9a96e"
+844:-                stroke="#f8e89a"
+853:-                stroke="#e8c96a"
+866:-                      fill="#c9a96e"
+874:-                      stroke="#e8c96a"
+889:-                stroke="#c9a96e"
+900:-                stroke="#c9a96e"
+911:-                stroke="#c9a96e"
+917:-                fill="#c9a96e"
+922:-                fill="#c9a96e"
+927:-                fill="#c9a96e"
+934:-                stroke="#e8c96a"
+943:-                stroke="#f8e89a"
+950:-                stroke="#e8c96a"
+959:-                stroke="#f8e89a"
+966:-                stroke="#c9a96e"
+975:-                stroke="#f8e89a"
+982:-                stroke="#c9a96e"
+991:-                stroke="#e8c96a"
+998:-                stroke="#c9a96e"
+1007:-                stroke="#e8c96a"
+1014:-                stroke="#c9a96e"
+1023:-                stroke="#e8c96a"
+1030:-                stroke="#c9a96e"
+1039:-                stroke="#e8c96a"
+1047:-                stroke="#e8c96a"
+1055:-                stroke="#e8c96a"
+1062:-                stroke="#c9a96e"
+1069:-                stroke="#c9a96e"
+1076:-                stroke="#c9a96e"
+1083:-                stroke="#c9a96e"
+1090:-                stroke="#c9a96e"
+1097:-                fill="#c9a96e"
+1106:-                fill="#f8e89a"
+1115:-                fill="#ffffff"
+1133:-                stroke="#f8e89a"
+1142:-                stroke="#e8c96a"
+1154:-                      fill="#c9a96e"
+1162:-                      stroke="#e8c96a"
+1176:-                stroke="#c9a96e"
+1187:-                stroke="#c9a96e"
+1198:-                stroke="#c9a96e"
+1204:-                fill="#c9a96e"
+1209:-                fill="#c9a96e"
+1214:-                fill="#c9a96e"
+1220:-                stroke="#e8c96a"
+1229:-                stroke="#f8e89a"
+1236:-                stroke="#e8c96a"
+1245:-                stroke="#f8e89a"
+1252:-                stroke="#c9a96e"
+1261:-                stroke="#f8e89a"
+1268:-                stroke="#c9a96e"
+1277:-                stroke="#e8c96a"
+1284:-                stroke="#c9a96e"
+1293:-                stroke="#e8c96a"
+1300:-                stroke="#c9a96e"
+1309:-                stroke="#e8c96a"
+1316:-                stroke="#c9a96e"
+1325:-                stroke="#e8c96a"
+1332:-                stroke="#e8c96a"
+1339:-                stroke="#e8c96a"
+1346:-                stroke="#c9a96e"
+1353:-                stroke="#c9a96e"
+1360:-                stroke="#c9a96e"
+1367:-                stroke="#c9a96e"
+1374:-                stroke="#c9a96e"
+1380:-                fill="#c9a96e"
+1389:-                fill="#f8e89a"
+1398:-                fill="#ffffff"
+1437:+              Enter the email registered with Bali Zero. We will ask for your
+1458:+                required
+1477:-              stroke="#f8e89a"
+1486:-              stroke="#f8e89a"
+1499:-              stroke="#e8c96a"
+1508:-              stroke="#f8e89a"
+1519:-              stroke="#c9a96e"
+1542:-              stroke="#c9a96e"
+1587:-                  fill="#c9a96e"
+1594:-                  fill="#c9a96e"
+1747:-                          required
+1822:-                          required
+1918:+                required
+ M apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+ M apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+ M apps/mouth/src/app/portal/login-upgraded/page.tsx
+ M evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
+ M evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
+ apps/mouth/e2e/portal-prodlike-smoke.spec.ts       |  6 ++--
+ .../src/app/portal/login-upgraded/page.test.tsx    |  3 +-
+ apps/mouth/src/app/portal/login-upgraded/page.tsx  |  9 +++---
+ .../agent-air-m5-mouth-r19p-w5-3f095807/brief.yml  |  2 +-
+ .../agent-air-m5-mouth-r19p-w5-3f095807/pack.yml   | 35 +++++++++++++++++++++-
+ 5 files changed, 44 insertions(+), 11 deletions(-)
+12d6359e94 feat(mouth): portal sign-in becomes concept F's split gate (R19P W5)
+6d505f1680 fix(portal): re-light passageGlow for the day theme (#6228)
+5acfbc52f5 fix(mouth): self-host the four fonts so the build stops fetching from Google (#4164)
+ce095c49af portal: deliver verified client portal launch candidate (#3741)
+4f1a6bf0b2 feat(mouth): WS3 final slice — partner/* + auth pages day pass (GARUDA OS train) (#3096)
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+codex
+La logica auth è byte-per-byte invariata nel diff: mapper degli status, chiamata `publicAuth.login`, gestione `retry-after`, anti-doppio-submit, redirect e timeout non sono stati toccati. La parte che richiede ancora attenzione è l’accessibilità del nuovo CSS e del nuovo asset logo, oltre alla reale copertura dei test dopo la rimozione del mock animation.
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "rg --files apps/mouth/public packages | rg 'balizero-logo-clean\\.png"'$'"'
+file apps/mouth/public/assets/logo/balizero-logo-clean.png 2>/dev/null || true
+nl -ba apps/mouth/src/app/globals.css | sed -n '270,410p'
+nl -ba apps/mouth/package.json | sed -n '1,90p'
+git show 2ce07f2ab5 | nl -ba | sed -n '110,390p'" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 338ms:
+apps/mouth/public/assets/logo/balizero-logo-clean.png
+apps/mouth/public/static/balizero-logo-clean.png
+apps/mouth/public/assets/logo/balizero-logo-clean.png: PNG image data, 512 x 512, 8-bit/color RGBA, non-interlaced
+   270	  --bz-accent-warm: #c9a96e;
+   271	  --bz-accent-cool: #5e7fb5;
+   272	
+   273	  /* God Tier Anthracite Tokens */
+   274	  --anthracite-base: #0f1419;
+   275	  --anthracite-elevated: #1b222b;
+   276	
+   277	  /* Cinematic Border Tokens */
+   278	  --glass-highlight: rgba(255, 255, 255, 0.12);
+   279	  --glass-rim: rgba(255, 255, 255, 0.03);
+   280	
+   281	  /* Typography */
+   282	  --tx-pure: #ffffff;
+   283	  --tx-primary: #f8fafc;
+   284	  --tx-secondary: #94a3b8;
+   285	  --tx-tertiary: #475569;
+   286	
+   287	  /* Neon Accents */
+   288	  --neon-blue: #3b82f6;
+   289	  --neon-purple: #8b5cf6;
+   290	  --neon-emerald: #10b981;
+   291	  --neon-amber: #f59e0b;
+   292	  --neon-rose: #f43f5e;
+   293	  --neon-cyan: #06b6d4;
+   294	  --bz-copper: #d4845a;
+   295	  /* Text-safe copper step. Dark: copper itself is AA on anthracite, so the
+   296	     text variant aliases it; operative-light overrides it below (WS3). */
+   297	  --bz-copper-text: var(--bz-copper);
+   298	
+   299	  /* Sidebar — GARUDA pill active */
+   300	  --sidebar-active-bg: #d4845a;
+   301	  /* Filled controls need a darker, white-text-safe copper than the accent
+   302	     used for icons and large text. This stays AA in both theme modes. */
+   303	  --bz-sidebar-active-fill: #9d5230;
+   304	  --bz-focus-ring: #d4845a;
+   305	  --border-focus: var(--bz-focus-ring);
+   306	  --sidebar-active-border: transparent;
+   307	  --sidebar-pill-radius: 12px;
+   308	
+   309	  --bz-text-1: #edeae4;
+   310	  --bz-text-2: var(--tx-secondary);
+   311	  --bz-text-3: #545c6a;
+   312	  --bz-border: rgba(255, 255, 255, 0.05);
+   313	  --bz-border-hover: rgba(255, 255, 255, 0.1);
+   314	  --bz-border-accent: rgba(201, 169, 110, 0.18);
+   315	  --bz-green: #3ecf8e;
+   316	  --bz-red: #d95f5a;
+   317	  --bz-amber: #d4923a;
+   318	  --success: #4db87a;
+   319	  --warning: #d4923a;
+   320	  --error: #d95f5a;
+   321	  --bz-sidebar-width: 216px;
+   322	  --bz-header-height: 48px;
+   323	  --bz-batik-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20'%3E%3Cpath d='M0 10 L10 0 L20 10 L10 20 Z' fill='none' stroke='%23c9a96e' stroke-width='0.5'/%3E%3C/svg%3E");
+   324	  /* Header surface — dark default; overridden under operative-light */
+   325	  --portal-header-bg: rgba(29, 39, 59, 0.7);
+   326	  --bz-shell-header-shadow: 0 8px 30px rgba(0, 0, 0, 0.14);
+   327	  --bz-bottom-nav-bg: rgba(19, 19, 21, 0.82);
+   328	  --bz-bottom-nav-border: rgba(255, 255, 255, 0.06);
+   329	  --bz-bottom-nav-shadow: 0 -12px 32px rgba(0, 0, 0, 0.2);
+   330	  --bz-bottom-nav-active: rgba(212, 132, 90, 0.12);
+   331	}
+   332	
+   333	/* ───────────────────────────────────────────────────────────────────────────
+   334	   PORTAL LIGHT SURFACE — "Rumah Putih / Lounge" (2026-06-21)
+   335	
+   336	   The pre-paint themeInitScript in layout.tsx routes `kita.`, `my.` and
+   337	   `zantara.` to data-theme="operative-light" by default; `prime.` retains the
+   338	   immersive operative-dark persona. This block arms the common daylight
+   339	   surface, then product-scoped tokens below differentiate the team workspace
+   340	   from the client portal. Accent copper is kept for brand continuity while
+   341	   base/text/border/elevated invert. WCAG AA verified:
+   342	   ink #16213a on paper #f4f1ea ≈ 12.8:1; soft-ink #475372 ≈ 6.4:1.
+   343	   ─────────────────────────────────────────────────────────────────────────── */
+   344	[data-theme="operative-light"] {
+   345	  color-scheme: light;
+   346	
+   347	  /* Shell base surfaces — warm paper, not glaring white */
+   348	  --bz-base: #f4f1ea;
+   349	  --bz-elevated: #ffffff;
+   350	  --bz-surface: #ffffff;
+   351	  --bz-card: #ffffff;
+   352	  --bz-card-hover: #faf8f3;
+   353	
+   354	  /* Generic background/foreground mappings (body + ui components) */
+   355	  --background: #f4f1ea;
+   356	  --background-secondary: #ffffff;
+   357	  --background-elevated: #ffffff;
+   358	  --background-hover: #faf8f3;
+   359	  --foreground: #16213a;
+   360	  --foreground-secondary: #475372;
+   361	  --foreground-muted: var(--tx-secondary);
+   362	  --border: rgba(9, 9, 11, 0.08);
+   363	  --border-hover: rgba(9, 9, 11, 0.14);
+   364	  --accent: #d4845a;
+   365	  --accent-hover: #bf7350;
+   366	  --accent-foreground: var(--tx-pure);
+   367	
+   368	  /* Typography on light */
+   369	  --tx-pure: #16213a;
+   370	  --tx-primary: #16213a;
+   371	  --tx-secondary: #475372;
+   372	  --tx-tertiary: var(--tx-secondary);
+   373	  --bz-text-1: #16213a;
+   374	  --bz-text-2: #475372;
+   375	  --bz-text-3: var(--tx-secondary);
+   376	
+   377	  /* Borders / glass on light (dark hairlines, not white) */
+   378	  --bz-border: rgba(9, 9, 11, 0.08);
+   379	  --bz-border-hover: rgba(9, 9, 11, 0.14);
+   380	  --bz-border-accent: rgba(201, 169, 110, 0.35);
+   381	  --glass-highlight: rgba(9, 9, 11, 0.05);
+   382	  --glass-rim: rgba(9, 9, 11, 0.06);
+   383	
+   384	  /* Header surface (consumed by PortalHeader, was hardcoded dark navy) */
+   385	  --portal-header-bg: rgba(244, 241, 234, 0.72);
+   386	
+   387	  /* Day-copper steps (GARUDA Day Edition, WS3 2026-07-24). Measured on
+   388	     paper #f4f1ea: #d4845a = 2.57:1 (fill/icon-grade only); the concept
+   389	     copper #b5633a = 3.87:1 — passes the 3:1 floor for icons/large text
+   390	     but NOT 4.5:1 for small text; #9d5230 (the concept's own copper
+   391	     gradient end) = 5.05:1 on paper / 5.70:1 on card → the small-text
+   392	     step. */
+   393	  --bz-copper: #b5633a;
+   394	  --bz-copper-text: #9d5230;
+   395	  --bz-focus-ring: #9d5230;
+   396	  --border-focus: var(--bz-focus-ring);
+   397	
+   398	  /* Daylight gold for warm accents / focus rings (was #c9a96e = 1.98:1 on
+   399	     paper, below even the 3:1 non-text floor). #8a6d3b = 4.30:1. */
+   400	  --bz-accent-warm: #8a6d3b;
+   401	
+   402	  /* Neon → state parity on light: mirror the WS2 AA steps from
+   403	     packages/core/tokens/semantic.css (:root[data-theme='operative-light'])
+   404	     so legacy --neon-* reads on not-yet-migrated portal pages keep ≥4.5:1
+   405	     until each page moves to --state-* (WS3 drain, page by page). */
+   406	  --neon-emerald: #147a3a;
+   407	  --neon-amber: #ad4f08;
+   408	  --neon-rose: #b91c1c;
+   409	  --neon-blue: #1d4ed8;
+   410	
+     1	{
+     2	  "name": "mouth",
+     3	  "version": "5.2.0",
+     4	  "private": true,
+     5	  "scripts": {
+     6	    "dev": "next dev",
+     7	    "build": "LLMS_GENERATE_ARTICLES_ONLY=1 tsx scripts/generate-llms-full.ts && next build --webpack && node scripts/assert-public-login-bundle.mjs && node scripts/assert-roster-not-in-public-chunks.mjs",
+     8	    "start": "next start",
+     9	    "typecheck": "tsc --noEmit",
+    10	    "lint": "eslint .",
+    11	    "test": "vitest",
+    12	    "test:coverage": "vitest --coverage",
+    13	    "test:ci": "vitest --run --coverage",
+    14	    "test:coverage:check": "node -e \"const fs=require('fs');const r=JSON.parse(fs.readFileSync('./coverage/coverage-summary.json','utf8'));const s=r.total.statements.pct;if(s<20){console.error('Coverage '+s+'% below 20% threshold');process.exit(1)}else{console.log('Coverage '+s+'% OK')}\"",
+    15	    "test:e2e": "playwright test -c playwright.config.ts",
+    16	    "test:e2e:portal:prodlike": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON e2e/support/prodlike-preflight-cli.ts && playwright test -c playwright.prodlike.config.ts",
+    17	    "test:e2e:portal:prodlike:preflight": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test e2e/support/prodlike-preflight.test.ts",
+    18	    "test:portal:public-live": "node scripts/check-portal-public-live.mjs",
+    19	    "test:portal:public-live:unit": "node --test scripts/check-portal-public-live.test.mjs",
+    20	    "test:e2e:ui": "playwright test --ui",
+    21	    "test:e2e:debug": "playwright test --debug",
+    22	    "test:e2e:report": "playwright show-report",
+    23	    "test:public-login-bundle": "node scripts/assert-public-login-bundle.mjs",
+    24	    "prepare": "husky",
+    25	    "generate:openapi": "cd ../backend-rag && zsh -c 'source .venv/bin/activate && PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python -m scripts.generate_openapi'",
+    26	    "generate:api": "openapi-typescript ../backend-rag/openapi.json -o src/lib/api/schema.d.ts",
+    27	    "gen:api-types": "npm run generate:api",
+    28	    "validate:openapi": "node ../../scripts/validate-openapi.cjs",
+    29	    "validate:visa-oracle-openapi": "node scripts/validate-visa-oracle-openapi.mjs",
+    30	    "contract:visa-oracle": "npm run generate:openapi && npm run generate:api && npm run validate:visa-oracle-openapi",
+    31	    "lighthouse": "node scripts/lighthouse-ci.mjs",
+    32	    "audit:links": "npx tsx scripts/audit-internal-links.ts",
+    33	    "visa-oracle:walk-corpus": "npx tsx scripts/visa-oracle/generate-walk-corpus.ts"
+    34	  },
+    35	  "dependencies": {
+    36	    "@ai-sdk/react": "^4.0.69",
+    37	    "@formkit/auto-animate": "^0.10.0",
+    38	    "@next/third-parties": "^16.3.1",
+    39	    "@radix-ui/react-dialog": "^1.1.23",
+    40	    "@radix-ui/react-progress": "^1.1.16",
+    41	    "@radix-ui/react-scroll-area": "^1.2.18",
+    42	    "@radix-ui/react-select": "^2.3.7",
+    43	    "@radix-ui/react-slot": "^1.3.3",
+    44	    "@radix-ui/react-tabs": "^1.1.21",
+    45	    "@sentry/nextjs": "^10.70.0",
+    46	    "@tanstack/react-query": "^5.101.4",
+    47	    "@tanstack/react-query-devtools": "^5.101.4",
+    48	    "@tanstack/react-virtual": "^3.14.9",
+    49	    "@types/dompurify": "^3.2.0",
+    50	    "ai": "^7.0.29",
+    51	    "class-variance-authority": "^0.7.1",
+    52	    "clsx": "^2.1.1",
+    53	    "date-fns": "^4.1.0",
+    54	    "dompurify": "^3.4.13",
+    55	    "framer-motion": "^13.1.0",
+    56	    "googleapis": "^174.0.1",
+    57	    "gray-matter": "^4.0.3",
+    58	    "lucide-react": "^1.17.0",
+    59	    "next": "^16.3.4",
+    60	    "next-mdx-remote": "^6.0.0",
+    61	    "qrcode": "^1.5.4",
+    62	    "react": "19.2.8",
+    63	    "react-countup": "^6.5.3",
+    64	    "react-dom": "19.2.8",
+    65	    "react-markdown": "^10.1.0",
+    66	    "recharts": "^3.10.1",
+    67	    "remark-gfm": "^4.0.1",
+    68	    "sonner": "^2.0.8",
+    69	    "swr": "^2.5.1",
+    70	    "tailwind-merge": "^3.4.0",
+    71	    "uuid": "^14.0.1",
+    72	    "web-vitals": "^6.1.0",
+    73	    "zod": "^4.5.4"
+    74	  },
+    75	  "lint-staged": {
+    76	    "*.{ts,tsx,json,md,css}": [
+    77	      "prettier --write"
+    78	    ]
+    79	  },
+    80	  "devDependencies": {
+    81	    "@axe-core/playwright": "^4.13.0",
+    82	    "@next/bundle-analyzer": "^16.3.1",
+    83	    "@playwright/test": "^1.62.1",
+    84	    "@tailwindcss/postcss": "^4.3.3",
+    85	    "@testing-library/dom": "^10.4.1",
+    86	    "@testing-library/jest-dom": "^7.0.1",
+    87	    "@testing-library/react": "^16.3.0",
+    88	    "@testing-library/user-event": "^14.6.4",
+    89	    "@types/node": "26.1.1",
+    90	    "@types/qrcode": "^1.5.6",
+   110	    expect(kicker.className).toContain("text-[var(--bz-copper-text)]");
+   111	  });
+   112	
+   113	  it("spotlight card is the token surface; inputs are warm paper with copper focus", () => {
+   114	    const { container } = render(<UpgradedLoginPage />);
+   115	
+   116	    const card = container.querySelector(".bg-\\[var\\(--bz-card\\)\\]\\/95");
+   117	    expect(card).not.toBeNull();
+   118	    expect(card?.className).toContain("border-[var(--bz-border)]");
+   119	
+   120	    const email = screen.getByPlaceholderText("client@company.com");
+   121	    expect(email.className).toContain("bg-[var(--bz-base)]");
+   122	    expect(email.className).toContain("border-[var(--bz-border)]");
+   123	    expect(email.className).toContain("text-[var(--tx-primary)]");
+   124	    expect(email.className).toContain("focus:border-[var(--bz-copper)]");
+   125	  });
+   126	
+   127	  it("CTA uses the darker copper step + --bz-on-warm (AA pair)", () => {
+   128	    render(<UpgradedLoginPage />);
+   129	
+   130	    const cta = screen.getByRole("button", { name: /Pass the Portal/ });
+   131	    expect(cta.style.background).toBe("var(--bz-copper-text)");
+   132	    expect(cta.style.color).toBe("var(--bz-on-warm)");
+   133	  });
+   134	
+   135	  it("email step advances to the PIN step with token-styled controls", async () => {
+   136	    render(<UpgradedLoginPage />);
+   137	
+   138	    fireEvent.change(screen.getByPlaceholderText("client@company.com"), {
+   139	      target: { value: "synthetic.user@example.test" },
+   140	    });
+   141	    fireEvent.click(screen.getByRole("button", { name: /Pass the Portal/ }));
+   142	
+   143	    const pin = await screen.findByLabelText("Access PIN");
+   144	    expect(pin.className).toContain("bg-[var(--bz-base)]");
+   145	    expect(pin.className).toContain("border-[var(--bz-border)]");
+   146	
+   147	    const verify = screen.getByRole("button", { name: /Verify Identity/ });
+   148	    expect(verify.style.background).toBe("var(--bz-copper-text)");
+   149	    expect(verify.style.color).toBe("var(--bz-on-warm)");
+   150	
+   151	    const magicLink = screen.getByRole("link", {
+   152	      name: /Sign in with an email link instead/,
+   153	    });
+   154	    expect(magicLink.className).toContain("text-[var(--bz-accent-warm)]");
+   155	  });
+   156	
+   157	  it("exposes durable labels and password-manager semantics", async () => {
+   158	    render(<UpgradedLoginPage />);
+   159	
+   160	    const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   161	    expect(email).toHaveAttribute("name", "email");
+   162	    expect(email).toHaveAttribute("autocomplete", "username");
+   163	
+   164	    fireEvent.change(email, {
+   165	      target: { value: "  synthetic.user@example.test  " },
+   166	    });
+   167	    fireEvent.submit(email.closest("form")!);
+   168	
+   169	    const pin = await screen.findByLabelText("Access PIN");
+   170	    expect(pin).toHaveAttribute("name", "password");
+   171	    expect(pin).toHaveAttribute("autocomplete", "current-password");
+   172	    expect(pin).toHaveAttribute("minlength", "4");
+   173	    expect(pin).toHaveAttribute("maxlength", "8");
+   174	  });
+   175	
+   176	  it.each([
+   177	    ["/portal/matters?tab=open", "/portal/matters?tab=open"],
+   178	    ["https://attacker.example/collect", "/portal"],
+   179	    ["//attacker.example/collect", "/portal"],
+   180	  ])(
+   181	    "routes redirect %s only through the allowlisted same-origin sanitizer",
+   182	    async (redirect, expected) => {
+   183	      window.history.replaceState(
+   184	        {},
+   185	        "",
+   186	        `/portal/login-upgraded?redirect=${encodeURIComponent(redirect)}`,
+   187	      );
+   188	      mockLogin.mockResolvedValue({
+   189	        access_token: "synthetic-token",
+   190	        token_type: "Bearer",
+   191	        user: {
+   192	          id: "client-1",
+   193	          email: "synthetic.user@example.test",
+   194	          name: "Synthetic Client",
+   195	          role: "client",
+   196	        },
+   197	        redirectTo: "/portal",
+   198	      });
+   199	      render(<UpgradedLoginPage />);
+   200	
+   201	      const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   202	      fireEvent.change(email, {
+   203	        target: { value: "synthetic.user@example.test" },
+   204	      });
+   205	      fireEvent.submit(email.closest("form")!);
+   206	
+   207	      const pin = await screen.findByLabelText("Access PIN");
+   208	      fireEvent.change(pin, { target: { value: "1234" } });
+   209	
+   210	      vi.useFakeTimers();
+   211	      try {
+   212	        await act(async () => {
+   213	          const form = pin.closest("form")!;
+   214	          fireEvent.submit(form);
+   215	          fireEvent.submit(form);
+   216	          await Promise.resolve();
+   217	        });
+   218	
+   219	        expect(mockLogin).toHaveBeenCalledTimes(1);
+   220	        expect(mockLogin).toHaveBeenCalledWith(
+   221	          "synthetic.user@example.test",
+   222	          "1234",
+   223	        );
+   224	
+   225	        act(() => {
+   226	          vi.advanceTimersByTime(1500);
+   227	        });
+   228	        expect(mockRouterReplace).toHaveBeenCalledWith(expected);
+   229	      } finally {
+   230	        vi.useRealTimers();
+   231	      }
+   232	    },
+   233	  );
+   234	
+   235	  it("routes a partner to the dedicated portal and rejects a client-only redirect", async () => {
+   236	    window.history.replaceState(
+   237	      {},
+   238	      "",
+   239	      "/portal/login-upgraded?redirect=%2Fportal%2Fbilling",
+   240	    );
+   241	    mockLogin.mockResolvedValue({
+   242	      access_token: "synthetic-token",
+   243	      token_type: "Bearer",
+   244	      user: {
+   245	        id: "partner-user-1",
+   246	        email: "synthetic.partner@example.test",
+   247	        name: "Synthetic Partner",
+   248	        role: "partner",
+   249	      },
+   250	      redirectTo: "/portal/partner/dashboard",
+   251	    });
+   252	    render(<UpgradedLoginPage />);
+   253	
+   254	    const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   255	    fireEvent.change(email, {
+   256	      target: { value: "synthetic.partner@example.test" },
+   257	    });
+   258	    fireEvent.submit(email.closest("form")!);
+   259	    const pin = await screen.findByLabelText("Access PIN");
+   260	    fireEvent.change(pin, { target: { value: "1234" } });
+   261	
+   262	    vi.useFakeTimers();
+   263	    try {
+   264	      await act(async () => {
+   265	        fireEvent.submit(pin.closest("form")!);
+   266	        await Promise.resolve();
+   267	      });
+   268	      act(() => vi.advanceTimersByTime(1500));
+   269	      expect(mockRouterReplace).toHaveBeenCalledWith(
+   270	        "/portal/partner/dashboard",
+   271	      );
+   272	    } finally {
+   273	      vi.useRealTimers();
+   274	    }
+   275	  });
+   276	
+   277	  it("never forwards credentials, email, current URL, or raw auth errors to telemetry", async () => {
+   278	    const rawError = Object.assign(new Error("synthetic auth failure"), {
+   279	      response: {
+   280	        status: 401,
+   281	        config: {
+   282	          data: {
+   283	            email: "synthetic.user@example.test",
+   284	            pin: "1234",
+   285	          },
+   286	        },
+   287	      },
+   288	    });
+   289	    mockLogin.mockRejectedValue(rawError);
+   290	    render(<UpgradedLoginPage />);
+   291	
+   292	    const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   293	    fireEvent.change(email, {
+   294	      target: { value: "synthetic.user@example.test" },
+   295	    });
+   296	    fireEvent.submit(email.closest("form")!);
+   297	
+   298	    const pin = await screen.findByLabelText("Access PIN");
+   299	    fireEvent.change(pin, { target: { value: "1234" } });
+   300	    fireEvent.submit(pin.closest("form")!);
+   301	
+   302	    await waitFor(() => {
+   303	      expect(mockLoggerInfo).toHaveBeenCalledWith("Login denied", {
+   304	        component: "UpgradedLoginPage",
+   305	        action: "handleLogin",
+   306	        code: 401,
+   307	        reason: "portal.login.errors.invalid_credentials",
+   308	      });
+   309	    });
+   310	    expect(mockLoggerInfo).toHaveBeenCalledWith("Login process started", {
+   311	      component: "UpgradedLoginPage",
+   312	      action: "handleLogin",
+   313	    });
+   314	
+   315	    const telemetryPayload = JSON.stringify([
+   316	      mockLoggerInfo.mock.calls,
+   317	      mockLoggerError.mock.calls,
+   318	    ]);
+   319	    expect(telemetryPayload).not.toContain("synthetic.user@example.test");
+   320	    expect(telemetryPayload).not.toContain("1234");
+   321	    expect(telemetryPayload).not.toContain("currentUrl");
+   322	    expect(telemetryPayload).not.toContain("config");
+   323	  });
+   324	
+   325	  it("renders a generic portal-unavailable denial for an eligible-credential 403", async () => {
+   326	    const rawError = Object.assign(
+   327	      new Error("private portal eligibility state"),
+   328	      { status: 403 },
+   329	    );
+   330	    mockLogin.mockRejectedValue(rawError);
+   331	    render(<UpgradedLoginPage />);
+   332	
+   333	    const email = screen.getByRole("textbox", { name: "Corporate Email" });
+   334	    fireEvent.change(email, {
+   335	      target: { value: "synthetic.disabled@example.test" },
+   336	    });
+   337	    fireEvent.submit(email.closest("form")!);
+   338	
+   339	    const pin = await screen.findByLabelText("Access PIN");
+   340	    fireEvent.change(pin, { target: { value: "1234" } });
+   341	    fireEvent.submit(pin.closest("form")!);
+   342	
+   343	    const denial = await screen.findByRole("alert");
+   344	    expect(denial).toHaveTextContent(
+   345	      "Portal access is not available for this account. Contact team@balizero.com.",
+   346	    );
+   347	    expect(denial).not.toHaveTextContent("private portal eligibility state");
+   348	    expect(mockRouterReplace).not.toHaveBeenCalled();
+   349	    expect(mockLoggerInfo).toHaveBeenCalledWith("Login denied", {
+   350	      component: "UpgradedLoginPage",
+   351	      action: "handleLogin",
+   352	      code: 403,
+   353	      reason: "portal.login.errors.portal_unavailable",
+   354	    });
+   355	  });
+   356	
+   357	  it("drain guard: no forced-dark UI utilities or gold hexes outside the scene", () => {
+   358	    const { container } = render(<UpgradedLoginPage />);
+   359	    const html = container.innerHTML;
+   360	
+   361	    expect(html).not.toContain("text-white");
+   362	    expect(html).not.toContain("bg-white/5");
+   363	    expect(html).not.toContain("bg-white/10");
+   364	    expect(html).not.toContain("from-[#d9bd7a]"); // token-lint-ok: drain-guard assertion string, not a color use
+   365	    expect(html).not.toContain("to-[#a07838]"); // token-lint-ok: drain-guard assertion string, not a color use
+   366	    expect(html).not.toContain("text-[#f0ece4]"); // token-lint-ok: drain-guard assertion string, not a color use
+   367	    expect(html).not.toContain("text-[#f8e89a]"); // token-lint-ok: drain-guard assertion string, not a color use
+   368	    expect(html).not.toContain("accent-gold-muted");
+   369	  });
+   370	});
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "rg --files apps/mouth/src/app | rg '/(privacy|terms)/page\\.(tsx|ts|jsx|js)"'$'"'
+rg -n '(/privacy|/terms)|privacy|terms' apps/mouth/next.config.* apps/mouth/src/middleware.* apps/mouth/middleware.* 2>/dev/null | head -120
+python3 -c 'from math import *
+def rgb(h):
+ h=h.lstrip(\"#\"); return tuple(int(h[i:i+2],16)/255 for i in (0,2,4))
+def comp(f,b,a): return tuple(a*x+(1-a)*y for x,y in zip(rgb(f),rgb(b)))
+def lum(v):
+ def f(x): return x/12.92 if x<=.04045 else ((x+.055)/1.055)**2.4
+ return sum(c*f(x) for c,x in zip((.2126,.7152,.0722),v))
+def cr(a,b):
+ l1,l2=lum(a),lum(b); return (max(l1,l2)+.05)/(min(l1,l2)+.05)
+pairs=[(\"ink/paper\",\"#1d2c3b\",\"#f7f4ee\"),(\"muted/paper\",\"#58626b\",\"#f7f4ee\"),(\"copper/paper\",\"#a44b36\",\"#f7f4ee\"),(\"paper/forest\",\"#f7f4ee\",\"#253e33\"),(\"line-strong/surface\",\"#a8aca9\",\"#fffcf7\")]
+for n,a,b in pairs: print(n,round(cr(rgb(a),rgb(b)),2))
+for alpha in (.72,.78): print(f\"paper@{alpha}/forest\",round(cr(comp(\"#f7f4ee\",\"#253e33\",alpha),rgb(\"#253e33\")),2))'
+npm test -- --run src/app/portal/login-upgraded/page.test.tsx" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth
+ succeeded in 9424ms:
+rg: apps/mouth/src/app: IO error for operation on apps/mouth/src/app: No such file or directory (os error 2)
+zsh:2: no matches found: apps/mouth/next.config.*
+ink/paper 12.96
+muted/paper 5.67
+copper/paper 5.26
+paper/forest 10.54
+line-strong/surface 2.25
+paper@0.72/forest 6.32
+paper@0.78/forest 7.11
+
+> mouth@5.2.0 test
+> vitest --run src/app/portal/login-upgraded/page.test.tsx
+
+ DEPRECATED  `test.poolOptions` was removed in Vitest 4. All previous `poolOptions` are now top-level options. Please, refer to the migration guide: https://vitest.dev/guide/migration#pool-rework
+
+ RUN  v4.1.10 /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth
+
+
+ Test Files  1 passed (1)
+      Tests  13 passed (13)
+   Start at  06:42:24
+   Duration  6.41s (transform 222ms, setup 370ms, import 516ms, tests 2.53s, environment 2.24s)
+
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+codex
+I test unitari mirati passano: 13/13. I rapporti di contrasto del nuovo testo sono conformi (minimo 5,26:1 per il rame su carta; 6,32:1 per il testo chiaro attenuato su forest); il bordo input è 2,25:1 ma migliora rispetto al bordo precedente e il focus ring resta nettamente visibile, quindi non è una regressione. Ho però individuato un possibile scostamento concreto: il nuovo logo potrebbe reintrodurre rosso; sto verificando anche che i nuovi link footer non puntino a route inesistenti.
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "rg --files src/app | rg '/(privacy|terms)/page\\.(tsx|ts|jsx|js)"'$'"'
+rg --files . | rg '("'^|/)next'"\\.config\\.(js|mjs|ts)"'$|(''^|/)middleware'"\\.(ts|js)"'$'"'
+rg -n 'source:.*(/privacy|/terms)|destination:.*(/privacy|/terms)|\"/privacy\"|\"/terms\"' . --glob '"'!node_modules/**'"' --glob '"'!coverage/**'"' --glob '"'!*package-lock.json'"' | head -160
+find src/app -type d \\( -name privacy -o -name terms \\) -print
+find public/assets/logo -maxdepth 1 -type f -name '*logo*' -print
+python3 -c 'from PIL import Image
+from collections import Counter
+im=Image.open(\"public/assets/logo/balizero-logo-clean.png\").convert(\"RGBA\")
+opaque=[p for p in im.getdata() if p[3]>128]
+red=sum(1 for r,g,b,a in opaque if r>120 and r>g*1.3 and r>b*1.3)
+print(\"opaque_pixels\",len(opaque),\"red_dominant_pixels\",red,\"share\",round(red/len(opaque),4))'
+git status --short" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth
+ succeeded in 956ms:
+src/app/v2/terms/page.tsx
+src/app/v2/privacy/page.tsx
+src/app/(visa-oracle)/visa-oracle/privacy/page.tsx
+src/app/terms/page.tsx
+src/app/visa/terms/page.tsx
+src/app/privacy/page.tsx
+src/app/visa/privacy/page.tsx
+./next.config.ts
+./src/__tests__/middleware.test.ts:723:      ["/privacy", "/visa/privacy"],
+./src/__tests__/middleware.test.ts:724:      ["/terms", "/visa/terms"],
+./src/app/terms/page.tsx:168:              href="/privacy"
+./src/app/portal/(authenticated)/layout.tsx:379:              href="/privacy"
+./src/app/portal/(authenticated)/layout.tsx:387:              href="/terms"
+./src/app/portal/login-upgraded/page.tsx:307:      <Link href="/privacy">Privacy</Link>
+./src/app/portal/login-upgraded/page.tsx:308:      <Link href="/terms">Terms</Link>
+./src/proxy.ts:335:      "/privacy": "/visa/privacy",
+./src/proxy.ts:336:      "/terms": "/visa/terms",
+src/app/privacy
+src/app/(visa-oracle)/visa-oracle/privacy
+src/app/terms
+src/app/visa/privacy
+src/app/visa/terms
+src/app/v2/privacy
+src/app/v2/terms
+public/assets/logo/balizero-logo.png
+public/assets/logo/logo_zan.png
+public/assets/logo/balizero-logo-clean.png
+public/assets/logo/balizero-logo-circle.png
+public/assets/logo/balizero-logo-512.png
+Traceback (most recent call last):
+  File "<string>", line 1, in <module>
+    from PIL import Image
+ModuleNotFoundError: No module named 'PIL'
+ M e2e/portal-prodlike-smoke.spec.ts
+ M src/app/portal/login-upgraded/page.test.tsx
+ M src/app/portal/login-upgraded/page.tsx
+ M ../../evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
+ M ../../evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "git show a75e1b85b2 | rg -n 'balizero-logo|<Image|src=' | tail -40
+printf '%s\\n' 'old errorKey' 'current errorKey'
+git show a75e1b85b2 | sed -n '32,53p' | shasum -a 256
+sed -n '105,126p' src/app/portal/login-upgraded/page.tsx | shasum -a 256
+printf '%s\\n' 'old state+hydration' 'current state+hydration'
+git show a75e1b85b2 | sed -n '66,86p' | shasum -a 256
+sed -n '139,159p' src/app/portal/login-upgraded/page.tsx | shasum -a 256
+printf '%s\\n' 'old handlers' 'current handlers'
+git show a75e1b85b2 | sed -n '101,207p' | shasum -a 256
+sed -n '179,285p' src/app/portal/login-upgraded/page.tsx | shasum -a 256
+printf '%s\\n' 'old behavior tests' 'current behavior tests'
+git show 2ce07f2ab5 | sed -n '157,355p' | shasum -a 256
+sed -n '117,315p' src/app/portal/login-upgraded/page.test.tsx | shasum -a 256
+printf '%s\\n' 'old i18n keys' 'current i18n keys'
+git show a75e1b85b2 | rg -o 'portal\\.login\\.[A-Za-z0-9_.]+' | sort -u
+rg -o 'portal\\.login\\.[A-Za-z0-9_.]+' src/app/portal/login-upgraded/page.tsx | sort -u
+printf '%s\\n' 'changed paths'
+rg '"'^diff --git '"' /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth
+ succeeded in 474ms:
+1325:        <Image
+1326:          src="/assets/logo/balizero-logo-clean.png"
+old errorKey
+current errorKey
+67f94ffe0ea17a4dabf2db83523126d60cefad0adc447da8816d4d44e5d0b9a4  -
+67f94ffe0ea17a4dabf2db83523126d60cefad0adc447da8816d4d44e5d0b9a4  -
+old state+hydration
+current state+hydration
+67b00001c9695a4db8bf429485bec61e0de5124ac65e10d09e8e3cf278799bae  -
+67b00001c9695a4db8bf429485bec61e0de5124ac65e10d09e8e3cf278799bae  -
+old handlers
+current handlers
+68d5abb62665762914af8a6412f840b57de03290ed8f70e9c34bdc10f2a0d4a9  -
+68d5abb62665762914af8a6412f840b57de03290ed8f70e9c34bdc10f2a0d4a9  -
+old behavior tests
+current behavior tests
+b4783a11cabc3e9f845e7206cb079a38aaf860457966b2da598ba77344bef616  -
+b4783a11cabc3e9f845e7206cb079a38aaf860457966b2da598ba77344bef616  -
+old i18n keys
+current i18n keys
+portal.login.errors.email_not_found
+portal.login.errors.invalid_2fa
+portal.login.errors.invalid_credentials
+portal.login.errors.maintenance
+portal.login.errors.network_error
+portal.login.errors.portal_unavailable
+portal.login.errors.rate_limited
+portal.login.errors.server_error
+portal.login.forgot_password
+portal.login.errors.email_not_found
+portal.login.errors.invalid_2fa
+portal.login.errors.invalid_credentials
+portal.login.errors.maintenance
+portal.login.errors.network_error
+portal.login.errors.portal_unavailable
+portal.login.errors.rate_limited
+portal.login.errors.server_error
+portal.login.forgot_password
+changed paths
+diff --git a/apps/mouth/e2e/portal-prodlike-smoke.spec.ts b/apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+diff --git a/apps/mouth/src/app/portal/login-upgraded/error.tsx b/apps/mouth/src/app/portal/login-upgraded/error.tsx
+diff --git a/apps/mouth/src/app/portal/login-upgraded/page.test.tsx b/apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+diff --git a/apps/mouth/src/app/portal/login-upgraded/page.tsx b/apps/mouth/src/app/portal/login-upgraded/page.tsx
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "rg -n '\"@balizero/core\"|@balizero/core' package.json apps/mouth/package.json package-lock.json tsconfig.json apps/mouth/tsconfig.json | head -100
+rg -l '@balizero/core' apps/mouth/src --glob '*.tsx' --glob '*.ts' | wc -l
+rg -n 'login-upgraded|UpgradedLoginPage' src --glob '*.tsx' --glob '*.ts' | head -80
+rg -l '\"invalid_credentials\"' src/i18n src --glob '*.json' --glob '*.ts' | head -40
+nl -ba e2e/portal-prodlike-smoke.spec.ts | sed -n '132,205p'
+nl -ba e2e/portal-prodlike-smoke.spec.ts | sed -n '352,382p'
+git log --oneline -S 'publicAuth.login(normalizedEmail, pin)' -- src/app/portal/login-upgraded/page.tsx | head -20
+git log --oneline -S 'loginInFlightRef.current' -- src/app/portal/login-upgraded/page.tsx | head -20" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth
+ succeeded in 862ms:
+rg: apps/mouth/package.json: No such file or directory (os error 2)
+rg: package-lock.json: No such file or directory (os error 2)
+rg: apps/mouth/tsconfig.json: No such file or directory (os error 2)
+tsconfig.json:24:      "@balizero/core": ["../../packages/core"],
+tsconfig.json:25:      "@balizero/core/*": ["../../packages/core/*"]
+rg: apps/mouth/src: IO error for operation on apps/mouth/src: No such file or directory (os error 2)
+       0
+src/proxy.ts:81:  "/portal/login-upgraded",
+src/proxy.ts:273:      const loginUrl = new URL("/portal/login-upgraded", redirectBase);
+src/__tests__/middleware.test.ts:116:          "http://127.0.0.1:3101/portal/login-upgraded?redirect=%2Fportal%2Fprocess%3Fview%3Dactive",
+src/__tests__/middleware.test.ts:139:        "https://my.balizero.com/portal/login-upgraded?redirect=%2Fportal%2Fdashboard",
+src/__tests__/middleware.test.ts:151:        "https://my.balizero.com/portal/login-upgraded?redirect=%2Fportal%2Fvault%3Ffolder%3Dannual",
+src/__tests__/middleware.test.ts:169:      "/portal/login-upgraded",
+src/lib/analytics-url.test.ts:33:      "https://my.balizero.com/portal/login-upgraded?expired=true&reason=token_expired" +
+src/lib/analytics-url.ts:12: * `dr=` (referrer) after the auto-redirect to `/portal/login-upgraded?…
+src/components/portal/settings/SecuritySettings.test.tsx:70:    expect(replaceMock).toHaveBeenCalledWith("/portal/login-upgraded");
+src/components/portal/settings/SecuritySettings.tsx:30:      router.replace("/portal/login-upgraded");
+src/lib/api/public-auth.test.ts:28:    window.history.replaceState({}, "", "/portal/login-upgraded");
+src/lib/api/__tests__/api-client-base.test.ts:607:        "/portal/login-upgraded?expired=true&reason=token_expired&redirect=%2Fportal%2Fprocess%3Fview%3Dactive",
+src/lib/api/client.ts:453:          const loginPath = isPortal ? "/portal/login-upgraded" : "/login";
+src/app/portal/login/route.ts:8:  const target = new URL(`/portal/login-upgraded${qs}`, request.nextUrl.origin);
+src/app/portal/login/route.test.ts:16:  it("308 to /portal/login-upgraded without redirect param", () => {
+src/app/portal/login/route.test.ts:20:      "http://localhost:3000/portal/login-upgraded",
+src/app/portal/login/route.test.ts:27:      "http://localhost:3000/portal/login-upgraded?redirect=%2Fportal%2Fdashboard",
+src/app/portal/login/route.test.ts:34:      "http://localhost:3000/portal/login-upgraded",
+src/app/portal/login/route.test.ts:41:      "http://localhost:3000/portal/login-upgraded",
+src/app/portal/login/route.test.ts:48:      "http://localhost:3000/portal/login-upgraded?redirect=%2Fworkspace%2Fkita",
+src/app/robots.ts:40:  "/portal/login-upgraded",
+src/app/portal/forgot-password/page.tsx:61:          href="/portal/login-upgraded"
+src/app/portal/magic/page.tsx:108:              href="/portal/login-upgraded"
+src/app/portal/forgot-password/page.test.tsx:53:    expect(back.getAttribute("href")).toBe("/portal/login-upgraded");
+src/app/portal/magic-link/page.tsx:81:              href="/portal/login-upgraded"
+src/app/portal/magic-link/page.tsx:125:              href="/portal/login-upgraded"
+src/app/portal/login-upgraded/page.tsx:1:// apps/mouth/src/app/portal/login-upgraded/page.tsx
+src/app/portal/login-upgraded/page.tsx:128:export default function UpgradedLoginPage() {
+src/app/portal/login-upgraded/page.tsx:130:  // not wrap one (only (blog) does). Wrap locally so /portal/login-upgraded
+src/app/portal/login-upgraded/page.tsx:134:      <UpgradedLoginPageInner />
+src/app/portal/login-upgraded/page.tsx:139:function UpgradedLoginPageInner() {
+src/app/portal/login-upgraded/page.tsx:211:      component: "UpgradedLoginPage",
+src/app/portal/login-upgraded/page.tsx:253:        component: "UpgradedLoginPage",
+src/app/portal/login-upgraded/page.test.tsx:40:import UpgradedLoginPage from "./page";
+src/app/portal/login-upgraded/page.test.tsx:42:describe("UpgradedLoginPage (R19 concept F sign-in)", () => {
+src/app/portal/login-upgraded/page.test.tsx:45:    window.history.replaceState({}, "", "/portal/login-upgraded");
+src/app/portal/login-upgraded/page.test.tsx:49:    const { container } = render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:59:    const { container } = render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:77:    render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:87:    render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:95:    render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:118:    render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:146:        `/portal/login-upgraded?redirect=${encodeURIComponent(redirect)}`,
+src/app/portal/login-upgraded/page.test.tsx:159:      render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:199:      "/portal/login-upgraded?redirect=%2Fportal%2Fbilling",
+src/app/portal/login-upgraded/page.test.tsx:212:    render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:250:    render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:264:        component: "UpgradedLoginPage",
+src/app/portal/login-upgraded/page.test.tsx:271:      component: "UpgradedLoginPage",
+src/app/portal/login-upgraded/page.test.tsx:291:    render(<UpgradedLoginPage />);
+src/app/portal/login-upgraded/page.test.tsx:310:      component: "UpgradedLoginPage",
+src/app/portal/login-upgraded/page.test.tsx:318:    const { container } = render(<UpgradedLoginPage />);
+src/app/layout.tsx:34:// palette — the login screen at /portal/login-upgraded rendered dark on
+src/app/portal/register/page.tsx:124:          router.push("/portal/login-upgraded");
+src/app/portal/(authenticated)/layout.test.tsx:204:        "/portal/login-upgraded?redirect=%2Fportal%3Fview%3Dactive",
+src/app/portal/(authenticated)/layout.test.tsx:373:      expect(mockReplace).toHaveBeenCalledWith("/portal/login-upgraded");
+src/app/portal/(authenticated)/layout.test.tsx:391:        "/portal/login-upgraded?redirect=%2Fportal%3Fview%3Dactive",
+src/app/__tests__/portal-theme-persona.test.ts:14: * hostname alone, so `/portal/login-upgraded` served from anything that is not
+src/app/__tests__/portal-theme-persona.test.ts:61:      ["127.0.0.1", "/portal/login-upgraded"],
+src/app/portal/(authenticated)/layout.tsx:29:  return `/portal/login-upgraded?redirect=${encodeURIComponent(pathname)}`;
+src/app/portal/(authenticated)/layout.tsx:213:      router.replace("/portal/login-upgraded");
+src/app/portal/(authenticated)/partner/layout.test.tsx:52:        "/portal/login-upgraded?redirect=%2Fportal%2Fpartner%2Fdashboard%3Fview%3Drecent",
+src/app/portal/(authenticated)/partner/layout.tsx:45:          `/portal/login-upgraded?redirect=${encodeURIComponent(destination)}`,
+src/i18n/locales/en.json
+src/i18n/locales/ru.json
+src/i18n/locales/it.json
+src/i18n/locales/fr.json
+src/i18n/locales/id.json
+src/i18n/locales/id.json
+src/i18n/locales/fr.json
+src/i18n/locales/it.json
+src/i18n/locales/en.json
+src/i18n/locales/ru.json
+   132	  );
+   133	}
+   134	
+   135	async function loginViaPortalUi(
+   136	  page: Page,
+   137	  email: string,
+   138	  pin: string,
+   139	): Promise<SyntheticSession> {
+   140	  await page.goto("/portal/login-upgraded?redirect=%2Fportal", {
+   141	    waitUntil: "domcontentloaded",
+   142	  });
+   143	  const emailInput = page.getByRole("textbox", { name: "Corporate Email" });
+   144	  const emailSubmit = page.getByRole("button", { name: "Continue" });
+   145	  await expect(emailInput).toBeEnabled();
+   146	  await emailInput.fill(email);
+   147	  await expect(emailSubmit).toBeEnabled();
+   148	  await emailSubmit.click();
+   149	  await page.getByLabel("Access PIN").fill(pin);
+   150	  const loginResponsePromise = page.waitForResponse((response) => {
+   151	    const url = new URL(response.url());
+   152	    return (
+   153	      url.pathname === "/api/auth/login" &&
+   154	      response.request().method() === "POST"
+   155	    );
+   156	  });
+   157	  await page.getByRole("button", { name: "Verify Identity" }).click();
+   158	  const loginResponse = await loginResponsePromise;
+   159	  expect(loginResponse.status()).toBe(200);
+   160	  const loginBody = (await loginResponse.json()) as {
+   161	    data?: {
+   162	      token?: unknown;
+   163	      user?: { client_id?: unknown };
+   164	    };
+   165	  };
+   166	  if (
+   167	    typeof loginBody.data?.token !== "string" ||
+   168	    typeof loginBody.data.user?.client_id !== "number"
+   169	  ) {
+   170	    throw new Error("Synthetic login did not return its session contract");
+   171	  }
+   172	  await expectDashboardSettled(page);
+   173	  return {
+   174	    clientId: loginBody.data.user.client_id,
+   175	    token: loginBody.data.token,
+   176	  };
+   177	}
+   178	
+   179	async function loginPartnerViaPortalUi(
+   180	  page: Page,
+   181	  email: string,
+   182	  pin: string,
+   183	): Promise<string> {
+   184	  // Start with a client-only redirect on purpose: the role contract must win.
+   185	  await page.goto("/portal/login-upgraded?redirect=%2Fportal%2Fbilling", {
+   186	    waitUntil: "domcontentloaded",
+   187	  });
+   188	  await page.getByRole("textbox", { name: "Corporate Email" }).fill(email);
+   189	  await page.getByRole("button", { name: "Continue" }).click();
+   190	  await page.getByLabel("Access PIN").fill(pin);
+   191	  const loginResponsePromise = page.waitForResponse((response) => {
+   192	    const url = new URL(response.url());
+   193	    return (
+   194	      url.pathname === "/api/auth/login" &&
+   195	      response.request().method() === "POST"
+   196	    );
+   197	  });
+   198	  await page.getByRole("button", { name: "Verify Identity" }).click();
+   199	  const loginResponse = await loginResponsePromise;
+   200	  expect(loginResponse.status()).toBe(200);
+   201	  const loginBody = (await loginResponse.json()) as {
+   202	    data?: {
+   203	      token?: unknown;
+   204	      redirectTo?: unknown;
+   205	      user?: { role?: unknown };
+   352	  const unsafeExternalWrites = collectUnsafeExternalWrites(
+   353	    page,
+   354	    allowedOrigins,
+   355	  );
+   356	  const disallowedNetworkRequests = collectDisallowedNetworkRequests(
+   357	    page,
+   358	    allowedOrigins,
+   359	  );
+   360	
+   361	  await page.goto("/portal/login-upgraded", {
+   362	    waitUntil: "domcontentloaded",
+   363	  });
+   364	  const emailInput = page.getByRole("textbox", { name: "Corporate Email" });
+   365	  await emailInput.fill(environment.disabledClientEmail);
+   366	  await page.getByRole("button", { name: "Continue" }).click();
+   367	  await page.getByLabel("Access PIN").fill(environment.disabledClientPin);
+   368	
+   369	  const loginResponsePromise = page.waitForResponse((response) => {
+   370	    const url = new URL(response.url());
+   371	    return (
+   372	      url.pathname === "/api/auth/login" &&
+   373	      response.request().method() === "POST"
+   374	    );
+   375	  });
+   376	  await page.getByRole("button", { name: "Verify Identity" }).click();
+   377	  const loginResponse = await loginResponsePromise;
+   378	
+   379	  expect(loginResponse.status()).toBe(403);
+   380	  expect(await loginResponse.json()).toMatchObject({
+   381	    detail: "Portal access is not available for this account",
+   382	  });
+ce095c49af portal: deliver verified client portal launch candidate (#3741)
+ce095c49af portal: deliver verified client portal launch candidate (#3741)
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "rg -l '@balizero/core' src --glob '*.tsx' --glob '*.ts' | wc -l
+rg -n '\"@balizero/core\"|@balizero/core' ../../package.json package.json ../../package-lock.json tsconfig.json | head -100
+for f in src/i18n/locales/en.json src/i18n/locales/id.json src/i18n/locales/it.json src/i18n/locales/fr.json src/i18n/locales/ru.json; do printf '%s ' \""'$f"; rg -c '"'\"(invalid_credentials|portal_unavailable|email_not_found|invalid_2fa|rate_limited|maintenance|server_error|network_error|forgot_password)\"' \""'$f"; done
+rg -n '"'\"(invalid_credentials|portal_unavailable|email_not_found|invalid_2fa|rate_limited|maintenance|server_error|network_error|forgot_password)\"' src/i18n/locales/en.json
+rg -ni '("'^|[''^a-z])(red|crimson|scarlet)([''^a-z]|$)|#[b-fB-F][0-9a-fA-F]{1}[0-4][0-9a-fA-F]{3}'"' src/app/portal/login-upgraded/page.tsx src/app/portal/login-upgraded/error.tsx packages/core/components/BZLogo.tsx 2>/dev/null || true" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth
+ succeeded in 399ms:
+     107
+tsconfig.json:24:      "@balizero/core": ["../../packages/core"],
+tsconfig.json:25:      "@balizero/core/*": ["../../packages/core/*"]
+../../package-lock.json:1894:    "node_modules/@balizero/core": {
+../../package-lock.json:27196:      "name": "@balizero/core",
+src/i18n/locales/en.json 10
+src/i18n/locales/id.json 10
+src/i18n/locales/it.json 10
+src/i18n/locales/fr.json 10
+src/i18n/locales/ru.json 10
+285:      "forgot_password": "Forgot PIN?",
+287:        "invalid_credentials": "Wrong email or PIN. Please try again.",
+289:        "portal_unavailable": "Portal access is not available for this account. Contact team@balizero.com.",
+290:        "rate_limited": "Too many attempts. Retry in {{seconds}} seconds.",
+291:        "invalid_2fa": "Invalid 2FA code.",
+292:        "network_error": "Connection lost. Check your network and retry.",
+293:        "email_not_found": "Email not found.",
+294:        "server_error": "Server error. Retry in a few minutes.",
+295:        "maintenance": "Maintenance in progress. Please return later."
+298:    "forgot_password": {
+src/app/portal/login-upgraded/error.tsx:21:      {/* R19 concept F: red does not exist on the portal surface — a failed
+src/app/portal/login-upgraded/page.tsx:21:// surface — and red does not exist on this surface at all.
+src/app/portal/login-upgraded/page.tsx:328:      {/* ACCESS DENIED OVERLAY — copper, never red: the state carries a word. */}
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc "git apply --reverse --check /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+git apply --numstat /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+python3 -c 'def rgb(h):
+ h=h.lstrip(\"#\"); return tuple(int(h[i:i+2],16)/255 for i in (0,2,4))
+def blend(f,b,a): return tuple(a*x+(1-a)*y for x,y in zip(rgb(f),rgb(b)))
+def lum(v):
+ def q(x): return x/12.92 if x<=.04045 else ((x+.055)/1.055)**2.4
+ return sum(c*q(x) for c,x in zip((.2126,.7152,.0722),v))
+def ratio(a,b):
+ x,y=lum(a),lum(b); return (max(x,y)+.05)/(min(x,y)+.05)
+for n,fg,bg,a in [(\"old ring\",\"#b5633a\",\"#f4f1ea\",.25),(\"new ring\",\"#a44b36\",\"#fffcf7\",.18)]: print(n,round(ratio(blend(fg,bg,a),rgb(bg)),2))'
+nl -ba /Users/balizero/.codex/memories/MEMORY.md | sed -n '4168,4178p;4204,4220p'
+git status --short" in /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5
+ succeeded in 366ms:
+3	3	apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+7	5	apps/mouth/src/app/portal/login-upgraded/error.tsx
+42	80	apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+291	1369	apps/mouth/src/app/portal/login-upgraded/page.tsx
+old ring 1.35
+new ring 1.29
+  4168	
+  4169	- /Users/balizero/.codex/memories/rollout_summaries/2026-06-25T04-34-03-gZzr-portal_client_ready_audit_and_deploy.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/sessions/2026/06/25/rollout-2026-06-25T12-34-03-019efd0e-7492-7213-b68e-9d826d73f3c9.jsonl, updated_at=2026-06-25T18:39:40+00:00, thread_id=019efd0e-7492-7213-b68e-9d826d73f3c9, portal readiness audit/fix/deploy and separate drive cron follow-up [rollout summary])
+  4170	- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T08-17-00-CXxX-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T08-17-00-CXxX-10min-memory-summary.md, updated_at=2026-06-25T08:17:00+00:00, thread_id=None, portal onboarding validation / sheet ops / mixed browsing [skysight memory])
+  4171	- /Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T13-00-00-VZed-10min-memory-summary.md (cwd=/Users/balizero/Desktop/nuzantara, rollout_path=/Users/balizero/.codex/memories/extensions/chronicle/resources/2026-06-25T13-00-00-VZed-10min-memory-summary.md, updated_at=2026-06-25T13:00:00+00:00, thread_id=None, portal validation and Google Sheets export deploy status [skysight memory])
+  4172	
+  4173	### keywords
+  4174	
+  4175	- `Prepara portale onboarding`, `my.balizero.com`, `Playwright`, `browser-live`, `two-step email then PIN`, `PortalNewsRail.tsx`, `gspread`, `List rups`, `GENERAL STATUS`, `fly status`, `PR #1731`, `PR #1730`, `drive_poll_service`, `cron-drive-poll`, `HTTP 502`
+  4176	
+  4177	## Task 3: WR2 Instagram publisher architecture and Fly dry-run gating
+  4178	
+  4204	- when a deploy or publish flow is live, prefer the live runtime/status image or backend gate over CI-only conclusions [Task 2][Task 3] [skysight memory]
+  4205	- when the user says GLM 5.2 is "installato nella claude code" because Claude MAX is exhausted, answer in Claude Code workflow and quota terms rather than abstract model marketing [Task 4] [skysight memory]
+  4206	- when the user asks for GLM 4.7 vs 5.2, make the practical default/escalation split explicit instead of implying a single best model [Task 4] [skysight memory]
+  4207	- when the user says the portal must be "pronti a far accedere il primo cliente", require repeated live browser checks and HTTP smoke before saying ready [Task 2] [skysight memory]
+  4208	- when `cron - drive poll (every 5 min)` throws `HTTP 502`, keep it as a separate Drive-ops follow-up instead of folding it into the portal patch [Task 2] [skysight memory]
+  4209	
+  4210	## Reusable knowledge
+  4211	
+  4212	- `kbli-2025.json` is the March base dataset; the June `L4 Bali-status` layer from commit `#1575` adds richer Bali-specific content, so the visible KBLI gap is layered data plus rerender state rather than a simple app-vs-site mismatch. [Task 1] [skysight memory]
+  4213	- `apps/war-room/output/...` is runtime output, not source code; changing the worktree alone does not update the rendered PNGs, so the live render flow or `Migliora` has to rerun before visible output changes. [Task 1] [skysight memory]
+  4214	- `KBLI_OPEN=<code>` was used as the direct-open path in the KBLI app, and multiscope codes were the useful stress-test for the overhaul. [Task 1] [skysight memory]
+  4215	- Portal validation used a real two-step email-then-PIN flow; `Playwright` was available locally, and `PortalNewsRail.tsx` carried the local cross-domain fix. [Task 2] [skysight memory]
+  4216	- The Google Sheets export rollout was healthy server-side, but the decisive follow-up was the image reference in `fly status`, not CI alone. [Task 2] [skysight memory]
+  4217	- `my.balizero.com` readiness work treated browser-live verification as part of the prompt, and `/portal/process` plus the home redirect were the practical smoke checks. [Task 2] [skysight memory]
+  4218	- WR2 IG publishing needed a server-side Fly backend path because Tigris credentials and DB live there; the local Mini dry-run failed on missing creds, so the dry-run gate should stay backend-first. [Task 3] [skysight memory]
+  4219	- The live Z.ai quota endpoints (`api/monitor/usage/quota/limit` and `api/monitor/usage/model-usage`) were authoritative; the verified window showed Pro plan, 5-hour quota at 100% used, about `59,545,920` tokens, and `GLM-5.2` carrying almost all of it. [Task 4] [skysight memory]
+  4220	- `GLM-4.7` is the routine default for small/medium patches, file reading, local refactors, docs, and cleanup; `GLM-5.2` is for architecture, hard multi-file bugs, long-context sessions, serious review, and when 4.7 gets stuck. [Task 4] [skysight memory]
+ M apps/mouth/e2e/portal-prodlike-smoke.spec.ts
+ M apps/mouth/src/app/portal/login-upgraded/page.test.tsx
+ M apps/mouth/src/app/portal/login-upgraded/page.tsx
+ M evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
+ M evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
+
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+hook: PostToolUse Completed
+codex
+No correctness defects found.
+
+- State machine and auth behavior are unchanged: email→PIN transition at [page.tsx:186](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:186), `publicAuth.login` and redirects at [page.tsx:196](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:196), status mapping and `retry-after` at [page.tsx:107](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:107), hydration guard at [page.tsx:142](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:142), and status/alert overlays at [page.tsx:317](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:317). The corresponding baseline/current logic hashes match.
+- The three E2E locator changes correctly follow the renamed “Continue” button at [portal-prodlike-smoke.spec.ts:144](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/e2e/portal-prodlike-smoke.spec.ts:144), [portal-prodlike-smoke.spec.ts:189](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/e2e/portal-prodlike-smoke.spec.ts:189), and [portal-prodlike-smoke.spec.ts:366](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/e2e/portal-prodlike-smoke.spec.ts:366). Neither affected test file uses `data-testid`.
+- All nine referenced i18n keys remain; auth redirects and alternative-path routes remain unchanged. The added privacy/terms links at [page.tsx:304](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:304) target existing routes. No manifest or lockfile changed, and the new `@balizero/core` import is an existing workspace dependency.
+- The behavioral test section remains byte-identical apart from presentation assertions and the CTA label update. Targeted Vitest result: 13/13 passed.
+- No accessibility regression found: text contrast is at least 5.26:1, primary controls remain 48–52px tall, input focus remains visible, and browser focus outlines are not suppressed. No new red is introduced; `state-danger` was removed, while the red-bearing logo asset was already used by the baseline.
+
+VERDICT: OK
+
+
+hook: Stop
+hook: Stop Completed
+tokens used
+148.904
+No correctness defects found.
+
+- State machine and auth behavior are unchanged: email→PIN transition at [page.tsx:186](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:186), `publicAuth.login` and redirects at [page.tsx:196](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:196), status mapping and `retry-after` at [page.tsx:107](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:107), hydration guard at [page.tsx:142](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:142), and status/alert overlays at [page.tsx:317](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:317). The corresponding baseline/current logic hashes match.
+- The three E2E locator changes correctly follow the renamed “Continue” button at [portal-prodlike-smoke.spec.ts:144](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/e2e/portal-prodlike-smoke.spec.ts:144), [portal-prodlike-smoke.spec.ts:189](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/e2e/portal-prodlike-smoke.spec.ts:189), and [portal-prodlike-smoke.spec.ts:366](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/e2e/portal-prodlike-smoke.spec.ts:366). Neither affected test file uses `data-testid`.
+- All nine referenced i18n keys remain; auth redirects and alternative-path routes remain unchanged. The added privacy/terms links at [page.tsx:304](/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth/src/app/portal/login-upgraded/page.tsx:304) target existing routes. No manifest or lockfile changed, and the new `@balizero/core` import is an existing workspace dependency.
+- The behavioral test section remains byte-identical apart from presentation assertions and the CTA label update. Targeted Vitest result: 13/13 passed.
+- No accessibility regression found: text contrast is at least 5.26:1, primary controls remain 48–52px tall, input focus remains visible, and browser focus outlines are not suppressed. No new red is introduced; `state-danger` was removed, while the red-bearing logo asset was already used by the baseline.
+
+VERDICT: OK
+
+

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/council/codex-gpt-5.6-sol.txt
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/council/codex-gpt-5.6-sol.txt
@@ -3840,7 +3840,7 @@ nl -ba apps/mouth/src/app/portal/login-upgraded/page.test.tsx | sed -n '1,420p'"
    146	        `/portal/login-upgraded?redirect=${encodeURIComponent(redirect)}`,
    147	      );
    148	      mockLogin.mockResolvedValue({
-   149	        access_token: "synthetic-token",
+   149	        access_token: "[redacted synthetic fixture value]",
    150	        token_type: "Bearer",
    151	        user: {
    152	          id: "client-1",
@@ -3893,7 +3893,7 @@ nl -ba apps/mouth/src/app/portal/login-upgraded/page.test.tsx | sed -n '1,420p'"
    199	      "/portal/login-upgraded?redirect=%2Fportal%2Fbilling",
    200	    );
    201	    mockLogin.mockResolvedValue({
-   202	      access_token: "synthetic-token",
+   202	      access_token: "[redacted synthetic fixture value]",
    203	      token_type: "Bearer",
    204	      user: {
    205	        id: "partner-user-1",
@@ -5523,7 +5523,7 @@ apps/mouth/public/assets/logo/balizero-logo-clean.png: PNG image data, 512 x 512
    186	        `/portal/login-upgraded?redirect=${encodeURIComponent(redirect)}`,
    187	      );
    188	      mockLogin.mockResolvedValue({
-   189	        access_token: "synthetic-token",
+   189	        access_token: "[redacted synthetic fixture value]",
    190	        token_type: "Bearer",
    191	        user: {
    192	          id: "client-1",
@@ -5576,7 +5576,7 @@ apps/mouth/public/assets/logo/balizero-logo-clean.png: PNG image data, 512 x 512
    239	      "/portal/login-upgraded?redirect=%2Fportal%2Fbilling",
    240	    );
    241	    mockLogin.mockResolvedValue({
-   242	      access_token: "synthetic-token",
+   242	      access_token: "[redacted synthetic fixture value]",
    243	      token_type: "Bearer",
    244	      user: {
    245	        id: "partner-user-1",

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/council/journal.jsonl
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/council/journal.jsonl
@@ -1,0 +1,2 @@
+{"seat":"codex-gpt-5.6-sol","role":"review","ok":true,"ts":"2026-09-12T22:45:22Z","verdict":"VERDICT: OK","round":3,"stdout":"council/codex-gpt-5.6-sol.txt"}
+{"seat":"kimi-code/k3","role":"review","ok":true,"ts":"2026-09-12T22:45:22Z","verdict":"VERDICT: OK","round":3,"stdout":"council/kimi-code-k3.txt"}

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/council/kimi-code-k3.txt
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/council/kimi-code-k3.txt
@@ -1,0 +1,461 @@
+kimi version 0.41.0
+• Let me start by reading the diff file and then examining the post-change sources in this checkout.
+
+  The diff is at /private/tmp/claude-501/-Users-balizero-nuzantara/471c2662-0e19-4a89-bc1d-8c7b29a7cb2c/scratchpad/r19p/w5-council.diff
+
+  Let me read it first.The diff is 1963 lines. Most of it is likely the removal of the SVG gate scene. Let me read the rest of the diff to see the new JSX structure (the parts after line 1000).Now I have the full diff. The diff covers:
+  1. `apps/mouth/e2e/portal-prodlike-smoke.spec.ts` — 3 locator updates ("Pass the Portal" → "Continue")
+  2. `apps/mouth/src/app/portal/login-upgraded/error.tsx` — red → copper tokens
+  3. `apps/mouth/src/app/portal/login-upgraded/page.test.tsx` — test updates
+  4. `apps/mouth/src/app/portal/login-upgraded/page.tsx` — full presentation refactor
+
+  Now I need to verify the post-change sources in this checkout. Key checks:
+
+  (a) Behavioral invariants in page.tsx:
+  - two-step email→PIN state machine (step state, handleSubmitEmail, handleLogin)
+  - publicAuth.login call
+  - HTTP-status→i18n error mapping (errorKeyFor)
+  - rate-limit retry-after handling
+  - hydration guard (isHydrated)
+  - success/denied overlays with role=status/alert
+  - every data-testid the tests use
+
+  Wait — the diff doesn't show the state machine logic itself (the part between line 404 and the JSX). The diff hunk "@@ -206,1370 +284,214 @@" starts after the handlers. So the handlers (handleSubmitEmail, handleLogin, errorKeyFor) are unchanged context... Actually the diff only shows changes; the unchanged parts include the state machine. But I must verify the post-change source in this checkout actually retains them — the review asks to verify against the post-change sources.
+
+  (b) no i18n key removed, no route changed, no new dependency:
+  - Imports changed: removed framer-motion, next/image, cormorant font; added @balizero/core/components/BZLogo. Is BZLogo a new dependency? It's from @balizero/core which is presumably an existing workspace package. Need to check it exists and is already a dependency of apps/mouth.
+  - i18n keys used: t("portal.login.forgot_password") — still used. Check for other t() calls in the new page.
+  - Routes: /portal/magic-link, /portal/forgot-password, /privacy, /terms — the new file adds /privacy and /terms links (new routes referenced, but do they exist?). "No route changed" — the page route itself is unchanged. But new links to /privacy and /terms are added — need to check those routes exist.
+
+  (c) tests still assert the same behaviors — check page.test.tsx post-change.
+
+  (d) accessibility: focus, contrast, target size, red colour:
+  - The error.tsx now uses --bz-copper-text instead of --state-danger. The page.tsx overlay denied now uses --r19-copper (#a44b36). No red introduced... wait, the question is "any accessibility regression (focus, contrast, target size) or any red colour introduced". The refactor deliberately removed red (--state-danger) — that's intended per the comment "red does not exist on this surface". Hmm, but does removing red from "Access Denied" constitute a regression? The task says verify "any red colour introduced" — the change removes red, doesn't introduce it. Also #a44b36 is a copper/terracotta — need to check contrast on the paper background #f7f4ee.
+
+  Let me now read the post-change sources. Key files:
+  1. src/app/portal/login-upgraded/page.tsx (post-change, full)
+  2. src/app/portal/login-upgraded/page.test.tsx (post-change, full)
+  3. src/app/portal/login-upgraded/error.tsx (post-change)
+  4. e2e/portal-prodlike-smoke.spec.ts (the three hunks)
+  5. Check BZLogo exists: @balizero/core/components/BZLogo
+  6. Check i18n keys used exist
+  7. Check /privacy and /terms routes exist
+  8. Check useSystemSound, sanitizeRedirect, publicAuth usage unchanged
+
+  Also check: the unit tests use data-testid? Let me check what data-testid the tests use. The task mentions "every data-testid the tests use are behaviourally unchanged". Let me grep for data-testid in the test file and page.
+
+  Also check the e2e spec for other locators that might break: "Corporate Email" textbox (kept — label "Corporate Email" with htmlFor portal-email), "Access PIN" label (kept), "Continue" button (new), "Verify Identity". Also the e2e test at line 363 area uses disabledClient flow. Also there may be other tests referencing "Pass the Portal" elsewhere — need to grep the whole repo for "Pass the Portal" to make sure no other test/spec breaks. That's part of "no route changed / tests assert same behaviors" and general correctness.
+
+  Also check that `motion` removal doesn't leave `framer-motion` unused in package.json — not required, removal of a dependency isn't required; "no new dependency" — BZLogo needs verification.
+
+  Also the test mock for framer-motion was removed from page.test.tsx — that's fine since the page no longer imports framer-motion. But wait — BZLogo might itself use framer-motion or next/image. Need to check BZLogo component. If BZLogo uses next/image, the unit test doesn't mock next/image — next/image in vitest/jsdom usually works fine (renders img). Let me check BZLogo source.
+
+  Also the test asserts `hero?.querySelector("img")` exists and alt "Bali Zero" and not rounded-full. BZLogo variant="full" — need to verify it renders an img with alt "Bali Zero".
+
+  Also check `--font-serif` variable exists (r19-serif uses var(--font-serif)). If not defined, falls back to Georgia,serif — fine.
+
+  Also check that page.tsx still exports default and has I18nProvider wrapper. The diff shows only UpgradedLoginPageInner's return changed; the default export wrapper with I18nProvider is presumably below and unchanged. Need to verify in post-change file.
+
+  Also verify: hydration guard — isHydrated state and the useEffect setting it, plus disabled={!isHydrated || ...} on email input and submit. PIN input disabled doesn't include !isHydrated in either version (only loginStage !== "idle") — unchanged behavior.
+
+  Rate-limit retry-after handling — in handleLogin, unchanged portion. Need to read the post-change page.tsx fully to confirm.
+
+  data-testid: let me grep the new page.tsx for data-testid. The old page might have had data-testid attributes... In the diff I don't see any data-testid added or removed. Let me check the test file and e2e spec for data-testid usage. The e2e uses getByRole/getByLabel, not testids, from what we've seen. But maybe other parts of the e2e spec use getByTestId — need to check the full spec.
+
+  Also check other e2e tests referencing this page: grep "login-upgraded" across e2e/.
+
+  Also "no i18n key removed": the old page used t("portal.login.forgot_password") — still present. Did the old page use any other t() calls? The diff doesn't show any removed t() calls... In the removed JSX I see hardcoded English text ("Turn On", "Your Bali Life.", etc.) and only one t() call. The new page also has one t() call. But wait — error mapping uses i18n keys via errorKeyFor + t() in handleLogin presumably. Those are in the unchanged portion; verify in post-change file.
+
+  Contrast check (d): 
+  - --r19-copper #a44b36 on --r19-paper #f7f4ee: compute contrast. Relative luminance of #a44b36: R=164/255=0.643 → lin: ((0.643+0.055)/1.055)^2.4 = (0.6616)^2.4. ln(0.6616)=-0.4132, ×2.4=-0.9917, e^-0.9917=0.371. G=75/255=0.294 → ((0.294+0.055)/1.055)^2.4 = (0.3308)^2.4. ln(0.3308)=-1.1066, ×2.4=-2.6558, e^-2.6558=0.0702. B=54/255=0.2118 → ((0.2118+0.055)/1.055)^2.4=(0.2529)^2.4. ln(0.2529)=-1.375, ×2.4=-3.3, e^-3.3=0.0369. L = 0.2126×0.371 + 0.7152×0.0702 + 0.0722×0.0369 = 0.0789 + 0.0502 + 0.00266 = 0.1317.
+  - Paper #f7f4ee: R=247/255=0.9686→lin≈0.930; G=244/255=0.9569→lin≈0.904; B=238/255=0.9333→lin≈0.855. L=0.2126×0.930+0.7152×0.904+0.0722×0.855=0.1978+0.6465+0.0617=0.906.
+  - Contrast = (0.906+0.05)/(0.1317+0.05) = 0.956/0.1817 = 5.26:1. OK for normal text AA (4.5:1).
+  - Forest #253e33 on paper #f7f4ee: R=37/255=0.145→lin=((0.145+0.055)/1.055)^2.4=(0.1896)^2.4. ln(0.1896)=-1.6629×2.4=-3.991, e^-3.991=0.01847. G=62/255=0.2431→((0.2431+0.055)/1.055)^2.4=(0.2826)^2.4. ln=-1.2638×2.4=-3.033, e^-3.033=0.04815. B=51/255=0.2→((0.2+0.055)/1.055)^2.4=(0.2417)^2.4. ln=-1.42×2.4=-3.408, e^-3.408=0.03306. L=0.2126×0.01847+0.7152×0.04815+0.0722×0.03306=0.003927+0.034437+0.002387=0.04075. Contrast vs paper: 0.956/0.09075=10.53:1. Great.
+  - Paper on forest (button): (0.906+0.05)/(0.04075+0.05)=10.53:1. Great.
+  - Muted #58626b on paper: R=88/255=0.345→((0.345+0.055)/1.055)^2.4=(0.3791)^2.4. ln(0.3791)=-0.9699×2.4=-2.3278, e=0.0974. G=98/255=0.3843→(0.4164)^2.4. ln=-0.8759×2.4=-2.1022, e=0.1221. B=107/255=0.4196→(0.4503)^2.4. ln=-0.7979×2.4=-1.915, e=0.1473. L=0.2126×0.0974+0.7152×0.1221+0.0722×0.1473=0.02071+0.08733+0.01063=0.1187. Contrast: 0.956/0.1687=5.67:1. OK.
+  - r19-brand-role rgba(247,244,238,0.72) on forest #253e33: composite = 0.72×paper + 0.28×forest. Composite RGB: R=0.72×247+0.28×37=188.2, G=0.72×244+0.28×62=193.0, B=0.72×238+0.28×51=185.6. Lin: R=0.738→((0.738+0.055)/1.055)^2.4=(0.7517)^2.4≈ ln=-0.2852×2.4=-0.6845,e=0.5045. G=0.757→(0.7697)^2.4: ln=-0.2616×2.4=-0.6278,e=0.5338. B=0.728→(0.7422)^2.4: ln=-0.298×2.4=-0.7153,e=0.489. L=0.2126×0.5045+0.7152×0.5338+0.0722×0.489=0.1073+0.3818+0.0353=0.5244. Contrast vs forest L=0.04075: (0.5244+0.05)/(0.04075+0.05)=0.5744/0.09075=6.33:1. Fine (it's small text — eyebrow 10px uppercase; 6.3:1 > 4.5 OK).
+  - hero-lede rgba(247,244,238,0.78) on forest: even higher contrast. Fine.
+
+  Target size: inputs height 52px, buttons 48px — ≥44px OK. The r19-back button ("← email") — font-size 12px, no explicit min-height. It's a small text button; target size may be <24px. WCAG 2.5.8 (AA, WCAG 2.2) requires 24×24 CSS px minimum except inline/undersized exceptions... A 12px font button with no padding would have height ~17px. Hmm — is that a regression? The old back button was `text-[11px]` with no min-height either. So similar. The formfoot links have min-height 24px explicitly. The r19-back button: font-size 12px, line-height inherits 1.75 → 21px height. Slightly under 24px. The old one: text-[11px], line-height... probably similar. Not a clear regression.
+
+  Focus: r19-input:focus has border-color copper + box-shadow 3px rgba(164,75,54,0.18). A 0.18-alpha shadow might be too faint for WCAG 2.4.13/2.4.11 focus visibility... but the border-color change from #a8aca9 to #a44b36 plus a 3px glow. Old: focus:border copper + ring-2 25% copper. Comparable.
+
+  Buttons: `.r19-gate button{...outline:none?}` — no, only .r19-input has outline:none. Buttons retain default outline on focus-visible. OK.
+
+  Links r19-link color copper #a44b36 — 5.26:1 on paper. OK.
+
+  Red color introduced? No — removed. #a44b36 is copper (hue ~9°... it's a terracotta red-brown). Hmm, hue of #a44b36: R164 G75 B54. Hue = 60×((G-B)/(max-min)) = 60×(21/110) = 11.5° — that's orange-red territory but perceptually terracotta/copper. The design intent comment says "red does not exist on this surface at all". The reviewer question (d) asks "any red colour introduced" — the change removed red rather than introducing it. I should note the denied overlay is now copper instead of red (--state-danger). Is that a behavioral/accessibility concern? role="alert" retained, aria-live assertive retained, errorMessage text retained, aria-invalid/aria-describedby retained. The color change is presentational and intentional (concept F). Not a defect per the brief.
+
+  But wait — one important check: in the denied overlay, the old had error paragraph styled with --state-danger color; new has plain p with r19-overlay p color --r19-ink. id="portal-login-error" retained. aria-describedby on pin input references it. Good.
+
+  Now potential defects to check carefully:
+
+  1. **The old page had `<div className="px-6 pb-6 ...">No PIN? Check your invitation email or contact support.</div>`** — removed. Presentational only.
+
+  2. **Forgot-password link placement**: old PIN step had forgot-password link inside the PIN field group; new has it in `alternatives` shown on both steps. Fine.
+
+  3. **Magic link**: old only on PIN step; new on both steps. Fine (addition, not removal).
+
+  4. **`BZLogo`** — verify existence and alt text. Test asserts img with alt "Bali Zero". Need to check BZLogo component.
+
+  5. **`--font-serif`** — check defined somewhere; fallback Georgia,serif exists so no defect.
+
+  6. **data-testid** — the task says "every data-testid the tests use". Let me grep test file for testId usage. From the diff, tests use getByRole/getByPlaceholderText/getByLabelText/getByText. The full post-change test file needs reading — the diff only shows the changed hunks; there are unchanged tests below (lines 239+ show context at 366→326). I need to read the full post-change page.test.tsx to see all tests, including ones not in the diff (e.g., tests about error mapping, retry-after, publicAuth.login call, etc.).
+
+  7. **e2e spec** — read the relevant parts; check for other references to the page that might break: e.g., waiting for response, overlay text "Access Denied" or "Portal Unlocked", etc.
+
+  8. **Other specs referencing "Pass the Portal"** — grep repo-wide.
+
+  9. **package.json** — confirm @balizero/core is an existing dependency; confirm framer-motion removal from page doesn't break imports elsewhere (not needed — other files may still use it; page.test.tsx removed the mock, fine).
+
+  10. **i18n keys** — the new page uses t("portal.login.forgot_password") only? Check errorKeyFor + handleLogin in post-change file for the error key mapping (portal.login.errors.* presumably). Verify those keys exist in i18n files and none removed. The task: "no i18n key removed" — since presentation-only, check that any t() usage in the new file references existing keys. Also check whether i18n files were touched by the diff — they weren't (diff only has 4 files). So no keys removed. But verify keys used in unchanged code still exist (they did before).
+
+  11. **Routes**: page route /portal/login-upgraded unchanged. Links: /portal/magic-link, /portal/forgot-password (pre-existing), plus new /privacy and /terms — check these exist in app router. If they don't exist, that's a new broken link — arguably a defect (dead link introduced). Let me check.
+
+  12. **useSystemSound / sanitizeRedirect / logger** usage unchanged — in unchanged portion; verify post-change file.
+
+  13. **`useRef` import retained** — new import line: `React, { useEffect, useState, useRef }`. Is useRef still used after cardRef removal? Check post-change file for other useRef usage. If unused → lint error (build failure on unused import? TypeScript with noUnusedLocals would fail). Need to check! Similarly `Image` and `motion` imports removed correctly. `MouseEvent` removed. Also in error.tsx, LogIn still imported? error.tsx diff only changed colors; LogIn import unchanged and still used.
+
+  Let me check page.tsx for useRef usage. The old code had cardRef (removed). Maybe there's another useRef (e.g., for timers/redirect timeout). Need to read the post-change file.
+
+  14. **Tests**: page.test.tsx — the diff shows tests 1-5 replaced; unchanged tests from line 239 onward ("exposes durable labels and password-manager semantics" and others through line ~330). Need to read the full post-change test file.
+
+  15. **error.tsx** — check --bz-copper-text token exists (it's used elsewhere? it was used in old page.tsx masthead, now removed from page but error.tsx uses it). Check token defined in mouth styles. Also check error.tsx full file for other issues (reset button etc.).
+
+  16. **The `gate-scene` CSS** in globals? Old page relied on attribute-selector CSS scoped inline; removed. Check no global CSS references `.gate-scene` leftovers — the test asserts `.gate-scene` absent from render. Fine.
+
+  17. Check `sanitizeRedirect` usage — unchanged portion.
+
+  18. Check the new page file compiles: I'll read the full post-change page.tsx.
+
+  Also check whether `framer-motion` is still used by BZLogo — if BZLogo imports framer-motion, the unit test no longer mocks it; the old mock existed because the page used motion. If BZLogo uses motion with RAF loops, tests could hang, but that's test-infra, and motion components render fine in jsdom typically. Let me check BZLogo.
+
+  Also check `@balizero/core/components/BZLogo` path resolution: apps/mouth has alias @balizero/core → packages/core? Check tsconfig paths and that the module exists.
+
+  Plan: read these files now. Use parallel reads:
+  - src/app/portal/login-upgraded/page.tsx (full — need to find size; probably ~500 lines now)
+  - src/app/portal/login-upgraded/page.test.tsx (full)
+  - src/app/portal/login-upgraded/error.tsx
+  - e2e/portal-prodlike-smoke.spec.ts (relevant portions; it's big, read around the login helpers)
+
+  Then greps:
+  - "Pass the Portal" repo-wide (should be zero now... well, zero outside maybe docs)
+  - "login-upgraded" in e2e/
+  - data-testid in login-upgraded files
+  - BZLogo component file
+  - --font-serif definition
+  - /privacy and /terms routes
+  - @balizero/core in package.json
+  - --bz-copper-text definition (for error.tsx)
+
+  Let me do it. First read the page.tsx post-change fully.
+
+• I have the full diff. Now let me verify the post-change sources in this checkout.
+
+• Now let me read the post-change test file and the e2e spec. Also check BZLogo, i18n keys, routes, package.json, and grep for leftover references.
+
+• Now the test file and the e2e spec:
+
+• The e2e spec uses role/label locators — "Corporate Email", "Continue", "Access PIN", "Verify Identity". Those match the new page. 
+
+  Wait — one important detail: in the new page, the email input's accessible name. The label "Corporate Email" is associated via htmlFor="portal-email" — good. PIN label htmlFor="portal-pin" — good.
+
+  Now, one subtle thing: `page.getByRole("button", { name: "Continue" })` — the email submit button has text "Continue". But the back button on the PIN step ("← userpart")... not relevant. Also note that the "Continue" name matching is exact by default in Playwright? `getByRole` with `name` option does case-insensitive substring? No — by default `name` matching is "accessible name" full-string case-insensitive... Actually Playwright getByRole name matching is by whole string, case-insensitive, ignoring whitespace unless `exact: true`. "Continue" matches a button named "Continue". But wait — could it also match "Continue" within another button's name? The only other buttons are "Verify Identity" and "← userpart". Fine.
+
+  Also in the e2e at line 144, they await `expect(emailSubmit).toBeEnabled()` before filling — the button is disabled until hydrated and email non-empty. They fill email first, then expect enabled. Order in helper: expect(emailInput).toBeEnabled() → fill → expect(emailSubmit).toBeEnabled() → click. The email input is disabled until isHydrated — `toBeEnabled` auto-waits, fine.
+
+  Now check the third hunk context in the spec (line ~363, @qa-be-003). Let me read that section. Also grep the entire spec for other references to the login page that might interact with removed elements (e.g., "Pass the Portal", "Access Denied", "Portal Unlocked", "Turn On", "Your Bali Life"). Also grep repo-wide for "Pass the Portal".
+
+  Also check:
+  - BZLogo component exists at @balizero/core/components/BZLogo and renders <img alt="Bali Zero">, no rounded-full, variant="full" size prop priority prop.
+  - @balizero/core is in apps/mouth/package.json dependencies (no NEW dependency).
+  - i18n keys used: portal.login.forgot_password, portal.login.errors.* (invalid_credentials, portal_unavailable, email_not_found, invalid_2fa, rate_limited, maintenance, server_error, network_error) — check they exist in i18n files and whether "rate_limited" supports the {seconds} interpolation.
+  - The 403 test expects text "Portal access is not available for this account. Contact team@balizero.com." — that comes from t("portal.login.errors.portal_unavailable"). Unchanged code, keys unchanged.
+  - Routes /privacy and /terms exist?
+  - --font-serif variable defined?
+  - useSystemSound hook unchanged usage: play("focus"), play("auth_start"), play("access_granted"), play("access_denied") — same as before presumably (unchanged region).
+  - framer-motion still in package.json? Removal from page doesn't require package removal; but check nothing else in login-upgraded imports motion.
+  - Check no other files import from the removed things (cormorant etc.) — not needed, they weren't deleted, just unused here.
+  - Check `next/image` removal — old page used Image for logo; new uses BZLogo. Does BZLogo use next/image? If BZLogo is in @balizero/core package, check its implementation renders an img with alt "Bali Zero".
+  - Also verify the test at line 64: `expect(hero?.textContent).not.toContain("Bali Zero")` — hero contains BZLogo img with alt "Bali Zero" — alt text is an attribute, not textContent, so fine. But wait — BZLogo variant="full" might render text "Bali Zero" alongside the mark! If variant "full" means logo + wordmark text, then hero.textContent would contain "Bali Zero" and the test would fail. Need to check BZLogo implementation.
+  - Also check that `BZLogo` doesn't use framer-motion (test no longer mocks it) — if it does, tests might still pass but with RAF... jsdom + framer-motion works usually. But check anyway.
+
+  Also check the third e2e hunk around line 363 and any other login-page interactions in the spec (e.g., magic-link test uses /portal/magic-link page — unchanged; forgot-password page unchanged).
+
+  Also check for other specs/tests referencing login-upgraded page elements: grep e2e/ for "login-upgraded", "Pass the Portal", "Access PIN", "Corporate Email", "Portal Unlocked", "Access Denied", "Continue".
+
+  Also check src/__tests__ or other unit tests referencing the page.
+
+  Also confirm no data-testid usage: grep "data-testid" in login-upgraded dir and in the spec. The task says "every data-testid the tests use are behaviourally unchanged" — if tests use none, that clause is vacuously satisfied; but let me check the e2e spec for getByTestId.
+
+  Let me also verify the magic-link and forgot-password routes exist (they did before — unchanged), and /privacy, /terms.
+
+  And check `useSystemSound` exists (unchanged import).
+
+  Also check i18n locale files for the keys. Find the i18n directory: apps/mouth/src/i18n or apps/mouth/messages? The import is "@/i18n". Let me look.
+
+  Also check tsconfig paths for @balizero/core.
+
+  Parallel calls now:
+  1. Read spec around line 340-420 (third hunk).
+  2. Grep "Pass the Portal" repo-wide (apps/mouth).
+  3. Grep "getByTestId|data-testid" in e2e/portal-prodlike-smoke.spec.ts and login-upgraded dir.
+  4. Find BZLogo: Glob packages/core components or Grep "BZLogo" in packages.
+  5. Read apps/mouth/package.json.
+  6. Grep i18n keys in i18n files.
+  7. Glob for /privacy and /terms routes: src/app/privacy/page.* and src/app/terms/page.* (note: might be under (blog) or similar group).
+  8. Grep "--font-serif" in apps/mouth src/styles.
+
+• The post-change page, error and test files are consistent with the diff. Now the remaining verification points — the third e2e hunk context, BZLogo, i18n keys, routes, dependencies:
+
+• - "Pass the Portal" no longer appears anywhere in apps/mouth — all locators updated.
+  - No data-testid usage in the spec or the login-upgraded directory — the "data-testid" clause is vacuously satisfied (tests use role/label locators, all unchanged or updated in the 3 hunks).
+  - The @qa-be-003 test uses getByRole("alert") filtered by "Access Denied" text and the i18n denial message — both retained in the new page (page.tsx:329-337).
+
+  Now check:
+  1. BZLogo component — location, alt text, variant="full" rendering (img vs text), rounded-full, priority/size props, whether it uses next/image or framer-motion.
+  2. @balizero/core in apps/mouth/package.json.
+  3. i18n keys existence.
+  4. /privacy and /terms routes.
+  5. --font-serif definition.
+  6. Other references to login-upgraded elements in other e2e/unit tests (grep "login-upgraded" across apps/mouth, grep "Access PIN", "Corporate Email" repo-wide to find other consumers).Interesting: `@balizero/core` is NOT in apps/mouth/package.json dependencies! The import `@balizero/core/components/BZLogo` — how does it resolve? Maybe via tsconfig paths. Let me check tsconfig.json / next.config.ts / vitest config for the alias. Other apps/mouth files already import BZLogo (src/components/workspace/AppSidebar.tsx, src/app/visa/layout.tsx etc. are inside apps/mouth — the grep result paths "src/app/..." are relative to apps/mouth since I passed path=apps/mouth... wait, no. The grep was on the whole worktree root `/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5` with glob *.tsx. Results include both `packages/core/components/BZLogo.tsx` and `src/...` paths — but "src/app/portal/login-upgraded/page.tsx" is relative... hmm, the first result is shown as `src/app/portal/login-upgraded/page.tsx` without the apps/mouth prefix — that's odd. Actually Grep output shows paths relative to the search path; the search path was the worktree root, so `src/app/portal/login-upgraded/page.tsx` would be worktree-root/src/... which doesn't exist... unless grep tool printed relative paths for files under cwd. The cwd is apps/mouth. Mixed output: files under apps/mouth printed relative to cwd, and packages/core printed with worktree-relative path? The second result is `/Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/packages/core/components/BZLogo.test.tsx` (absolute). Hmm, inconsistent. Likely: results under cwd (apps/mouth) shown relative, others absolute. So `src/components/workspace/AppSidebar.tsx` = apps/mouth/src/... Good — BZLogo is already used by several apps/mouth pages, so it's an existing import pattern, not a new dependency. Let me verify how it resolves: check tsconfig paths in apps/mouth/tsconfig.json.
+
+  Also confirm BZLogo.tsx implementation. Read it.
+
+  Also package.json: framer-motion still a dependency (fine — used elsewhere presumably; removing import from one page is not "new dependency"). No new dependency added to package.json — but wait: is @balizero/core a workspace package that mouth already depends on via tsconfig paths? If mouth's tsconfig maps @balizero/core/* to ../../packages/core/*, fine. Check.
+
+  Next checks:
+  1. Read packages/core/components/BZLogo.tsx.
+  2. Read apps/mouth/tsconfig.json (paths).
+  3. Check i18n keys — find i18n directory: apps/mouth/src/i18n. Grep for "portal.login.errors.rate_limited" and "portal_unavailable" etc.
+  4. Check /privacy and /terms routes in apps/mouth/src/app — earlier grep shows src/app/v2/privacy/page.tsx and src/app/v2/terms/page.tsx exist, but the new footer links point to "/privacy" and "/terms" (root). Do root-level privacy/terms routes exist? Check via Glob: src/app/privacy/** and src/app/terms/**, also (blog) groups etc. If they don't exist → dead links introduced (href target 404). Is that a "route changed" defect? The task (b) says "no route changed" — adding dead links would be a correctness defect worth flagging. Let me check.
+  5. --font-serif variable: grep in apps/mouth src (globals.css / layout). Fallback exists, so cosmetic only if missing. But check if --font-serif is defined — if defined via next/font in root layout it applies globally (CSS var on html/body). The page sets font-family:var(--font-serif),Georgia,serif — fine either way.
+  6. Check scripts/assert-public-login-bundle.mjs — since page changed, this build assert might check the login bundle contents (e.g., that certain heavy deps like framer-motion are NOT in the public login chunk, or roster not included). Read it to see whether the refactor affects it. It could assert things about the login page's client bundle. If the assert expects framer-motion excluded... now it is excluded. If it expects specific strings (e.g., "login-upgraded"), check.
+  7. Check src/app/portal/login/route.ts — redirects /portal/login → /portal/login-upgraded presumably; unchanged (not in diff). Good — no route changed.
+  8. Check other e2e tests that reference the login page UI: e2e/theme-toggle.spec.ts references login-upgraded — check what it asserts (theme toggle on login page?). The new page forces dataset.theme to operative-light/dark and there's no theme toggle on the page. Let me read theme-toggle.spec.ts to see whether it depends on removed UI.
+  9. Check portal-theme-persona.test.ts — references login-upgraded; the new page adds data-product="my" persona effect. That test may assert the persona behavior of the (authenticated) layout; check whether it covers the login page and whether new effect matches.
+  10. Check src/app/portal/(authenticated)/layout.tsx persona declaration to compare with the new effect (the comment claims parity).
+
+  Also verify the magic-link page exists at /portal/magic-link (it does — src/app/portal/magic-link/page.tsx in grep results) and forgot-password (exists). Those links unchanged.
+
+  Also check check-portal-public-live.mjs — might assert login page content live (e.g., "Corporate Email" string, or title). If it greps for removed strings like "Pass the Portal" or "Your Bali Life", it would break — it references login-upgraded. Read it.
+
+  Also middleware/proxy.ts references login-upgraded — unchanged behavior (route unchanged).
+
+  Let me batch: read BZLogo.tsx, tsconfig.json, theme-toggle.spec.ts, check-portal-public-live.mjs, assert-public-login-bundle.mjs.
+
+• `@balizero/core` isn't in package.json dependencies — BZLogo is already imported by several mouth pages, so it must resolve via tsconfig paths. Let me verify that and the remaining consumers:
+
+• BZLogo: renders next/image `<Image alt="Bali Zero">` for variant "full", className passed through (none here → no rounded-full). Test assertions hold: img exists, alt "Bali Zero", no rounded-full class. Note: BZLogo uses `next/image` — the unit test doesn't mock next/image; next/image renders an img in jsdom fine. Good.
+
+  tsconfig paths: `@balizero/core/*` → `../../packages/core/*` — existing alias, not a new dependency. BZLogo was already used by AppSidebar etc. Good.
+
+  theme-toggle.spec.ts: "My defaults to day mode without a stored preference" — visits /portal/login-upgraded and expects html[data-theme="operative-light"]. How was this satisfied before the change? The new page's persona effect sets data-theme to operative-light if not already operative-* (page.tsx:166-177). But was there something doing this before? Previously the login page did NOT set data-theme — the old page read --bz-base tokens. Something else must set data-theme — maybe root layout or a theme script. Since theme-toggle.spec passed before, whatever set data-theme=operative-light on the login page before must still exist... OR the new useEffect is precisely what now sets it. Wait — the old page didn't have that effect (the diff adds it). So how did the theme-toggle spec pass pre-change? Maybe the root layout sets a default data-theme on my.localhost domain. The new effect would then be redundant but consistent: if root already sets operative-light, the effect's conditions leave it unchanged (root.dataset.theme === "operative-light" → no change). And sets data-product="my".
+
+  Hmm, but actually maybe the theme spec passed because the (authenticated) portal layout sets it? No — login-upgraded is not under (authenticated). Let me check src/app/layout.tsx and proxy.ts for theme defaults on the "my" hostname. Not strictly necessary for the review: the key question is whether the new effect BREAKS anything. It maps "light"→"operative-light", "dark"→"operative-dark", default→"operative-light". This only ADDs data-product="my" and normalizes theme. Could it break the "explicit dark preference wins" test? That test is Kita-origin only. For My origin with stored operative-dark: root layout presumably sets data-theme="operative-dark" from localStorage; the page effect leaves it (it's operative-dark). OK.
+
+  One more check: portal-theme-persona.test.ts references login-upgraded — let me read it to see if it asserts something about the login page persona.
+
+  Also check the (authenticated) layout persona effect for parity claim, and check-portal-public-live.mjs + assert-public-login-bundle.mjs since they reference the login page and run in build/CI.
+
+  Also i18n keys. Find i18n message files: apps/mouth/src/i18n — grep for rate_limited.
+
+  And routes: check for src/app/privacy and src/app/terms (root-level) — the footer links. If only /v2/privacy exists, /privacy is a 404 → dead link defect. Check glob.
+
+  Let me batch these.
+
+• BZLogo and the `@balizero/core` alias check out (existing path alias, existing component, `alt="Bali Zero"`, no `rounded-full`). Now the remaining consumers and the i18n/routes checks:
+
+• Excellent. Findings so far:
+
+  1. i18n: all 8 error keys + forgot_password exist in all 5 locales (en/it/id/fr/ru), including the `{{seconds}}` placeholder for rate_limited. No i18n key removed (the diff touches no locale files; the page's t() usage is unchanged in count: forgot_password + errorKeyFor keys).
+
+  2. Routes: `src/app/privacy/page.tsx` and `src/app/terms/page.tsx` EXIST (glob found them). So /privacy and /terms links are valid. /portal/magic-link and /portal/forgot-password exist. /portal/login-upgraded route unchanged; /portal/login/route.ts unchanged (not in diff).
+
+  3. persona: the root layout has a pre-paint themeInitScript that sets data-product="my" + operative-light for /portal/* paths on ANY host (portal-theme-persona.test.ts). The new page-level effect (page.tsx:166-177) is consistent with it: maps legacy "light"/"dark" to operative-*, defaults to operative-light. Wait — one subtlety: the pre-paint script honors a stored "dark" preference → data-theme="operative-dark". The page effect: if theme is "light" → operative-light; "dark" → operative-dark; if already operative-*, leave; else operative-light. What if the pre-paint script sets theme="editorial" (non-portal path)? On /portal/login-upgraded the pre-paint script always sets product="my" and theme operative-light or operative-dark (per the test). So the page effect leaves it. Consistent. No defect.
+
+  But wait — is the page effect's comment accurate ("Same persona declaration the authenticated portal layout makes")? Let me quickly check portal/(authenticated)/layout.tsx for the same effect — not critical for behavioral correctness of the login page itself. Actually let me check it to make sure the comment's claim holds and there's no mismatch (e.g., the authenticated layout doesn't default unknown themes to operative-light, creating a flash difference). Minor.
+
+  4. assert-public-login-bundle.mjs: scans the login page chunks for internal API routes (anything not /api/auth/). The new page adds no new /api/ strings... wait — the page has no /api/ strings at all; publicAuth.login is in @/lib/api/public-auth which contains /api/auth/login presumably — allowed prefix. The new page adds links /privacy, /terms, /portal/magic-link, /portal/forgot-password — not API routes. BZLogo adds /assets/logo/... — not /api/. So the bundle assert still passes. 
+
+  Hmm — one thing: the old page imported framer-motion; the new one doesn't. Bundle gets smaller. No issue.
+
+  5. check-portal-public-live.mjs — need to check what it asserts about the live login page (it references login-upgraded). If it greps HTML for strings like "Corporate Email" or "Pass the Portal", the refactor could break it. Let me read it.
+
+  6. Also `src/proxy.ts` references login-upgraded — route unchanged, fine. Not in diff.
+
+  7. Also `scripts/check-portal-public-live.test.mjs` — its unit test. Read check-portal-public-live.mjs.
+
+  8. Check the (authenticated) layout persona effect for the comment parity claim (minor; the comment is not behavior). I'll check quickly.
+
+  9. Focus/target size/contrast — computed contrasts:
+     - copper #a44b36 on paper #f7f4ee ≈ 5.3:1 (AA pass for text)
+     - forest #253e33 on paper ≈ 10.5:1
+     - paper on forest ≈ 10.5:1
+     - muted #58626b on paper ≈ 5.7:1
+     - brand-role rgba(paper,0.72) on forest ≈ 6.3:1
+     - lede rgba(paper,0.78) on forest ≈ ~7:1
+     - placeholder muted on surface #fffcf7 ≈ ~5.6:1
+     - input border #a8aca9 on #fffcf7: contrast ~2:1 — non-text UI component contrast (WCAG 1.4.11 wants 3:1 for input boundaries). #a8aca9 on #fffcf7: L(#a8aca9): R168→0.6588→lin 0.391; G172→0.6745→lin 0.409; B169→0.6627→lin 0.395. L≈0.2126×0.391+0.7152×0.409+0.0722×0.395≈0.0831+0.2925+0.0285=0.404. L(#fffcf7): ≈0.938. Ratio=(0.988)/(0.454)=2.18:1 < 3:1. Hmm — borderline WCAG 1.4.11 fail for input boundaries... BUT the old inputs had border --bz-border tokens; what was the old contrast? Unknown tokens. Is this a "regression"? The task asks about "any accessibility regression (focus, contrast, target size)". A 2.2:1 border is below the 3:1 SC 1.4.11 guideline for identifying input fields, but inputs are also identifiable by their 52px height, surface #fffcf7 vs page paper #f7f4ee background difference, and placeholder text. SC 1.4.11 has an exception: if the visual presentation is not required to identify the component... a filled rect with lighter bg vs page bg — #fffcf7 vs #f7f4ee is nearly invisible (ratio ~1.03). Hmm. This is a judgement call. The old design: border --bz-border. Let me check what --bz-border is on operative-light. If old border was also light, not a regression. Let me grep tokens.
+     
+     Also focus ring: 3px rgba(164,75,54,0.18) glow + border-color change to copper. Old: focus:border-copper + ring-2 25% copper. Comparable or better (3px vs 2px).
+     
+     Target sizes: email input 52px, CTA 48px, PIN input 52px, links in formfoot min-height 24px. The r19-back button: 12px font, inherits line-height 1.75 → ~21px tall, and padding 0 (`.r19-gate button{border:0;background:none}` — padding not reset! button default padding remains? `font:inherit` set; padding not zeroed — browsers give buttons ~1px 6px padding). So back button ≈ 21px height × auto width. WCAG 2.5.8 target size minimum 24×24 (AA, 2.2). The old back button: text-[11px], also no explicit size — line-height default ~16px + padding. Both under 24px; not a regression per se (similar before). The magic-link/forgot links: 13px font, line-height 1.75 → ~23px, gap 10px — inline links exception applies (they're in a block list, not inline sentences...). WCAG 2.5.8 "inline" exception is for links in sentences. These are block-level links in a flex column — strictly they should be 24px. 13px×1.75=22.75px ≈ close. This is getting into the weeds; old design had 11px links with default line-height ~16-17px, so new is bigger. Not a regression.
+
+  10. Red colour introduced? No — the opposite: --state-danger removed from error.tsx and denied overlay; copper #a44b36 is the most "red-adjacent" color but it's the concept's "needs you" copper, deliberate. No literal red (#f00, red-500 etc.) introduced. The drain-guard test asserts no gold hexes; nothing about red, but error.tsx previously used --state-danger. The question (d) asks "any red colour introduced" — answer: none introduced; red-family usage was *reduced* (--state-danger → copper in error.tsx and denied overlay).
+
+  11. Unit tests (c): page.test.tsx still asserts: state machine advance (email→PIN), mockLogin called once with normalized credentials, double-submit guard, redirect sanitization ×3 cases, partner role routing, telemetry hygiene (401), 403 denial with role=alert text, labels/password-manager semantics, drain guard. Same behaviors as before per diff context (the unchanged tests 6-10). The 5 rewritten tests are presentation assertions. The framer-motion mock removal is fine because page no longer imports framer-motion... but wait — does BZLogo or anything else in the render tree import framer-motion? BZLogo imports only next/image. I18nProvider? Possibly — but it was already rendered in the old tests outside the motion mock's concern (old test also rendered I18nProvider with the motion mock active; if I18nProvider used motion, the mock would have intercepted it before too... the mock replaced the whole framer-motion module, so if I18nProvider used motion it would have gotten the mocked version before and real one now — behavioral change in tests possible). Check @/i18n provider imports quickly.
+
+  12. Check that nothing else references the removed test-id/anchors... already done (no data-testid anywhere).
+
+  13. Check check-portal-public-live.mjs for asserted page content.
+
+  14. Also check `src/app/portal/(authenticated)/layout.tsx` persona effect for the comment parity (quick grep for data.product there).
+
+  15. Check that framer-motion removal doesn't break the build elsewhere — framer-motion still in package.json, fine.
+
+  16. Check that `useRef` is still used — yes, loginInFlightRef (page.tsx:151). Good, no unused import. `React` import used? React.FormEvent used in handlers — yes. `Loader2` used — yes. `Link` used — yes. `useRouter` — yes. `Image` import removed and no longer used — correct. `cormorant` import removed and no longer used — correct. `motion, AnimatePresence` removed — correct. `MouseEvent` removed from react import — no longer used — correct.
+
+  17. One more: the vitest setup — does jsdom render next/image fine without config? The old test didn't render next/image either (old page used next/image for the logo! Old page had `<Image src="/assets/logo/balizero-logo-clean.png" ...>` — and old tests passed with next/image unmocked). Good precedent.
+
+  18. Also verify the e2e spec's magic-link/forgot flows don't touch the login page's removed elements. The spec is 2599 lines; the login helper functions were the only hunks in the diff. But maybe other parts reference "Turn On" or "Your Bali Life" or the overlays. Grep the spec for "Portal Unlocked|Access Denied|Turn On|Your Bali Life|Continue|Verify Identity". I saw "Access Denied" at line 384. Let me grep to be thorough.
+
+  19. Also grep other e2e specs for locators hitting the login page (e2e/auth/, e2e/portal/). Grep "Corporate Email" across e2e/.
+
+  Let me run these final checks.
+
+• i18n keys all present in 5 locales, `/privacy` and `/terms` routes exist, bundle-assert script unaffected by presentation changes. Final sweep — other e2e consumers of the login page, the live-check script, and the persona-layout parity claim:
+
+• The persona effect in page.tsx:166-177 is byte-identical to the one in portal/(authenticated)/layout.tsx:60-71 — the comment's parity claim holds.
+
+  check-portal-public-live.mjs only checks HTTP status/metadata/CSP for /portal/login-upgraded — presentation changes don't affect it.
+
+  Remaining e2e consumers:
+  - e2e/portal-prodlike-smoke.spec.ts:484 and :2282 use "Corporate Email" textbox — role+name locator, retained (label htmlFor association preserved).
+  - e2e/offline/auth-critical-flow.spec.ts:44 expects heading "Access Denied" — retained (page.tsx:335, h1 "Access Denied" inside role=alert overlay). It's a heading role? h1 → heading role, name "Access Denied". Yes, retained.
+  - e2e/crm/crm-real-ui.spec.ts:69 — text=Access Denied or text=Login — "Access Denied" text only appears on denial; "Login"... hmm, does the new page contain the text "Login" anywhere? Old page? This is an `.or()` — either matches. If neither matches it fails. What page is this? Let me check the context — crm-real-ui.spec.ts is probably about the CRM (kita) login, not the portal login page. "text=Login" — the old portal page: did it contain "Login"? Hmm, the old page had... "Portal Unlocked", "Access Denied", "Pass the Portal", "Verify Identity"... no literal "Login" text either (id "portal-login-error" is not text). So the CRM spec likely targets a different page (kita CRM). Not affected by this diff since it matched before via one of the alternatives... Actually wait, if it targeted the portal login page, neither "Access Denied" (only on denial) nor "Login" would match in either old or new versions. Let me check the context of that line to be safe.
+
+  Let me check crm-real-ui.spec.ts:50-80.
+
+  Also e2e/auth/ directory may have login specs. Grep found only these. Let me also check e2e/production/ specs that reference the portal login... the grep covered all of e2e/.
+
+  One more check: the unit tests for the OLD page asserted `.min-h-screen` shell with bg-[var(--bz-base)] — those were replaced. Fine.
+
+  Now — did I miss checking `page.getByRole("button", { name: "Continue" })` ambiguity on the PIN step? On PIN step there's no "Continue" button; helper uses it only on email step. OK.
+
+  And one subtle e2e detail in loginViaPortalUi: after `emailSubmit.click()`, it does `page.getByLabel("Access PIN").fill(pin)` — the PIN step renders with autoFocus and the label "Access PIN" — retained.
+
+  Another subtle point: in the OLD page the PIN form was inside AnimatePresence with mode="popLayout" — behaviorally the step swap was conditional render; new is plain conditional render. Same state machine.
+
+  Hydration guard: isHydrated useEffect (page.tsx:157-159), disabled={!isHydrated || loginStage !== "idle"} on email input (396) and email submit (405) — identical to old. PIN input disabled={loginStage !== "idle"} (462) — same as old (old also lacked !isHydrated on PIN). Unchanged.
+
+  Rate-limit retry-after: page.tsx:265-275 — reads response.headers.get("retry-after"), parseInt, Number.isFinite fallback 60, t("portal.login.errors.rate_limited", {seconds}). Unchanged from old (not in diff = identical context lines around 206... wait, the diff hunk @@ -206,1370 +284,214 @@ starts AT line 206 of old — everything before (errorKeyFor through handleLogin end) is unchanged. Confirmed by post-change file containing them.
+
+  publicAuth.login: page.tsx:219, with normalizedEmail and pin; double-submit guard loginInFlightRef (151, 201-208, 281). Tests assert toHaveBeenCalledTimes(1) with two submits. Unchanged.
+
+  Error mapping errorKeyFor: page.tsx:107-126 — 401/403/404/422/429/503/default ≥500 server_error else network_error. Unchanged (diff context shows it at lines 365-367 area — the comment above it appears in diff as context: "Map HTTP status code → i18n error key..." unchanged).
+
+  Overlays: success role=status aria-live=polite "Portal Unlocked" (318-326); denied role=alert aria-live=assertive "Access Denied" + errorMessage p#portal-login-error (329-338). Old had same roles/live/text. Unchanged behaviorally; colors changed (copper vs --state-danger) — intentional per concept F.
+
+  data-testid: none used by tests — vacuously satisfied.
+
+  New dependency: none — @balizero/core is a tsconfig path alias to packages/core (tsconfig.json:24-25), already used by ~20 other mouth files; BZLogo already exists with its own test. framer-motion remains in package.json (still used elsewhere presumably) — no manifest change at all.
+
+  Routes: page route unchanged; /portal/login route.ts unchanged; links /portal/magic-link, /portal/forgot-password unchanged; new /privacy, /terms links → both routes exist (src/app/privacy/page.tsx, src/app/terms/page.tsx). No route changed.
+
+  i18n: no keys removed (locale files untouched); the single t() key in JSX (forgot_password) + 8 error keys all present in 5 locales with {{seconds}} placeholder; interpolation API t(key, {seconds}) — check the useTranslation t signature supports interpolation... The rate_limited test file locale-key-parity.test.ts checks {{seconds}} placeholder exists. The old code used the same call — unchanged.
+
+  Accessibility (d):
+  - Focus: inputs get copper border + 3px rgba(164,75,54,0.18) ring (R19_STYLES line 64) — vs old 2px 25% copper ring. Comparable; ring is visible (3px at 18% alpha over paper ≈ blend #d8b3a8-ish… border color change from #a8aca9 to #a44b36 is the primary indicator — hue+lightness change, contrast between focused/unfocused border colors ~2.4:1). Buttons keep native outline (no outline:none on buttons — only .r19-input has outline:none). Links have hover underline; focus relies on native outline. OK.
+  - Contrast: computed — copper-on-paper 5.3:1, forest-on-paper 10.5:1, paper-on-forest 10.5:1, muted-on-paper 5.7:1, brand-role/lede/foot on forest 6.3-7:1. All ≥4.5:1 for text. Eyebrow text is 10px but 650 weight uppercase — 5.7:1 passes AA even for small text. Input border #a8aca9 on #fffcf7 ≈ 2.2:1 — below 3:1 for SC 1.4.11 non-text contrast... but the old border was --bz-border; check value? The old input also had bg-[var(--bz-base)] inside a --bz-card/95 card, so field was distinguished by background contrast rather than border. New: surface #fffcf7 on paper #f7f4ee — nearly identical backgrounds, so the field is identified mainly by the 2.2:1 border and placeholder text. Hmm. WCAG 1.4.11 requires 3:1 for "visual information required to identify user interface components" — a text input's boundary. Many design systems fail this strictly; but is it a REGRESSION? Old: border --bz-border — need the token value. Let me check globals.css for --bz-border on operative-light. If old border was similarly faint, not a regression. Let me grep.
+  - Target size: inputs 52px, CTAs 48px, formfoot links min-height 24px (explicit), back button ~21px (12px font × 1.75 lh) — old back button was 11px font, similar ~19px; small but not regressed. alt links 13px×1.75≈23px vs old 11px links ~17px. Improved.
+  - Red: none introduced. --state-danger removed from error.tsx (→ --bz-copper-text) and denied overlay (→ --r19-copper #a44b36). Deliberate concept-F decision, stated in comments.
+
+  Let me check --bz-border value quickly, and crm-real-ui.spec.ts context. Then done.
+
+  Actually — one more possible defect to check: the denied overlay previously rendered the error `<p>` styled --state-danger; new overlay p has no id-related style loss... id="portal-login-error" retained (336). aria-describedby on PIN input (447-449) points to it. OK.
+
+  And: the old page auto-focused email input; new retains autoFocus (399). PIN autoFocus retained (465). Focus management on step change identical (autoFocus on mount of the new form). Since forms are conditionally rendered, autoFocus fires on PIN mount — same as before with motion.form... Actually with AnimatePresence mode="popLayout" the motion.form mounted and autoFocus fired too. Same.
+
+  One more subtle thing: in the OLD email form, the submit button was motion.button with whileHover/whileTap — the unit test mock stripped those. E2E: getByRole button name "Pass the Portal →"... the accessible name included the arrow "→"? Playwright name matching is substring/case-insensitive by default... they used "Pass the Portal" which matched "Pass the Portal →". New button text "Continue" — locator "Continue" matches. Fine.
+
+  Also check offline/auth-critical-flow.spec.ts:44 context — expects heading "Access Denied". In new page the denied overlay h1 is "Access Denied" — heading role retained. Let me peek at that spec briefly to confirm it targets this page (it's offline/auth-critical-flow). Line 44 context: probably goes to login page with offline, submits, expects denial... The denied overlay requires loginStage==="denied" which requires a failed publicAuth.login — offline would produce status 0 → network_error message, overlay shows "Access Denied" + message. Retained.
+
+  Let me quickly read both spec contexts (offline/auth-critical-flow.spec.ts:30-60, crm/crm-real-ui.spec.ts:55-80) and grep --bz-border in styles. Then run the unit tests? Running vitest for this page would strengthen the review. The task says don't modify files — running tests is allowed (read-only-ish; may write coverage cache... vitest run may create cache. It's acceptable? "Do not modify any file" — running tests could create node_modules/.vite cache. To be safe, I could run with --no-cache... vitest run page.test.tsx. Hmm, the review is independent correctness; running the test suite is strong evidence. Risk: creates temp files (coverage only with --coverage). vitest run doesn't write by default. Let me try running it — it's the project's standard test command (npm test = vitest). I'll run `npx vitest run src/app/portal/login-upgraded/page.test.tsx` in apps/mouth. That verifies (c) empirically. Also typecheck? tsc --noEmit takes long; skip or run? It would catch unused imports etc. But full tsc on a big app may take minutes. The eslint unused-import issue: all imports verified used manually. Skip tsc; rely on manual check.
+
+  Also worth verifying: does `useSystemSound` hook exist and export `play`? It's unchanged import, existed before. Fine.
+
+  Also: `@/i18n` I18nProvider — does it import framer-motion? If it does, tests still fine (framer-motion works in jsdom; the old mock was to avoid RAF noise). Not a correctness issue for the review. Skip.
+
+  Let me do the last greps and run the test.- offline/auth-critical-flow.spec.ts: uses "Authenticate" button and URL /login — that's the KITA operator login (different page, /login not /portal/login-upgraded). Not affected.
+  - crm-real-ui.spec.ts: asserts "Access Denied"/"Login" text NOT visible on /clients (kita CRM). Not affected by portal login changes.
+  - Old --bz-border on light themes: rgba(9,9,11,0.08) or rgba(55,44,32,0.1) — extremely faint borders (<1.5:1). New --r19-line-strong #a8aca9 (~2.2:1 on surface) is STRONGER than the old border. So no contrast regression on input boundaries — actually an improvement.
+
+  Now let me run the unit tests for the page to empirically confirm (c). Command: npx vitest run src/app/portal/login-upgraded/page.test.tsx in apps/mouth. That's the project's standard test runner. It shouldn't modify files (no coverage flag). Let me run it with a reasonable timeout. DEPRECATED  `test.poolOptions` was removed in Vitest 4. All previous `poolOptions` are now top-level options. Please, refer to the migration guide: https://vitest.dev/guide/migration#pool-rework
+
+ RUN  v4.1.10 /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5/apps/mouth
+
+
+ Test Files  1 passed (1)
+      Tests  13 passed (13)
+   Start at  06:41:39
+   Duration  5.58s (transform 333ms, setup 259ms, import 472ms, tests 2.60s, environment 1.99s)
+
+All 13 tests pass. The review is complete. Let me also double check one thing — the BZLogo alt test passed, which empirically confirms BZLogo renders the img correctly in this checkout.
+
+  Summary of the review:
+
+  (a) Behavioral invariants — all verified in post-change page.tsx:
+  - Two-step state machine: step state (page.tsx:145), handleSubmitEmail trims + advances (186-194), handleLogin (196-285), back button (430-439). Unchanged from pre-change (diff context confirms).
+  - publicAuth.login(normalizedEmail, pin) at page.tsx:219; in-flight guard loginInFlightRef (151, 201-208, 281); test asserts single call under double-submit (page.test.tsx:170-183).
+  - HTTP-status→i18n mapping errorKeyFor (page.tsx:107-126): 401/403/404/422/429/503, ≥500 server_error, else network_error — byte-identical to pre-change (unchanged diff context).
+  - 429 retry-after: page.tsx:265-275 reads response.headers.get("retry-after"), parseInt, NaN→60 fallback, interpolates {{seconds}} — unchanged; placeholder exists in all 5 locales (e.g. en.json:290).
+  - Hydration guard: isHydrated (142, 157-159), disables email input (396) and email CTA (405) — identical to old.
+  - Overlays: success role=status aria-live=polite "Portal Unlocked" (318-326); denied role=alert aria-live=assertive "Access Denied" + errorMessage p#portal-login-error (329-338), aria-describedby/aria-invalid wiring on PIN (447-450) — same roles/text/wiring as old.
+  - data-testid: none used by any test (grep empty in spec and page dir) — vacuously unchanged.
+
+  (b) i18n/routes/deps:
+  - No i18n key removed: locale files untouched by diff; t() usage unchanged (forgot_password + 8 error keys present in en/it/id/fr/ru).
+  - No route changed: /portal/login-upgraded untouched as a route; proxy/login route unchanged; links /portal/magic-link, /portal/forgot-password pre-existing; new /privacy + /terms links resolve to existing src/app/privacy/page.tsx and src/app/terms/page.tsx.
+  - No new dependency: package.json untouched; @balizero/core resolves via existing tsconfig path alias (tsconfig.json:24-25) to packages/core; BZLogo pre-exists (packages/core/components/BZLogo.tsx) and is already imported by ~20 other mouth files. framer-motion import removed (still in deps for other pages). All imports in page.tsx are used (useRef → loginInFlightRef).
+
+  (c) Tests: page.test.tsx still asserts the same behaviors — state machine advance, credential normalization + single login call, redirect sanitizer (3 cases), partner role routing, telemetry hygiene, 403 denial role=alert content, label/password-manager semantics, drain guard; 13/13 pass when executed just now. The framer-motion mock removal is safe: the page no longer imports framer-motion and BZLogo imports only next/image, which the old suite also rendered unmocked (old page used next/image too).
+
+  (d) Accessibility:
+  - Focus: .r19-input:focus copper border + 3px rgba(164,75,54,0.18) ring (page.tsx:64) — comparable to old 2px/25% ring; buttons/links keep native focus outline (only inputs have outline:none).
+  - Contrast: forest/paper 10.5:1 both directions, copper-on-paper 5.3:1, muted-on-paper 5.7:1, 0.72-0.78 alpha paper-on-forest 6.3-7:1 — all AA. Input border #a8aca9 ≈2.2:1 is stronger than the old --bz-border (rgba(9,9,11,0.08)) — improved, not regressed.
+  - Target size: inputs 52px, CTAs 48px, footer links min-height 24px (page.tsx:76); back button small (~21px) but old equivalent was smaller (~11px font, no min size) — no regression.
+  - Red: none introduced; the change *removes* --state-danger from error.tsx (→ --bz-copper-text, error.tsx:26-33) and from the denied overlay (→ --r19-copper #a44b36, page.tsx:82/335) — deliberate concept-F semantics, word + role=alert carry the state.
+  - Empirical: 13/13 unit tests pass.
+
+  One minor observation, not a defect: the error overlay's error <p> lost its red color styling (now --r19-ink) — intentional per concept F; still announced via role=alert + aria-describedby. Not flagging.
+
+  Verdict: OK.
+
+  The final line must be exactly "VERDICT: OK".
+
+• All 13 unit tests pass. Review complete — here are the findings.
+
+  **(a) Behavioral invariants — all unchanged**
+
+  - **Two-step state machine**: `step` state `page.tsx:145`, `handleSubmitEmail` (trim → advance) `page.tsx:186-194`, `handleLogin` `page.tsx:196-285`, back-to-email button `page.tsx:430-439` — byte-identical to pre-change (these lines are untouched context in the diff).
+  - **`publicAuth.login`**: `page.tsx:219` called with `(normalizedEmail, pin)`; double-submit guard `loginInFlightRef` at `page.tsx:151,201-208,281`; test asserts exactly one call under double submit `page.test.tsx:170-183`.
+  - **HTTP-status→i18n mapping**: `errorKeyFor` `page.tsx:107-126` — 401/403/404/422/429/503, ≥500→`server_error`, else `network_error` — unchanged.
+  - **429 retry-after**: `page.tsx:265-275` reads `response.headers.get("retry-after")`, `parseInt`, NaN→60 fallback, `{{seconds}}` interpolation; placeholder present in all 5 locales (`src/i18n/locales/en.json:290` etc.).
+  - **Hydration guard**: `isHydrated` `page.tsx:142,157-159`, gating email input `page.tsx:396` and email CTA `page.tsx:405` — same as before (PIN input never had it, still doesn't).
+  - **Overlays**: success `role="status" aria-live="polite"` "Portal Unlocked" `page.tsx:318-326`; denied `role="alert" aria-live="assertive"` "Access Denied" + `p#portal-login-error` `page.tsx:329-338`; `aria-describedby`/`aria-invalid` wiring on PIN `page.tsx:447-450` — same roles, texts, and ids.
+  - **data-testid**: none used by any test (grep over spec + page dir is empty) — clause vacuously satisfied.
+
+  **(b) i18n / routes / dependencies**
+
+  - No locale file touched; all 8 error keys + `forgot_password` exist in en/it/id/fr/ru.
+  - No route changed; new footer links `/privacy` and `/terms` resolve to existing `src/app/privacy/page.tsx` and `src/app/terms/page.tsx`.
+  - No new dependency: `package.json` untouched; `@balizero/core` is an existing tsconfig path alias (`tsconfig.json:24-25`), `BZLogo` pre-exists (`packages/core/components/BZLogo.tsx:39`, renders `<Image alt="Bali Zero">`, no `rounded-full`) and is already imported by ~20 other mouth files. `framer-motion` import removed; all remaining imports are used (`useRef`→`loginInFlightRef`).
+
+  **(c) Tests**: `page.test.tsx` still asserts the same behaviours (state-machine advance, credential normalization + single login, redirect sanitizer ×3, partner routing, telemetry hygiene, 403 denial via `role=alert`, password-manager semantics, drain guard); the motion-mock removal is safe (page no longer imports framer-motion; BZLogo only uses next/image, which the old suite also rendered unmocked). Ran just now: **13/13 pass**.
+
+  **(d) Accessibility**: focus ring on inputs is copper border + 3px glow (`page.tsx:64`), buttons/links keep native outlines; contrast AA throughout (forest↔paper ≈10.5:1, copper-on-paper ≈5.3:1, muted ≈5.7:1, translucent paper-on-forest ≈6.3–7:1; input border 2.2:1 is *stronger* than the old `--bz-border` rgba(9,9,11,0.08)); targets 52px inputs / 48px CTAs / 24px-min footer links. **No red introduced** — the change removes `--state-danger` (error.tsx:26-33, denied overlay `page.tsx:82`) in favour of copper, with the state carried by word + `role=alert`, which is the stated concept-F intent. The three e2e locator updates match the new "Continue" label, and no other spec references the old label.
+
+  VERDICT: OK
+
+To resume this session: kimi -r session_80c18afb-7083-4e60-8acf-fd50c1e893c9

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
@@ -1,12 +1,45 @@
-gear: 2
+gear: 3
 brief_ref: evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
 ruling: RULED 2026-09-12 SAETTA
 lanes:
   - lane: R19P-W5
     role: build
     seat: Claude Opus 5 (Dux of window W5, implements directly)
+  - lane: R19P-W5-council-codex
+    role: review
+    seat: codex-gpt-5.6-sol (OpenAI, codex exec --sandbox read-only, independent correctness review of the merge-base diff)
+  - lane: R19P-W5-council-kimi
+    role: review
+    seat: kimi-code/k3 (Moonshot, kimi -p, independent correctness review of the merge-base diff)
+council_run: council/journal.jsonl
 pii_scan: clean
 decisions:
+  - id: D-gear
+    decision: >-
+      Gear raised 2 -> 3 to match the deterministic floor computed by
+      evidence_pack_lint.py compute_floor(): SIZE term, churn 1997 >= 1828 on the
+      merge-base diff (the night-scene teardown in page.tsx), not a hot-zone path.
+      A two-seat council (Codex GPT-5.6-sol, Kimi K3) was then run for real on the
+      diff; its raw stdout is filed under council/ and its journal is council_run.
+  - id: D-e2e
+    decision: >-
+      Second council round (Kimi K3, VERDICT DEFECT): e2e/portal-prodlike-smoke.spec.ts
+      located the email-step submit by its old label "Pass the Portal" (lines 144, 189,
+      366), which this window renamed to "Continue"; the three locators now use
+      "Continue". The step-2 button keeps its aria-label "Verify Identity", so those
+      locators were already correct. The prodlike suite is a direct consumer of the
+      label and is edited in the same PR although outside the brief's file list —
+      recorded as a CONFIRMED dissent, not hidden.
+  - id: D-logo
+    decision: >-
+      The first council round (both seats, VERDICT DEFECT) found the hero used
+      BZLogo variant "mark", which resolves to the red asset balizero-3-red.png,
+      against this pack's own D6 and the brief's no-red rule, and Zero's 2026-09-13
+      03:15 order (the full logo, no serif wordmark beside it). Fixed at depth 1:
+      variant "full" at 36px, the serif "Bali Zero" text removed (the asset carries
+      the wordmark), the hero footer and brand-role alpha raised 0.55/0.6 -> 0.72
+      (>= 4.5:1 on forest), footer links given a 24px minimum target. Tests, eslint,
+      prettier re-run; the council re-run on the corrected diff.
   - id: D1
     decision: >-
       The palette lives as page-local custom properties (--r19-*) on .r19-gate, each

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
@@ -1,0 +1,163 @@
+gear: 2
+brief_ref: evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
+ruling: RULED 2026-09-12 SAETTA
+lanes:
+  - lane: R19P-W5
+    role: build
+    seat: Claude Opus 5 (Dux of window W5, implements directly)
+pii_scan: clean
+decisions:
+  - id: D1
+    decision: >-
+      The palette lives as page-local custom properties (--r19-*) on .r19-gate, each
+      declaration line carrying a token-lint-ok reason, instead of reading --bz-* tokens.
+      Reason - the R19 values are W1's mandate and are NOT on origin/main yet (grep for
+      "forest" in apps/mouth/src/app/globals.css returns nothing, and --bz-base is
+      #f4f1ea, not paper #F7F4EE). Reading today's tokens would render the wrong palette;
+      editing globals.css is outside this window's perimeter. The seam W5 owes W1 is the
+      persona declaration, which IS shipped.
+  - id: D2
+    decision: >-
+      BZLogo variant="mark" (the wordmark-less glyph), not variant="full" (a black disc
+      carrying the wordmark). The brief asks for "the clean wordmark-less logo variant";
+      the hero already sets "Bali Zero" in serif beside it, so a second wordmark would
+      double it, and a black disc on the forest panel reads as a hole. concept.md §3
+      permits the red brand mark inside the mark itself.
+  - id: D3
+    decision: >-
+      The quiet line is the "nothing to register" sentence, not a /portal/register link.
+      /portal/register exists but is an invitation-token route (analytics-url.ts redacts
+      its ?token=), and no page links it as self-registration - grep over apps/mouth/src
+      returns only proxy/middleware/analytics/test references, no <Link href>.
+  - id: D4
+    decision: >-
+      The step-1 hint says "your PIN" where the mock says "your six-digit PIN". The field
+      itself accepts 4-8 digits (minLength/maxLength unchanged), so "six-digit" would be
+      copy the control contradicts.
+  - id: D5
+    decision: >-
+      Field labels stay "Corporate Email" and "Access PIN" (mock says "Email"). They are
+      the accessible names three behavioural tests select by; the window brief lists the
+      copy it wants changed and does not list them.
+  - id: D6
+    decision: >-
+      error.tsx swaps --state-danger for --bz-copper-text. It is in the owned perimeter
+      "for colour classes only", and concept F §3 says red does not exist in this concept.
+receipts:
+  - claim: The worktree was created by the broker on the mouth lane for this task id.
+    cmd: python3 scripts/agent_start.py --lane mouth --task-id r19p-w5
+    result: "WORKTREE_READY /Users/balizero/nuzantara/.worktrees/mouth-r19p-w5 ; branch agent/air-m5/mouth/r19p-w5"
+    exit: 0
+    ts: "2026-09-13T02:39:00+08:00"
+    seat: Claude Opus 5
+  - claim: A1 - the diff touches 3 files, all under login-upgraded/, and is strongly net-negative.
+    cmd: git -C <wt> diff --cached --numstat origin/main
+    result: "page.test.tsx 41/80 ; page.tsx 292/1369 ; error.tsx 5/4 (added after this measurement, see the final diffstat receipt). Net for the two main files -1116 lines."
+    exit: 0
+    ts: "2026-09-13T02:58:00+08:00"
+    seat: Claude Opus 5
+  - claim: A2 - the two test files in the folder are green and the origin/main test-case count is preserved.
+    cmd: cd apps/mouth && npx vitest --run src/app/portal/login-upgraded ; grep -c on both the new and the origin/main page.test.tsx
+    result: "Test Files 2 passed (2) ; Tests 16 passed (16) ; duration 18.91s. Test-case count: 11 on HEAD, 11 on origin/main (it( / it.each( / test( at describe-body indent). csp.test.ts unchanged."
+    exit: 0
+    ts: "2026-09-13T02:52:33+08:00"
+    seat: Claude Opus 5
+  - claim: A3 - no illustration SVG, no starfield, no framer-motion and no raw hex outside the three marked palette lines survive in page.tsx.
+    cmd: grep -n "<svg|<circle|<rect|starDrift|twinkle|gate-scene|passageGlow|framer-motion" and grep -nEi "#[0-9a-f]{3,8}" on page.tsx
+    result: "first grep: no match. hex grep: exactly 3 lines, all --r19-* declarations carrying token-lint-ok reasons; the only red in the surface is the brand mark asset. The only remaining svg is the lucide Loader2 at w-5 h-5 (20px)."
+    exit: 1
+    ts: "2026-09-13T02:58:10+08:00"
+    seat: Claude Opus 5
+  - claim: A3 - the token-lint CI gate accepts the added lines in the scoped portal surface.
+    cmd: python3 -I scripts/token_lint.py --base origin/main
+    result: "token-lint: clean - no new hardcoded hex colors in scoped surfaces. (Run again after the commit; the scanner diffs REF...HEAD, so the pre-commit run scanned 0 files.)"
+    exit: 0
+    ts: "2026-09-13T02:58:30+08:00"
+    seat: Claude Opus 5
+  - claim: A4 - typecheck green.
+    cmd: cd apps/mouth && npx tsc --noEmit
+    result: "no diagnostics, exit 0 (ran ~14 min; pnpm -F mouth typecheck refuses on this checkout with ERR_PNPM_UNSAFE_MODULES_DIR because node_modules is a symlink outside the worktree, so the underlying script was run directly)."
+    exit: 0
+    ts: "2026-09-13T03:12:00+08:00"
+    seat: Claude Opus 5
+  - claim: A4 - eslint and prettier green on every touched file.
+    cmd: cd apps/mouth && npx eslint src/app/portal/login-upgraded/{page,page.test,error}.tsx ; npx prettier --check the same files
+    result: "eslint 0 errors (page.test.tsx is matched by an ignore pattern, reported as 1 warning) ; prettier: All matched files use Prettier code style!"
+    exit: 0
+    ts: "2026-09-13T03:05:00+08:00"
+    seat: Claude Opus 5
+  - claim: A5 - four screenshots of the real route rendered by a local dev server; /portal/login 308s onto the component.
+    cmd: npx next dev --webpack -p 3987 ; playwright chromium channel=chrome, viewports 1440x900 and 390x844, goto /portal/login, step 2 reached by filling the email and submitting
+    result: "status 200, final url http://localhost:3987/portal/login-upgraded for all four. Files: 01-entry-step1-desktop-1440x900.png, 02-entry-step1-mobile-390x844.png, 03-entry-step2-desktop-1440x900.png, 04-entry-step2-mobile-390x844.png under /Users/balizero/Desktop/R19-PORTAL-RENDERS-20260912/build/r19p-w5/."
+    exit: 0
+    ts: "2026-09-13T03:38:00+08:00"
+    seat: Claude Opus 5
+  - claim: The persona effect really fires in the browser - data-product/data-theme observed on documentElement.
+    cmd: playwright evaluate document.documentElement.dataset.product and .dataset.theme on the loaded page
+    result: 'product: "my" ; theme: "operative-light"'
+    exit: 0
+    ts: "2026-09-13T03:30:00+08:00"
+    seat: Claude Opus 5
+  - claim: A5 comparison against concepts/concept-F/01-entry.html - the visible differences.
+    cmd: read the rendered PNGs and the mock side by side
+    result: >-
+      (1) headline serif is Cormorant, not Fraunces - --font-serif is still the Cormorant
+      wiring on origin/main and the font swap is W1's window; the page reads the variable,
+      so it follows W1 automatically. (2) the brand mark is the red "3" glyph, not the
+      mock's paper-coloured abstract square (Zero's logo order, D2). (3) "Forgot PIN?"
+      instead of the mock's "Forgot your PIN?" - the string is the i18n value
+      portal.login.forgot_password and the locale JSON is forbidden ground. (4) the
+      primary button renders grey-green in both captures because it is correctly disabled
+      with an empty field; the forest fill is asserted by the vitest CTA test. (5) a
+      Next.js dev-mode indicator badge sits bottom-left of the step-2 capture. Everything
+      else - split 5fr/6fr, forest panel, copper 56x3 rule, two step ticks, eyebrows,
+      52px field, copper links, hairline, quiet line, footer row - matches the mock.
+    exit: 0
+    ts: "2026-09-13T03:40:00+08:00"
+    seat: Claude Opus 5
+dissent:
+  - seat: Claude Opus 5 (self-refutation, on the local toolchain)
+    objection: >-
+      The first vitest/typecheck/dev-server attempts all failed with missing modules
+      (@vitejs/plugin-react, lru-cache, typescript). Four sibling windows were running
+      pnpm install CONCURRENTLY against the SAME node_modules (the worktrees symlink it
+      from the main checkout) - cicatrix family #5, sibling race on a shared checkout
+      resource. Reporting green tooling during that window would have been reporting a
+      half-built tree.
+    status: CONFIRMED
+    cure: >-
+      No install of my own (that would have been the fifth racer). Waited for the four to
+      drain, then re-ran every check on the settled tree. The tree now resolves through
+      .worktrees/mouth-r19p-w2/node_modules/.pnpm - a store owned by another window's
+      worktree, which will break for everyone the moment that worktree is released.
+      Recorded as a leftover for the imperator, not cured from inside this window.
+  - seat: Claude Opus 5 (self-refutation, on the visual proof)
+    objection: >-
+      The dev server had to be started with --webpack (turbopack refuses the worktree's
+      node_modules symlink: "points out of the filesystem root"), and the webpack dev
+      runtime uses eval, which the portal CSP forbids - so the client bundle never
+      hydrated and the email field stayed disabled. The first step-2 capture attempt
+      timed out on a disabled input.
+    status: CONFIRMED
+    cure: >-
+      Playwright context opened with bypassCSP:true, which suspends CSP enforcement in
+      the browser only - it changes nothing in the markup or the CSS under capture. Both
+      step-2 captures then rendered. The production CSP itself is untouched and
+      csp.test.ts passes unchanged.
+  - seat: Claude Opus 5 (self-refutation, on the palette)
+    objection: >-
+      Page-local --r19-* variables duplicate values that W1 is about to put in the token
+      seam; when W1 lands, this page will keep its own copy instead of following the seam.
+    status: PLAUSIBLE
+    cure: >-
+      Not cured - deliberately. W1 is not on origin/main, and a page that reads a token
+      that does not exist yet renders the wrong colours today. The follow-up (repoint the
+      six --r19-* declarations at the my-product tokens once W1 is live) is one line each
+      and is recorded as a leftover.
+leftovers:
+  - The M5 checkout's node_modules now resolves through .worktrees/mouth-r19p-w2/node_modules/.pnpm after four concurrent pnpm installs; every mouth worktree depends on w2's store surviving. Imperator-level cleanup, outside this window.
+  - Once W1's my-product token seam is on main, the six --r19-* declarations should be repointed at the tokens and their token-lint-ok markers dropped.
+  - The headline renders in Cormorant until W1 swaps --font-serif to Fraunces; nothing in this window needs to change when it does.
+  - The mock's "Forgot your PIN?" stays "Forgot PIN?" (i18n locale JSON is outside the perimeter); an i18n window could align the string.
+  - The success/denied overlays were restyled to paper/forest/copper but are not in the mock, so their R19 treatment is this window's own reading, not a compared render.
+  - loading.tsx was left untouched (neutral Skeletons, no colour to correct).

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
@@ -30,6 +30,13 @@ decisions:
       locators were already correct. The prodlike suite is a direct consumer of the
       label and is edited in the same PR although outside the brief's file list —
       recorded as a CONFIRMED dissent, not hidden.
+  - id: D-redact
+    decision: >-
+      The required Detect Secrets check flagged the Codex council transcript for a
+      quoted test fixture (access_token: "synthetic-token", four occurrences copied
+      from page.test.tsx). The value is a synthetic fixture, not a credential; the
+      four occurrences are replaced by "[redacted synthetic fixture value]" in the
+      transcript. Nothing else in either transcript changed; the verdict lines stand.
   - id: D-logo
     decision: >-
       The first council round (both seats, VERDICT DEFECT) found the hero used

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/pack.yml
@@ -1,5 +1,5 @@
 gear: 3
-brief_ref: evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/brief.yml
+brief_ref: evidence/brief.yml
 ruling: RULED 2026-09-12 SAETTA
 lanes:
   - lane: R19P-W5


### PR DESCRIPTION
Window W5 of mission SAETTA-R19P (BLUE, host M5): the client-portal sign-in page in the R19 language of concept F ("RAPI").

**What goes.** The SVG candi-bentar gate, three animated starfield layers, the moon, the `passageGlow` gradient, the framer-motion spotlight glass card, and the `[data-theme="operative-light"] .gate-scene` block whose only job was to re-light that illustration for the day theme. `page.tsx` loses 1369 lines and gains 292.

**What arrives.** A split gate. Left, the one forest surface of the portal: the full Bali Zero logo (`BZLogo variant="full"`, 36px, uncropped, no serif wordmark beside it — Zero's order of 2026-09-13 03:15; the first council round caught the earlier `mark` variant, which is the red asset), the serif hero "Your Bali file, / kept in order.", one lede, and the two footer eyebrows. Right, on paper: two step ticks, `Sign in · step 1 of 2`, "Welcome back.", the 52px field with a copper focus ring, one 48px forest button, and the two existing alternative paths ("Sign in with an email link instead", "Forgot PIN?") as copper text links, a hairline, the quiet line for new clients, and the © / Privacy / Terms row. Forest is the only button fill; copper is text, numeral and outline, never a fill; red is gone from the surface, including `error.tsx`.

**What does not move.** The two-step state machine, `publicAuth.login`, the HTTP-status → i18n error map, the hydration guard, the rate-limit / retry-after handling, the `useSystemSound` and `navigator.vibrate` calls, every accessible name the tests select by, the "Portal Unlocked" / "Access Denied" overlays with their `role="status"` / `role="alert"` (restyled to paper / forest / copper), and `csp.test.ts`, which passes unchanged. The page now sets `data-product="my"` at mount exactly as `portal/(authenticated)/layout.tsx` does, so the product token seam covers sign-in too.

The palette is page-local (`--r19-*` on `.r19-gate`, three lines carrying `token-lint-ok` reasons) because the R19 token values are window W1's mandate and are not on `origin/main` yet — `grep forest apps/mouth/src/app/globals.css` returns nothing today. Repointing those six declarations at the tokens once W1 lands is one line each, recorded in the pack's leftovers.

**Bites:** the live `my.balizero.com/portal/login` sign-in page served by the apps/mouth Vercel deploy — `/portal/login` 308s onto this component. Observed before the merge on a local dev server of this branch: `GET /portal/login` → 200 at `/portal/login-upgraded`, rendering the split gate at 1440×900 and 390×844 on both steps (four screenshots under `/Users/balizero/Desktop/R19-PORTAL-RENDERS-20260912/build/r19p-w5/`), with `document.documentElement.dataset.product === "my"` read back from the loaded page. The second consumer ships in the same PR: the required check **Frontend Tests (Next.js) (mouth, true)** runs `page.test.tsx` + `csp.test.ts` — 16 tests, all green locally, same test-case count as `origin/main`.

Checks run in the worktree: `npx vitest --run src/app/portal/login-upgraded` 2 files / 16 tests passed · `tsc --noEmit` exit 0 · `eslint` 0 errors · `prettier --check` clean · `scripts/token_lint.py --base origin/main` clean.

Evidence: `evidence/2026-09/agent-air-m5-mouth-r19p-w5-3f095807/{brief,pack}.yml` (gear 2, `pii_scan: clean`, lint clean).

Gear 2 — this PR cannot merge until a fresh gate posts `harness/fable-gate` on the head sha. Auto-merge is armed at open per the ship sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



**Gear 3 (size floor, churn 1997 ≥ 1828).** Council on the final diff: Codex GPT-5.6-sol and Kimi K3, both `VERDICT: OK` (round 3; rounds 1–2 found the red mark and the stale prodlike locators, both fixed at depth 1). Transcripts and journal under `evidence/…/council/`.
