### PR TITLE
feat(mouth): dress the portal matter detail in the R19 concept-F language (SAETTA-R19P W4)

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/matters/[id]/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/matters/[id]/page.test.tsx
@@ -62,7 +62,9 @@ describe("PortalMatterDetailPage", () => {
     render(<PortalMatterDetailPage />);
 
     expect(screen.getByText("Company Setup")).toBeInTheDocument();
-    expect(screen.getByText("Approved Intelligence")).toBeInTheDocument();
+    expect(
+      screen.getByText("The file · what we know for certain"),
+    ).toBeInTheDocument();
     expect(screen.getByText("PT Safe Client Story")).toBeInTheDocument();
     expect(
       screen.getAllByText("The company profile is approved for client review."),

--- a/apps/mouth/src/app/portal/(authenticated)/matters/[id]/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/matters/[id]/page.tsx
@@ -3,21 +3,18 @@
 /**
  * Portal Matter Detail — single matter with approved intelligence panel.
  *
- * WS3 slice 2 (GARUDA Day Edition, 2026-07-24): day-theme token alignment,
- * mirroring slice 1 (portal home, PR #3050). Panels read --bz-card /
- * --bz-border (warm paper + hairline), state colors read the semantic
- * --state-* tokens (WS2 operative-light AA overrides), masthead = copper
- * rule + Cormorant serif (--font-serif). No hardcoded hexes.
+ * SAETTA-R19P W4 (2026-09-13): concept-F "RAPI" presentation pass. Same data,
+ * same hooks, same branches — new clothes. Four colour meanings: slate
+ * (--state-info) = ours/moving, copper (--bz-copper*) = needs you, forest
+ * (--state-success) = done/healthy and the only button fill, muted
+ * (--tx-secondary) = waiting. Hairlines instead of tinted boxes, Fraunces
+ * (--font-serif) headlines, and the "Where it stands" column first on mobile.
+ * No route, field, hook or fetch changed.
  */
 
 import { useParams } from "next/navigation";
-import {
-  AlertTriangle,
-  CheckCircle2,
-  Clock3,
-  FileText,
-  ShieldCheck,
-} from "lucide-react";
+import Link from "next/link";
+import { AlertTriangle, Archive, MessageSquare } from "lucide-react";
 import { usePortalMatter } from "@/hooks";
 import { PortalBackButton } from "@/components/portal";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -26,6 +23,18 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import type { PortalApprovedIntelligence } from "@/lib/api/portal/portal.types";
 import { usePortalDateFormat } from "@/lib/format/usePortalDateFormat";
+
+/** 650 / 10px / 0.14em uppercase — the one label style of the concept. */
+const EYEBROW =
+  "text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--tx-secondary)]";
+/** Fraunces 450, the only headline face. */
+const SERIF = {
+  fontFamily: "var(--font-serif)",
+  fontWeight: 450,
+} as const;
+/** Copper never fills a control: the alert keeps its shape, loses the red. */
+const ALERT_TONE =
+  "border-[var(--bz-border-hover)] text-[var(--state-danger)] [&>svg]:text-[var(--state-danger)]";
 
 function parseMatterId(value: string | string[] | undefined): number | null {
   const raw = Array.isArray(value) ? value[0] : value;
@@ -50,6 +59,58 @@ function formatReviewedAt(
   );
 }
 
+/** Day count read off the deadline already returned — a word, never a red. */
+function formatDayCount(value: string | null): string | null {
+  if (!value) return null;
+  const due = new Date(value);
+  if (Number.isNaN(due.getTime())) return null;
+  const days = Math.round((due.getTime() - Date.now()) / 86_400_000);
+  if (days > 1) return `${days} days`;
+  if (days === 1) return "Tomorrow";
+  if (days === 0) return "Today";
+  return "Overdue";
+}
+
+type StatusTone = "ours" | "ok" | "you" | "wait";
+
+const TONE_CLASS: Record<StatusTone, string> = {
+  ours: "text-[var(--state-info)] border-[var(--state-info)]/35",
+  ok: "text-[var(--state-success)] border-[var(--state-success)]/35",
+  you: "text-[var(--bz-copper-text)] border-[var(--bz-copper-text)]/40",
+  wait: "text-[var(--tx-secondary)] border-[var(--bz-border-hover)]",
+};
+
+function statusTone(...values: (string | null | undefined)[]): StatusTone {
+  const text = values.filter(Boolean).join(" ").toLowerCase();
+  if (/complete|approved|done|issued|active/.test(text)) return "ok";
+  if (/wait|need|action|client/.test(text)) return "you";
+  if (/progress|review|submit|process/.test(text)) return "ours";
+  return "wait";
+}
+
+function StatusPill({
+  label,
+  tone,
+  className,
+}: {
+  label: string;
+  tone: StatusTone;
+  className?: string;
+}) {
+  return (
+    <Badge
+      variant="outline"
+      className={`h-6 gap-[7px] px-[10px] text-[10px] font-semibold uppercase tracking-[0.12em] ${TONE_CLASS[tone]} ${className ?? ""}`}
+    >
+      <span
+        aria-hidden="true"
+        className="h-1.5 w-1.5 shrink-0 rounded-full bg-current"
+      />
+      {label}
+    </Badge>
+  );
+}
+
 function LoadingState() {
   return (
     <div className="space-y-6 p-6">
@@ -61,7 +122,7 @@ function LoadingState() {
         className="h-10 w-64 animate-pulse rounded"
         style={{ background: "var(--glass-rim)" }}
       />
-      <div className="grid gap-4 md:grid-cols-[1fr_280px]">
+      <div className="grid gap-6 md:grid-cols-[1fr_300px]">
         <div
           className="h-56 animate-pulse rounded-lg border"
           style={{
@@ -95,23 +156,34 @@ function ApprovedIntelligencePanel({
   if (!intelligence.available) {
     return (
       <section
-        className="rounded-lg border p-5"
+        className="rounded-lg border p-6"
         style={{
           background: "var(--bz-card)",
           borderColor: "var(--bz-border)",
         }}
       >
-        <div className="flex items-start gap-3">
-          <Clock3 className="mt-0.5 h-5 w-5 text-[var(--state-warning)]" />
-          <div>
-            <h2 className="text-lg font-semibold text-[var(--bz-text-1)]">
-              No approved summary yet
-            </h2>
-            <p className="mt-2 text-sm leading-6 text-[var(--tx-secondary)]">
-              Your Bali Zero team will publish a client-ready summary after
-              review.
-            </p>
-          </div>
+        <p className={EYEBROW}>The file · what we know for certain</p>
+        <h2
+          className="mt-4 text-[22px] leading-[1.35] tracking-[-0.015em] text-[var(--tx-pure)]"
+          style={SERIF}
+        >
+          No approved summary yet
+        </h2>
+        <p className="mt-3 max-w-[62ch] text-sm leading-7 text-[var(--tx-secondary)]">
+          Your Bali Zero team will publish a client-ready summary after review.
+        </p>
+        <div
+          className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t pt-4 text-xs text-[var(--tx-secondary)]"
+          style={{ borderColor: "var(--bz-border)" }}
+        >
+          <span>Facts are checked by your team before they appear here.</span>
+          <Link
+            href="/portal/vault"
+            prefetch={false}
+            className="font-semibold text-[var(--bz-copper-text)]"
+          >
+            Open the Vault
+          </Link>
         </div>
       </section>
     );
@@ -119,62 +191,71 @@ function ApprovedIntelligencePanel({
 
   return (
     <section
-      className="rounded-lg border p-5"
+      className="rounded-lg border p-6"
       style={{
         background: "var(--bz-card)",
         borderColor: "var(--bz-border)",
       }}
     >
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 className="flex items-center gap-2 text-lg font-semibold text-[var(--bz-text-1)]">
-            <ShieldCheck className="h-5 w-5 text-[var(--state-success)]" />
-            Approved Intelligence
-          </h2>
+          <h2 className={EYEBROW}>The file · what we know for certain</h2>
           {intelligence.company_name && (
-            <p className="mt-1 text-sm text-[var(--tx-secondary)]">
+            <p className="mt-2 text-sm text-[var(--tx-secondary)]">
               {intelligence.company_name}
             </p>
           )}
         </div>
-        <Badge className="border-[color-mix(in_srgb,var(--state-success)_25%,transparent)] bg-[color-mix(in_srgb,var(--state-success)_10%,transparent)] text-[var(--state-success)]">
-          Approved
-        </Badge>
+        {reviewedAt && (
+          <span
+            className="inline-flex shrink-0 -rotate-2 items-center gap-2 self-start rounded-[2px] border border-[var(--state-success)] px-2.5 py-1.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-[var(--state-success)]"
+            style={{ background: "var(--bz-card)" }}
+          >
+            <span
+              aria-hidden="true"
+              className="h-1.5 w-1.5 rounded-full bg-[var(--state-success)]"
+            />
+            Reviewed · Bali Zero · {reviewedAt}
+          </span>
+        )}
       </div>
 
       {intelligence.summary && (
-        <p className="mt-4 text-sm leading-6 text-[var(--bz-text-1)]">
+        <p
+          className="mt-5 border-b pb-5 text-[19px] leading-[1.35] tracking-[-0.015em] text-[var(--tx-pure)] sm:text-[22px]"
+          style={{ ...SERIF, borderColor: "var(--bz-border)" }}
+        >
           {intelligence.summary}
-        </p>
-      )}
-      {reviewedAt && (
-        <p className="mt-2 text-xs text-[var(--tx-secondary)]">
-          Reviewed {reviewedAt}
         </p>
       )}
 
       {intelligence.facts.length > 0 && (
-        <div className="mt-5 divide-y divide-[var(--bz-border)]">
+        <dl className="mt-1.5 grid grid-cols-1 gap-x-6 sm:grid-cols-2">
           {intelligence.facts.map((fact) => (
             <div
               key={`${fact.category}-${fact.label}`}
-              className="py-3 first:pt-0 last:pb-0"
+              className="border-b py-3.5"
+              style={{ borderColor: "var(--bz-border)" }}
             >
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="text-sm font-medium text-[var(--bz-text-1)]">
-                  {fact.label}
-                </p>
-                <span className="rounded bg-[var(--glass-rim)] px-2 py-0.5 text-[10px] uppercase tracking-wider text-[var(--tx-secondary)]">
-                  {fact.confidence}
-                </span>
-              </div>
-              <p className="mt-2 text-sm leading-6 text-[var(--tx-secondary)]">
+              <dt className={EYEBROW}>{fact.label}</dt>
+              <dd className="mt-0.5 text-sm font-semibold leading-6 text-[var(--bz-text-1)]">
                 {fact.detail}
-              </p>
+              </dd>
             </div>
           ))}
-        </div>
+        </dl>
       )}
+
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-3 text-xs text-[var(--tx-secondary)]">
+        <span>Facts are checked by your team before they appear here.</span>
+        <Link
+          href="/portal/vault"
+          prefetch={false}
+          className="font-semibold text-[var(--bz-copper-text)]"
+        >
+          Open the Vault
+        </Link>
+      </div>
     </section>
   );
 }
@@ -189,7 +270,7 @@ export default function PortalMatterDetailPage() {
     return (
       <div className="space-y-6 p-6">
         <PortalBackButton href="/portal/matters" label="Matters" />
-        <Alert variant="destructive">
+        <Alert variant="destructive" className={ALERT_TONE}>
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle>Unable to load matter</AlertTitle>
           <AlertDescription>Invalid matter id.</AlertDescription>
@@ -204,7 +285,7 @@ export default function PortalMatterDetailPage() {
     return (
       <div className="space-y-6 p-6">
         <PortalBackButton href="/portal/matters" label="Matters" />
-        <Alert variant="destructive">
+        <Alert variant="destructive" className={ALERT_TONE}>
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle>Unable to load matter</AlertTitle>
           <AlertDescription>
@@ -219,117 +300,186 @@ export default function PortalMatterDetailPage() {
     );
   }
 
-  return (
-    <div className="space-y-6 p-6">
-      <PortalBackButton href="/portal/matters" label="Matters" />
+  const needs = [
+    ...data.pending_docs,
+    ...data.approved_intelligence.missing_items,
+  ];
+  const steps = [
+    ...(data.next_step ? [data.next_step] : []),
+    ...data.approved_intelligence.next_steps,
+  ];
+  const deadlineText = data.next_deadline
+    ? (formatReviewedAt(data.next_deadline, formatDate) ?? data.next_deadline)
+    : null;
+  const dayCount = formatDayCount(data.next_deadline);
 
-      <section className="space-y-3">
+  return (
+    <div className="space-y-8 p-6">
+      <PortalBackButton
+        href="/portal/matters"
+        label="Matters"
+        className="uppercase tracking-[0.06em] font-semibold"
+      />
+
+      <section>
         <div className="flex flex-wrap items-center gap-2">
-          <Badge
-            variant="outline"
-            className="capitalize text-[var(--tx-secondary)]"
-          >
-            {data.type}
-          </Badge>
-          <Badge className="border-[color-mix(in_srgb,var(--state-success)_25%,transparent)] bg-[color-mix(in_srgb,var(--state-success)_10%,transparent)] text-[var(--state-success)]">
-            {data.status_label}
-          </Badge>
-        </div>
-        <div>
-          {/* Day masthead (WS3): copper rule + Cormorant serif, per concept */}
-          <div
-            aria-hidden="true"
-            className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
+          <StatusPill
+            label={data.type}
+            tone="wait"
+            className="capitalize tracking-[0.12em]"
           />
-          <h1
-            className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]"
-            style={{ fontFamily: "var(--font-serif)" }}
-          >
-            {data.title}
-          </h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-[var(--tx-secondary)]">
-            {data.description}
-          </p>
+          <StatusPill
+            label={data.status_label}
+            tone={statusTone(data.status, data.status_label)}
+          />
         </div>
+        <p className={`${EYEBROW} mt-4 tabular-nums`}>Matter {data.id}</p>
+        <h1
+          className="mt-2.5 max-w-[22ch] text-[clamp(34px,3.6vw,46px)] leading-[1.06] tracking-[-0.03em] text-[var(--tx-pure)]"
+          style={SERIF}
+        >
+          {data.title}
+        </h1>
+        <p className="mt-3 max-w-[62ch] text-sm leading-7 text-[var(--tx-secondary)]">
+          {data.description}
+        </p>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-[1fr_280px]">
+      <section className="grid items-start gap-6 md:grid-cols-[1fr_300px]">
         <ApprovedIntelligencePanel intelligence={data.approved_intelligence} />
 
         <aside
-          className="space-y-4 rounded-lg border p-4"
-          style={{
-            background: "var(--bz-card)",
-            borderColor: "var(--bz-border)",
-          }}
+          aria-label="Where it stands"
+          className="order-first flex flex-col gap-6 md:order-none md:sticky md:top-[calc(64px+24px)]"
         >
           <div>
-            <div className="flex items-center justify-between text-sm">
-              <span className="font-medium text-[var(--bz-text-1)]">
-                Progress
-              </span>
-              <span className="text-[var(--tx-secondary)]">
-                {data.progress}%
-              </span>
-            </div>
+            <h2 className={EYEBROW}>Progress</h2>
+            <p
+              className="mt-2 text-[28px] leading-none tracking-[-0.02em] tabular-nums text-[var(--tx-pure)]"
+              style={SERIF}
+            >
+              {data.progress}%
+            </p>
             <Progress
               value={data.progress}
-              className="mt-2 h-2 bg-[var(--glass-rim)]"
-              indicatorClassName="bg-[var(--bz-copper)]"
+              className="mt-2.5 h-1 rounded-sm bg-[var(--glass-rim)]"
+              indicatorClassName="bg-[var(--state-info)]"
             />
           </div>
 
-          {data.next_deadline && (
-            <div
-              className="border-t pt-3"
-              style={{ borderColor: "var(--bz-border)" }}
-            >
-              <p className="text-xs uppercase tracking-wider text-[var(--tx-secondary)]">
-                Next deadline
-              </p>
-              <p className="mt-1 text-sm font-medium text-[var(--bz-text-1)]">
-                {formatReviewedAt(data.next_deadline, formatDate) ??
-                  data.next_deadline}
-              </p>
+          {deadlineText && (
+            <div>
+              <h2 className={EYEBROW}>Next deadline</h2>
+              <div
+                className="mt-2 flex items-center justify-between gap-3 rounded border px-3.5 py-3"
+                style={{ borderColor: "var(--bz-border-hover)" }}
+              >
+                <span className="text-sm font-semibold tabular-nums text-[var(--bz-text-1)]">
+                  {deadlineText}
+                </span>
+                {dayCount && (
+                  <span
+                    className="shrink-0 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] tabular-nums text-[var(--tx-secondary)]"
+                    style={{ borderColor: "var(--bz-border)" }}
+                  >
+                    {dayCount}
+                  </span>
+                )}
+              </div>
             </div>
           )}
 
-          {(data.pending_docs.length > 0 ||
-            data.approved_intelligence.missing_items.length > 0) && (
+          {needs.length > 0 && (
             <div>
-              <p className="flex items-center gap-2 text-sm font-semibold text-[var(--bz-text-1)]">
-                <FileText className="h-4 w-4 text-[var(--state-warning)]" />
-                What we still need
-              </p>
-              <ul className="mt-2 space-y-2 text-sm leading-6 text-[var(--tx-secondary)]">
-                {[
-                  ...data.pending_docs,
-                  ...data.approved_intelligence.missing_items,
-                ].map((item, index) => (
-                  <li key={`need-${index}-${item}`}>{item}</li>
+              <h2 className={EYEBROW}>We need from you</h2>
+              <ul className="mt-1.5">
+                {needs.map((item, index) => (
+                  <li
+                    key={`need-${index}-${item}`}
+                    className="flex items-start gap-2.5 border-t py-2.5 text-sm font-semibold leading-6 text-[var(--bz-copper-text)]"
+                    style={{ borderColor: "var(--bz-border)" }}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="mt-2 h-2 w-2 shrink-0 rounded-full bg-[var(--bz-copper)]"
+                    />
+                    <span>{item}</span>
+                  </li>
                 ))}
               </ul>
+              <Link
+                href="/portal/vault"
+                prefetch={false}
+                className="mt-3.5 flex h-12 w-full items-center justify-center gap-2 rounded bg-[var(--state-success)] text-[13px] font-semibold tracking-[0.02em] text-white"
+              >
+                <Archive className="h-4 w-4" />
+                Open the Vault
+              </Link>
             </div>
           )}
 
-          {(data.next_step ||
-            data.approved_intelligence.next_steps.length > 0) && (
+          {steps.length > 0 && (
             <div>
-              <p className="flex items-center gap-2 text-sm font-semibold text-[var(--bz-text-1)]">
-                <CheckCircle2 className="h-4 w-4 text-[var(--state-success)]" />
-                Next steps
-              </p>
-              <ul className="mt-2 space-y-2 text-sm leading-6 text-[var(--tx-secondary)]">
-                {[
-                  ...(data.next_step ? [data.next_step] : []),
-                  ...data.approved_intelligence.next_steps,
-                ].map((item, index) => (
-                  <li key={`next-${index}-${item}`}>{item}</li>
+              <h2 className={EYEBROW}>What happens next</h2>
+              <ol className="mt-1.5">
+                {steps.map((item, index) => (
+                  <li
+                    key={`next-${index}-${item}`}
+                    className={`grid grid-cols-[28px_1fr] gap-2.5 border-t py-2.5 text-sm leading-6 ${
+                      index === 0
+                        ? "text-[var(--bz-text-1)]"
+                        : "text-[var(--tx-secondary)]"
+                    }`}
+                    style={{ borderColor: "var(--bz-border)" }}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={`text-[20px] leading-[1.2] tabular-nums ${
+                        index === 0
+                          ? "text-[var(--bz-copper-text)]"
+                          : "text-[var(--tx-tertiary)]"
+                      }`}
+                      style={SERIF}
+                    >
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <span>{item}</span>
+                  </li>
                 ))}
-              </ul>
+              </ol>
             </div>
           )}
         </aside>
+      </section>
+
+      <section
+        className="flex flex-col items-start justify-between gap-5 rounded-lg border p-6 sm:flex-row sm:items-center"
+        style={{
+          background: "var(--bz-card)",
+          borderColor: "var(--bz-border)",
+        }}
+      >
+        <div>
+          <p
+            className="text-[20px] leading-[1.2] tracking-[-0.015em] text-[var(--tx-pure)]"
+            style={SERIF}
+          >
+            A question about this matter?
+          </p>
+          <p className="mt-1.5 max-w-[56ch] text-sm leading-7 text-[var(--tx-secondary)]">
+            Your Bali Zero team answers in the messages thread, usually within
+            one working day.
+          </p>
+        </div>
+        <Link
+          href="/portal/messages"
+          prefetch={false}
+          className="inline-flex h-12 w-full shrink-0 items-center justify-center gap-2 rounded border px-5 text-[13px] font-semibold text-[var(--bz-text-1)] sm:w-auto"
+          style={{ borderColor: "var(--bz-border-hover)" }}
+        >
+          <MessageSquare className="h-4 w-4" />
+          Message the team
+        </Link>
       </section>
     </div>
   );

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w4-d58f9a29/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w4-d58f9a29/brief.yml
@@ -1,0 +1,33 @@
+gear: 2
+ruling: RULED 2026-09-12 SAETTA
+mission: SAETTA-R19P W4 (BLUE) — the client-portal matter detail redressed in concept F ("RAPI")
+objective: >-
+  apps/mouth/src/app/portal/(authenticated)/matters/[id]/page.tsx renders the same
+  PortalMatterDetail data — same hook, same three non-happy branches, same routes — in the
+  R19 language of concept F: four colour meanings and no red, outlined status pills with a
+  leading dot, a serif clamp(34px,3.6vw,46px) title, the approved-intelligence panel as
+  "The file · what we know for certain" with a rotated Reviewed stamp and a two-column
+  definition list, a "Where it stands" column (progress, next deadline, what we need from
+  you in copper, what happens next with serif numerals) that comes FIRST on mobile, and a
+  closing band linking the existing messages thread. Presentation only.
+scope:
+  - apps/mouth/src/app/portal/(authenticated)/matters/[id]/page.tsx
+  - apps/mouth/src/app/portal/(authenticated)/matters/[id]/page.test.tsx
+constraints:
+  - PRESENTATION ONLY — no route, field, hook, fetch, API type or i18n key added or removed.
+  - Shared primitives (PortalBackButton, Badge, Progress, Button, Alert) are used, never edited; restyling happens through the className each already accepts.
+  - No red hex and no --state-danger fill in what is written; no client PII (synthetic names only).
+  - Forbidden — hooks, api clients, types, the Badge/Progress/PortalBackButton components themselves, any other page, PENDING-ARMS.md, any ledger file.
+  - No ledger PR, no PENDING-ARMS.md edit (SAETTA rule 2).
+acceptance:
+  - A1 git diff against the merge base lists at most 2 files; the count of use[A-Z]( calls and of api. calls equals origin/main's.
+  - A2 all three non-happy branches (loading, error/invalid id, unavailable intelligence) still render — the sibling vitest suite green, selectors adjusted only where the copy changed.
+  - A3 zero color-mix --state-success tints; no hardcoded hex; no red class or token in the file.
+  - A4 pnpm -F mouth typecheck and npx eslint on the touched file green.
+  - A5 best-effort route-intercepted screenshots of a matter page at 1440 and 390 under /Users/balizero/Desktop/R19-PORTAL-RENDERS-20260912/build/r19p-w4/, else "not rendered" with the reason.
+consumer_map:
+  - The live my.balizero.com/portal/matters/<id> screen served by the apps/mouth Vercel deploy on merge to main — the client reading their own matter.
+  - The required GitHub check "Frontend Tests (Next.js) (mouth, true)", which runs the sibling suite that pins the new markup on every future PR.
+appetite:
+  budget: 75 minutes active, 1 PR
+  stop_loss: three reds on the same cause suspends; a harness-caused red is reported, never cured by rebuilding the branch

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w4-d58f9a29/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w4-d58f9a29/pack.yml
@@ -1,0 +1,142 @@
+gear: 2
+brief_ref: evidence/2026-09/agent-air-m5-mouth-r19p-w4-d58f9a29/brief.yml
+ruling: RULED 2026-09-12 SAETTA
+lanes:
+  - lane: R19P-W4
+    role: build
+    seat: Claude Opus 5 (Dux of window W4, implements directly)
+pii_scan: clean
+decisions:
+  - id: D1
+    decision: >-
+      The head eyebrow reads "Matter {id}" with no open date. PortalMatterDetail (and the
+      PortalMatter it extends) carries id, title, status, type, progress, pending_docs,
+      next_deadline, next_step, status_label, description, approved_intelligence — no
+      opened/created field. The window brief makes the date conditional on the page already
+      having one, so the detail is dropped rather than requested.
+  - id: D2
+    decision: >-
+      The forest button in "We need from you" is "Open the Vault" (/portal/vault), not the
+      mock's "Upload document": the page links no upload route today, and the brief makes the
+      upload button conditional on one already existing.
+  - id: D3
+    decision: >-
+      Progress shows the percent alone, without "x of y steps done": the payload has no steps
+      array, and assembling a count from next_steps would be a silent data request.
+  - id: D4
+    decision: >-
+      The day count beside the deadline is computed client-side from next_deadline
+      (concept F §5 sanctions client-side day counts) instead of importing DeadlineBadge from
+      @balizero/core — that primitive is shared with kita/prime and this window may not restyle
+      it, and a day count needs no component.
+  - id: D5
+    decision: >-
+      Forest reads --state-success and slate reads --state-info, the two semantic tokens W1
+      re-aliases at the [data-theme="operative-light"][data-product="my"] seam
+      (--state-success #253E33, --state-info #233D52). Writing var(--bz-forest) instead would be
+      a dangling reference today — no such token exists in globals.css — and an invalid
+      colour renders as inherited, not as forest.
+  - id: D6
+    decision: >-
+      fact.confidence is no longer displayed: the brief specifies the facts as a two-column
+      definition list of dt eyebrow + dd 600, and the mock has no confidence chip. Recorded as
+      a leftover, not a data change — the field is still in the payload.
+  - id: D7
+    decision: >-
+      The error/invalid-id branches keep Alert variant="destructive" (same shape, same copy,
+      same Retry) but pass a className that overrides the component's text-red-500 /
+      border-red-500 with --state-danger, which the my seam aliases to copper. No red survives
+      in what this window writes, and the shared Alert is untouched.
+  - id: D8
+    decision: >-
+      "Message the team" links plain /portal/messages: the page never built a practiceId query,
+      and the brief makes that query conditional on it already existing.
+receipts:
+  - claim: The window works in its own broker worktree on branch agent/air-m5/mouth/r19p-w4; the main checkout stayed clean.
+    cmd: python3 scripts/agent_start.py --lane mouth --task-id r19p-w4 ; git -C /Users/balizero/nuzantara status --short
+    result: "WORKTREE_READY /Users/balizero/nuzantara/.worktrees/mouth-r19p-w4 ; main checkout shows only the pre-existing untracked shared/hotfix_audit.jsonl"
+    exit: 0
+    ts: "2026-09-12T18:38:00Z"
+    seat: Claude Opus 5
+  - claim: A2 — the sibling suite is green on all four cases, including the pending-intelligence branch and the error branch with its Retry.
+    cmd: cd apps/mouth && npx vitest --run "src/app/portal/(authenticated)/matters/[id]/page.test.tsx"
+    result: "Test Files 1 passed (1) ; Tests 4 passed (4) ; duration 4.07s. One selector adjusted: the panel heading 'Approved Intelligence' became the eyebrow 'The file · what we know for certain'. The WS3 token test passed unchanged — --bz-card panel background, >=2 elements carrying --state-success, and the no-hardcoded-hex guard."
+    exit: 0
+    ts: "2026-09-12T18:45:34Z"
+    seat: Claude Opus 5
+  - claim: A4 — typecheck clean.
+    cmd: PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm -F mouth typecheck
+    result: "$ tsc --noEmit — exited with code 0"
+    exit: 0
+    ts: "2026-09-12T19:20:00Z"
+    seat: Claude Opus 5
+  - claim: A4 — eslint clean on the page; the sibling test file is outside the eslint ignore-free set, which is pre-existing config, not a defect of this diff.
+    cmd: cd apps/mouth && npx eslint "src/app/portal/(authenticated)/matters/[id]/page.tsx" "src/app/portal/(authenticated)/matters/[id]/page.test.tsx"
+    result: "1 problem (0 errors, 1 warning) — the warning is 'File ignored because of a matching ignore pattern' on page.test.tsx"
+    exit: 0
+    ts: "2026-09-12T18:52:00Z"
+    seat: Claude Opus 5
+  - claim: A1 — the diff is two files, and the page's hook/fetch surface is byte-for-byte as many calls as origin/main's.
+    cmd: git -C <wt> diff origin/main --stat ; grep -oE 'use[A-Z][A-Za-z]*\(' on the working file and on git show origin/main:<file> ; grep -c 'api\.'
+    result: "2 files changed, 289 insertions(+), 137 deletions(-) — page.tsx and page.test.tsx. use[A-Z]( calls 3 vs 3 on origin/main (useParams, usePortalMatter, usePortalDateFormat); api. calls 0 vs 0."
+    exit: 0
+    ts: "2026-09-12T18:55:00Z"
+    seat: Claude Opus 5
+  - claim: A3 — no hardcoded hex, no red, no color-mix tint fill anywhere in the page.
+    cmd: grep -cE '#[0-9a-fA-F]{3,8}' ; grep -c 'color-mix' ; grep -c 'state-success' ; grep -c 'state-danger' ; grep -ciE 'red-[0-9]|rose-|crimson' ; grep -c 'shadow'
+    result: "hex 0 ; color-mix 0 ; state-success 5 ; state-danger 1 ; red/rose/crimson 0 ; shadow 0"
+    exit: 0
+    ts: "2026-09-12T19:28:57Z"
+    seat: Claude Opus 5
+  - claim: A failed pnpm dependency check (pnpm's own pre-run install) had appended an allowBuilds line to pnpm-workspace.yaml inside the worktree; it was reverted before commit, so the diff carries only the two owned files.
+    cmd: git -C <wt> diff origin/main -- pnpm-workspace.yaml ; git -C <wt> checkout -- pnpm-workspace.yaml ; git -C <wt> diff origin/main --stat
+    result: 'the stray line was "''@parcel/watcher'': set this to true or false" ; after the revert the stat lists only the two matters/[id] files'
+    exit: 0
+    ts: "2026-09-12T18:58:00Z"
+    seat: Claude Opus 5
+  - claim: A5 — the local render did NOT complete inside its 15-minute box, so nothing is claimed about pixels. Turbopack refuses the worktree (node_modules symlink points out of the project root) and the webpack fallback never finished compiling /portal/matters/[id].
+    cmd: npx next dev -p 3477 (turbopack) ; npx next dev --webpack -p 3477 ; node <scratchpad>/w4-shot.mjs (Playwright, chrome channel, route interception of /api/portal/matters/142)
+    result: "turbopack — 'Symlink [project]/apps/mouth/node_modules is invalid, it points out of the filesystem root', exit 1. webpack — 'Ready in 6.2s', then the route compiled only after ~15 minutes; with the route mocks, the auth cookie, the seeded localStorage session and bypassCSP the page still answered body text 'Loading...' with h1 count 0 and aside count 0, i.e. it never left the portal gate's loading branch, so no matter markup was ever painted. The two PNGs of that loading screen were deleted rather than filed as a render."
+    exit: 1
+    ts: "2026-09-12T19:26:00Z"
+    seat: Claude Opus 5
+dissent:
+  - seat: window contract A3, read literally
+    objection: >-
+      A3 asks for grep -c "state-success" = 0 in fills; the file has 5 occurrences.
+    status: CONFIRMED
+    cure: >-
+      The fills clause is satisfied and measured: 0 color-mix tint fills (the two the old page
+      had are gone). The 5 remaining occurrences are the outlined Reviewed stamp (border +
+      text), its 6px dot, the "ok" entry of the pill tone map, and the ONE forest primary-button
+      fill that COMMON §1 mandates as the only permitted button fill. W1 aliases
+      --state-success to forest #253E33 at the my seam, so the token IS forest there; inventing
+      an undefined --bz-forest to dodge the grep would ship a dangling colour.
+  - seat: self-review (adversarial pass by the same seat — generator is not grader, so this is recorded, not adjudicated)
+    objection: >-
+      order-first is CSS only. On mobile the "Where it stands" column is painted above the file
+      panel while the DOM and tab order still put the panel first, so a screen-reader or
+      keyboard user meets them in the opposite order from a sighted one.
+    status: PLAUSIBLE
+    cure: >-
+      Not cured. The window brief prescribes exactly "order-first md:order-none on the aside;
+      nothing else changes", and moving the aside in the DOM would change the desktop reading
+      order too. The aside carries aria-label="Where it stands" so it is at least announced as
+      a named region. Recorded as a leftover for the mission's a11y pass.
+  - seat: self-review (adversarial pass by the same seat)
+    objection: >-
+      The status pill tone is derived from a regex over status + status_label, so an unforeseen
+      label falls through to the muted "wait" tone.
+    status: PLAUSIBLE
+    cure: >-
+      Not cured, by design — muted/waiting is the safe default of the concept's four meanings
+      (it never claims "done" for something that is not), and a status→tone map living in the
+      API types would be a data change this window may not make.
+leftovers:
+  - fact.confidence is no longer rendered (the facts are a dt/dd definition list per the brief); the field is untouched in the payload.
+  - 'The "x of y steps done" line is not rendered — no steps array exists in PortalMatterDetail.'
+  - "The eyebrow has no opened-date segment — no opened/created field exists in PortalMatterDetail."
+  - 'The deadline box has no sub-label (the mock reads "Interview slot must be booked") — no deadline label field exists.'
+  - The palette and the type land with W1 — on this head sha --state-success is still #147a3a, --state-info #1d4ed8 and --font-serif is Cormorant, so the page ships R19 structure, spacing and hierarchy, and inherits R19 colour and Fraunces the moment the token window merges.
+  - "No local screenshot — turbopack rejects the broker worktree's node_modules symlink, and under the webpack fallback the dev portal never left its loading gate (h1 count 0), so the matter markup was never painted locally. The mission's visual truth for this window stays the concept-F mock 03-matter.html until a deploy preview renders it."
+  - Mobile visual order vs DOM order on the aside (see dissent 2) is left for the mission's a11y pass.


### PR DESCRIPTION
## What

Window W4 of mission SAETTA-R19P (BLUE): `/portal/matters/[id]` — the client's matter detail — is redressed in concept F ("RAPI") without touching a single byte of its data contract.

- head: type + `status_label` as outlined pills (leading 6px dot, 10px tracked uppercase; slate = moving, forest = done, copper = needs you, muted = waiting), `Matter {id}` eyebrow, serif `clamp(34px,3.6vw,46px)` title, 62ch description.
- left: the approved-intelligence panel becomes **"The file · what we know for certain"** — a rotated (-2deg) outlined forest `Reviewed · Bali Zero · {date}` stamp, the summary in serif 22px over a hairline, `facts[]` as a two-column definition list, and a footer line plus a copper "Open the Vault" link. The unavailable/pending branch keeps its copy in the same card.
- right: **"Where it stands"**, sticky on md and painted FIRST on mobile (`order-first md:order-none`) — serif percent + 4px slate `Progress`, an outlined deadline box with a client-side day count as a muted pill, `pending_docs` + `missing_items` as copper items with a copper dot under one forest button, and `next_step` + `next_steps[]` numbered with serif numerals (current = copper numeral + ink text).
- bottom: "A question about this matter?" into the existing `/portal/messages` thread.
- Four colour meanings, no red: the two `--state-success` `color-mix` tint fills are gone, the destructive `Alert` keeps its shape but loses its red to `--state-danger` (copper at the `my` seam), zero hardcoded hex, zero shadows.

Presentation only — no route, field, hook, fetch or API type added or removed: `use[A-Z](` calls 3 = 3 on `origin/main`, `api.` calls 0 = 0. Shared primitives (`PortalBackButton`, `Badge`, `Progress`, `Button`, `Alert`) are restyled only through the `className` each already accepts; none is edited.

## Checks

- `npx vitest --run "src/app/portal/(authenticated)/matters/[id]/page.test.tsx"` → 4 passed (4). One selector adjusted, because the panel heading "Approved Intelligence" became the eyebrow "The file · what we know for certain"; the WS3 token test passes unchanged (`--bz-card` panel background, `--state-success` elements, no-hardcoded-hex guard).
- `pnpm -F mouth typecheck` → `tsc --noEmit` exit 0 (and again inside the pre-commit hook).
- `npx eslint` on the page → 0 errors.

Bites: the live `my.balizero.com/portal/matters/<id>` screen served by the apps/mouth Vercel deploy — the client reading their own matter meets the new markup the moment this merges. The observation that proves it is in force before the deploy: the sibling suite that ships in this same PR asserts the new surface on the rendered DOM — `screen.getByText("The file · what we know for certain")` is green and the old "Approved Intelligence" heading is gone, while the same suite's WS3 guard still finds the `--bz-card` panel and no hardcoded hex. Every future PR that regresses this page turns "Frontend Tests (Next.js) (mouth, true)" red.

Evidence: `evidence/2026-09/agent-air-m5-mouth-r19p-w4-d58f9a29/` (gear 2, `RULED 2026-09-12 SAETTA`, pack lint clean).

Not proven here: no local screenshot. Turbopack refuses the broker worktree (`node_modules` symlink out of the project root) and under the webpack fallback the dev portal never left its loading gate, so the matter markup was never painted locally. The palette and the type land with window W1 — on this head sha `--state-success` is still `#147a3a` and `--font-serif` is Cormorant, so this PR ships R19 structure and inherits R19 colour and Fraunces when the token window merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)