### PR TITLE
fix(mouth): kita wave 2e — Drive card always offers Reconnect, honours configured, drops stale docs

### DIFF
--- a/apps/mouth/DOCUMENTATION.md
+++ b/apps/mouth/DOCUMENTATION.md
@@ -212,9 +212,7 @@ apps/mouth/
 │   │   ├── chat/                     # Chat UI
 │   │   │   ├── ChatHeader.tsx
 │   │   │   ├── ChatInputBar.tsx
-│   │   │   ├── ChatMessageList.tsx
-│   │   │   ├── ChatSourcesPanel.tsx
-│   │   │   ├── FeedbackWidget.tsx
+│   │   │   ├── ChatMessageListVirtualized.tsx
 │   │   │   ├── MessageBubble.tsx
 │   │   │   └── ThinkingIndicator.tsx
 │   │   ├── dashboard/                # Dashboard widgets
@@ -450,7 +448,6 @@ API Routes:
 ├── /api/[...path]          → Proxy universale al backend
 ├── /api/blog/articles      → Lista articoli
 ├── /api/blog/articles/[category]/[slug]  → Articolo singolo
-├── /api/blog/articles/[category]/[slug]/views  → Track views
 ├── /api/blog/newsletter    → Subscribe newsletter
 └── /api/blog/newsletter/confirm  → Conferma email
 ```
@@ -485,9 +482,8 @@ App
 │       │       │   └── ComplianceWidget
 │       │       ├── ChatPage
 │       │       │   ├── ChatHeader
-│       │       │   ├── ChatMessageList
+│       │       │   ├── ChatMessageListVirtualized
 │       │       │   │   └── MessageBubble[]
-│       │       │   ├── ChatSourcesPanel
 │       │       │   └── ChatInputBar
 │       │       └── ...
 │       └── BlogLayout
@@ -501,15 +497,13 @@ App
 
 ### Componenti Chat
 
-| Componente          | File                         | Props                                     | Descrizione                |
-| ------------------- | ---------------------------- | ----------------------------------------- | -------------------------- |
-| `ChatHeader`        | `chat/ChatHeader.tsx`        | sessionId, onNewChat                      | Header con info sessione   |
-| `ChatInputBar`      | `chat/ChatInputBar.tsx`      | input, isLoading, onSend, onImageGenerate | Input multimodale          |
-| `ChatMessageList`   | `chat/ChatMessageList.tsx`   | messages, onFollowUp                      | Lista messaggi scrollabile |
-| `MessageBubble`     | `chat/MessageBubble.tsx`     | message, isLast, onFollowUp               | Singolo messaggio          |
-| `ChatSourcesPanel`  | `chat/ChatSourcesPanel.tsx`  | sources, isOpen                           | Panel sorgenti laterale    |
-| `ThinkingIndicator` | `chat/ThinkingIndicator.tsx` | status                                    | Indicatore elaborazione    |
-| `FeedbackWidget`    | `chat/FeedbackWidget.tsx`    | messageId, onSubmit                       | Feedback thumbs            |
+| Componente                   | File                                  | Props                                     | Descrizione                |
+| ---------------------------- | ------------------------------------- | ----------------------------------------- | -------------------------- |
+| `ChatHeader`                 | `chat/ChatHeader.tsx`                 | sessionId, onNewChat                      | Header con info sessione   |
+| `ChatInputBar`               | `chat/ChatInputBar.tsx`               | input, isLoading, onSend, onImageGenerate | Input multimodale          |
+| `ChatMessageListVirtualized` | `chat/ChatMessageListVirtualized.tsx` | messages, onFollowUp                      | Lista messaggi scrollabile |
+| `MessageBubble`              | `chat/MessageBubble.tsx`              | message, isLast, onFollowUp               | Singolo messaggio          |
+| `ThinkingIndicator`          | `chat/ThinkingIndicator.tsx`          | status                                    | Indicatore elaborazione    |
 
 ### Componenti Blog
 
@@ -696,21 +690,6 @@ const {
 
 // useMemoryContext - User memory
 const { profileFacts, summary, counters, refresh } = useMemoryContext(userId);
-
-// useWebSocket - Real-time
-const { isConnected, connect, disconnect, send, subscribe } = useWebSocket();
-```
-
-### Providers
-
-```typescript
-// WebSocket Provider
-<WebSocketProvider url={wsUrl}>
-  <App />
-</WebSocketProvider>
-
-// Usage in components
-const { send, subscribe } = useWebSocketContext();
 ```
 
 ### Local Storage Keys
