### PR TITLE
refactor(mouth): kita pruning wave 2c — one OCR polling hook for the four document cards

### DIFF
--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/FamilyTab.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/FamilyTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState, useRef, useCallback, useEffect } from "react";
+import React, { useState, useRef } from "react";
+import { useOcrPolling } from "@/hooks/useOcrPolling";
 import {
   User,
   Users,
@@ -42,51 +43,12 @@ function FamilyMemberUploadButton({
   onRefresh: () => Promise<void> | void;
 }) {
   const [isUploading, setIsUploading] = useState(false);
-  const [ocrPolling, setOcrPolling] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const ocrTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const ocrAbortedRef = useRef(false);
-  const onRefreshRef = useRef(onRefresh);
-  onRefreshRef.current = onRefresh;
 
-  // Cleanup OCR polling timers when component unmounts
-  useEffect(() => {
-    ocrAbortedRef.current = false;
-    return () => {
-      ocrAbortedRef.current = true;
-      if (ocrTimerRef.current) clearTimeout(ocrTimerRef.current);
-    };
-  }, []);
-
-  const pollOcrStatus = useCallback(async () => {
-    setOcrPolling(true);
-    let attempts = 0;
-    const poll = async () => {
-      if (ocrAbortedRef.current) return;
-      try {
-        const status = (await api.request(
-          `/api/crm/clients/${clientId}/ocr-status`,
-        )) as {
-          pending_ocr: number;
-        };
-        if (status.pending_ocr === 0 || attempts >= 10) {
-          if (!ocrAbortedRef.current) {
-            setOcrPolling(false);
-            await onRefreshRef.current();
-          }
-          return;
-        }
-        attempts++;
-        ocrTimerRef.current = setTimeout(poll, 3000);
-      } catch {
-        if (!ocrAbortedRef.current) {
-          setOcrPolling(false);
-          await onRefreshRef.current();
-        }
-      }
-    };
-    ocrTimerRef.current = setTimeout(poll, 2000);
-  }, [clientId]);
+  const { ocrPolling, pollOcrStatus } = useOcrPolling({
+    clientId,
+    onDone: onRefresh,
+  });
 
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PassportCard.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PassportCard.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { logger } from "@/lib/logger";
 import { api } from "@/lib/api";
 import { fileToBase64 } from "@/lib/utils";
+import { useOcrPolling } from "@/hooks/useOcrPolling";
 import type { ClientProfile, ClientDocument } from "@/lib/api/crm/crm.types";
 import {
   extractDriveFileId,
@@ -38,52 +39,14 @@ export function PassportCard({
   const [isExtracting, setIsExtracting] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [ocrPolling, setOcrPolling] = useState(false);
   const [ocrError, setOcrError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const ocrTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const ocrAbortedRef = useRef(false);
-
-  // Cleanup OCR polling timers when component unmounts
-  useEffect(() => {
-    ocrAbortedRef.current = false;
-    return () => {
-      ocrAbortedRef.current = true;
-      if (ocrTimerRef.current) clearTimeout(ocrTimerRef.current);
-    };
-  }, []);
 
   // Poll OCR status after upload/extract
-  const pollOcrStatus = useCallback(async () => {
-    setOcrPolling(true);
-    let attempts = 0;
-    const maxAttempts = 10; // 3s * 10 = 30s max
-    const poll = async () => {
-      if (ocrAbortedRef.current) return;
-      try {
-        const status = (await api.request(
-          `/api/crm/clients/${clientId}/ocr-status`,
-        )) as {
-          pending_ocr: number;
-        };
-        if (status.pending_ocr === 0 || attempts >= maxAttempts) {
-          if (!ocrAbortedRef.current) {
-            setOcrPolling(false);
-            await onRefresh();
-          }
-          return;
-        }
-        attempts++;
-        ocrTimerRef.current = setTimeout(poll, 3000);
-      } catch {
-        if (!ocrAbortedRef.current) {
-          setOcrPolling(false);
-          await onRefresh();
-        }
-      }
-    };
-    ocrTimerRef.current = setTimeout(poll, 2000); // Initial delay for OCR to start
-  }, [clientId, onRefresh]);
+  const { ocrPolling, pollOcrStatus } = useOcrPolling({
+    clientId,
+    onDone: onRefresh,
+  });
 
   // Find passport document from documents — only the client's own passport (no family members)
   const passportDoc = documents.find(

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/VisaCard.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/VisaCard.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 import { logger } from "@/lib/logger";
 import { api } from "@/lib/api";
 import { fileToBase64 } from "@/lib/utils";
+import { useOcrPolling } from "@/hooks/useOcrPolling";
 import type { ClientProfile, ClientDocument } from "@/lib/api/crm/crm.types";
 import {
   extractDriveFileId,
@@ -40,36 +41,18 @@ export function VisaCard({
   const [isUploading, setIsUploading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isExtracting, setIsExtracting] = useState(false);
-  const [ocrPolling, setOcrPolling] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const hasTriggeredVisaOcr = useRef(false);
 
   // Poll OCR status after upload
-  const pollOcrStatus = useCallback(async () => {
-    setOcrPolling(true);
-    let attempts = 0;
-    const maxAttempts = 10;
-    const poll = async () => {
-      try {
-        const status = (await api.request(
-          `/api/crm/clients/${clientId}/ocr-status`,
-        )) as {
-          pending_ocr: number;
-        };
-        if (status.pending_ocr === 0 || attempts >= maxAttempts) {
-          setOcrPolling(false);
-          await onRefresh();
-          return;
-        }
-        attempts++;
-        setTimeout(poll, 3000);
-      } catch {
-        setOcrPolling(false);
-        await onRefresh();
-      }
-    };
-    setTimeout(poll, 2000);
-  }, [clientId, onRefresh]);
+  // NOTE: cleanupOnUnmount=false reproduces this copy's original gap — it
+  // never guarded against firing setState after unmount. Not fixed here
+  // per the "no behaviour change" mandate; see PR body.
+  const { ocrPolling, pollOcrStatus } = useOcrPolling({
+    clientId,
+    onDone: onRefresh,
+    cleanupOnUnmount: false,
+  });
 
   // Find latest visa/KITAS document
   const visaDocs = documents.filter(

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/company/CompanyDocUpload.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/company/CompanyDocUpload.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef } from "react";
 import { Loader2, Upload, Download, Eye, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { fileToBase64 } from "@/lib/utils";
+import { useOcrPolling } from "@/hooks/useOcrPolling";
 import type { CompanyDocument } from "@/lib/api/crm/crm.types";
 
 export function CompanyDocUpload({
@@ -28,48 +29,18 @@ export function CompanyDocUpload({
   onUploaded?: () => void;
 }) {
   const [isUploading, setIsUploading] = useState(false);
-  const [ocrPolling, setOcrPolling] = useState(false);
   const [uploadedFile, setUploadedFile] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const ocrTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const ocrAbortedRef = useRef(false);
-  const onUploadedRef = useRef(onUploaded);
-  onUploadedRef.current = onUploaded;
 
-  useEffect(() => {
-    ocrAbortedRef.current = false;
-    return () => {
-      ocrAbortedRef.current = true;
-      if (ocrTimerRef.current) clearTimeout(ocrTimerRef.current);
-    };
-  }, []);
-
-  const pollOcrStatus = useCallback(async () => {
-    setOcrPolling(true);
-    let attempts = 0;
-    const poll = async () => {
-      if (ocrAbortedRef.current) return;
-      try {
-        const status = (await api.request(
-          `/api/crm/clients/${clientId}/ocr-status`,
-        )) as {
-          pending_ocr: number;
-        };
-        if (status.pending_ocr === 0 || attempts >= 10) {
-          if (!ocrAbortedRef.current) {
-            setOcrPolling(false);
-            onUploadedRef.current?.();
-          }
-          return;
-        }
-        attempts++;
-        ocrTimerRef.current = setTimeout(poll, 3000);
-      } catch {
-        if (!ocrAbortedRef.current) setOcrPolling(false);
-      }
-    };
-    ocrTimerRef.current = setTimeout(poll, 2000);
-  }, [clientId]);
+  // NOTE: callOnDoneOnError=false / awaitOnDone=false reproduce this copy's
+  // original behaviour — onUploaded is optional, fire-and-forget, and was
+  // never called on the error path. Not changed here (no behaviour change).
+  const { ocrPolling, pollOcrStatus } = useOcrPolling({
+    clientId,
+    onDone: () => onUploaded?.(),
+    callOnDoneOnError: false,
+    awaitOnDone: false,
+  });
 
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/apps/mouth/src/hooks/useOcrPolling.test.ts
+++ b/apps/mouth/src/hooks/useOcrPolling.test.ts
@@ -1,0 +1,148 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    request: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({ api: mocks.api }));
+
+import { useOcrPolling } from "./useOcrPolling";
+
+function pending(n: number) {
+  return { pending_ocr: n };
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("useOcrPolling", () => {
+  beforeEach(() => {
+    mocks.api.request.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("polls at the configured interval and hits the ocr-status endpoint", async () => {
+    mocks.api.request.mockResolvedValue(pending(3));
+    const onDone = vi.fn();
+    const { result } = renderHook(() =>
+      useOcrPolling({ clientId: 42, onDone }),
+    );
+
+    act(() => result.current.pollOcrStatus());
+    expect(result.current.ocrPolling).toBe(true);
+
+    // initial delay (2000ms default)
+    await advance(2000);
+    expect(mocks.api.request).toHaveBeenCalledTimes(1);
+    expect(mocks.api.request).toHaveBeenCalledWith(
+      "/api/crm/clients/42/ocr-status",
+    );
+
+    // subsequent poll cadence (3000ms default)
+    await advance(3000);
+    expect(mocks.api.request).toHaveBeenCalledTimes(2);
+    await advance(3000);
+    expect(mocks.api.request).toHaveBeenCalledTimes(3);
+
+    expect(onDone).not.toHaveBeenCalled();
+    expect(result.current.ocrPolling).toBe(true);
+  });
+
+  it("stops on the terminal status (pending_ocr === 0) and calls onDone", async () => {
+    mocks.api.request
+      .mockResolvedValueOnce(pending(2))
+      .mockResolvedValueOnce(pending(0));
+    const onDone = vi.fn();
+    const { result } = renderHook(() => useOcrPolling({ clientId: 7, onDone }));
+
+    act(() => result.current.pollOcrStatus());
+    await advance(2000); // 1st check: still pending
+    expect(mocks.api.request).toHaveBeenCalledTimes(1);
+    expect(result.current.ocrPolling).toBe(true);
+
+    await advance(3000); // 2nd check: pending_ocr === 0 → terminal
+    expect(mocks.api.request).toHaveBeenCalledTimes(2);
+    expect(result.current.ocrPolling).toBe(false);
+    expect(onDone).toHaveBeenCalledTimes(1);
+
+    // no further checks scheduled
+    await advance(10000);
+    expect(mocks.api.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after maxAttempts and calls onDone", async () => {
+    mocks.api.request.mockResolvedValue(pending(5)); // never terminal on its own
+    const onDone = vi.fn();
+    const { result } = renderHook(() =>
+      useOcrPolling({ clientId: 1, onDone, maxAttempts: 2 }),
+    );
+
+    act(() => result.current.pollOcrStatus());
+    await advance(2000); // check #1: attempts=0 < maxAttempts, attempts -> 1
+    await advance(3000); // check #2: attempts=1 < maxAttempts, attempts -> 2
+    expect(mocks.api.request).toHaveBeenCalledTimes(2);
+    expect(result.current.ocrPolling).toBe(true);
+
+    await advance(3000); // check #3: attempts=2 >= maxAttempts -> terminal
+    expect(mocks.api.request).toHaveBeenCalledTimes(3);
+    expect(result.current.ocrPolling).toBe(false);
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops scheduling further checks on unmount (default cleanupOnUnmount)", async () => {
+    mocks.api.request.mockResolvedValue(pending(9));
+    const onDone = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useOcrPolling({ clientId: 5, onDone }),
+    );
+
+    act(() => result.current.pollOcrStatus());
+    await advance(2000);
+    expect(mocks.api.request).toHaveBeenCalledTimes(1);
+
+    unmount();
+    await advance(30000);
+
+    // the in-flight timer was cleared, and the aborted guard blocks any
+    // straggler from scheduling a follow-up poll
+    expect(mocks.api.request).toHaveBeenCalledTimes(1);
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the error path and calls onDone by default (guilt)", async () => {
+    mocks.api.request.mockRejectedValue(new Error("network down"));
+    const onDone = vi.fn();
+    const { result } = renderHook(() => useOcrPolling({ clientId: 9, onDone }));
+
+    act(() => result.current.pollOcrStatus());
+    await advance(2000);
+
+    expect(result.current.ocrPolling).toBe(false);
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onDone on the error path when callOnDoneOnError is false (innocence)", async () => {
+    mocks.api.request.mockRejectedValue(new Error("network down"));
+    const onDone = vi.fn();
+    const { result } = renderHook(() =>
+      useOcrPolling({ clientId: 9, onDone, callOnDoneOnError: false }),
+    );
+
+    act(() => result.current.pollOcrStatus());
+    await advance(2000);
+
+    expect(result.current.ocrPolling).toBe(false);
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mouth/src/hooks/useOcrPolling.ts
+++ b/apps/mouth/src/hooks/useOcrPolling.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "@/lib/api";
+
+export interface UseOcrPollingOptions {
+  /** Client whose OCR status is being polled. */
+  clientId: number;
+  /**
+   * Called when polling reaches a terminal state (`pending_ocr === 0` or
+   * `maxAttempts` reached). Also called on the error path unless
+   * `callOnDoneOnError` is false.
+   */
+  onDone: () => void | Promise<void>;
+  /**
+   * Whether `onDone` is invoked when the status request throws.
+   * Default `true` (PassportCard/VisaCard/FamilyTab behaviour).
+   * CompanyDocUpload's original copy did NOT call its callback on the
+   * error path — pass `false` there to preserve that.
+   */
+  callOnDoneOnError?: boolean;
+  /**
+   * Whether the (possible) promise returned by `onDone` is awaited before
+   * the poll loop considers itself finished. Default `true`
+   * (Passport/Visa/FamilyTab all `await onRefresh()`). CompanyDocUpload's
+   * `onUploaded` is fire-and-forget — pass `false` there.
+   */
+  awaitOnDone?: boolean;
+  /**
+   * Whether the loop tracks unmount and stops scheduling further timeouts /
+   * state updates. Default `true` (Passport/FamilyTab/CompanyDocUpload all
+   * guard on an aborted ref). VisaCard's original copy had NO such guard —
+   * pass `false` there to reproduce it as-is (pre-existing gap, not
+   * introduced here).
+   */
+  cleanupOnUnmount?: boolean;
+  /** Delay before the first status check, ms. Default 2000. */
+  initialDelayMs?: number;
+  /** Delay between subsequent status checks, ms. Default 3000. */
+  intervalMs?: number;
+  /** Max status checks before giving up. Default 10 (10 * 3s = 30s max). */
+  maxAttempts?: number;
+}
+
+export interface UseOcrPollingResult {
+  ocrPolling: boolean;
+  pollOcrStatus: () => void;
+}
+
+/**
+ * Shared OCR-result polling loop, extracted from four near-identical copies
+ * in PassportCard, VisaCard, FamilyTab and CompanyDocUpload. Hits
+ * `/api/crm/clients/{clientId}/ocr-status` on an interval until
+ * `pending_ocr === 0` or `maxAttempts` is reached, then calls `onDone`.
+ */
+export function useOcrPolling({
+  clientId,
+  onDone,
+  callOnDoneOnError = true,
+  awaitOnDone = true,
+  cleanupOnUnmount = true,
+  initialDelayMs = 2000,
+  intervalMs = 3000,
+  maxAttempts = 10,
+}: UseOcrPollingOptions): UseOcrPollingResult {
+  const [ocrPolling, setOcrPolling] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortedRef = useRef(false);
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
+
+  useEffect(() => {
+    if (!cleanupOnUnmount) return;
+    abortedRef.current = false;
+    return () => {
+      abortedRef.current = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [cleanupOnUnmount]);
+
+  const isAborted = useCallback(
+    () => cleanupOnUnmount && abortedRef.current,
+    [cleanupOnUnmount],
+  );
+
+  const callOnDone = useCallback(async () => {
+    const result = onDoneRef.current();
+    if (awaitOnDone) await result;
+  }, [awaitOnDone]);
+
+  const pollOcrStatus = useCallback(() => {
+    setOcrPolling(true);
+    let attempts = 0;
+    const poll = async () => {
+      if (isAborted()) return;
+      try {
+        const status = (await api.request(
+          `/api/crm/clients/${clientId}/ocr-status`,
+        )) as { pending_ocr: number };
+        if (status.pending_ocr === 0 || attempts >= maxAttempts) {
+          if (!isAborted()) {
+            setOcrPolling(false);
+            await callOnDone();
+          }
+          return;
+        }
+        attempts++;
+        timerRef.current = setTimeout(poll, intervalMs);
+      } catch {
+        if (!isAborted()) {
+          setOcrPolling(false);
+          if (callOnDoneOnError) await callOnDone();
+        }
+      }
+    };
+    timerRef.current = setTimeout(poll, initialDelayMs);
+  }, [
+    clientId,
+    isAborted,
+    callOnDone,
+    callOnDoneOnError,
+    initialDelayMs,
+    intervalMs,
+    maxAttempts,
+  ]);
+
+  return { ocrPolling, pollOcrStatus };
+}

--- a/evidence/2026-09/agent-air-m5-frontend-kita-w2c-ocr-polling-79546c2f/brief.yml
+++ b/evidence/2026-09/agent-air-m5-frontend-kita-w2c-ocr-polling-79546c2f/brief.yml
@@ -1,0 +1,62 @@
+task_id: kita-w2c-ocr-polling
+gear: 2
+l_level: L1
+gate_class: sonnet
+base_sha: e83615c7f7b7986b153833190f74e7d5514d3ee3 # pragma: allowlist secret
+# Floor for this diff: 2, source `size`. Churn 457 lines over 6 files (305 added, 152 deleted).
+# No hot-zone path, no PII path, no ground-truth path.
+objective: >-
+  Kita pruning wave 2, PR-C: dedupe the OCR-result polling loop copied four times under
+  apps/mouth/src/app/(workspace)/clients/[id]/components/ (PassportCard, VisaCard, FamilyTab's
+  FamilyMemberUploadButton, CompanyDocUpload) into one hook, apps/mouth/src/hooks/useOcrPolling.ts,
+  with no observable behaviour change at any of the four call sites.
+constraints:
+  - >-
+    Same endpoint (/api/crm/clients/{clientId}/ocr-status), same initial delay (2000ms), same
+    poll cadence (3000ms) and same maxAttempts (10) at all four call sites — none of these
+    genuinely differed across the four copies, so none became a hook option.
+  - >-
+    Three genuine behavioural differences between the four copies were preserved as explicit
+    hook options rather than normalized away: VisaCard's original copy never guarded against
+    firing state after unmount (no abort ref, no cleanup effect) — reproduced via
+    cleanupOnUnmount: false; CompanyDocUpload's original copy did not call its onUploaded
+    callback on the error path — reproduced via callOnDoneOnError: false; CompanyDocUpload's
+    onUploaded is optional and fire-and-forget (not awaited) — reproduced via awaitOnDone: false.
+  - >-
+    No new dependency. No change to apps/backend-rag, zantara_core.py, fly.toml or any .env*
+    file. No client PII in this pack, in the PR body or in any log.
+appetite:
+  wall_clock_hours: 1
+  adversarial_rounds: 0
+  tokens: 300000
+acceptance:
+  - text: >-
+      A1: WHEN `tsc --noEmit` runs in apps/mouth on this head SHALL exit 0.
+    probe: cd apps/mouth && npx tsc --noEmit
+  - text: >-
+      A2: WHEN the mouth unit suite runs with its own config on this head SHALL pass every file,
+      including the new useOcrPolling hook test (polls at the interval, stops on terminal
+      status, stops scheduling after unmount, surfaces the error path both with and without
+      callOnDoneOnError).
+    probe: cd apps/mouth && npx vitest --run --root . --config vitest.config.ts
+  - text: >-
+      A3: WHEN `npm run build` runs in apps/mouth on this head SHALL complete `next build` and
+      SHALL print PUBLIC_LOGIN_BUNDLE_OK.
+    probe: cd apps/mouth && npm run build
+assumptions:
+  - text: >-
+      The four copies' endpoint, initial delay, poll interval and maxAttempts were byte-for-byte
+      identical, so those four values did not need to become hook options.
+    status: verified
+    probe: >-
+      grep -n "ocr-status\|setTimeout(poll\|maxAttempts\|attempts >= " "apps/mouth/src/app/(workspace)/clients/[id]/components/PassportCard.tsx"
+      "apps/mouth/src/app/(workspace)/clients/[id]/components/VisaCard.tsx"
+      "apps/mouth/src/app/(workspace)/clients/[id]/components/FamilyTab.tsx"
+      "apps/mouth/src/app/(workspace)/clients/[id]/components/company/CompanyDocUpload.tsx"
+  - text: >-
+      VisaCard's original pollOcrStatus had no ocrAbortedRef/ocrTimerRef and no unmount cleanup
+      effect, unlike the other three copies.
+    status: verified
+    probe: >-
+      git show origin/main:"apps/mouth/src/app/(workspace)/clients/[id]/components/VisaCard.tsx"
+      | grep -n "ocrAbortedRef\|ocrTimerRef\|useEffect"


### PR DESCRIPTION
## What

The OCR-result polling loop was copied four times under
`apps/mouth/src/app/(workspace)/clients/[id]/components/`: `PassportCard`,
`VisaCard`, `FamilyTab`'s `FamilyMemberUploadButton`, and
`company/CompanyDocUpload`. This extracts one hook,
`apps/mouth/src/hooks/useOcrPolling.ts`, and wires all four call sites to it.

## The four copies, side by side

| | endpoint | initial delay | poll interval | max attempts | stop condition | on terminal | on error |
|---|---|---|---|---|---|---|---|
| PassportCard | `/api/crm/clients/{id}/ocr-status` | 2000ms | 3000ms | 10 | `pending_ocr===0 \|\| attempts>=10` | `setOcrPolling(false); await onRefresh()` | same as terminal |
| VisaCard | same | 2000ms | 3000ms | 10 | same | same | same |
| FamilyTab (`FamilyMemberUploadButton`) | same | 2000ms | 3000ms | 10 | same | `setOcrPolling(false); await onRefreshRef.current()` | same |
| CompanyDocUpload | same | 2000ms | 3000ms | 10 | same | `setOcrPolling(false); onUploadedRef.current?.()` (fire-and-forget) | `setOcrPolling(false)` only — callback NOT called |

Endpoint, initial delay, poll interval and max attempts were byte-for-byte
identical across all four — those did not become hook options. Three
**genuine** differences did, each preserved via an explicit option so wiring
the call sites is a pure extraction with no behaviour change:

- **VisaCard's original copy had no unmount guard at all** — no abort ref, no
  cleanup `useEffect`. Reproduced with `cleanupOnUnmount: false` (a
  pre-existing gap, not introduced or fixed here).
- **CompanyDocUpload's original copy did not call its callback on the error
  path** (only the other three do). Reproduced with `callOnDoneOnError: false`.
- **CompanyDocUpload's `onUploaded` is optional and fire-and-forget** (not
  awaited), unlike the other three's `await onRefresh()`. Reproduced with
  `awaitOnDone: false`.

## Verification

- `cd apps/mouth && npx tsc --noEmit` → exit 0
- `cd apps/mouth && npx vitest --run --root . --config vitest.config.ts` → exit 0, 475 files / 5114 tests passed (includes the new `useOcrPolling.test.ts`)
- `cd apps/mouth && npm run build` → exit 0, prints `PUBLIC_LOGIN_BUNDLE_OK`
- New hook test: `apps/mouth/src/hooks/useOcrPolling.test.ts` — 6 cases with fake timers proving: polls at the configured interval, stops on the terminal status, gives up after `maxAttempts`, stops scheduling further checks on unmount, and surfaces the error path both with (`guilt`) and without (`innocence`) `callOnDoneOnError`.

Floor for this diff is 2 (size term, 457-line churn over 6 files, no
hot-zone/PII path) — `evidence/2026-09/agent-air-m5-frontend-kita-w2c-ocr-polling-79546c2f/brief.yml`
declares gear 2 accordingly.

## Bites

Consumer: kita operators uploading a client's passport, visa, family-member
document or company document. Observation: OCR results still appear on the
same 2s-initial / 3s-cadence / 10-attempt polling behaviour at all four
upload cards, now backed by one hook file on main, with zero `setInterval`/ad-hoc
`setTimeout` polling loops left duplicated in the four cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
