### PR TITLE
feat(mouth): dress the client dashboard in the R19 language (concept F)

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/_components/TimelineItem.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/_components/TimelineItem.test.tsx
@@ -12,39 +12,56 @@ const baseEntry: TimelineEntry = {
   description: "Something happened",
 };
 
-describe("TimelineItem (WS3 · GARUDA Day Edition)", () => {
-  it("maps message entries to the info state token", () => {
+describe("TimelineItem (SAETTA-R19P · concept-F spine)", () => {
+  it("gives team events a hollow slate dot", () => {
     const { container } = render(
       <TimelineItem entry={baseEntry} isLast={false} />,
     );
-    expect(container.innerHTML).toContain("var(--state-info)");
-    expect(container.innerHTML).not.toContain("neon-blue");
+    expect(container.innerHTML).toContain("border-[var(--state-info)]");
+    expect(container.innerHTML).toContain("bg-[var(--bz-base)]");
+    expect(container.innerHTML).not.toContain("crystal-stat-card");
   });
 
-  it("maps deadline entries to the danger state token", () => {
-    const entry: TimelineEntry = { ...baseEntry, id: "t2", type: "deadline" };
+  it("gives client uploads a filled copper dot", () => {
+    const entry: TimelineEntry = { ...baseEntry, id: "t2", type: "document" };
     const { container } = render(<TimelineItem entry={entry} isLast={false} />);
-    expect(container.innerHTML).toContain("var(--state-danger)");
-    expect(container.innerHTML).not.toContain("neon-rose");
+    expect(container.innerHTML).toContain("bg-[var(--bz-copper)]");
   });
 
-  it("maps future entries to the warning state token", () => {
+  it("gives a message the client sent a filled copper dot", () => {
     const entry: TimelineEntry = {
       ...baseEntry,
       id: "t3",
+      status: "client_to_team",
+    };
+    const { container } = render(<TimelineItem entry={entry} isLast={false} />);
+    expect(container.innerHTML).toContain("bg-[var(--bz-copper)]");
+  });
+
+  it("keeps deadlines on the spine without any danger fill", () => {
+    const entry: TimelineEntry = { ...baseEntry, id: "t4", type: "deadline" };
+    const { container } = render(<TimelineItem entry={entry} isLast={false} />);
+    expect(container.innerHTML).not.toContain("var(--state-danger)");
+    expect(screen.getByText("Test entry")).toBeInTheDocument();
+  });
+
+  it("marks a future entry with the word Upcoming, not a warning fill", () => {
+    const entry: TimelineEntry = {
+      ...baseEntry,
+      id: "t5",
       type: "document",
       isFuture: true,
       occurredAt: new Date(Date.now() + 5 * 86400000).toISOString(),
     };
     const { container } = render(<TimelineItem entry={entry} isLast={false} />);
-    expect(container.innerHTML).toContain("var(--state-warning)");
-    expect(container.innerHTML).not.toContain("neon-amber");
+    expect(screen.getByText(/Upcoming/)).toBeInTheDocument();
+    expect(container.innerHTML).not.toContain("var(--state-warning)");
   });
 
   it("reply link uses the daylight copper text step (AA small text)", () => {
     const entry: TimelineEntry = {
       ...baseEntry,
-      id: "t4",
+      id: "t6",
       type: "message",
       status: "team_to_client",
     };
@@ -52,17 +69,15 @@ describe("TimelineItem (WS3 · GARUDA Day Edition)", () => {
     const reply = screen.getByText("Reply").closest("button");
     expect(reply).not.toBeNull();
     expect(reply?.className).toContain("text-[var(--bz-copper-text)]");
-    // white hover is invisible on paper — must hover to theme text instead
     expect(reply?.className).not.toContain("hover:text-white");
     expect(reply?.className).toContain("hover:text-[var(--tx-pure)]");
   });
 
-  it("relative-date chips use state tokens, not dark-theme utilities", () => {
-    const today: TimelineEntry = { ...baseEntry, id: "t5" };
+  it("keeps the relative day as quiet text, not a coloured chip", () => {
+    const today: TimelineEntry = { ...baseEntry, id: "t7" };
     const { container } = render(<TimelineItem entry={today} isLast={false} />);
-    expect(screen.getByText("Today")).toBeInTheDocument();
-    expect(container.innerHTML).toContain("var(--state-success)");
-    expect(container.innerHTML).not.toContain("text-emerald-400");
+    expect(screen.getByText(/Today/)).toBeInTheDocument();
+    expect(container.innerHTML).not.toContain("var(--state-success)");
     expect(container.innerHTML).not.toContain("text-amber-400");
   });
 });

--- a/apps/mouth/src/app/portal/(authenticated)/_components/TimelineItem.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/_components/TimelineItem.tsx
@@ -4,23 +4,37 @@
  * TimelineItem — extracted from the portal home so the timeline section
  * can be dynamic-imported, trimming the portal home's initial bundle.
  *
- * WS3 (GARUDA Day Edition, 2026-07-24): day-theme token alignment —
- * semantic --state-* tokens (WS2 AA light overrides) instead of dark-theme
- * neon/utility colors; no hardcoded hexes or white-alpha tints.
+ * SAETTA-R19P W3 (2026-09-13): concept-F "RAPI" presentation pass. The card,
+ * the icon chip and the coloured relative-date pills are gone: each event is
+ * one entry on the page's hairline spine with a single 9px dot — copper and
+ * filled when the event came from the client (a document, a message they
+ * sent), hollow slate when it came from the team. Same props, same copy,
+ * same reply handler.
  */
 
 import React from "react";
-import {
-  Clock,
-  MessageCircle,
-  FileText,
-  Briefcase,
-  AlertTriangle,
-  ChevronRight,
-} from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { TimelineEntry } from "@/lib/api/types/timeline.types";
 import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
+
+/** Events the client themself produced: uploads and messages they sent. */
+function isClientEvent(entry: TimelineEntry): boolean {
+  if (entry.type === "document") return true;
+  return entry.type === "message" && entry.status === "client_to_team";
+}
+
+function relativeLabel(occurredAt: string): string | null {
+  const diff = Math.round(
+    (new Date(occurredAt).getTime() - Date.now()) / 86400000,
+  );
+  if (diff === 0) return "Today";
+  if (diff > 0) return `In ${diff}d`;
+  const abs = Math.abs(diff);
+  if (abs <= 7) return `${abs}d ago`;
+  if (abs <= 30) return `${Math.floor(abs / 7)}w ago`;
+  return null;
+}
 
 export function TimelineItem({
   entry,
@@ -34,168 +48,56 @@ export function TimelineItem({
     "isFuture" in entry
       ? Boolean((entry as unknown as { isFuture?: boolean }).isFuture)
       : false;
-
-  const getIcon = () => {
-    switch (entry.type) {
-      case "message":
-        return <MessageCircle className="w-4 h-4" />;
-      case "document":
-        return <FileText className="w-4 h-4" />;
-      case "practice":
-        return <Briefcase className="w-4 h-4" />;
-      case "deadline":
-        return <AlertTriangle className="w-4 h-4" />;
-      default:
-        return <Clock className="w-4 h-4" />;
-    }
-  };
-
-  const getBgColor = () => {
-    if (isFuture)
-      return "bg-[color-mix(in_srgb,var(--state-warning)_12%,transparent)] text-[var(--state-warning)]";
-    switch (entry.type) {
-      case "message":
-        return "bg-[color-mix(in_srgb,var(--state-info)_12%,transparent)] text-[var(--state-info)]";
-      case "deadline":
-        return "bg-[color-mix(in_srgb,var(--state-danger)_12%,transparent)] text-[var(--state-danger)]";
-      default:
-        return "text-[var(--tx-secondary)]";
-    }
-  };
-
-  const getDotStyle = (): React.CSSProperties => {
-    if (isFuture)
-      return {
-        background: "color-mix(in srgb, var(--state-warning) 10%, transparent)",
-        color: "var(--state-warning)",
-        borderColor: "var(--state-warning)",
-      };
-    switch (entry.type) {
-      case "message":
-        return {
-          background: "color-mix(in srgb, var(--state-info) 10%, transparent)",
-          color: "var(--state-info)",
-          borderColor: "var(--state-info)",
-        };
-      case "deadline":
-        return {
-          background:
-            "color-mix(in srgb, var(--state-danger) 10%, transparent)",
-          color: "var(--state-danger)",
-          borderColor: "var(--state-danger)",
-        };
-      default:
-        return {
-          background: "var(--glass-rim)",
-          color: "var(--tx-secondary)",
-          borderColor: "var(--bz-border-hover)",
-        };
-    }
-  };
+  const fromClient = isClientEvent(entry);
+  const relative = relativeLabel(entry.occurredAt);
 
   const _isLast = isLast; // retained for API compatibility
   void _isLast;
 
   return (
-    <div className="relative pl-6">
+    <div className={cn("relative", isLast ? "pb-0" : "pb-[18px]")}>
       <div
-        className="absolute -left-[9px] top-0 w-4 h-4 rounded-full flex items-center justify-center border-2 border-[var(--bz-base)] shadow-[0_0_10px_currentColor]"
-        style={getDotStyle()}
+        aria-hidden="true"
+        className={cn(
+          "absolute -left-[21px] top-[9px] h-[9px] w-[9px] rounded-full border-[1.5px]",
+          fromClient
+            ? "border-[var(--bz-copper)] bg-[var(--bz-copper)]"
+            : "border-[var(--state-info)] bg-[var(--bz-base)]",
+        )}
+      />
+
+      <div
+        className="text-[10px] font-semibold uppercase tracking-[0.12em] tabular-nums text-[var(--tx-secondary)]"
+        title={formatDate(entry.occurredAt, {
+          weekday: "long",
+          month: "long",
+          day: "numeric",
+          year: "numeric",
+        })}
       >
-        {/* Dot only */}
+        {formatDate(entry.occurredAt, { month: "short", day: "numeric" })}
+        {relative ? ` · ${relative}` : ""}
+        {isFuture && " · Upcoming"}
       </div>
 
-      <div
-        className="crystal-stat-card !border !p-4 !shadow-none"
-        style={{
-          ...(isFuture
-            ? {
-                background:
-                  "color-mix(in srgb, var(--state-warning) 3%, transparent)",
-              }
-            : {}),
-          borderColor: isFuture
-            ? "color-mix(in srgb, var(--state-warning) 25%, transparent)"
-            : "var(--glass-rim)",
-        }}
-      >
-        <div className="flex items-center gap-2 mb-2">
-          <div
-            className={cn(
-              "p-1.5 rounded-lg border border-[var(--bz-border)] bg-[var(--glass-rim)]",
-              getBgColor(),
-            )}
-          >
-            {getIcon()}
-          </div>
-          <span
-            className="text-[10px] font-bold uppercase tracking-widest text-[var(--tx-secondary)]"
-            title={formatDate(entry.occurredAt, {
-              weekday: "long",
-              month: "long",
-              day: "numeric",
-              year: "numeric",
-            })}
-          >
-            {formatDate(entry.occurredAt, {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-            })}
-            {isFuture && " (Upcoming)"}
-          </span>
-          {(() => {
-            const diff = Math.round(
-              (new Date(entry.occurredAt).getTime() - Date.now()) / 86400000,
-            );
-            if (diff === 0)
-              return (
-                <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[color-mix(in_srgb,var(--state-success)_12%,transparent)] text-[var(--state-success)] font-semibold">
-                  Today
-                </span>
-              );
-            if (diff > 0)
-              return (
-                <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[color-mix(in_srgb,var(--state-warning)_12%,transparent)] text-[var(--state-warning)] font-semibold">
-                  ⏰ In {diff}d
-                </span>
-              );
-            const abs = Math.abs(diff);
-            if (abs <= 7)
-              return (
-                <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--glass-rim)] text-[var(--bz-text-2)] font-semibold">
-                  {abs}d ago
-                </span>
-              );
-            if (abs <= 30)
-              return (
-                <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--glass-rim)] text-[var(--bz-text-2)] font-semibold">
-                  {Math.floor(abs / 7)}w ago
-                </span>
-              );
-            return null;
-          })()}
-        </div>
-
-        <h3 className="font-bold text-[var(--tx-pure)] text-sm">
-          {entry.title}
-        </h3>
-        <p className="text-xs mt-1.5 text-[var(--tx-secondary)] line-clamp-2">
+      <h3 className="font-semibold text-[var(--tx-pure)]">{entry.title}</h3>
+      {entry.description && (
+        <p className="text-[13px] text-[var(--tx-secondary)] line-clamp-2">
           {entry.description}
         </p>
+      )}
 
-        {entry.type === "message" && entry.status === "team_to_client" && (
-          <button
-            type="button"
-            onClick={() => {
-              window.location.href = "/portal/chat";
-            }}
-            className="mt-3 text-[10px] font-bold uppercase tracking-widest flex items-center text-[var(--bz-copper-text)] hover:text-[var(--tx-pure)] transition-colors cursor-pointer w-fit inline-flex"
-          >
-            Reply <ChevronRight className="w-3 h-3 ml-1" />
-          </button>
-        )}
-      </div>
+      {entry.type === "message" && entry.status === "team_to_client" && (
+        <button
+          type="button"
+          onClick={() => {
+            window.location.href = "/portal/chat";
+          }}
+          className="mt-1.5 inline-flex w-fit cursor-pointer items-center text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--bz-copper-text)] transition-colors hover:text-[var(--tx-pure)]"
+        >
+          Reply <ChevronRight className="w-3 h-3 ml-1" />
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/mouth/src/app/portal/(authenticated)/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/page.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import PortalHomePage from "./page";
@@ -145,7 +151,7 @@ describe("PortalHomePage", () => {
     renderWithQueryClient(<PortalHomePage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Welcome Back")).toBeInTheDocument();
+      expect(screen.getByText("Welcome back.")).toBeInTheDocument();
       expect(
         screen.getByText("Here is your Bali life overview."),
       ).toBeInTheDocument();
@@ -267,7 +273,7 @@ describe("PortalHomePage", () => {
     renderWithQueryClient(<PortalHomePage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Timeline")).toBeInTheDocument();
+      expect(screen.getByText("Recent activity")).toBeInTheDocument();
       expect(screen.getByText("Test Message")).toBeInTheDocument();
     });
   });
@@ -299,14 +305,7 @@ describe("PortalHomePage", () => {
       expect(screen.getByText("Immigration")).toBeInTheDocument();
     });
 
-    const visaCard = screen.getByText("Immigration").closest("div");
-    if (visaCard && visaCard.onclick) {
-      visaCard.click();
-    } else if (visaCard) {
-      // Simulate click event
-      const clickEvent = new MouseEvent("click", { bubbles: true });
-      visaCard.dispatchEvent(clickEvent);
-    }
+    fireEvent.click(screen.getByLabelText("Immigration status"));
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith("/portal/visa");
@@ -322,7 +321,7 @@ describe("PortalHomePage", () => {
     await waitFor(() => {
       // When dashboard API fails, error state is shown (not default cards)
       expect(screen.getByText("Unable to load dashboard")).toBeInTheDocument();
-      expect(screen.getByText("Welcome Back")).toBeInTheDocument();
+      expect(screen.getByText("Welcome back.")).toBeInTheDocument();
     });
   });
 
@@ -339,7 +338,7 @@ describe("PortalHomePage", () => {
     await waitFor(() => {
       const h1 = screen.getByRole("heading", {
         level: 1,
-        name: "Welcome Back",
+        name: "Welcome back.",
       });
       // Cormorant via the globally wired --font-serif token (inline style)
       expect(h1.style.fontFamily).toContain("--font-serif");
@@ -349,7 +348,7 @@ describe("PortalHomePage", () => {
     });
   });
 
-  it("status cards carry semantic state-token classes (AA on light)", async () => {
+  it("status columns carry the state as an outlined word, not a fill", async () => {
     mockGetDashboard.mockResolvedValue(
       createMockDashboard({
         visa: {
@@ -370,17 +369,22 @@ describe("PortalHomePage", () => {
     renderWithQueryClient(<PortalHomePage />);
 
     await waitFor(() => {
+      // R19: the card is a hairline column; the state is an outlined WORD
       const visaCard = screen.getByLabelText("Immigration status");
-      expect(visaCard.className).toContain("text-[var(--state-success)]");
-      expect(visaCard.className).not.toContain("neon-");
+      expect(within(visaCard).getByText("Active").className).toContain(
+        "text-[var(--state-success)]",
+      );
+      expect(visaCard.className).not.toContain("crystal-stat-card");
 
       const taxCard = screen.getByLabelText("Tax status");
-      expect(taxCard.className).toContain("text-[var(--state-warning)]");
-      expect(taxCard.className).not.toContain("neon-");
+      expect(within(taxCard).getByText("Needs you").className).toContain(
+        "text-[var(--bz-copper-text)]",
+      );
+      expect(taxCard.innerHTML).not.toContain("var(--state-danger)");
     });
   });
 
-  it("quick-stats chips use warning/info state tokens, not dark-theme utilities", async () => {
+  it("quick-stats chips are hairline pills with a copper icon, no state fill", async () => {
     mockGetDashboard.mockResolvedValue(
       createMockDashboard({
         documents: { total: 10, pending: 2 },
@@ -392,21 +396,24 @@ describe("PortalHomePage", () => {
     renderWithQueryClient(<PortalHomePage />);
 
     await waitFor(() => {
-      const docsChip = screen
-        .getByText(/2 documents pending/)
-        .closest("button");
-      expect(docsChip).not.toBeNull();
-      expect(docsChip?.getAttribute("style")).toContain("var(--state-warning)");
-      expect(docsChip?.innerHTML).not.toContain("text-amber-400");
+      const docsChip = screen.getByRole("button", {
+        name: /2 documents pending/,
+      });
+      expect(docsChip.className).toContain("rounded-full");
+      expect(docsChip.className).toContain("border-[var(--tx-tertiary)]");
+      expect(docsChip.getAttribute("style")).toBeNull();
+      expect(docsChip.innerHTML).toContain("text-[var(--bz-copper)]");
 
-      const msgsChip = screen.getByText(/3 unread messages/).closest("button");
-      expect(msgsChip).not.toBeNull();
-      expect(msgsChip?.getAttribute("style")).toContain("var(--state-info)");
-      expect(msgsChip?.innerHTML).not.toContain("text-blue-400");
+      const msgsChip = screen.getByRole("button", {
+        name: /3 unread messages/,
+      });
+      expect(msgsChip.className).toContain("rounded-full");
+      expect(msgsChip.getAttribute("style")).toBeNull();
+      expect(msgsChip.innerHTML).toContain("text-[var(--bz-copper)]");
     });
   });
 
-  it("action items map priorities to semantic state tokens", async () => {
+  it("action items carry the priority as a word in an outlined pill", async () => {
     mockGetDashboard.mockResolvedValue(
       createMockDashboard({
         documents: { total: 0, pending: 0 },
@@ -429,8 +436,50 @@ describe("PortalHomePage", () => {
     await waitFor(() => {
       const actionBtn = screen.getByText("Pay invoice").closest("button");
       expect(actionBtn).not.toBeNull();
-      expect(actionBtn?.className).toContain("text-[var(--state-danger)]");
-      expect(actionBtn?.className).not.toContain("neon-rose");
+      expect(actionBtn?.className).not.toContain("var(--state-danger)");
+      expect(
+        within(actionBtn as HTMLElement).getByText("Needs you").className,
+      ).toContain("text-[var(--bz-copper-text)]");
+    });
+  });
+  it("renders the leading matter as the next move and the rest as an index", async () => {
+    mockGetDashboard.mockResolvedValue(createEmptyDashboard());
+    mockGetTimeline.mockResolvedValue({ entries: [] });
+    mockGetDashboardSummary.mockResolvedValue({
+      open_actions: [
+        {
+          id: 142,
+          title: "Second Home Visa renewal",
+          type: "visa_e33",
+          pending_from_client: "bank statement, last three months",
+          status: "waiting_documents",
+        },
+        {
+          id: 98,
+          title: "LKPM Q3 report",
+          type: "lkpm",
+          pending_from_client: null,
+          status: "in_progress",
+        },
+      ],
+      upcoming_deadlines: [],
+      unread_messages: 0,
+    });
+
+    renderWithQueryClient(<PortalHomePage />);
+
+    expect(await screen.findByText(/Your next move/)).toBeInTheDocument();
+    expect(
+      screen.getByText("bank statement, last three months").className,
+    ).toContain("text-[var(--bz-copper-text)]");
+    // the second matter is a numbered index row, not a second card
+    const indexRow = screen.getByText("LKPM Q3 report").closest("button");
+    expect(indexRow).not.toBeNull();
+    expect(within(indexRow as HTMLElement).getByText("02")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open matter" }));
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/portal/matters/142");
     });
   });
 });

--- a/apps/mouth/src/app/portal/(authenticated)/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/page.tsx
@@ -5,19 +5,21 @@
  *
  * Usa React Query per caching e ottimizzazione
  *
- * WS3 (GARUDA Day Edition, 2026-07-24): day-theme token alignment.
- * State colors read the semantic --state-* tokens (WS2 AA light overrides),
- * copper accents read --bz-copper / --bz-copper-text (daylight steps armed
- * in globals.css [data-theme="operative-light"]). No hardcoded hexes.
+ * SAETTA-R19P W3 (2026-09-13): concept-F "RAPI" presentation pass. Same data
+ * flow, same seven sections in the same order — paper/hairline dressing:
+ * copper rule + serif masthead, one "next move" band + numbered matter index,
+ * three status columns in one frame, quiet chips, numbered actions whose
+ * priority is a WORD, and a hairline activity spine. Four colour meanings
+ * only: forest = done (--state-success), slate = ours (--state-info), copper =
+ * needs you (--bz-copper*), muted = waiting (--tx-secondary). No filled
+ * danger/warning rows anywhere on this page.
  */
 
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import {
-  CheckCircle2,
   AlertTriangle,
-  Clock,
   ChevronRight,
   FileText,
   MessageCircle,
@@ -38,7 +40,6 @@ import {
 import {
   PortalCardSkeleton,
   PortalEmptyState,
-  PortalPageLoader,
   PortalListSkeleton,
   PracticeRecapCard,
 } from "@/components/portal";
@@ -48,6 +49,113 @@ import type { TimelineEntry } from "@/lib/api/types/timeline.types";
 import type { DashboardSummary } from "@/lib/api/portal/portal.types";
 import { DeadlineBadge } from "@balizero/core";
 import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
+
+// ── R19 presentation primitives (page-local, nothing shared is restyled) ──
+const SERIF: React.CSSProperties = {
+  fontFamily: "var(--font-serif)",
+  fontWeight: 450,
+};
+const EYEBROW =
+  "text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--tx-secondary)]";
+const SECTION_H2 = "text-[24px] leading-[1.14] tracking-[-0.02em]";
+const HAIRLINE = "border border-[var(--bz-border)]";
+const CARD = `rounded-lg bg-[var(--bz-surface)] ${HAIRLINE}`;
+const FOCUS =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bz-copper)]";
+
+type PillTone = "ok" | "ours" | "you" | "wait";
+
+const PILL_TONE: Record<PillTone, string> = {
+  ok: "text-[var(--state-success)] border-[var(--state-success)]",
+  ours: "text-[var(--state-info)] border-[var(--state-info)]",
+  you: "text-[var(--bz-copper-text)] border-[var(--bz-copper)]",
+  wait: "text-[var(--tx-secondary)] border-[var(--bz-border-hover)]",
+};
+
+/** Outlined status pill — one vocabulary, four words, never a filled state. */
+function StatePill({ tone, label }: { tone: PillTone; label: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 items-center gap-[7px] whitespace-nowrap rounded-full border px-[10px] text-[10px] font-semibold uppercase tracking-[0.12em]",
+        PILL_TONE[tone],
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="h-1.5 w-1.5 rounded-full bg-current"
+      />
+      {label}
+    </span>
+  );
+}
+
+function Masthead() {
+  return (
+    <section>
+      <div
+        aria-hidden="true"
+        className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
+      />
+      <h1
+        className="text-[clamp(34px,3.4vw,44px)] leading-[1.06] tracking-[-0.03em] text-[var(--tx-pure)]"
+        style={SERIF}
+      >
+        Welcome back.
+      </h1>
+      <p className="mt-2 text-[var(--tx-secondary)]">
+        Here is your Bali life overview.
+      </p>
+    </section>
+  );
+}
+
+function SectionHead({
+  title,
+  linkLabel,
+  href,
+}: {
+  title: string;
+  linkLabel: string;
+  href: string;
+}) {
+  return (
+    <div className="mb-3.5 flex items-baseline justify-between gap-4">
+      <h2 className={cn(SECTION_H2, "text-[var(--tx-pure)]")} style={SERIF}>
+        {title}
+      </h2>
+      <a
+        href={href}
+        className="text-xs font-semibold text-[var(--bz-copper-text)] hover:text-[var(--tx-pure)] transition-colors"
+      >
+        {linkLabel}
+      </a>
+    </div>
+  );
+}
+
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+/** practice status codes (inquiry / in_progress / waiting_documents) as words */
+function matterState(status: string | null, pending: string | null) {
+  if (pending || status === "waiting_documents")
+    return {
+      tone: "you" as PillTone,
+      label: "Needs you",
+      sentence: "Waiting for documents from you.",
+    };
+  if (status === "in_progress")
+    return {
+      tone: "ours" as PillTone,
+      label: "In progress",
+      sentence: "In progress with your team.",
+    };
+  return {
+    tone: "wait" as PillTone,
+    label: "Pending",
+    sentence: "Open with your team.",
+  };
+}
 
 function getStatusCode(error: unknown): number | undefined {
   if (!error || typeof error !== "object") return undefined;
@@ -94,21 +202,7 @@ export default function PortalHomePage() {
   if (clientConnectionMissing) {
     return (
       <div className="space-y-6 animate-in fade-in duration-500">
-        <section>
-          <div
-            aria-hidden="true"
-            className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
-          />
-          <h1
-            className="text-2xl font-semibold tracking-tight text-[var(--foreground)]"
-            style={{ fontFamily: "var(--font-serif)" }}
-          >
-            Welcome Back
-          </h1>
-          <p className="text-[var(--foreground-muted)]">
-            Here is your Bali life overview.
-          </p>
-        </section>
+        <Masthead />
 
         <PortalEmptyState
           icon={UserRoundX}
@@ -159,21 +253,7 @@ export default function PortalHomePage() {
   if (unexpectedError) {
     return (
       <div className="space-y-6">
-        <section>
-          <div
-            aria-hidden="true"
-            className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
-          />
-          <h1
-            className="text-2xl font-semibold tracking-tight text-[var(--foreground)]"
-            style={{ fontFamily: "var(--font-serif)" }}
-          >
-            Welcome Back
-          </h1>
-          <p className="text-[var(--foreground-muted)]">
-            Here is your Bali life overview.
-          </p>
-        </section>
+        <Masthead />
 
         <Alert variant="destructive">
           <AlertTriangle className="h-4 w-4" />
@@ -216,36 +296,26 @@ export default function PortalHomePage() {
   };
 
   return (
-    <div className="space-y-8 animate-in fade-in duration-500">
-      {/* Welcome Section — Day masthead (GARUDA Day Edition): copper rule +
-          Cormorant serif headline per concept (--font-serif, wired on <html>);
-          Inter everywhere else. */}
-      <section>
-        <div
-          aria-hidden="true"
-          className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
-        />
-        <h1
-          className="text-3xl font-semibold tracking-tight text-[var(--tx-pure)]"
-          style={{ fontFamily: "var(--font-serif)" }}
-        >
-          Welcome Back
-        </h1>
-        <p className="text-[var(--tx-secondary)] mt-1">
-          Here is your Bali life overview.
-        </p>
-      </section>
+    <div className="space-y-9 animate-in fade-in duration-500">
+      {/* 1 · masthead — copper rule + serif headline + the existing subtitle */}
+      <Masthead />
 
-      {/* V2 Matter-First Hero Cards */}
+      {/* 2 · matters: one next move + the numbered index of the others */}
       <HeroCards
         summary={summary}
         onOpenMatter={(id) => router.push(`/portal/matters/${id}`)}
       />
 
+      {/* 3 · the team's recap sentence */}
       <PracticeRecapCard recap={summary?.recap} />
 
-      {/* Status Cards (Traffic Lights) */}
-      <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {/* 4 · three status columns inside one hairline frame */}
+      <section
+        className={cn(
+          CARD,
+          "grid grid-cols-1 divide-y divide-[var(--bz-border)] overflow-hidden md:grid-cols-3 md:divide-x md:divide-y-0",
+        )}
+      >
         <StatusCard
           title="Immigration"
           aria-label="Immigration status"
@@ -284,29 +354,24 @@ export default function PortalHomePage() {
         />
       </section>
 
-      {/* Quick Stats Bar */}
+      {/* 5 · quick stats — two quiet chips, same conditions and handlers */}
       {(defaultDashboard.documents.pending > 0 ||
         defaultDashboard.messages.unread > 0) && (
-        <section className="flex flex-wrap gap-3">
+        <section className="flex flex-wrap gap-2.5">
           {defaultDashboard.documents.pending > 0 && (
             <button
               type="button"
               onClick={() => {
                 window.location.href = "/portal/process";
               }}
-              className="flex items-center gap-2 px-4 py-2.5 rounded-lg border cursor-pointer transition-all hover:scale-[1.01]"
-              style={{
-                background:
-                  "color-mix(in srgb, var(--state-warning) 7%, transparent)",
-                borderColor:
-                  "color-mix(in srgb, var(--state-warning) 25%, transparent)",
-              }}
+              className={cn(
+                "flex h-10 items-center gap-2 rounded-full border border-[var(--tx-tertiary)] px-4 text-[13px] font-semibold text-[var(--tx-primary)] transition-colors hover:bg-[var(--bz-surface)]",
+                FOCUS,
+              )}
             >
-              <FileText className="w-4 h-4 text-[var(--state-warning)]" />
-              <span className="text-sm font-medium text-[var(--state-warning)]">
-                {defaultDashboard.documents.pending} document
-                {defaultDashboard.documents.pending !== 1 ? "s" : ""} pending
-              </span>
+              <FileText className="h-4 w-4 text-[var(--bz-copper)]" />
+              {defaultDashboard.documents.pending} document
+              {defaultDashboard.documents.pending !== 1 ? "s" : ""} pending
             </button>
           )}
           {defaultDashboard.messages.unread > 0 && (
@@ -315,69 +380,87 @@ export default function PortalHomePage() {
               onClick={() => {
                 window.location.href = "/portal/messages";
               }}
-              className="flex items-center gap-2 px-4 py-2.5 rounded-lg border cursor-pointer transition-all hover:scale-[1.01]"
-              style={{
-                background:
-                  "color-mix(in srgb, var(--state-info) 7%, transparent)",
-                borderColor:
-                  "color-mix(in srgb, var(--state-info) 25%, transparent)",
-              }}
+              className={cn(
+                "flex h-10 items-center gap-2 rounded-full border border-[var(--tx-tertiary)] px-4 text-[13px] font-semibold text-[var(--tx-primary)] transition-colors hover:bg-[var(--bz-surface)]",
+                FOCUS,
+              )}
             >
-              <MessageCircle className="w-4 h-4 text-[var(--state-info)]" />
-              <span className="text-sm font-medium text-[var(--state-info)]">
-                {defaultDashboard.messages.unread} unread message
-                {defaultDashboard.messages.unread !== 1 ? "s" : ""}
-              </span>
+              <MessageCircle className="h-4 w-4 text-[var(--bz-copper)]" />
+              {defaultDashboard.messages.unread} unread message
+              {defaultDashboard.messages.unread !== 1 ? "s" : ""}
             </button>
           )}
         </section>
       )}
 
-      {/* Action Items */}
+      {/* 6 · action required — numbered, priority is a word, never a fill */}
       {defaultDashboard.actions.length > 0 && (
-        <section className="space-y-3">
-          <h2
-            className="text-lg font-semibold"
-            style={{ color: "var(--bz-text-1)" }}
-          >
-            Action Required
-          </h2>
-          <div className="space-y-2">
-            {defaultDashboard.actions.map((action) => (
-              <button
-                key={action.id}
-                type="button"
-                onClick={() => {
-                  window.location.href = action.href;
-                }}
-                className={cn(
-                  "flex items-center justify-between p-4 rounded-lg border cursor-pointer transition-all hover:scale-[1.01] w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bz-accent-warm)]",
-                  action.priority === "high"
-                    ? "bg-[color-mix(in_srgb,var(--state-danger)_8%,transparent)] border-[color-mix(in_srgb,var(--state-danger)_25%,transparent)] text-[var(--state-danger)]"
-                    : action.priority === "medium"
-                      ? "bg-[color-mix(in_srgb,var(--state-warning)_8%,transparent)] border-[color-mix(in_srgb,var(--state-warning)_25%,transparent)] text-[var(--state-warning)]"
-                      : "bg-[color-mix(in_srgb,var(--state-info)_8%,transparent)] border-[color-mix(in_srgb,var(--state-info)_25%,transparent)] text-[var(--state-info)]",
-                )}
-              >
-                <div>
-                  <h3 className="font-medium">{action.title}</h3>
-                  <p className="text-sm opacity-80">{action.description}</p>
-                </div>
-                <ChevronRight className="w-5 h-5" />
-              </button>
-            ))}
-          </div>
+        <section>
+          <SectionHead
+            title="Action required"
+            linkLabel="All processes"
+            href="/portal/process"
+          />
+          <ol className="flex flex-col gap-2">
+            {defaultDashboard.actions.map((action, i) => {
+              const priority =
+                action.priority === "high"
+                  ? { tone: "you" as PillTone, label: "Needs you" }
+                  : action.priority === "medium"
+                    ? { tone: "ours" as PillTone, label: "Soon" }
+                    : { tone: "wait" as PillTone, label: "Pending" };
+              return (
+                <li key={action.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      window.location.href = action.href;
+                    }}
+                    className={cn(
+                      CARD,
+                      "grid w-full grid-cols-[30px_1fr] items-center gap-3 px-4 py-3.5 text-left transition-colors hover:border-[var(--bz-border-hover)] md:grid-cols-[36px_1fr_auto] md:gap-4 md:px-5 md:py-4",
+                      FOCUS,
+                    )}
+                  >
+                    <span
+                      className="text-[22px] leading-none tabular-nums text-[var(--bz-copper-text)]"
+                      style={SERIF}
+                    >
+                      {pad2(i + 1)}
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block font-semibold text-[var(--tx-pure)]">
+                        {action.title}
+                      </span>
+                      <span className="block text-[13px] text-[var(--tx-secondary)]">
+                        {action.description}
+                      </span>
+                    </span>
+                    <span className="col-start-2 flex items-center justify-between gap-3.5 md:col-start-3 md:justify-end">
+                      <StatePill tone={priority.tone} label={priority.label} />
+                      <ChevronRight className="h-4 w-4 text-[var(--tx-secondary)]" />
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
         </section>
       )}
 
-      {/* The Timeline */}
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold flex items-center gap-2 text-[var(--tx-primary)] mb-6">
-          <Clock className="w-5 h-5 text-[var(--bz-copper)]" />
-          Timeline
-        </h2>
+      {/* 7 · recent activity — hairline spine, one dot per event */}
+      <section>
+        <SectionHead
+          title="Recent activity"
+          linkLabel="Vault"
+          href="/portal/vault"
+        />
 
-        <div className="relative border-l-2 ml-3 space-y-8 pb-10 border-[var(--glass-rim)]">
+        <div className="relative pl-[22px]">
+          <div
+            aria-hidden="true"
+            className="absolute left-[5px] top-[6px] bottom-[6px] w-px bg-[var(--bz-border-hover)]"
+          />
           {visibleTimeline.map((entry: TimelineEntry, index: number) => (
             <TimelineItem
               key={entry.id}
@@ -387,10 +470,7 @@ export default function PortalHomePage() {
           ))}
 
           {timeline.length === 0 && (
-            <div
-              className="pl-6 py-4 italic"
-              style={{ color: "var(--bz-text-2)" }}
-            >
+            <div className="py-2 text-[var(--tx-secondary)]">
               No activity yet. Your journey starts here.
             </div>
           )}
@@ -398,13 +478,12 @@ export default function PortalHomePage() {
 
         {!showAllTimeline && timeline.length > TIMELINE_PREVIEW_COUNT && (
           <button
+            type="button"
             onClick={() => setShowAllTimeline(true)}
-            className="w-full text-center text-xs py-2 rounded-lg transition-opacity hover:opacity-80"
-            style={{
-              color: "var(--bz-copper-text)",
-              background:
-                "color-mix(in srgb, var(--bz-copper) 8%, transparent)",
-            }}
+            className={cn(
+              "mt-2 text-xs font-semibold text-[var(--bz-copper-text)] transition-colors hover:text-[var(--tx-pure)]",
+              FOCUS,
+            )}
           >
             Show {timeline.length - TIMELINE_PREVIEW_COUNT} more events
           </button>
@@ -448,40 +527,30 @@ function StatusCard({
   "aria-label"?: string;
 }) {
   const { formatDate } = usePortalDateFormat();
-  // Semantic state tokens: WS2 light overrides keep these ≥4.5:1 on paper
-  // (success 4.80, warning 4.78, danger 5.74, info 5.94 — see semantic.css).
-  const getStatusStyle = (s: string) => {
+
+  // One vocabulary for the whole portal: four words, four meanings, no fill.
+  const getState = (s: string): { tone: PillTone; label: string } => {
     switch (s) {
       case "active":
-        return "bg-[color-mix(in_srgb,var(--state-success)_6%,transparent)] text-[var(--state-success)] border-[color-mix(in_srgb,var(--state-success)_25%,transparent)]";
+        return { tone: "ok", label: "Active" };
       case "warning":
       case "attention":
-        return "bg-[color-mix(in_srgb,var(--state-warning)_6%,transparent)] text-[var(--state-warning)] border-[color-mix(in_srgb,var(--state-warning)_25%,transparent)]";
+        return { tone: "you", label: "Needs you" };
       case "expired":
+        return { tone: "you", label: "Expired" };
       case "overdue":
-        return "bg-[color-mix(in_srgb,var(--state-danger)_6%,transparent)] text-[var(--state-danger)] border-[color-mix(in_srgb,var(--state-danger)_25%,transparent)]";
+        return { tone: "you", label: "Overdue" };
+      case "pending":
+      case "upcoming":
+        return { tone: "ours", label: "In progress" };
       default:
-        return "bg-[var(--glass-rim)] text-[var(--tx-secondary)] border-[var(--glass-rim)]";
+        return { tone: "wait", label: "Nothing tracked" };
     }
   };
+  const state = getState(status);
 
-  const getIcon = (s: string) => {
-    switch (s) {
-      case "active":
-        return <CheckCircle2 className="w-5 h-5" />;
-      case "warning":
-      case "attention":
-      case "expired":
-      case "overdue":
-        return <AlertTriangle className="w-5 h-5" />;
-      default:
-        return <Clock className="w-5 h-5" />;
-    }
-  };
-
-  // Expiry tiers consolidated 4→3 for AA on the day theme (WS3): the old
-  // 31–90d tier used yellow-300 (1.17:1 on paper — unreadable); it now
-  // shares the warning step with the ≤30d tier.
+  // Expiry tiers consolidated 4→3 for AA on the day theme (WS3); the copper
+  // step carries every "needs you" case — no red on this surface.
   const getExpiryInfo = () => {
     if (!expiry) return { text: subLabel || "", color: "" };
     const formatted = formatDate(expiry, {
@@ -493,20 +562,20 @@ function StatusCard({
       if (daysRemaining < 0)
         return {
           text: `Expired ${Math.abs(daysRemaining)}d ago`,
-          color: "text-[var(--state-danger)]",
+          color: "text-[var(--bz-copper-text)]",
         };
       if (daysRemaining === 0)
-        return { text: "Expires today", color: "text-[var(--state-danger)]" };
+        return {
+          text: "Expires today",
+          color: "text-[var(--bz-copper-text)]",
+        };
       if (daysRemaining <= 90)
         return {
-          text: `⏰ ${daysRemaining}d left`,
-          color: "text-[var(--state-warning)]",
+          text: `${daysRemaining}d left`,
+          color: "text-[var(--bz-copper-text)]",
         };
     }
-    return {
-      text: `Expires: ${formatted}`,
-      color: "text-[var(--state-success)]",
-    };
+    return { text: `Expires ${formatted}`, color: "" };
   };
   const expiryInfo = getExpiryInfo();
 
@@ -516,22 +585,20 @@ function StatusCard({
       onClick={onClick}
       aria-label={ariaLabel}
       className={cn(
-        "crystal-stat-card cursor-pointer !flex !flex-col border transition-all duration-200 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bz-accent-warm)]",
-        getStatusStyle(status),
+        "flex min-h-[150px] cursor-pointer flex-col items-start gap-1.5 px-5 py-5 text-left transition-colors hover:bg-[var(--bz-base)] md:px-6",
+        FOCUS,
       )}
     >
-      <div className="flex justify-between items-start mb-2">
-        <span className="text-[10px] font-bold uppercase tracking-widest text-[var(--tx-secondary)]">
-          {title}
-        </span>
-        {getIcon(status)}
-      </div>
-      <div className="font-bold text-2xl font-mono text-[var(--tx-pure)] leading-tight truncate">
+      <span className={EYEBROW}>{title}</span>
+      <span
+        className="mt-1 max-w-full truncate text-[24px] leading-[1.14] tracking-[-0.02em] text-[var(--tx-pure)]"
+        style={SERIF}
+      >
         {label}
-      </div>
-      <div
+      </span>
+      <span
         className={cn(
-          "text-[10px] uppercase font-bold tracking-widest mt-2",
+          "text-[13px] tabular-nums text-[var(--tx-secondary)]",
           expiryInfo.color,
         )}
         title={
@@ -545,13 +612,16 @@ function StatusCard({
         }
       >
         {expiryInfo.text}
-      </div>
+      </span>
+      <span className="mt-auto pt-3">
+        <StatePill tone={state.tone} label={state.label} />
+      </span>
     </button>
   );
 }
 
 // ============================================================================
-// V2 Matter-First Hero Cards
+// V2 Matter-First Hero Cards — next move + numbered index
 // ============================================================================
 
 function HeroCards({
@@ -570,96 +640,172 @@ function HeroCards({
 
   if (empty) {
     return (
-      <section className="crystal-stat-card !flex !flex-col items-center justify-center p-8 text-center">
-        <CheckCircle2 className="w-10 h-10 text-[var(--state-success)] mb-3" />
-        <h2 className="text-xl font-bold text-[var(--tx-pure)]">
+      <section
+        className={cn(CARD, "px-6 py-8 text-center")}
+        aria-label="Your matters"
+      >
+        <h2
+          className={cn(SECTION_H2, "text-[var(--state-success)]")}
+          style={SERIF}
+        >
           All caught up
         </h2>
-        <p className="text-sm text-[var(--tx-secondary)] mt-1">
+        <p className="mt-1.5 text-sm text-[var(--tx-secondary)]">
           No open actions, no deadlines in the next 30 days.
         </p>
       </section>
     );
   }
 
+  const total = summary.open_actions.length;
+  const [lead, ...rest] = summary.open_actions;
+
   return (
-    <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <article className="crystal-stat-card !flex !flex-col p-5 min-h-[180px]">
-        <h2 className="text-[10px] font-bold uppercase tracking-widest text-[var(--tx-secondary)] mb-3">
-          Open Actions
-        </h2>
-        {summary.open_actions.length === 0 ? (
-          <p className="text-sm text-[var(--tx-secondary)] italic">
-            None pending
-          </p>
-        ) : (
-          <ul className="space-y-2">
-            {summary.open_actions.slice(0, 5).map((a) => (
+    <section className="space-y-5" aria-label="Your matters">
+      {lead && (
+        <article
+          className={cn(
+            CARD,
+            "grid gap-6 p-6 shadow-[0_10px_30px_rgba(29,44,59,0.045)] md:grid-cols-[1fr_auto] md:items-end md:p-7",
+          )}
+        >
+          <div>
+            <p className={EYEBROW}>
+              Your next move · matter{" "}
+              <span className="tabular-nums">{pad2(1)}</span> of{" "}
+              <span className="tabular-nums">{pad2(total)}</span>
+            </p>
+            <h2
+              className="mt-2.5 max-w-[26ch] text-[26px] leading-[1.12] tracking-[-0.02em] text-[var(--tx-pure)] md:text-[30px]"
+              style={SERIF}
+            >
+              {lead.title}
+            </h2>
+            <p className="mt-2.5 max-w-[56ch] text-[var(--tx-secondary)]">
+              {matterState(lead.status, lead.pending_from_client).sentence}
+              {lead.pending_from_client ? (
+                <>
+                  {" "}
+                  Still needed from you:{" "}
+                  <b className="font-semibold text-[var(--bz-copper-text)]">
+                    {lead.pending_from_client}
+                  </b>
+                  .
+                </>
+              ) : null}
+            </p>
+            <p className="mt-3.5 flex flex-wrap gap-x-[18px] gap-y-2 text-xs text-[var(--tx-secondary)]">
+              <span>
+                Ref{" "}
+                <b className="font-semibold tabular-nums text-[var(--tx-pure)]">
+                  {lead.id}
+                </b>
+              </span>
+              {lead.type && (
+                <span>
+                  Type{" "}
+                  <b className="font-semibold text-[var(--tx-pure)]">
+                    {lead.type.replace(/[_-]+/g, " ")}
+                  </b>
+                </span>
+              )}
+            </p>
+          </div>
+          <Button
+            onClick={() => onOpenMatter(lead.id)}
+            className="h-12 rounded px-[22px] text-[13px] font-semibold tracking-[0.02em] bg-[var(--state-success)] text-white hover:bg-[var(--state-success)]/90 md:min-w-[180px]"
+          >
+            Open matter
+          </Button>
+        </article>
+      )}
+
+      {rest.length > 0 && (
+        <ol className="border-t border-[var(--bz-border)]">
+          {rest.map((a, i) => {
+            const state = matterState(a.status, a.pending_from_client);
+            return (
               <li key={a.id}>
                 <button
                   type="button"
                   onClick={() => onOpenMatter(a.id)}
-                  className="text-left text-sm text-[var(--tx-primary)] hover:text-[var(--bz-copper-text)] transition-colors w-full truncate"
+                  className={cn(
+                    "grid w-full grid-cols-[36px_1fr] items-center gap-3 border-b border-[var(--bz-border)] py-4 text-left md:grid-cols-[44px_1fr_auto] md:gap-4",
+                    FOCUS,
+                  )}
                 >
-                  {a.title}
+                  <span
+                    className="text-[26px] leading-none tabular-nums text-[var(--bz-copper-text)]"
+                    style={SERIF}
+                  >
+                    {pad2(i + 2)}
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block truncate font-semibold text-[var(--tx-pure)]">
+                      {a.title}
+                    </span>
+                    <span className="block truncate text-[13px] text-[var(--tx-secondary)]">
+                      {a.pending_from_client || state.sentence}
+                    </span>
+                  </span>
+                  <span className="col-start-2 flex items-center justify-between gap-3.5 md:col-start-3 md:justify-end">
+                    <StatePill tone={state.tone} label={state.label} />
+                    <ChevronRight className="h-4 w-4 text-[var(--tx-secondary)]" />
+                  </span>
                 </button>
               </li>
-            ))}
-          </ul>
-        )}
-      </article>
+            );
+          })}
+        </ol>
+      )}
 
-      <article className="crystal-stat-card !flex !flex-col p-5 min-h-[180px]">
-        <h2 className="text-[10px] font-bold uppercase tracking-widest text-[var(--tx-secondary)] mb-3">
-          Deadlines · Next 30 days
-        </h2>
-        {summary.upcoming_deadlines.length === 0 ? (
-          <p className="text-sm text-[var(--tx-secondary)] italic">
-            No upcoming deadlines
-          </p>
-        ) : (
-          <ul className="flex flex-col gap-2">
-            {summary.upcoming_deadlines.slice(0, 5).map((d) => (
-              <li key={d.id} className="flex items-center gap-2 text-sm">
-                {d.due_date && <DeadlineBadge date={new Date(d.due_date)} />}
-                <span className="text-[var(--tx-primary)] truncate">
-                  {d.label}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <span className={EYEBROW}>Deadlines · next 30 days</span>
         <a
           href="/api/portal/deadlines/ical"
           download
-          className="mt-auto text-[10px] uppercase tracking-widest font-bold text-[var(--bz-copper-text)] hover:text-[var(--tx-pure)] transition-colors"
+          className="text-xs font-semibold text-[var(--bz-copper-text)] hover:text-[var(--tx-pure)] transition-colors"
         >
-          Export iCal →
+          Export iCal
         </a>
-      </article>
+      </div>
+      {summary.upcoming_deadlines.length === 0 ? (
+        <p className="text-[13px] text-[var(--tx-secondary)]">
+          No upcoming deadlines.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {summary.upcoming_deadlines.slice(0, 5).map((d) => (
+            <li key={d.id} className="flex items-center gap-2.5 text-[13px]">
+              {d.due_date && <DeadlineBadge date={new Date(d.due_date)} />}
+              <span className="truncate text-[var(--tx-primary)]">
+                {d.label}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
 
-      <article className="crystal-stat-card !flex !flex-col p-5 min-h-[180px]">
-        <h2 className="text-[10px] font-bold uppercase tracking-widest text-[var(--tx-secondary)] mb-3">
-          Team Messages
-        </h2>
-        <div className="flex-1 flex flex-col items-center justify-center">
-          <span className="text-4xl font-bold text-[var(--tx-pure)]">
-            {summary.unread_messages}
-          </span>
-          <span className="text-xs text-[var(--tx-secondary)] mt-1">
-            unread
-          </span>
-        </div>
+      {(summary.unread_messages ?? 0) > 0 && (
         <button
           type="button"
           onClick={() => {
             window.location.href = "/portal/messages";
           }}
-          className="mt-auto text-[10px] uppercase tracking-widest font-bold text-[var(--bz-copper-text)] hover:text-[var(--tx-pure)] transition-colors self-start"
+          className={cn(
+            "flex w-full items-center justify-between gap-4 border-t border-[var(--bz-border)] pt-4 text-left text-[13px] text-[var(--tx-secondary)]",
+            FOCUS,
+          )}
         >
-          Open →
+          <span>
+            <b className="font-semibold tabular-nums text-[var(--tx-pure)]">
+              {summary.unread_messages}
+            </b>{" "}
+            unread from your team
+          </span>
+          <ChevronRight className="h-4 w-4" />
         </button>
-      </article>
+      )}
     </section>
   );
 }

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w3-5bf0fbaa/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w3-5bf0fbaa/brief.yml
@@ -1,0 +1,36 @@
+gear: 2
+ruling: RULED 2026-09-12 SAETTA
+mission: SAETTA-R19P W3 (BLUE) — the client dashboard /portal in the concept-F "RAPI" language
+objective: >-
+  apps/mouth/src/app/portal/(authenticated)/page.tsx keeps its data flow (the three
+  portal hooks, summary, defaultDashboard, the router pushes, the lazy TimelineItem,
+  PracticeRecapCard) and its seven sections in the same order, but every section renders
+  as in concept-F's 02-home.html: copper rule + serif masthead, ONE "Your next move" card
+  for the leading matter plus a numbered index of the others, the three StatusCards as
+  three columns inside one hairline frame, the quick-stats bar as two quiet pill chips,
+  Action Required as numbered rows whose priority is a WORD in an outlined pill, and the
+  activity list on a hairline spine with a 9px dot — copper filled for the client's own
+  events, hollow slate for the team's. No filled danger/warning/info row survives.
+scope:
+  - apps/mouth/src/app/portal/(authenticated)/page.tsx
+  - apps/mouth/src/app/portal/(authenticated)/_components/TimelineItem.tsx
+  - apps/mouth/src/app/portal/(authenticated)/page.test.tsx
+  - apps/mouth/src/app/portal/(authenticated)/_components/TimelineItem.test.tsx
+constraints:
+  - PRESENTATION ONLY — no route, field, hook, fetch, API type or i18n key added or removed; class names, inline styles, markup order inside a section, copy.
+  - A mock detail that would need data the page does not already have is DROPPED and recorded as a leftover, never invented.
+  - Shared components (@balizero/core, components/ui/*, AppSidebar, PracticeRecapCard, StatusBadge) are other windows' property — not touched, not restyled globally.
+  - No red hex, no --state-danger fill, no client PII (synthetic names only), no vendor name in a code comment.
+  - No ledger PR, no PENDING-ARMS.md edit (SAETTA rule 2). One PR, branch agent/air-m5/mouth/r19p-w3.
+acceptance:
+  - A1 the diff is the page, the timeline item and their two sibling tests; no new data hook; the hook-call count in page.tsx is unchanged vs origin/main.
+  - A2 every router.push / window.location.href target present on origin/main is still present.
+  - A3 no bg-[color-mix(in_srgb,var(--state-danger) remains; no red hex; grep -c crystal-stat-card = 0 in both source files.
+  - A4 vitest green on both sibling test files; tsc --noEmit green; eslint 0 errors on the four files.
+  - A5 a route-intercepted screenshot of /portal at 1440 and 390 under build/r19p-w3/, else "not rendered".
+consumer_map:
+  - The live my.balizero.com /portal dashboard served by the apps/mouth Vercel deploy on merge to main — the client's first screen after sign-in.
+  - The required GitHub check "Frontend Tests (Next.js) (mouth, true)", which runs both rewritten sibling suites on every future PR touching them.
+appetite:
+  budget: 75 minutes active, 1 PR
+  stop_loss: three reds on the same cause suspends; a harness-caused red is reported, never cured by rebuilding the branch

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w3-5bf0fbaa/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w3-5bf0fbaa/pack.yml
@@ -1,0 +1,159 @@
+gear: 2
+brief_ref: evidence/2026-09/agent-air-m5-mouth-r19p-w3-5bf0fbaa/brief.yml
+ruling: RULED 2026-09-12 SAETTA
+lanes:
+  - lane: R19P-W3
+    role: build
+    seat: Claude Opus 5 (1M) — Dux of window r19p-w3, implements directly
+  - lane: R19P-W3-review
+    role: review
+    seat: none available — the codex MCP server (plugin:second-opinion:codex) failed to connect this session (CONNECTION_CLOSED); the adversarial pass was run by this seat against the data contract instead, and every disagreement is recorded under dissent.
+pii_scan: clean
+notes_on_pii: >-
+  Every name, company, reference and figure in the code, the tests and the two screenshots is
+  synthetic (Alex Nusantara, PT Contoh Nusantara, Second Home Visa renewal, BZ-INV-2026-00255,
+  ref 142/98/77). No client record was read, and the local render was fed by Playwright route
+  interception, never by a real portal API.
+decisions:
+  - id: D1
+    decision: >-
+      The mock's "Deadline · Progress · Ref" meta row is rendered as "Ref" + "Type" only.
+      DashboardSummaryAction carries exactly {id, title, type, pending_from_client, status}
+      (apps/mouth/src/lib/api/portal/portal.types.ts:575-581, built by
+      apps/backend-rag/backend/app/routers/portal_dashboard.py::_fetch_open_actions) — there is no
+      progress, no per-matter deadline and no client reference on this payload. Pairing the
+      account-level upcoming_deadlines with the leading matter would have invented an association,
+      so the two absent fields were dropped, per the mission's drop-and-record rule.
+  - id: D2
+    decision: >-
+      The outlined "Open matter" sibling "Upload document" button is omitted: the dashboard has no
+      upload route or handler in scope, and adding one would be a behavioural change.
+  - id: D3
+    decision: >-
+      The status pills are a page-local StatePill (four tones: ok / ours / you / wait) rather than
+      the shared StatusBadge. StatusBadge belongs to window W2 and is being rewritten in parallel;
+      importing it here would couple this PR to another window's in-flight variant map. The pill is
+      the concept's vocabulary expressed with existing tokens only — no new token, no shared file.
+  - id: D4
+    decision: >-
+      The masthead reads "Welcome back." without a first name. The page has no user name in scope,
+      and the only way to get one is a profile hook the acceptance forbids (A1, no new data hook).
+      Recorded as a leftover for the window that owns the header.
+  - id: D5
+    decision: >-
+      The deadlines list, its "Export iCal" link and the unread-messages count — the other two V2
+      hero cards — survive as two quiet hairline blocks under the matter index instead of being
+      deleted. The concept only prescribes what the hero BECOMES; deleting the iCal consumer and the
+      summary.unread_messages read would have been a behavioural change, not a restyle.
+  - id: D6
+    decision: >-
+      The serif is applied with an inline style ({fontFamily: "var(--font-serif)", fontWeight: 450})
+      and not the Tailwind class font-[var(--font-serif)]: under Tailwind v4 a bare arbitrary
+      font-[...] is ambiguous between family and weight, and the inline form is the shape the
+      existing masthead test already asserts.
+receipts:
+  - claim: The worktree is the broker's, on the branch the broker named; the main checkout was never written.
+    cmd: python3 scripts/agent_start.py --lane mouth --task-id r19p-w3 ; git -C <wt> branch --show-current
+    result: "WORKTREE_READY /Users/balizero/nuzantara/.worktrees/mouth-r19p-w3 ; branch agent/air-m5/mouth/r19p-w3"
+    exit: 0
+    ts: "2026-09-12T18:45:00Z"
+    seat: Claude Opus 5 (1M)
+  - claim: A1 — the change set is exactly the four files of the perimeter (two sources, two sibling tests), +113 net lines.
+    cmd: git -C <wt> status --porcelain ; git -C <wt> diff --stat
+    result: "4 files modified — page.tsx, page.test.tsx, _components/TimelineItem.tsx, _components/TimelineItem.test.tsx ; 564 insertions, 451 deletions (+113 net). pnpm-workspace.yaml had been touched by a failed `pnpm -F mouth typecheck` (allowBuilds prompt line) and was restored before the commit."
+    exit: 0
+    ts: "2026-09-12T19:30:00Z"
+    seat: Claude Opus 5 (1M)
+  - claim: A1 — no new data hook; the hook-call count in page.tsx is identical to origin/main.
+    cmd: git -C <wt> show origin/main:<page.tsx> | grep -c "useEffect\|use[A-Z][A-Za-z]*(" ; grep -c same <wt>/<page.tsx>
+    result: "origin/main 7 ; worktree 7. The imports from @/hooks are the same three (usePortalDashboard, usePortalDashboardSummary, usePortalTimeline)."
+    exit: 0
+    ts: "2026-09-12T19:31:00Z"
+    seat: Claude Opus 5 (1M)
+  - claim: A2 — every navigation target present on origin/main is still present; one link was added to an existing route.
+    cmd: grep -oE '"/portal/[a-z/]*"|/portal/matters/\$\{id\}|"/api/portal/deadlines/ical"' on both revisions of page.tsx and TimelineItem.tsx
+    result: "origin/main page.tsx — /api/portal/deadlines/ical, /portal/companies, /portal/messages, /portal/process, /portal/taxes, /portal/visa, /portal/matters/${id}. Worktree — the same seven PLUS /portal/vault (the 'Vault' link of the Recent activity head). TimelineItem — /portal/chat on both. action.href is still the row's href, unchanged."
+    exit: 0
+    ts: "2026-09-12T19:32:00Z"
+    seat: Claude Opus 5 (1M)
+  - claim: A3 — the old identity is gone and nothing red was written.
+    cmd: grep -c "crystal-stat-card" ; grep -c "bg-[color-mix(in_srgb,var(--state-danger)" ; grep -Eic red-hex patterns
+    result: "crystal-stat-card 0 in page.tsx and 0 in TimelineItem.tsx (5 and 1 on origin/main) ; the danger color-mix fill 0 ; no hex literal of any kind in either file — every colour is a var() token."
+    exit: 0
+    ts: "2026-09-12T19:33:00Z"
+    seat: Claude Opus 5 (1M)
+  - claim: A4 — both sibling suites are green after the selector rewrite.
+    cmd: cd apps/mouth && ./node_modules/.bin/vitest --run --testTimeout=60000 "src/app/portal/(authenticated)/page.test.tsx" "src/app/portal/(authenticated)/_components/TimelineItem.test.tsx"
+    result: "Test Files 2 passed (2) ; Tests 23 passed (23) ; duration 53.34s. Before the test rewrite the same command reported 11 failed / 9 passed — every failure a changed selector, text or class, none a data-flow break."
+    exit: 0
+    ts: "2026-09-12T19:23:00Z"
+    seat: Claude Opus 5 (1M)
+  - claim: A4 — typecheck green on the whole mouth project, after the test edits.
+    cmd: cd apps/mouth && ../../node_modules/.bin/tsc --noEmit
+    result: "TSC_EXIT=0, no diagnostics. (pnpm -F mouth typecheck cannot be used in a broker worktree — its dep-status check re-runs pnpm install and fails on ERR_PNPM_IGNORED_BUILDS; the binary is invoked directly instead.)"
+    exit: 0
+    ts: "2026-09-12T19:37:00Z"
+    seat: Claude Opus 5 (1M)
+  - claim: A4 — eslint reports 0 errors on the four files; the 4 warnings are the pre-existing window.location.href advisory the page already carried.
+    cmd: cd apps/mouth && ./node_modules/.bin/eslint <the four files>
+    result: "6 problems (0 errors, 6 warnings) — 2 of them 'File ignored because of a matching ignore pattern' for the two test files, 4 the @next/next/no-location-assign-relative-destination advisory. The count of window.location.href call sites is unchanged vs origin/main (4 on the page: process chip, messages chip, action.href, hero unread row — the last replaces the deleted hero 'Open →')."
+    exit: 0
+    ts: "2026-09-12T19:26:00Z"
+    seat: Claude Opus 5 (1M)
+  - claim: A5 — /portal renders the concept-F dashboard locally at 1440 and 390, with the portal APIs route-intercepted.
+    cmd: next dev --webpack -p 3187 in the worktree ; node shot-w3.mjs (chromium channel chrome, bypassCSP, context.route on /.*\/api\/.*/ serving synthetic dashboard + summary + timeline + profile)
+    result: "portal-desktop-1440.png and portal-mobile-390.png written under /Users/balizero/Desktop/R19-PORTAL-RENDERS-20260912/build/r19p-w3/. The desktop capture shows the copper rule + serif 'Welcome back.', the next-move card ('YOUR NEXT MOVE · MATTER 01 OF 03', 'Second Home Visa renewal', the copper 'bank statement, last three months', Ref 142 / Type visa e33, the forest 'Open matter'), index rows 02 and 03 with their outlined pills, the deadlines block with Export iCal, the unread row, the recap, the three hairline status columns (NEEDS YOU / ACTIVE / IN PROGRESS), the two round chips, the three numbered actions with NEEDS YOU / SOON / PENDING, and the activity spine with copper dots on the two client uploads and hollow slate dots on the team events. Turbopack cannot serve a broker worktree (it refuses the node_modules symlink pointing outside the worktree root), and webpack dev mode needs bypassCSP because the app's own CSP forbids unsafe-eval."
+    exit: 0
+    ts: "2026-09-12T19:43:00Z"
+    seat: Claude Opus 5 (1M)
+dissent:
+  - seat: Claude Opus 5 (1M), adversarial pass against the window brief
+    objection: >-
+      The brief's section 2 asks the next-move card for "the existing next_step sentence", the first
+      pending_docs[0], a Deadline, a Progress percentage and a Ref, and the index rows for a 72px
+      progress rule. The dashboard summary does not carry any of those fields — next_step,
+      pending_docs, progress and next_deadline live on PortalMatter / PortalMatterDetail, which is
+      the MATTER page's payload, not the dashboard's.
+    status: CONFIRMED
+    cure: >-
+      Verified on disk (portal.types.ts:575-581 vs 607-616) and against the producing SQL
+      (_fetch_open_actions). The card renders what exists — title, a status sentence derived from
+      the practice status code, pending_from_client in copper, Ref and Type — and the progress rule
+      and deadline are dropped, recorded as leftovers rather than invented.
+  - seat: Claude Opus 5 (1M), adversarial pass against the acceptance
+    objection: >-
+      A1 asks for "≤ 3 files"; the diff has 4.
+    status: CONFIRMED
+    cure: >-
+      The fourth file is the second sibling TEST, which the owned perimeter explicitly allows "where
+      a selector/text changed" — and every selector in both suites changed (the status card is no
+      longer a filled button, the timeline dots replaced the icon chips, the masthead copy changed).
+      Sources touched: 2. Tests touched: 2. No file outside the perimeter is in the diff.
+  - seat: Claude Opus 5 (1M), adversarial pass against the concept
+    objection: >-
+      The four colour meanings are written with the existing --state-success / --state-info tokens,
+      which today resolve to a green (#147a3a) and a blue (#1d4ed8), not to concept-F's forest and
+      slate.
+    status: PLAUSIBLE
+    cure: >-
+      Not cured here, by design: the token VALUES are the token window's perimeter (concept-F build
+      order step 1), and globals.css is off-limits to this window. Writing the meanings against the
+      semantic tokens is what makes that later remap land on this page for free; writing the hexes
+      would have made it permanent. Recorded as a leftover.
+  - seat: Claude Opus 5 (1M), on the local render
+    objection: >-
+      The first screenshot attempt showed only "Loading...", which could have meant the restyled page
+      does not mount.
+    status: RETRACTED
+    cure: >-
+      The cause was the dev harness, not the page: webpack dev mode evaluates its HMR bundle with
+      eval, which the app's own CSP forbids, so React never booted. With bypassCSP the same build
+      renders the full dashboard — the capture above.
+leftovers:
+  - The next-move card has no Deadline, no Progress bar and no client reference, and the index rows have no 72px progress rule — DashboardSummaryAction carries none of those fields. Giving the dashboard a per-matter progress/deadline is an API change, i.e. another mission.
+  - No "Upload document" secondary button — the dashboard owns no upload route or handler.
+  - The masthead says "Welcome back." with no first name; the name would need a profile hook the acceptance forbids. The header window owns the greeting that already renders "Good morning, Alex".
+  - The status pills are a page-local StatePill, not the shared StatusBadge that W2 is rewriting; the two vocabularies should be unified once W2 lands.
+  - --state-success / --state-info still resolve to green/blue until the token window remaps them to forest/slate; the page is written against the tokens, not the values.
+  - The loading skeleton still paints with --glass-rim (the old identity's rim token) and PortalCardSkeleton, both outside this window's perimeter.
+  - Fraunces/Manrope are not wired yet: the serif renders as whatever --font-serif is (Cormorant today); the font swap is the token/font window's.


### PR DESCRIPTION
Window W3 of mission SAETTA-R19P (BLUE): the client dashboard `/portal` rendered in the
R19 language of concept F ("RAPI"), from
`/Users/balizero/Desktop/R19-PORTAL-RENDERS-20260912/concepts/concept-F/02-home.html`.

**What changes.** The seven sections stay in the code's order and keep their data flow —
`usePortalDashboard`, `usePortalDashboardSummary`, `usePortalTimeline`, `summary`,
`defaultDashboard`, the router pushes, the lazy `TimelineItem`, `PracticeRecapCard`. What
changes is what they look like: a copper rule and a serif "Welcome back." masthead shared
by the loaded/error/account-link states; the V2 hero replaced by one "Your next move" card
for the leading matter plus a numbered index of the others (the deadlines list, its iCal
export and the unread count survive as two quiet blocks under it); the three status cards
as three columns inside one hairline frame whose state is an outlined WORD; two 40px pill
chips; numbered action rows whose priority is "Needs you" / "Soon" / "Pending" in an
outlined pill; and a hairline activity spine with one 9px dot per event — filled copper for
the client's own uploads and messages, hollow slate for the team's. No filled danger,
warning or info row is left on the page, and `crystal-stat-card` is gone from both files.

**What does not change.** No route, field, hook, fetch or API type. Every `router.push` /
`window.location.href` target present on `origin/main` is still present (`/portal/visa`,
`/portal/companies`, `/portal/taxes`, `/portal/process`, `/portal/messages`,
`/portal/chat`, `/portal/matters/${id}`, `/api/portal/deadlines/ical`), plus one new link
to the existing `/portal/vault`. The hook-call count in `page.tsx` is identical (7 vs 7).
Details the dashboard payload cannot feed — per-matter progress, per-matter deadline, an
upload handler, the client's first name — are dropped, not invented; they are listed under
`leftovers:` in the pack.

**Checks.** `vitest --run` on both sibling suites 23/23 green (both were rewritten: every
failure was a changed selector, text or class, none a data-flow break); `tsc --noEmit`
exit 0; `eslint` 0 errors on the four files (4 pre-existing `window.location.href`
warnings, same call-site count as `origin/main`).

Bites: the live `my.balizero.com/portal` dashboard served by the apps/mouth Vercel deploy
— the client's first screen after sign-in. Observed before reporting: `/portal` served by
this branch's own build (`next dev --webpack`, portal APIs route-intercepted with synthetic
data) renders the concept-F dashboard at 1440 and 390 —
`/Users/balizero/Desktop/R19-PORTAL-RENDERS-20260912/build/r19p-w3/portal-desktop-1440.png`
shows "YOUR NEXT MOVE · MATTER 01 OF 03", the copper "bank statement, last three months",
the forest "Open matter", index rows `02`/`03` with outlined pills, the three hairline
status columns, the two chips, the three numbered actions (NEEDS YOU / SOON / PENDING) and
the copper-vs-slate dots on the activity spine. The second consumer is the required check
`Frontend Tests (Next.js) (mouth, true)`, which runs both rewritten suites.

Evidence: `evidence/2026-09/agent-air-m5-mouth-r19p-w3-5bf0fbaa/` (gear 2,
`RULED 2026-09-12 SAETTA`, `pii_scan: clean` — every name and figure synthetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