@@ -822,15 +801,14 @@ MDX File → gray-matter (frontmatter) → next-mdx-remote/serialize → MDXCont
 
 ### API Endpoints Blog
 
-| Endpoint                                | Method | Descrizione               |
-| --------------------------------------- | ------ | ------------------------- |
-| `/api/blog/articles`                    | GET    | Lista articoli con filtri |
-| `/api/blog/articles?category=X`         | GET    | Filtra per categoria      |
-| `/api/blog/articles?featured=true`      | GET    | Solo featured             |
-| `/api/blog/articles?q=search`           | GET    | Cerca articoli            |
-| `/api/blog/articles/[cat]/[slug]`       | GET    | Singolo articolo          |
-| `/api/blog/articles/[cat]/[slug]/views` | POST   | Track view                |
-| `/api/blog/newsletter`                  | POST   | Subscribe                 |
+| Endpoint                           | Method | Descrizione               |
+| ---------------------------------- | ------ | ------------------------- |
+| `/api/blog/articles`               | GET    | Lista articoli con filtri |
+| `/api/blog/articles?category=X`    | GET    | Filtra per categoria      |
+| `/api/blog/articles?featured=true` | GET    | Solo featured             |
+| `/api/blog/articles?q=search`      | GET    | Cerca articoli            |
+| `/api/blog/articles/[cat]/[slug]`  | GET    | Singolo articolo          |
+| `/api/blog/newsletter`             | POST   | Subscribe                 |
 
 ---
 

