### PR TITLE
feat(mouth): the authenticated portal shell in the R19 language (concept F, W2)

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/layout.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/layout.tsx
@@ -366,7 +366,12 @@ export default function PortalLayout({
           </main>
 
           {/* Portal Footer */}
-          <footer className="md:ml-0 flex flex-col sm:flex-row items-center justify-between gap-2 px-4 md:px-10 py-[18px] text-[12px] border-t border-[var(--bz-border)] bg-[var(--bz-footer,#EEE9E1)] text-[var(--tx-secondary)]">
+          <footer
+            className="md:ml-0 flex flex-col sm:flex-row items-center justify-between gap-2 px-4 md:px-10 py-[18px] text-[12px] border-t border-[var(--bz-border)] text-[var(--tx-secondary)]"
+            // R19 footer band. The token is the sibling token window's to
+            // define; until it lands the band sits on the page base.
+            style={{ background: "var(--bz-footer, var(--bz-base))" }}
+          >
             <span>© {new Date().getFullYear()} Bali Zero</span>
             <span>
               <a href="/privacy" className="hover:underline">

--- a/apps/mouth/src/app/portal/(authenticated)/layout.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/layout.tsx
@@ -366,30 +366,16 @@ export default function PortalLayout({
           </main>
 
           {/* Portal Footer */}
-          <footer
-            className="md:ml-0 px-4 py-3 text-xs text-center border-t"
-            style={{
-              color: "var(--text-secondary)",
-              borderColor: "var(--border)",
-            }}
-          >
+          <footer className="md:ml-0 flex flex-col sm:flex-row items-center justify-between gap-2 px-4 md:px-10 py-[18px] text-[12px] border-t border-[var(--bz-border)] bg-[var(--bz-footer,#EEE9E1)] text-[var(--tx-secondary)]">
             <span>© {new Date().getFullYear()} Bali Zero</span>
-            <span className="mx-2">·</span>
-            <a
-              href="/privacy"
-              className="hover:underline"
-              style={{ color: "var(--text-secondary)" }}
-            >
-              Privacy Policy
-            </a>
-            <span className="mx-2">·</span>
-            <a
-              href="/terms"
-              className="hover:underline"
-              style={{ color: "var(--text-secondary)" }}
-            >
-              Terms of Service
-            </a>
+            <span>
+              <a href="/privacy" className="hover:underline">
+                Privacy Policy
+              </a>
+              <a href="/terms" className="ml-4 hover:underline">
+                Terms of Service
+              </a>
+            </span>
           </footer>
         </div>
 

--- a/apps/mouth/src/components/portal/PortalBottomNav.tsx
+++ b/apps/mouth/src/components/portal/PortalBottomNav.tsx
@@ -92,7 +92,7 @@ export function PortalBottomNav({ variant = "client" }: PortalBottomNavProps) {
   return (
     <nav
       aria-label="Main navigation"
-      className="fixed bottom-0 left-0 right-0 border-t border-[var(--bz-bottom-nav-border)] bg-[var(--bz-bottom-nav-bg)] shadow-[var(--bz-bottom-nav-shadow)] backdrop-blur-[20px] md:hidden z-50 safe-area-bottom"
+      className="fixed bottom-0 left-0 right-0 border-t border-[var(--bz-border)] bg-[var(--bz-bottom-nav-bg)] backdrop-blur-[20px] md:hidden z-50 safe-area-bottom"
     >
       <div className="flex items-center justify-around h-16">
         {tabs.map((tab) => {
@@ -111,21 +111,28 @@ export function PortalBottomNav({ variant = "client" }: PortalBottomNavProps) {
               aria-current={isActive ? "page" : undefined}
               aria-label={tab.name}
               className={cn(
-                "flex flex-col items-center justify-center gap-1 w-full h-full min-h-11 transition-colors relative rounded-xl",
+                "flex flex-col items-center justify-center gap-[5px] w-full h-full min-h-11 transition-colors relative",
                 isActive
-                  ? "text-[var(--bz-copper-text)] bg-[var(--bz-bottom-nav-active,transparent)] font-semibold"
-                  : "text-[var(--bz-text-2)] hover:text-[var(--bz-text-1)]",
+                  ? "text-[var(--tx-pure)]"
+                  : "text-[var(--tx-secondary)] hover:text-[var(--tx-pure)]",
               )}
             >
               <div className="relative">
-                <Icon className="w-5 h-5" />
+                <Icon
+                  className={cn(
+                    "w-5 h-5",
+                    isActive && "text-[var(--bz-copper)]",
+                  )}
+                />
                 {showBadge && (
-                  <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 px-1 flex items-center justify-center rounded-full bg-[var(--state-danger)] text-white text-[10px] font-bold">
+                  <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 px-1 flex items-center justify-center rounded-full bg-[var(--bz-copper)] text-white text-[9px] font-[650] tabular-nums">
                     {tab.badge > 99 ? "99+" : tab.badge}
                   </span>
                 )}
               </div>
-              <span className="text-[10px]">{tab.name}</span>
+              <span className="text-[9px] font-[650] uppercase tracking-[.1em]">
+                {tab.name}
+              </span>
             </Link>
           );
         })}

--- a/apps/mouth/src/components/portal/PortalHeader.tsx
+++ b/apps/mouth/src/components/portal/PortalHeader.tsx
@@ -92,7 +92,7 @@ export function PortalHeader({
   };
 
   return (
-    <header className="sticky top-0 z-30 w-full bg-[var(--portal-header-bg)] backdrop-blur-[24px] border-b border-[var(--bz-border)] shadow-[var(--bz-shell-header-shadow)]">
+    <header className="sticky top-0 z-30 w-full bg-[var(--portal-header-bg)] backdrop-blur-[24px] border-b border-[var(--bz-border)]">
       <div className="flex items-center justify-between h-[var(--bz-header-height,64px)] px-4 md:px-6">
         {/* Left Section */}
         <div className="flex items-center gap-3">
@@ -103,7 +103,7 @@ export function PortalHeader({
               size="icon"
               onClick={onBack}
               aria-label="Go back"
-              className="hover:bg-[var(--background-elevated)]"
+              className="h-10 w-10 rounded-[0.25rem] hover:bg-[var(--background-elevated)]"
             >
               <ChevronLeft className="w-5 h-5 text-[var(--foreground)]" />
             </Button>
@@ -115,7 +115,7 @@ export function PortalHeader({
             type="button"
             onClick={onMobileMenuToggle}
             className={cn(
-              "p-2 rounded-xl hover:bg-[var(--background-elevated)] transition-colors md:hidden",
+              "h-10 w-10 grid place-items-center rounded-[0.25rem] text-[var(--tx-secondary)] hover:bg-[var(--background-elevated)] hover:text-[var(--tx-pure)] transition-colors md:hidden",
             )}
             aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
             aria-controls="workspace-mobile-nav"
@@ -130,20 +130,23 @@ export function PortalHeader({
 
           {/* Page Title */}
           <div className="hidden sm:block">
-            <h1 className="text-xl font-semibold text-[var(--tx-pure)] tracking-[-0.01em] [font-family:var(--bz-product-heading-font)]">
+            <h1 className="text-[20px] font-medium leading-[1.1] text-[var(--tx-pure)] tracking-[-0.01em] [font-family:var(--font-serif)]">
               {getPageTitle()}
             </h1>
-            <p className="text-xs text-[var(--tx-secondary)] mt-0.5">
-              {formatDate()}{" "}
-              <span aria-hidden="true" className="text-[var(--bz-copper)] px-1">
+            <p className="text-[12px] text-[var(--tx-secondary)] mt-[3px]">
+              {formatDate()}
+              <span
+                aria-hidden="true"
+                className="text-[var(--bz-copper)] px-[5px]"
+              >
                 ·
-              </span>{" "}
+              </span>
               {getGreeting()}, {userName.split(" ")[0] || "there"}
             </p>
           </div>
 
           {/* Mobile Page Title */}
-          <h1 className="sm:hidden text-lg font-semibold text-[var(--tx-pure)] [font-family:var(--bz-product-heading-font)]">
+          <h1 className="sm:hidden text-[18px] font-medium text-[var(--tx-pure)] tracking-[-0.01em] [font-family:var(--font-serif)]">
             {getPageTitle()}
           </h1>
         </div>

--- a/apps/mouth/src/components/portal/PracticeRecapCard.tsx
+++ b/apps/mouth/src/components/portal/PracticeRecapCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Sparkles, Info } from "lucide-react";
+import { Info } from "lucide-react";
 import type { DashboardRecap } from "@/lib/api/portal/portal.types";
 
 /**
@@ -25,11 +25,7 @@ export function PracticeRecapCard({
   if (loading) {
     return (
       <div
-        className={`rounded-2xl border p-5 ${className ?? ""}`}
-        style={{
-          background: "var(--bz-elevated)",
-          borderColor: "var(--bz-border)",
-        }}
+        className={`border-l-[3px] border-[var(--bz-copper)] bg-[var(--bz-card)] rounded-r-[0.5rem] px-6 py-5 ${className ?? ""}`}
       >
         <div
           className="h-4 w-24 rounded animate-pulse"
@@ -51,43 +47,22 @@ export function PracticeRecapCard({
 
   return (
     <div
-      className={`rounded-2xl border p-5 ${className ?? ""}`}
-      style={{
-        background: "var(--bz-elevated)",
-        borderColor: "var(--bz-border-accent)",
-        boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
-      }}
+      className={`border-l-[3px] border-[var(--bz-copper)] bg-[var(--bz-card)] rounded-r-[0.5rem] px-6 py-5 ${className ?? ""}`}
     >
-      <div className="flex items-center gap-2 mb-2">
-        <Sparkles
-          className="w-4 h-4"
-          style={{ color: "var(--bz-accent-warm)" }}
-          aria-hidden
-        />
-        <span
-          className="text-xs font-bold uppercase tracking-wider"
-          style={{ color: "var(--bz-accent-warm)" }}
-        >
-          Your update
-        </span>
-      </div>
+      <span className="block text-[10px] font-[650] uppercase tracking-[.14em] text-[var(--tx-secondary)]">
+        Your update
+      </span>
 
       <p
-        className="text-base leading-relaxed"
-        style={{
-          color: "var(--bz-text-1)",
-          fontFamily: "var(--font-serif, inherit)",
-        }}
+        className="mt-3 text-[21px] leading-[1.35] tracking-[-0.015em] text-[var(--tx-pure)]"
+        style={{ fontFamily: "var(--font-serif, inherit)" }}
       >
         {recap.text}
       </p>
 
       {/* Permanent not-legal-advice disclaimer, never hidden */}
-      <p
-        className="mt-3 flex items-start gap-1.5 text-[11px] leading-snug"
-        style={{ color: "var(--bz-text-3)" }}
-      >
-        <Info className="w-3 h-3 mt-0.5 shrink-0" aria-hidden />
+      <p className="mt-[10px] flex items-start gap-1.5 text-[12px] leading-snug text-[var(--tx-secondary)]">
+        <Info className="w-3 h-3 mt-1 shrink-0" aria-hidden />
         <span>{recap.disclaimer}</span>
       </p>
     </div>

--- a/apps/mouth/src/components/portal/StatusBadge.tsx
+++ b/apps/mouth/src/components/portal/StatusBadge.tsx
@@ -9,33 +9,46 @@ import { CheckCircle, Clock, AlertTriangle } from "lucide-react";
  * warning 4.78:1, danger 5.74:1, info 5.94:1 on paper) instead of
  * hardcoded neon hexes (#34d399 / #fbbf24 / #f87171 / #60a5fa). Badge
  * backgrounds are color-mix tints OF the state token, so each theme gets a
- * tint of its own AA step — on dark the mix reproduces the previous
- * rgba(16,185,129,0.12)-style tints exactly (state primitives ARE those
- * hexes). No hardcoded colors.
+ * tint of its own AA step. No hardcoded colors.
+ *
+ * R19 (concept F): the pill is outlined — a hairline of the same state token
+ * at 35%, a 6px leading dot in currentColor and an uppercase 10px label. The
+ * meaning still lives in the token, not here: the four R19 meanings (forest
+ * done / slate moving / copper needs-you / muted waiting) are what the theme
+ * layer aliases --state-success / --state-info / --state-warning +
+ * --state-danger / --tx-secondary to.
  */
 
 type StatusTone = "success" | "warning" | "danger" | "info" | "neutral";
 
-const TONE_STYLES: Record<StatusTone, { bg: string; color: string }> = {
+const TONE_STYLES: Record<
+  StatusTone,
+  { bg: string; color: string; border: string }
+> = {
   success: {
-    bg: "color-mix(in srgb, var(--state-success) 12%, transparent)",
+    bg: "color-mix(in srgb, var(--state-success) 7%, transparent)",
     color: "var(--state-success)",
+    border: "color-mix(in srgb, var(--state-success) 35%, transparent)",
   },
   warning: {
-    bg: "color-mix(in srgb, var(--state-warning) 12%, transparent)",
+    bg: "color-mix(in srgb, var(--state-warning) 7%, transparent)",
     color: "var(--state-warning)",
+    border: "color-mix(in srgb, var(--state-warning) 35%, transparent)",
   },
   danger: {
-    bg: "color-mix(in srgb, var(--state-danger) 12%, transparent)",
+    bg: "color-mix(in srgb, var(--state-danger) 7%, transparent)",
     color: "var(--state-danger)",
+    border: "color-mix(in srgb, var(--state-danger) 35%, transparent)",
   },
   info: {
-    bg: "color-mix(in srgb, var(--state-info) 12%, transparent)",
+    bg: "color-mix(in srgb, var(--state-info) 7%, transparent)",
     color: "var(--state-info)",
+    border: "color-mix(in srgb, var(--state-info) 35%, transparent)",
   },
   neutral: {
-    bg: "var(--bz-border)",
-    color: "var(--bz-text-2)",
+    bg: "color-mix(in srgb, var(--tx-secondary) 5%, transparent)",
+    color: "var(--tx-secondary)",
+    border: "var(--bz-border)",
   },
 };
 
@@ -58,7 +71,8 @@ const STATUS_MAP: Record<
   // Amber group
   applied: { icon: Clock, label: "Applied", tone: "warning" },
   pending: { icon: Clock, label: "Pending", tone: "warning" },
-  processing: { icon: Clock, label: "Processing", tone: "warning" },
+  // R19: work that is ours and moving reads slate (info), not needs-you.
+  processing: { icon: Clock, label: "Processing", tone: "info" },
   attention: { icon: AlertTriangle, label: "Attention", tone: "warning" },
   warning: { icon: AlertTriangle, label: "Expiring", tone: "warning" },
   expiring: { icon: AlertTriangle, label: "Expiring", tone: "warning" },
@@ -110,14 +124,20 @@ export function StatusBadge({
 }) {
   const config = STATUS_MAP[status.toLowerCase()] ?? STATUS_MAP.none;
   const tone = TONE_STYLES[config.tone];
-  const Icon = config.icon;
 
   return (
     <div
-      className={`px-2.5 py-1 rounded-full flex items-center gap-1.5 text-xs font-medium ${className ?? ""}`}
-      style={{ background: tone.bg, color: tone.color }}
+      className={`inline-flex items-center gap-[7px] h-6 pl-[9px] pr-2.5 rounded-full border text-[10px] font-[650] uppercase tracking-[.12em] whitespace-nowrap ${className ?? ""}`}
+      style={{
+        background: tone.bg,
+        color: tone.color,
+        borderColor: tone.border,
+      }}
     >
-      <Icon className="w-3.5 h-3.5" />
+      <span
+        aria-hidden="true"
+        className="w-1.5 h-1.5 rounded-full bg-current shrink-0"
+      />
       {config.label}
     </div>
   );

--- a/apps/mouth/src/components/workspace/AppSidebar.tsx
+++ b/apps/mouth/src/components/workspace/AppSidebar.tsx
@@ -343,12 +343,12 @@ export function AppSidebar({
               <div
                 className={
                   isPortal
-                    ? "w-8 h-8 rounded-full flex items-center justify-center text-[11px] font-[650] text-[var(--tx-pure)] bg-[var(--bz-wash,#EAE3D8)]"
+                    ? "w-8 h-8 rounded-full flex items-center justify-center text-[11px] font-[650] text-[var(--tx-pure)]"
                     : "w-[28px] h-[28px] rounded-[8px] flex items-center justify-center text-[10px] font-bold text-white"
                 }
                 style={
                   isPortal
-                    ? undefined
+                    ? { background: "var(--bz-wash, var(--bz-elevated))" }
                     : {
                         background:
                           "linear-gradient(135deg, var(--bz-accent-warm) 0%, var(--bz-sidebar-active-fill) 100%)",

--- a/apps/mouth/src/components/workspace/AppSidebar.tsx
+++ b/apps/mouth/src/components/workspace/AppSidebar.tsx
@@ -115,15 +115,24 @@ export function AppSidebar({
     const badge = item.href === "/review" ? reviewCount : item.badge;
 
     // GARUDA active: AA-safe copper fill + white text, rounded-[12px]
-    const sharedClassName = cn(
+    const workspaceClassName = cn(
       "flex items-center gap-2.5 px-2.5 py-[7px] rounded-[12px] mb-[2px] text-[11.5px] font-medium uppercase tracking-[0.5px] transition-all group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bz-base)]",
       active
         ? "font-semibold"
         : "hover:bg-[var(--surface-raised)] hover:text-[var(--bz-text-1)]",
     );
-    const sharedStyle = active
+    // R19 portal rail: hairline paper, 40px rows, copper left rule on active.
+    const portalClassName = cn(
+      "flex items-center gap-2.5 h-10 px-2.5 rounded-[0.25rem] mb-[2px] text-[14px] font-medium border-l-2 transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bz-base)]",
+      active
+        ? "text-[var(--tx-pure)] bg-[var(--bz-card)] border-[var(--bz-copper)]"
+        : "text-[var(--tx-secondary)] border-transparent hover:bg-[var(--bz-card)] hover:text-[var(--tx-pure)]",
+    );
+    const sharedClassName = isPortal ? portalClassName : workspaceClassName;
+    const workspaceStyle = active
       ? { background: "var(--bz-sidebar-active-fill)", color: "#fff" }
       : { color: "var(--bz-text-2)" };
+    const sharedStyle = isPortal ? undefined : workspaceStyle;
 
     const sharedContent = (
       <>
@@ -137,12 +146,20 @@ export function AppSidebar({
           <ExternalLink
             size={9}
             style={{
-              color: active ? "rgba(255,255,255,0.5)" : "var(--bz-text-3)",
+              color:
+                active && !isPortal
+                  ? "rgba(255,255,255,0.5)"
+                  : "var(--bz-text-3)",
               opacity: 0.5,
             }}
           />
         )}
-        {badge && badge > 0 && (
+        {badge && badge > 0 && isPortal && (
+          <span className="ml-auto text-[10px] font-[650] text-[var(--bz-copper)] tabular-nums">
+            {badge > 99 ? "99+" : badge}
+          </span>
+        )}
+        {badge && badge > 0 && !isPortal && (
           <span
             className="text-[8px] font-bold px-1.5 py-0.5 rounded-full"
             style={{
@@ -193,8 +210,12 @@ export function AppSidebar({
       {section.title && (
         // More muted section headers — "structure felt not seen"
         <div
-          className="text-[8px] font-semibold uppercase tracking-[1.2px] px-2.5 pt-4 pb-1.5"
-          style={{ color: "var(--bz-text-3)" }}
+          className={
+            isPortal
+              ? "text-[9px] font-[650] uppercase tracking-[.16em] text-[var(--tx-secondary)] px-3 pt-[18px] pb-2"
+              : "text-[8px] font-semibold uppercase tracking-[1.2px] px-2.5 pt-4 pb-1.5"
+          }
+          style={isPortal ? undefined : { color: "var(--bz-text-3)" }}
         >
           {section.title}
         </div>
@@ -215,7 +236,10 @@ export function AppSidebar({
     <aside
       id={id}
       aria-label={ariaLabel}
-      className="fixed left-0 top-0 z-40 h-screen flex flex-col border-r transition-all duration-300 glass-panel-deep"
+      className={cn(
+        "fixed left-0 top-0 z-40 h-screen flex flex-col border-r transition-all duration-300",
+        isPortal ? "bg-[var(--bz-base)]" : "glass-panel-deep",
+      )}
       style={{
         width: "var(--bz-sidebar-width, 216px)",
         borderColor: "var(--bz-border)",
@@ -223,9 +247,14 @@ export function AppSidebar({
     >
       {/* Logo Header */}
       <div
-        className="border-b flex items-center justify-center px-3"
+        className={cn(
+          "border-b flex items-center",
+          isPortal ? "px-[18px]" : "justify-center px-3",
+        )}
         style={{
-          height: "var(--bz-header-height, 48px)",
+          height: isPortal
+            ? "var(--bz-header-height, 64px)"
+            : "var(--bz-header-height, 48px)",
           borderColor: "var(--bz-border)",
         }}
       >
@@ -234,9 +263,29 @@ export function AppSidebar({
           // Apply the same protected-route rule to the workspace home link.
           prefetch={isPortal ? false : undefined}
           aria-label="Bali Zero — workspace home"
-          className="flex items-center justify-center rounded-full transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bz-base)]"
+          className={cn(
+            "flex items-center transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bz-base)]",
+            isPortal
+              ? "gap-2.5 rounded-[0.25rem]"
+              : "justify-center rounded-full",
+          )}
         >
-          <BZLogo variant="full" size={36} className="rounded-full" priority />
+          <BZLogo
+            variant="full"
+            size={isPortal ? 28 : 36}
+            className={isPortal ? undefined : "rounded-full"}
+            priority
+          />
+          {isPortal && (
+            <span className="flex flex-col leading-none">
+              <span className="text-[17px] font-medium tracking-[-0.01em] text-[var(--tx-pure)] [font-family:var(--font-serif)]">
+                Bali Zero
+              </span>
+              <span className="mt-[5px] text-[9px] font-[650] uppercase tracking-[.16em] text-[var(--tx-secondary)]">
+                Client portal
+              </span>
+            </span>
+          )}
         </Link>
       </div>
 
@@ -292,11 +341,19 @@ export function AppSidebar({
               />
             ) : (
               <div
-                className="w-[28px] h-[28px] rounded-[8px] flex items-center justify-center text-[10px] font-bold text-white"
-                style={{
-                  background:
-                    "linear-gradient(135deg, var(--bz-accent-warm) 0%, var(--bz-sidebar-active-fill) 100%)",
-                }}
+                className={
+                  isPortal
+                    ? "w-8 h-8 rounded-full flex items-center justify-center text-[11px] font-[650] text-[var(--tx-pure)] bg-[var(--bz-wash,#EAE3D8)]"
+                    : "w-[28px] h-[28px] rounded-[8px] flex items-center justify-center text-[10px] font-bold text-white"
+                }
+                style={
+                  isPortal
+                    ? undefined
+                    : {
+                        background:
+                          "linear-gradient(135deg, var(--bz-accent-warm) 0%, var(--bz-sidebar-active-fill) 100%)",
+                      }
+                }
               >
                 {user.name?.[0]?.toUpperCase() || "U"}
               </div>
@@ -304,14 +361,22 @@ export function AppSidebar({
           </div>
           <div className="flex-1 min-w-0">
             <div
-              className="text-[11.5px] font-semibold uppercase tracking-[0.3px] truncate"
-              style={{ color: "var(--bz-text-1)" }}
+              className={
+                isPortal
+                  ? "text-[13px] font-semibold leading-[1.2] text-[var(--tx-pure)] truncate"
+                  : "text-[11.5px] font-semibold uppercase tracking-[0.3px] truncate"
+              }
+              style={isPortal ? undefined : { color: "var(--bz-text-1)" }}
             >
               {user.name}
             </div>
             <div
-              className="text-[9.5px] uppercase tracking-[0.5px]"
-              style={{ color: "var(--bz-text-2)" }}
+              className={
+                isPortal
+                  ? "text-[11px] text-[var(--tx-secondary)]"
+                  : "text-[9.5px] uppercase tracking-[0.5px]"
+              }
+              style={isPortal ? undefined : { color: "var(--bz-text-2)" }}
             >
               {isPortal ? "Client Portal" : user.role || user.team || "Team"}
             </div>

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w2-0a37d1ed/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w2-0a37d1ed/brief.yml
@@ -1,0 +1,41 @@
+gear: 2
+ruling: RULED 2026-09-12 SAETTA
+mission: SAETTA-R19P window W2 (BLUE) — the authenticated portal shell and the portal-only primitives in the R19 language (concept F, "RAPI")
+objective: >-
+  Dress the my.balizero.com authenticated shell in concept F's chrome without
+  touching a route, a field, a hook, a fetch or an i18n key: the 216px paper
+  sidebar carrying the REAL Bali Zero logo (BZLogo) beside a serif "Bali Zero"
+  and a "Client portal" eyebrow, 9px tracked section titles, 40px items with a
+  2px copper left rule on the active one and a copper unread count; a 64px
+  header on a translucent surface with a hairline and no shadow, a 20px serif
+  page title and a "date · greeting" line with a copper middot; a footer band on
+  the R19 footer wash; a 4-tab bottom nav with a copper active icon and a copper
+  count pip; StatusBadge as an outlined pill with a leading dot and an uppercase
+  10px label; PracticeRecapCard as the serif sentence behind a 3px copper left
+  rule with the disclaimer beneath.
+scope:
+  - apps/mouth/src/components/workspace/AppSidebar.tsx (ONLY inside isPortal branches)
+  - apps/mouth/src/components/portal/PortalHeader.tsx
+  - apps/mouth/src/components/portal/PortalBottomNav.tsx
+  - apps/mouth/src/components/portal/StatusBadge.tsx
+  - apps/mouth/src/components/portal/PracticeRecapCard.tsx
+  - apps/mouth/src/app/portal/(authenticated)/layout.tsx (the <footer> block only)
+constraints:
+  - Presentation only — class names, inline styles, markup order inside a section, copy. No route, field, hook, fetch, API type or i18n key touched; every aria attribute, ref, handler, dynamic import and the auth gate stay as they are.
+  - AppSidebar is shared with the kita/prime workspaces — every changed line must sit inside an isPortal conditional, and the non-portal branch must keep byte-identical class strings and inline styles.
+  - Forbidden — types/navigation.ts, components/ui/*, packages/core/**, every page.tsx, hooks, i18n files, PortalNotificationsPopover, SuperuserImpersonationBar, PENDING-ARMS.md, any ledger file.
+  - No red hex and no --state-danger *fill* authored by this window; no client PII (synthetic names only); no vendor names in code comments.
+  - Colour comes from tokens, never from a literal, except the two documented fallbacks for tokens that do not exist yet (--bz-wash, --bz-footer), which the sibling token window owns.
+  - No ledger PR, no PENDING-ARMS.md edit (SAETTA rule 2).
+acceptance:
+  - A1 git diff origin/main...HEAD --stat lists only the six scope files plus this evidence pair; net lines ≤ 300.
+  - A2 kita/prime safety — every changed line in AppSidebar.tsx sits inside an isPortal conditional, with the diff hunks and a one-line justification each recorded in the pack.
+  - A3 vitest green on src/components/portal, src/components/workspace and "src/app/portal/(authenticated)"; tsc --noEmit green; eslint on the six files with 0 errors.
+  - A4 no shadow- class remains on PortalHeader; no red hex authored; the logo is the BZLogo asset (variant full = /assets/logo/balizero-logo-clean.png) and the string "Client portal" appears in the sidebar brand block.
+  - A5 screenshots of /portal desktop + mobile under /Users/balizero/Desktop/R19-PORTAL-RENDERS-20260912/build/r19p-w2/, else "not rendered" with the reason.
+consumer_map:
+  - The live my.balizero.com authenticated portal surface (sidebar, header, footer, bottom nav, status pills, recap card) served by the apps/mouth Vercel deploy on merge to main.
+  - The kita/prime workspaces, which render the same AppSidebar with isPortal=false and must be unchanged — the innocence side of the same change.
+appetite:
+  budget: 75 minutes active, 1 PR
+  stop_loss: three reds on the same cause suspends; a harness-caused red is reported, never cured by rebuilding the branch

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w2-0a37d1ed/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w2-0a37d1ed/pack.yml
@@ -165,6 +165,30 @@ receipts:
     exit: 0
     ts: "2026-09-13T03:51:00+08:00"
     seat: Claude Opus 5 (r19p-w2)
+  - claim: >-
+      CI red #1 on the first head sha (1af70c1ece) was MINE - "token-lint - no new
+      hardcoded brand hex in redesigned surfaces" convicted the footer fallback
+      #EEE9E1 in apps/mouth/src/app/portal/(authenticated)/layout.tsx:369. The lint
+      scopes apps/mouth/src/app/portal/ and apps/mouth/src/app/(workspace)/, which is
+      why the sidebar's #EAE3D8 was not named. Cured at depth 1 - both literals became
+      token chains in inline styles (var(--bz-footer, var(--bz-base)) and
+      var(--bz-wash, var(--bz-elevated))), so no hex is authored anywhere in the diff.
+    cmd: gh run view --job 103612394350 --log-failed ; git diff | grep "^+" | grep -oE "#[0-9A-Fa-f]{3,8}" | sort -u ; python3 scripts/token_lint.py --base origin/main
+    result: "the job named layout.tsx:369 #EEE9E1, 1 violation in 1 file ; after the cure the added-line hex list is EMPTY and token_lint is clean on the new commit"
+    exit: 0
+    ts: "2026-09-13T04:10:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: >-
+      CI red #2 - "Harness floor recompute" - is HARNESS-caused and is not cured by this
+      window - harness_gate_read reports PENDING because no harness/fable-gate verdict
+      has been posted on the head sha yet. Its own message says "This is NOT a defect".
+      The fresh gate session posts the verdict and the run is re-triggered with
+      `gh run rerun` (never `gh workflow run --ref`).
+    cmd: gh run view --job 103612394641 --log-failed
+    result: "harness_gate_read: PENDING - no harness/fable-gate verdict has been posted yet on this commit ; real head sha = 1af70c1ece77e2fd0572d122ea873573b46e095c"
+    exit: 1
+    ts: "2026-09-13T04:07:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
 dissent:
   - seat: Claude Opus 5 (r19p-w2, self-review against the window brief)
     objection: >-
@@ -201,6 +225,6 @@ leftovers:
   - PortalBottomNav.test.tsx still queries ".bg-[var(--state-danger)]" to prove the absence of the count pip; the pip is now bg-[var(--bz-copper)], so that assertion passes vacuously. Re-point it when a window owns that test file.
   - The notification pip and the impersonation bar keep their current styling — PortalNotificationsPopover / SuperuserImpersonationBar are outside this window's perimeter.
   - The sidebar "who" block still prints "Client Portal" under the user's name, which now repeats the brand eyebrow above it (D4). The mock's line ("Client since March 2024") needs a field the portal profile does not return.
-  - --bz-wash and --bz-footer do not exist yet; two literals ride as var() fallbacks until the token window defines them.
+  - --bz-wash and --bz-footer do not exist yet; they ride as token chains (var(--bz-wash, var(--bz-elevated)) / var(--bz-footer, var(--bz-base))) until the token window defines them, so the footer band and the initials circle are paper/elevated for now instead of the concept's wash.
   - The authenticated /portal shell is not rendered locally (A5): turbopack refuses the broker worktree's symlinked node_modules, and under webpack the route-intercepted session stayed in the layout's isLoading state. A window with a working portal mock harness (or the deploy preview) should capture it.
   - The nav section label stayed a <div> instead of the mock's <h6> (D3).

--- a/evidence/2026-09/agent-air-m5-mouth-r19p-w2-0a37d1ed/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-r19p-w2-0a37d1ed/pack.yml
@@ -1,0 +1,206 @@
+gear: 2
+brief_ref: evidence/2026-09/agent-air-m5-mouth-r19p-w2-0a37d1ed/brief.yml
+ruling: RULED 2026-09-12 SAETTA
+lanes:
+  - lane: R19P-W2
+    role: build
+    seat: Claude Opus 5 (Dux of window r19p-w2, implements directly)
+  - lane: R19P-gate
+    role: review
+    seat: a FRESH session posts harness/fable-gate on the head sha — not this window (generator is never grader)
+pii_scan: clean
+decisions:
+  - id: D1
+    decision: >-
+      The logo is BZLogo variant "full" — packages/core/components/BZLogo.tsx maps
+      it to /assets/logo/balizero-logo-clean.png, the clean wordmark-less asset the
+      brief asked for. It is rendered at 28px WITHOUT rounded-full (the workspace
+      branch keeps its 36px rounded-full rendering byte-identical).
+  - id: D2
+    decision: >-
+      Serif comes from var(--font-serif) — the same slot the portal pages already
+      use inline (page.tsx, settings/notifications, partner/referrals) and the root
+      of --bz-product-heading-font. The sibling token window swaps its value; this
+      window names the slot and never a font family.
+  - id: D3
+    decision: >-
+      The nav section label stays a <div> instead of becoming the mock's <h6>. The
+      brief's rule sheet describes the mock's element; changing the tag is a markup
+      change with an a11y consequence (a heading inside a nav) and the window is
+      presentation-only, so only its type scale changed.
+  - id: D4
+    decision: >-
+      The sidebar "who" block keeps the existing string "Client Portal" for the
+      portal role line. The brand block above it now carries the eyebrow
+      "Client portal", so the second line is redundant — but changing it is a copy
+      decision on a line no mock block covers (the mock shows "Client since March
+      2024", a field the portal profile does not carry). Recorded as a leftover.
+  - id: D5
+    decision: >-
+      StatusBadge keeps reading the semantic --state-* tokens and keeps a 7%
+      color-mix tint (down from 12%) instead of dropping the fill entirely. Six
+      page tests outside this window's perimeter assert
+      `badge.style.color === "var(--state-*)"` and
+      `badge.style.background` contains "color-mix"; the four R19 meanings are
+      produced by the token layer (the sibling window re-aliases success→forest,
+      info→slate, warning/danger→copper), which is also where the concept puts
+      them. The outline (1px border at 35% of the same token), the 6px leading dot
+      and the uppercase 10px label are what this window authored.
+  - id: D6
+    decision: >-
+      The bottom-nav count pip is filled with var(--bz-copper), not
+      var(--state-danger) — the brief's one sanctioned copper fill, because it is a
+      counter and not a button. PortalBottomNav.test.tsx's absence assertion still
+      queries the old .bg-[var(--state-danger)] selector; it passes but is now
+      vacuous. Recorded as a leftover, since that test file is outside the perimeter.
+  - id: D7
+    decision: >-
+      Two tokens the concept names do not exist yet (--bz-wash, --bz-footer). They
+      are written as var(--bz-wash,#EAE3D8) / var(--bz-footer,#EEE9E1) so the
+      surface is right today and inherits the token the moment the sibling token
+      window defines it.
+kita_prime_safety:
+  claim: A2 — every changed line in AppSidebar.tsx sits inside an isPortal conditional; the non-portal branch keeps byte-identical strings.
+  hunks:
+    - hunk: "renderNavItem class/style"
+      justification: >-
+        sharedClassName/sharedStyle were renamed to workspaceClassName/workspaceStyle
+        with their strings unchanged, and the new sharedClassName/sharedStyle are
+        `isPortal ? portal… : workspace…`. With isPortal=false the rendered className
+        and style are the pre-change values, character for character.
+    - hunk: "ExternalLink colour"
+      justification: >-
+        `active ? white : text-3` became `active && !isPortal ? white : text-3`.
+        For isPortal=false the added conjunct is constant-true, so the expression is
+        equivalent; only the portal branch changes.
+    - hunk: "badge span"
+      justification: >-
+        The original span is now guarded by `!isPortal` and is otherwise untouched; a
+        separate portal-only span renders the copper count. No workspace pixel moves.
+    - hunk: "section title"
+      justification: >-
+        className and style became `isPortal ? … : <original>`; the workspace strings
+        are the original ones.
+    - hunk: "aside / brand row / logo / brand text"
+      justification: >-
+        glass-panel-deep, justify-center px-3, height var(--bz-header-height,48px),
+        rounded-full and BZLogo size 36 all survive on the non-portal side of the
+        ternaries; the 64px row, the 28px un-rounded logo and the serif brand block
+        exist only under isPortal.
+    - hunk: "who block (avatar, name, role)"
+      justification: >-
+        Three `isPortal ? … : <original>` ternaries. The workspace gradient avatar,
+        the 11.5px uppercase name and the 9.5px role line are unchanged; note the
+        portal avatar branch is only reachable when user.avatar is undefined, which
+        is always true in the portal (the layout passes avatar: undefined).
+  test_receipt: >-
+    AppSidebar.test.tsx's workspace case — "uses the accessible active-fill token for
+    the current navigation item", which asserts toHaveStyle({background:
+    "var(--bz-sidebar-active-fill)", color: "#fff"}) with isPortal unset — is green in
+    the run below. That is the innocence side; the portal prefetch case is the guilt side.
+receipts:
+  - claim: The window runs in its own broker worktree on the branch the broker named.
+    cmd: python3 scripts/agent_start.py --lane mouth --task-id r19p-w2 ; git -C <wt> branch --show-current
+    result: "WORKTREE_READY /Users/balizero/nuzantara/.worktrees/mouth-r19p-w2 ; branch agent/air-m5/mouth/r19p-w2 ; base commit e83615c7f7"
+    exit: 0
+    ts: "2026-09-13T02:39:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: D1 — BZLogo variant "full" is the clean logo asset, and the asset exists under apps/mouth/public.
+    cmd: cat packages/core/components/BZLogo.tsx ; ls -la apps/mouth/public/assets/logo/
+    result: 'SOURCES.full.src = "/assets/logo/balizero-logo-clean.png" (alt "Bali Zero"); balizero-logo-clean.png present, 246k. The other variants are balizero-3-red.png (mark), balizero-logo-circle.png (round), /static/zantara-lotus.png (zantara).'
+    exit: 0
+    ts: "2026-09-13T02:41:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: A3 — the portal and workspace component suites are green after the reskin.
+    cmd: cd apps/mouth && ../../node_modules/.bin/vitest --run src/components/portal src/components/workspace
+    result: "Test Files 29 passed (29) ; Tests 152 passed (152) ; duration 144.20s"
+    exit: 0
+    ts: "2026-09-13T03:04:46+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: A3 — the whole authenticated portal route tree is green, including the six page tests that assert StatusBadge inline styles and the page test that asserts the recap card's "Your update" label.
+    cmd: cd apps/mouth && ../../node_modules/.bin/vitest --run "src/app/portal/(authenticated)"
+    result: "Test Files 29 passed (29) ; Tests 189 passed (189) ; duration 187.23s"
+    exit: 0
+    ts: "2026-09-13T03:08:31+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: A3 — typecheck green over the whole mouth app.
+    cmd: cd apps/mouth && ../../node_modules/.bin/tsc --noEmit
+    result: "no diagnostics ; 33m49s wall (three sibling windows were typechecking on the same machine)"
+    exit: 0
+    ts: "2026-09-13T03:20:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: A3 — eslint on the six touched files reports 0 errors; the 5 warnings are pre-existing patterns (the ref-cleanup warning in the layout's focus trap and the <a href="/privacy">/<a href="/terms"> footer links, which were <a> before this window too).
+    cmd: cd apps/mouth && ../../node_modules/.bin/eslint <the six files>
+    result: "5 problems (0 errors, 5 warnings) ; exit 0"
+    exit: 0
+    ts: "2026-09-13T03:12:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: A4 — no shadow- class survives on PortalHeader; no red hex is authored by this window; the only red-hex string in the perimeter is the pre-existing comment in StatusBadge that documents the neon hexes REMOVED in 2026-07.
+    cmd: grep -c "shadow-" PortalHeader.tsx ; grep -nEi "#(f87171|ef4444|dc2626|e11d48|ff0000|b91c1c)" <the six files> ; git diff | grep "^+" | grep -oE "#[0-9A-Fa-f]{3,8}" | sort -u
+    result: "shadow- count 0 ; the single red-hex line is StatusBadge.tsx:10, a comment; the only hexes added by the diff are #EAE3D8 (wash fallback) and #EEE9E1 (footer fallback)"
+    exit: 0
+    ts: "2026-09-13T03:45:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: A4 — the sidebar brand block renders the BZLogo component and the string "Client portal".
+    cmd: grep -n "BZLogo\|Client portal" apps/mouth/src/components/workspace/AppSidebar.tsx
+    result: 'line 36 import { BZLogo } from "@balizero/core/components/BZLogo" ; line 273 <BZLogo ... /> ; line 285 "Client portal"'
+    exit: 0
+    ts: "2026-09-13T03:45:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: A1 — the change touches only the six scope files plus this evidence pair, and the code net is 56 lines (297 with the pack).
+    cmd: git -C <wt> diff --cached $(git merge-base origin/main HEAD) --stat ; same with --numstat summed ; same restricted to -- apps/mouth
+    result: "8 files changed, 406 insertions(+), 109 deletions(-) — layout.tsx, PortalBottomNav.tsx, PortalHeader.tsx, PracticeRecapCard.tsx, StatusBadge.tsx, AppSidebar.tsx, brief.yml, pack.yml. Code only (apps/mouth): added 165, deleted 109, net 56. Whole change net 297."
+    exit: 0
+    ts: "2026-09-13T03:52:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: A5 — the authenticated /portal shell was NOT rendered locally. The dev server had to run on webpack (turbopack refuses this worktree's symlinked node_modules — "Symlink [project]/apps/mouth/node_modules is invalid, it points out of the filesystem root"), /portal answered HTTP 200 after a 314s first compile, but the route-intercepted client session never left the layout's isLoading state within a 120s wait, so both captures showed only the loading spinner and were deleted rather than passed off as the shell.
+    cmd: next dev --webpack -p 3117 ; curl -o /dev/null -w "%{http_code} %{time_total}" http://127.0.0.1:3117/portal ; node <scratchpad>/w2-shot.mjs (playwright, channel chrome, 1440x900 + 390x844)
+    result: "warmup=200 t=314.688788 ; both screenshots captured the Loading… state ; page.waitForSelector('text=Client portal') timed out at 120000ms ; files removed, declared not rendered"
+    exit: 1
+    ts: "2026-09-13T03:36:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+  - claim: The implicit `pnpm install` that `pnpm -F mouth typecheck` triggers wrote an allowBuilds line into pnpm-workspace.yaml; it was reverted, so no lockfile-adjacent file rides in this PR.
+    cmd: git -C <wt> diff --cached -- pnpm-workspace.yaml ; git -C <wt> restore --staged --worktree -- pnpm-workspace.yaml ; git -C <wt> status --porcelain
+    result: 'the added line was "''@parcel/watcher'': set this to true or false" under allowBuilds ; after the restore the porcelain lists only the six scope files and the two evidence files'
+    exit: 0
+    ts: "2026-09-13T03:51:00+08:00"
+    seat: Claude Opus 5 (r19p-w2)
+dissent:
+  - seat: Claude Opus 5 (r19p-w2, self-review against the window brief)
+    objection: >-
+      The brief says "drop the filled backgrounds" on StatusBadge; the shipped pill keeps
+      a 7% color-mix tint of the state token.
+    status: CONFIRMED
+    cure: >-
+      Not fully cured, by constraint rather than by choice: companies/visa/taxes/company[id]
+      and two partner page tests assert `style.background` contains "color-mix" on the badge,
+      and those files are outside this window's perimeter (A1 would fail). The tint was
+      halved (12% → 7%) and the outline + dot + uppercase label were added, so the pill reads
+      as an outlined pill. Recorded as a leftover for the window that owns those tests.
+  - seat: Claude Opus 5 (r19p-w2, self-review)
+    objection: >-
+      The brief's status→colour map is stated as forest/slate/copper/muted, but this window
+      writes --state-success / --state-info / --state-warning / --state-danger instead.
+    status: RETRACTED
+    cure: >-
+      Not a defect. Concept F §3 puts the four meanings in the TOKEN layer ("--state-danger is
+      re-aliased to copper"), which the sibling token window owns. Hardcoding copper here would
+      break two tests AND duplicate the mapping in two places. The one status whose MEANING
+      changed — processing, which is ours-and-moving, not needs-you — was moved from the
+      warning tone to the info (slate) tone in this window, because that is a mapping decision,
+      not a colour value.
+  - seat: Claude Opus 5 (r19p-w2, self-review)
+    objection: >-
+      The notification pip is specified copper in the brief but was not touched.
+    status: CONFIRMED
+    cure: >-
+      Not cured: the pip lives inside PortalNotificationsPopover, which the brief lists as
+      forbidden. Recorded as a leftover.
+leftovers:
+  - StatusBadge keeps a 7% color-mix tint behind the outline; six page tests outside this perimeter (companies, visa, taxes, company/[id], partner/commissions, partner/dashboard) assert style.background contains "color-mix". Dropping the fill needs a window that owns those tests.
+  - PortalBottomNav.test.tsx still queries ".bg-[var(--state-danger)]" to prove the absence of the count pip; the pip is now bg-[var(--bz-copper)], so that assertion passes vacuously. Re-point it when a window owns that test file.
+  - The notification pip and the impersonation bar keep their current styling — PortalNotificationsPopover / SuperuserImpersonationBar are outside this window's perimeter.
+  - The sidebar "who" block still prints "Client Portal" under the user's name, which now repeats the brand eyebrow above it (D4). The mock's line ("Client since March 2024") needs a field the portal profile does not return.
+  - --bz-wash and --bz-footer do not exist yet; two literals ride as var() fallbacks until the token window defines them.
+  - The authenticated /portal shell is not rendered locally (A5): turbopack refuses the broker worktree's symlinked node_modules, and under webpack the route-intercepted session stayed in the layout's isLoading state. A window with a working portal mock harness (or the deploy preview) should capture it.
+  - The nav section label stayed a <div> instead of the mock's <h6> (D3).


### PR DESCRIPTION
Mission SAETTA-R19P (BLUE, host M5), window W2 — the authenticated shell and the portal-only primitives, in concept F's language. Presentation only: no route, field, hook, fetch, API type or i18n key is touched, and every aria attribute, ref, handler, dynamic import and the auth gate stay exactly as they were.

**What changed (six files, code net +56 lines)**
- `AppSidebar.tsx` — **only inside `isPortal` branches**: the real Bali Zero logo (`BZLogo variant="full"` → `/assets/logo/balizero-logo-clean.png`, 28px, no `rounded-full`) beside a serif "Bali Zero" and the eyebrow "Client portal" on a 64px brand row; 9px tracked section titles; 40px items with a 2px copper left rule + card wash on the active one; a copper unread count; a 32px initials circle in the who block.
- `PortalHeader.tsx` — the shell shadow is gone, the title is 20px serif, the `date · greeting` line keeps its copper middot, hamburger and back button are 40px at radius 0.25rem.
- `PortalBottomNav.tsx` — hairline border, uppercase 9px labels, copper active icon, and the count pip filled **copper** instead of `--state-danger` (it is a counter, not a button — the one copper fill the design allows).
- `StatusBadge.tsx` — an outlined pill: 1px hairline at 35% of the same state token, a 6px leading dot in `currentColor`, an uppercase 10px tracked label. The meaning stays in the semantic `--state-*` tokens (the sibling token window re-aliases them to forest / slate / copper / muted); `processing` moves to the slate tone because that work is ours and moving.
- `PracticeRecapCard.tsx` — the recap sentence in 21px serif behind a 3px copper left rule, disclaimer beneath.
- `(authenticated)/layout.tsx` — the `<footer>` block only: the R19 footer band, 12px muted, hairline top.

**kita / prime safety.** `AppSidebar` is shared. Every changed line sits inside an `isPortal ? … : …` conditional, and the non-portal side keeps its class strings and inline styles character for character (`sharedClassName`/`sharedStyle` were renamed to `workspaceClassName`/`workspaceStyle` with their contents untouched; `active ? white : text-3` became `active && !isPortal ? …`, which is the same expression when `isPortal` is false). The workspace innocence case in `AppSidebar.test.tsx` — the one asserting `background: var(--bz-sidebar-active-fill)`, `color: #fff` with `isPortal` unset — is green.

**Bites:** the consumer is the live my.balizero.com authenticated portal surface served by the apps/mouth Vercel deploy — the sidebar, header, footer, bottom nav, status pills and recap card a signed-in client sees on `/portal`. The observation that proves the change is in force, made in the worktree before this PR: `vitest --run "src/app/portal/(authenticated)"` renders the reskinned shell and the six page tests that assert the badge's inline `--state-*` tokens stay green (29 files / 189 tests), `vitest --run src/components/portal src/components/workspace` 29 files / 152 tests green, `tsc --noEmit` exit 0, `eslint` on the six files 0 errors (5 pre-existing warnings), `grep -c "shadow-" PortalHeader.tsx` = 0, and `grep -n "BZLogo\|Client portal" AppSidebar.tsx` shows the component import and the brand-block string on the rendered path. The local `/portal` render is NOT part of this evidence: turbopack refuses the broker worktree's symlinked `node_modules`, and under webpack the route-intercepted session stayed in the layout's `isLoading` state, so the two captures showed only the spinner and were deleted rather than passed off as the shell.

**Evidence:** `evidence/2026-09/agent-air-m5-mouth-r19p-w2-0a37d1ed/` (gear 2, `RULED 2026-09-12 SAETTA`, `pii_scan: clean`, receipts with exit codes, dissent and leftovers). `evidence_pack_lint.py` clean.

**Leftovers (in the pack):** the badge keeps a 7% tint because six page tests outside this window's perimeter assert `style.background` contains `color-mix`; `PortalBottomNav.test.tsx` still queries the old `.bg-[var(--state-danger)]` selector, so that absence assertion now passes vacuously; the notification pip is inside `PortalNotificationsPopover`, which is out of perimeter; `--bz-wash` / `--bz-footer` ride as `var()` fallbacks until the token window defines them.

Gear 2: this PR cannot merge until a fresh gate posts `harness/fable-gate` on the head sha. That gate is not this window's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)