--- a/apps/mouth/src/app/(workspace)/dashboard/__tests__/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/dashboard/__tests__/page.test.tsx
@@ -59,32 +59,6 @@ vi.mock("next/link", () => ({
 }));
 // Mock dashboard components
 vi.mock("@/components/dashboard", () => ({
-  StatsCard: ({
-    title,
-    value,
-    href,
-  }: {
-    title: string;
-    value: string | number;
-    href: string;
-  }) => (
-    <div data-testid={`stats-card-${title.toLowerCase().replaceAll(" ", "-")}`}>
-      <a href={href}>
-        {title}: {value}
-      </a>
-    </div>
-  ),
-  CasesPreview: ({
-    cases,
-    isLoading,
-  }: {
-    cases: unknown[];
-    isLoading: boolean;
-  }) => (
-    <div data-testid="cases-preview">
-      {isLoading ? "Loading..." : `${cases.length} cases`}
-    </div>
-  ),
   AiPulseWidget: () => <div data-testid="ai-pulse-widget">AI Pulse</div>,
   FinancialRealityWidget: ({
     revenue,
@@ -106,19 +80,6 @@ vi.mock("@/components/dashboard", () => ({
   ),
   MiniSparkline: ({ data }: { data: unknown[] }) => (
     <div data-testid="mini-sparkline">{data?.length ?? 0} points</div>
-  ),
-  DashboardStatCard: ({
-    label,
-    value,
-  }: {
-    label: string;
-    value: string | number;
-  }) => (
-    <div
-      data-testid={`dash-stat-card-${label.toLowerCase().replaceAll(" ", "-")}`}
-    >
-      {label}: {value}
-    </div>
   ),
   RoleWidget: ({ role }: { role: string }) => (
     <div data-testid="role-widget">{role}</div>

--- a/apps/mouth/src/app/(workspace)/settings/integrations/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/settings/integrations/page.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import IntegrationsPage from "./page";
+
+/**
+ * kita wave 2e — Drive card reconnect path.
+ *
+ * `connected` is a stored-token check, not a live one: is_connected() on the
+ * backend never re-asks Google, so a grant revoked on Google's side still
+ * reads "Connected" with the pre-cure card offering no way back. These tests
+ * pin: connected always offers Reconnect (GUILT would be no button at all),
+ * disconnected offers Connect (INNOCENCE: no Reconnect leaks into that
+ * state), `configured: false` disables both and shows the admin message, and
+ * an auth-url failure surfaces inline instead of silently resetting.
+ */
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  get: vi.fn(),
+  getAuthUrl: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: mocks.get,
+    drive: {
+      getAuthUrl: mocks.getAuthUrl,
+    },
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: mocks.error,
+  },
+}));
+
+// jsdom throws "Not implemented: navigation" if a test lets the real
+// assignment through; the redirect target is asserted, not followed.
+function stubLocation() {
+  // @ts-expect-error -- test-only stub
+  delete window.location;
+  // @ts-expect-error -- test-only stub
+  window.location = { href: "" };
+}
+
+describe("Google Drive integration card (kita wave 2e)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("connected: offers Reconnect and clicking it calls the auth-url endpoint", async () => {
+    stubLocation();
+    mocks.get.mockResolvedValue({ connected: true, configured: true });
+    mocks.getAuthUrl.mockResolvedValue({
+      auth_url: "https://accounts.google.com/o/oauth2/auth",
+    });
+
+    render(<IntegrationsPage />);
+
+    const button = await screen.findByRole("button", { name: "Reconnect" });
+    expect(screen.queryByRole("button", { name: "Connect" })).toBeNull();
+
+    button.click();
+
+    await waitFor(() => expect(mocks.getAuthUrl).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(window.location.href).toBe(
+        "https://accounts.google.com/o/oauth2/auth",
+      ),
+    );
+  });
+
+  it("disconnected: offers Connect, not Reconnect", async () => {
+    mocks.get.mockResolvedValue({ connected: false, configured: true });
+
+    render(<IntegrationsPage />);
+
+    await screen.findByRole("button", { name: "Connect" });
+    expect(screen.queryByRole("button", { name: "Reconnect" })).toBeNull();
+  });
+
+  it("configured=false: disables the action and shows the admin message", async () => {
+    mocks.get.mockResolvedValue({ connected: false, configured: false });
+
+    render(<IntegrationsPage />);
+
+    const button = await screen.findByRole("button", { name: "Connect" });
+    expect(button).toBeDisabled();
+    expect(
+      await screen.findByText(/OAuth is not configured on the server/i),
+    ).toBeInTheDocument();
+  });
+
+  it("configured=false while connected: Reconnect is disabled too", async () => {
+    mocks.get.mockResolvedValue({ connected: true, configured: false });
+
+    render(<IntegrationsPage />);
+
+    const button = await screen.findByRole("button", { name: "Reconnect" });
+    expect(button).toBeDisabled();
+  });
+
+  it("auth-url failure: shows an inline error instead of silently resetting", async () => {
+    mocks.get.mockResolvedValue({ connected: false, configured: true });
+    mocks.getAuthUrl.mockRejectedValue(new Error("service unavailable"));
+
+    render(<IntegrationsPage />);
+
+    const button = await screen.findByRole("button", { name: "Connect" });
+    button.click();
+
+    await waitFor(() => expect(mocks.getAuthUrl).toHaveBeenCalledTimes(1));
+    expect(
+      await screen.findByText(/could not start the google drive connection/i),
+    ).toBeInTheDocument();
+    // The button must be usable again, not stuck on "Redirecting…".
+    expect(
+      await screen.findByRole("button", { name: "Connect" }),
+    ).not.toBeDisabled();
+  });
+});

--- a/apps/mouth/src/app/(workspace)/settings/integrations/page.tsx
+++ b/apps/mouth/src/app/(workspace)/settings/integrations/page.tsx
@@ -31,10 +31,18 @@ const GOOGLE_BLUE = "#4285F4"; // token-lint-ok: third-party brand identity colo
 // were constants flipped in local state, so they are gone. Disconnect is
 // deliberately NOT offered: the backend route revokes the Google token and
 // deletes the grant, irreversibly, and this page has no confirmation flow.
+//
+// `connected` above is a stored-token check, not a live one — is_connected()
+// on the backend never re-asks Google, so a grant revoked on Google's side
+// still reads "Connected" here. Reconnect reruns the same OAuth flow as
+// Connect and is always offered once configured, so there is a way back
+// without a Disconnect button.
 export default function IntegrationsPage() {
   const router = useRouter();
   const [status, setStatus] = useState<DriveStatus>("checking");
+  const [configured, setConfigured] = useState(true);
   const [busy, setBusy] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
 
   useEffect(() => {
     const check = async () => {
@@ -43,6 +51,7 @@ export default function IntegrationsPage() {
           "/api/integrations/google-drive/status",
         );
         setStatus(s.connected ? "connected" : "disconnected");
+        setConfigured(s.configured);
       } catch (error) {
         logger.error("Failed to check Google Drive status", {}, error as Error);
         setStatus("error");
@@ -63,12 +72,16 @@ export default function IntegrationsPage() {
 
   const connect = async () => {
     setBusy(true);
+    setAuthError(null);
     try {
       const { auth_url } = await api.drive.getAuthUrl();
       window.location.href = auth_url;
     } catch (error) {
       logger.error("Failed to get auth URL", {}, error as Error);
       setBusy(false);
+      setAuthError(
+        "Could not start the Google Drive connection. Please try again in a moment.",
+      );
     }
   };
 
@@ -137,28 +150,40 @@ export default function IntegrationsPage() {
               </p>
             </div>
           </div>
-          {status === "connected" ? (
-            <p className="text-xs text-[var(--foreground-muted)] text-right max-w-[220px]">
-              Connected via your Google account. Revoke access from your Google
-              account permissions page.
-            </p>
-          ) : (
+          <div className="flex flex-col items-end gap-1">
             <Button
               size="sm"
+              variant={status === "connected" ? "outline" : "default"}
               onClick={connect}
-              disabled={busy || status === "checking"}
+              disabled={busy || status === "checking" || !configured}
             >
               {busy ? (
                 <>
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                   Redirecting…
                 </>
+              ) : status === "connected" ? (
+                "Reconnect"
               ) : (
                 "Connect"
               )}
             </Button>
-          )}
+            {status === "connected" && configured && (
+              <p className="text-xs text-[var(--foreground-muted)] text-right max-w-[220px]">
+                Use this if Drive access stopped working
+              </p>
+            )}
+          </div>
         </div>
+        {!configured && (
+          <p className="mt-3 text-xs text-[var(--state-danger)]">
+            Google Drive OAuth is not configured on the server — ask the
+            administrator.
+          </p>
+        )}
+        {authError && (
+          <p className="mt-3 text-xs text-[var(--state-danger)]">{authError}</p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Codex council seat on merged PR #6296 flagged three issues on the Google Drive integration card (`apps/mouth/src/app/(workspace)/settings/integrations/page.tsx`):

1. **MEDIUM** — once `connected`, the card offered no action. The backend's `is_connected()` trusts the stored token without re-asking Google, so a grant revoked on Google's side left the card stuck on "Connected" with no way back. Added a Reconnect button next to the Connected badge (same `connect()` → fetch auth URL → redirect flow), with helper text "Use this if Drive access stopped working". No Disconnect button — the backend route revokes irreversibly and this page has no confirmation flow.
2. **LOW** — the page ignored the `configured` field the status endpoint already returns. Now `configured === false` shows an inline message ("Google Drive OAuth is not configured on the server — ask the administrator") and disables Connect/Reconnect. An auth-url request failure (e.g. 503) now shows an inline error instead of silently resetting the button.
3. **LOW** — stale doc/test references to deleted modules, verified against `main` with `git ls-files`/route-handler grep before touching anything:
   - `apps/mouth/DOCUMENTATION.md`: removed the `useWebSocket`/`WebSocketProvider`/`useWebSocketContext` section (none exist), removed `ChatSourcesPanel.tsx`/`FeedbackWidget.tsx` entries (deleted), renamed `ChatMessageList.tsx` references to `ChatMessageListVirtualized.tsx` (the actual current filename), and removed the `POST /api/blog/articles/[category]/[slug]/views` endpoint row (no such route handler exists — only GET/PATCH/DELETE remain).
   - `apps/mouth/src/app/(workspace)/dashboard/__tests__/page.test.tsx`: dropped the `StatsCard`/`CasesPreview`/`DashboardStatCard` mock entries for `@/components/dashboard` — that barrel now exports only `MiniSparkline` and `RoleWidget`.

## Verification

- `npx tsc --noEmit` — exit 0
- `npx vitest --run --root . --config vitest.config.ts` — full suite green: 475 files, 5113 tests passed (targeted run of the 3 touched suites also green: 23/23)
  - New: `apps/mouth/src/app/(workspace)/settings/integrations/page.test.tsx` — "connected: offers Reconnect and clicking it calls the auth-url endpoint", "disconnected: offers Connect, not Reconnect", "configured=false: disables the action and shows the admin message", "configured=false while connected: Reconnect is disabled too", "auth-url failure: shows an inline error instead of silently resetting"
  - Existing `settings/__tests__/token-drain.guard.test.ts` stays green (unmarked-hex / palette-utility guards on the integrations page)
- `npm run build` — exit 0, printed `PUBLIC_LOGIN_BUNDLE_OK`; `apps/mouth/public/llms*.txt` build churn reverted before commit
- `python3 -I scripts/token_lint.py --base origin/main` — clean

## Floor

Churn-based floor = 1 (`compute_floor` on the 4-file numstat), below the Gear-2 evidence-pack threshold. No brief written.

Bites: kita operators on `/settings/integrations` — a connected user now sees a Reconnect button, and an unconfigured server shows the message instead of a dead-end Connected badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
