### PR TITLE
fix(visaoracle): retire the dead STEPCHILD sponsor-permit copy and withdraw a false claim about the pack (PR-D3d)

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -845,9 +845,16 @@ describe("support reasons are sentences, not machine codes", () => {
 
   // Mirror image: these SUPPORT reasons named a dollar figure on `main` with
   // NO backing rule anywhere in the signed pack (verified: no fact for
-  // proof-of-funds, living cost or an income threshold exists in ANY rule's
-  // `when` tree). Per the same rule as the anchor test above, an unbacked
-  // figure may not be stated — this pins that the fix stays applied.
+  // proof-of-funds or living cost exists in ANY rule's `when` tree, and no
+  // fact anywhere holds an ANNUAL income threshold). Narrowed (PR-D3d,
+  // 2026-09-13, fresh grader review): the pack does carry ONE income fact —
+  // `secondhome.passive_monthly_income_usd`, gte 3000 — but it is a MONTHLY
+  // figure backing `el.e33e.retirement`/`el.e33f.retirement` (pinned by
+  // `FIGURE_BACKED_BY_RULE` above), a different quantity from
+  // `E33G_INCOME_60K_ADVISOR_CHECK`'s USD 60,000 PER YEAR below; it backs no
+  // key in this list. Per the same rule as the anchor test above, an
+  // unbacked figure may not be stated — this pins that the fix stays
+  // applied.
   it("states no figure for SUPPORT reasons the signed pack has no rule to back", () => {
     const NO_BACKING_KEYS = [
       "PROOF_OF_FUNDS_D1",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -266,6 +266,33 @@ describe("Visa Oracle authoritative outcome adapter", () => {
     expect(message.en).not.toContain("Verified reason:");
   });
 
+  it("gives a STEPCHILD walk the same ambiguous-sponsor copy as anyone else — the dead sponsor-permit fact no longer branches it", () => {
+    // D3-4 (PR-D3, owner ruling SHWEB-20260911) had `reviewReason` special-
+    // case a STEPCHILD applicant's `family_stepchild_sponsor_permit_
+    // confirmed` answer here. That question was REMOVED from tree.ts (owner
+    // ruling SHWEB-20260911, 2026-09-13, fresh grader review; no such
+    // requirement exists for E31D) and PR-D3d retired the now-unreachable
+    // branch. `facts` below still carries the fact's old key — nothing in
+    // the current interview can set it any more, but the adapter must not
+    // resurrect the special case if a stale value ever showed up in it.
+    const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
+    response.decision.review_reasons[0].code =
+      "DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW";
+    const facts: OracleFacts = {
+      family_relation: "STEPCHILD",
+      family_stepchild_sponsor_permit_confirmed: "no",
+    };
+
+    const outcome = buildEngineOutcome(response, { facts });
+    expect(outcome.state).toBe("HUMAN_REVIEW_REQUIRED");
+    if (outcome.state !== "HUMAN_REVIEW_REQUIRED")
+      throw new Error("unexpected state");
+    expect(outcome.reviewReasons[0].message).toEqual(
+      REVIEW_REASON_COPY.DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW,
+    );
+    expect(outcome.reviewReasons[0].message.en).not.toContain("KITAS/KITAP");
+  });
+
   it("falls back to an honest generic sentence for an unmapped review-reason code", () => {
     const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
     response.decision.review_reasons[0].code = "SOME_FUTURE_RULE_CODE";

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -336,10 +336,12 @@ export const SUPPORT_REASON_COPY: Record<string, LocalizedText> = {
   // `el.e33e.age-55-59-disputed-band` / `el.e33e.retirement` /
   // `el.e33f.retirement` — is a MONTHLY figure backing E33E/E33F retirement,
   // a different quantity from E33G's USD 60,000 PER YEAR; it does not back
-  // this reason code and does not contradict "no income fact exists" as
-  // broadly as the prior wording claimed. The conclusion is unchanged: this
-  // figure is dropped — same "confirm the current figure" template already
-  // used by the three sibling advisor checks below, for the same reason.
+  // this reason code, and its existence is what made the prior wording ("no
+  // income fact exists") false — the true statement is the narrower one
+  // above: no fact holds an ANNUAL income threshold. The conclusion is
+  // unchanged: this figure is dropped — same "confirm the current figure"
+  // template already used by the three sibling advisor checks below, for
+  // the same reason.
   E33G_INCOME_60K_ADVISOR_CHECK: text(
     "This route has a minimum annual income threshold. We confirm the current figure and your evidence with one of our advisors.",
     "Jalur ini memiliki ambang penghasilan tahunan minimum. Kami memastikan angka terkini dan bukti Anda bersama konsultan kami.",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -330,9 +330,16 @@ export const SUPPORT_REASON_COPY: Record<string, LocalizedText> = {
   // here rather than guessed.
   // D3c/C-D5: no rule in the signed pack carries this reason code at all
   // (verified: no `E33G_INCOME_60K_ADVISOR_CHECK` reason_code anywhere, and
-  // no income fact exists to hold a `gte` threshold), so the figure is
-  // dropped — same "confirm the current figure" template already used by
-  // the three sibling advisor checks below, for the same reason.
+  // no fact anywhere holds an ANNUAL income threshold). Narrowed (PR-D3d,
+  // 2026-09-13, fresh grader review): the pack's only income fact —
+  // `secondhome.passive_monthly_income_usd`, gte 3000, on
+  // `el.e33e.age-55-59-disputed-band` / `el.e33e.retirement` /
+  // `el.e33f.retirement` — is a MONTHLY figure backing E33E/E33F retirement,
+  // a different quantity from E33G's USD 60,000 PER YEAR; it does not back
+  // this reason code and does not contradict "no income fact exists" as
+  // broadly as the prior wording claimed. The conclusion is unchanged: this
+  // figure is dropped — same "confirm the current figure" template already
+  // used by the three sibling advisor checks below, for the same reason.
   E33G_INCOME_60K_ADVISOR_CHECK: text(
     "This route has a minimum annual income threshold. We confirm the current figure and your evidence with one of our advisors.",
     "Jalur ini memiliki ambang penghasilan tahunan minimum. Kami memastikan angka terkini dan bukti Anda bersama konsultan kami.",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -808,42 +808,24 @@ const GENERIC_REVIEW_REASON: LocalizedText = text(
   "Beberapa jawaban Anda memerlukan penilaian dari seseorang sebelum kami dapat mengonfirmasi jalur.",
 );
 
-// D3-4 (PR-D3, owner ruling SHWEB-20260911): `DISCLOSED_AMBIGUOUS_SPONSOR_
-// REVIEW`'s generic copy ("has not been established here") is true for an
-// `unsure` answer but would be FALSE for a STEPCHILD applicant who told the
-// interview their sponsor holds NO KITAS/KITAP — that fact IS established,
-// just not one any seq-20 rule reads. D2-bis forbids reusing an
-// "unresolved" sentence for a resolved-negative answer, so this one trigger
-// gets its own two variants, selected in `reviewReason` below from the
-// interview facts already threaded through `BuildEngineOutcomeOptions`. Not
-// the general D3-6 mechanism (deferred, three OTHER parameter-less codes) —
-// scoped to this one code and this one question.
-const STEPCHILD_SPONSOR_PERMIT_NO_REVIEW: LocalizedText = text(
-  "You told us your sponsor does not hold a valid KITAS/KITAP of their own. A sponsor without a stay permit cannot sponsor the Family Reunification Visa — Stepchild (E31D); this does not affect the Multiple-Entry Visa (C1), which stays available on its own terms. A person needs to confirm the E31D sponsorship route separately before it can be resolved.",
-  "Anda menyatakan bahwa sponsor Anda tidak memiliki KITAS/KITAP yang sah. Sponsor tanpa izin tinggal sendiri tidak dapat mensponsori Visa Penyatuan Keluarga — Anak Tiri (E31D); hal ini tidak memengaruhi Visa Kunjungan Berkali-kali (C1), yang tetap tersedia dengan syaratnya sendiri. Diperlukan konfirmasi terpisah oleh seseorang atas jalur sponsor E31D sebelum dapat diselesaikan.",
-);
-const STEPCHILD_SPONSOR_PERMIT_UNSURE_REVIEW: LocalizedText = text(
-  "Whether your sponsor holds a valid KITAS/KITAP of their own has not been established — confirming your sponsor's own stay permit is what resolves it before the Family Reunification Visa — Stepchild (E31D) can be confirmed.",
-  "Belum dapat dipastikan apakah sponsor Anda memiliki KITAS/KITAP yang sah — konfirmasi izin tinggal sponsor Anda sendiri adalah yang akan menyelesaikannya sebelum Visa Penyatuan Keluarga — Anak Tiri (E31D) dapat dipastikan.",
-);
-
+// D3-4 (PR-D3, owner ruling SHWEB-20260911) had added a STEPCHILD-only
+// variant here: `reviewReason` special-cased a
+// `family_stepchild_sponsor_permit_confirmed` answer threaded through
+// `BuildEngineOutcomeOptions.facts`, on the theory that E31D might
+// implicitly need the sponsor's own stay permit. REMOVED (owner ruling
+// SHWEB-20260911, 2026-09-13, fresh grader review; PR-D3d): no such
+// requirement exists for E31D (tree.ts no longer asks the question; see the
+// comment left in its place), so the fact can never be populated and the
+// branch below was dead. `DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW`'s own copy in
+// `REVIEW_REASON_COPY` is correct for every caller now, STEPCHILD included —
+// pinned by the "gives a STEPCHILD walk the same ambiguous-sponsor copy..."
+// test in engine-adapter.test.ts.
 function reviewReason(
   code: string,
   sourceIds: readonly string[],
   trustedIds: ReadonlySet<string>,
-  facts?: OracleFacts,
 ): OutcomeReason {
-  const stepchildSponsorPermitAnswer =
-    code === "DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW" &&
-    facts?.family_relation === "STEPCHILD"
-      ? facts.family_stepchild_sponsor_permit_confirmed
-      : undefined;
-  const message =
-    stepchildSponsorPermitAnswer === "no"
-      ? STEPCHILD_SPONSOR_PERMIT_NO_REVIEW
-      : stepchildSponsorPermitAnswer === "unsure"
-        ? STEPCHILD_SPONSOR_PERMIT_UNSURE_REVIEW
-        : (REVIEW_REASON_COPY[code] ?? GENERIC_REVIEW_REASON);
+  const message = REVIEW_REASON_COPY[code] ?? GENERIC_REVIEW_REASON;
   return {
     code,
     message,
@@ -1265,12 +1247,7 @@ function buildValidatedOutcome(
         pathsRemaining: Math.max(1, options.interviewBranchesRemaining ?? 1),
         reviewReasons: response.decision.review_reasons.map((item) => {
           requireReviewHoldRefs(item.source_refs);
-          return reviewReason(
-            item.code,
-            item.source_refs,
-            trustedIds,
-            options.facts,
-          );
+          return reviewReason(item.code, item.source_refs, trustedIds);
         }) as [OutcomeReason, ...OutcomeReason[]],
       };
     case "NO_SUPPORTED_PATH":

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3d-2026091-d620814d/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3d-2026091-d620814d/brief.yml
@@ -1,0 +1,189 @@
+gear: 1
+gear_reason: >-
+  Measured the way CI measures it, with BOTH inputs:
+  `scripts/evidence_pack_lint.py --print-floor --changed-files-file <f> --numstat-file <n>`
+  (changed-files-file listing the two touched files, numstat-file their real
+  `git diff --numstat origin/main`: engine-adapter.test.ts +37/-3,
+  engine-adapter.ts +24/-40) returns 1, and `--print-floor-source` returns `none`
+  (no size/path escalation triggered). Omitting `--numstat-file` was rejected three
+  times already in this mandate (#6240, PR-O2's brief, PR-D3c's brief) for
+  under-reporting the floor — both flags were passed here, and no digit is typed:
+  re-run both invocations to check. Two files, ~60 net lines, no rule-pack change,
+  no new corpus, one dead-code removal plus one comment correction — nothing here
+  crosses a size/risk threshold that would raise the floor above 1.
+task_id: shweb-w-oracle-d3d-20260913
+mandate_id: SHWEB-20260911/W-ORACLE/PR-D3d
+colour: BLUE
+l_level: L1
+gate_class: opus
+objective: >-
+  Two independent, comment/dead-code-only items in engine-adapter.ts/.test.ts, no
+  rulepack change and no corpus change (D4d's lane, running concurrently, owns
+  flow.ts/fact-mapper.ts/tree.ts/the walk corpus).
+  (1) PR-D4a (817cd8674b) removed the question `family_stepchild_sponsor_permit_
+  confirmed` from tree.ts, leaving only a comment. That made three things in
+  engine-adapter.ts unreachable: the two STEPCHILD_SPONSOR_PERMIT_{NO,UNSURE}_REVIEW
+  copy constants and the `stepchildSponsorPermitAnswer` branch in `reviewReason`
+  that selected between them. Verified unreachable (see acceptance/self_report
+  below) and removed; `reviewReason` now always falls through to
+  `REVIEW_REASON_COPY[code] ?? GENERIC_REVIEW_REASON`, pinned by a new test.
+  (2) Two comments (engine-adapter.ts ~L331-335, engine-adapter.test.ts ~L845-849)
+  claimed "no income fact exists in any rule's `when` tree" to justify dropping the
+  USD 60,000/year figure from E33G_INCOME_60K_ADVISOR_CHECK. Measured against the
+  active signed pack (rulepack-prod-020.signed.json, sequence 20), that is false:
+  `secondhome.passive_monthly_income_usd` (gte 3000) backs
+  `el.e33e.age-55-59-disputed-band` / `el.e33e.retirement` / `el.e33f.retirement`,
+  and the test file's own `FIGURE_BACKED_BY_RULE` map two blocks earlier pins
+  `E33F_RETIREMENT_ELIGIBLE` to exactly that fact — a self-contradiction. Both
+  comments are narrowed to the true statement: no rule carries the reason code
+  `E33G_INCOME_60K_ADVISOR_CHECK`, and no fact anywhere holds an ANNUAL income
+  threshold; the pack's one income fact is a MONTHLY passive-income floor backing a
+  different product (E33E/E33F retirement), not E33G. The verdict (E33G states no
+  figure) is unchanged — only the reason given for it was too broad. No behaviour
+  change in item 2.
+scope:
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+  - this brief
+constraints:
+  - >-
+    Only the two files above are touched. flow.ts, fact-mapper.ts, tree.ts and every
+    walk fixture are untouched — D4d is live on them concurrently. Verified:
+    `git diff --name-only origin/main...HEAD` names only these two files plus this
+    brief (see acceptance below).
+  - No rule-pack edit; `sign_pack.py`/`activate_pack.py` never run; `VISA_ENGINE_EVALUATE_MODE` untouched.
+  - No corpus walk added or modified (C6 regression walk is D4d's, per the 20:37Z ruling).
+  - Item 2 is comment-only: no `SUPPORT_REASON_COPY`/`REVIEW_REASON_COPY` string, no test assertion, and no verdict changed.
+  - No client PII in any file added or edited.
+  - No push, no PR, no arm, no merge — committed locally only; the orchestrator ships.
+acceptance:
+  - text: >-
+      WHEN `family_stepchild_sponsor_permit_confirmed` is searched for across the
+      repo, THEN the only non-comment occurrence SHALL be the new test's literal
+      (simulating a stale value the current interview can no longer produce) — no
+      producer exists in fact-mapper.ts and no question node exists in tree.ts.
+    status: verified
+    ts: "2026-09-13T04:50+08:00"
+    probe: 'grep -rn "family_stepchild_sponsor_permit_confirmed" --include=''*.ts'' . | grep -v node_modules'
+    result: >-
+      6 hits: generate-walk-corpus.ts:438 (comment), fact-mapper.ts:605 (comment),
+      engine-adapter.ts:820 (comment, this PR's own), engine-adapter.test.ts:283
+      (this PR's new test literal), fact-mapper.test.ts:330 (comment), tree.ts:957
+      (comment). Zero live producers/consumers besides the new test's deliberate
+      literal.
+  - text: >-
+      WHEN `STEPCHILD_SPONSOR_PERMIT_NO_REVIEW`/`_UNSURE_REVIEW` are searched for
+      after removal, THEN zero references SHALL remain anywhere.
+    status: verified
+    ts: "2026-09-13T04:50+08:00"
+    probe: "grep -rn 'STEPCHILD_SPONSOR_PERMIT_NO_REVIEW|STEPCHILD_SPONSOR_PERMIT_UNSURE_REVIEW' --include='*.ts' --include='*.tsx' . | grep -v node_modules"
+    result: "0 hits."
+  - text: >-
+      WHEN a STEPCHILD walk's `reviewReason` is called for
+      `DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW` with a stale
+      `family_stepchild_sponsor_permit_confirmed: \"no\"` fact still present in
+      `options.facts`, THEN it SHALL return `REVIEW_REASON_COPY.
+      DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW` (the same copy every other caller gets),
+      never the removed STEPCHILD-specific text. Red before this PR's deletion
+      (with the dead branch still in place, this exact scenario returned
+      `STEPCHILD_SPONSOR_PERMIT_NO_REVIEW` instead), green after — proving the
+      branch was live-reachable code with observable behaviour, now retired on
+      purpose rather than silently.
+    status: verified
+    ts: "2026-09-13T04:47+08:00"
+    probe: >-
+      cd apps/mouth && npx --no-install vitest run
+      'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' -t 'gives a
+      STEPCHILD walk the same ambiguous-sponsor copy'
+    result: >-
+      BEFORE (dead branch still present): 1 failed — received
+      STEPCHILD_SPONSOR_PERMIT_NO_REVIEW's KITAS/KITAP text instead of the expected
+      DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW copy. AFTER (branch removed): 1 passed.
+  - text: >-
+      WHEN the active signed pack (highest sequence) is walked structurally for
+      every `gte` node's (fact, rule_id) pair, THEN the only fact containing
+      "income" SHALL be `secondhome.passive_monthly_income_usd` (a MONTHLY figure,
+      value 3000), attached only to `el.e33e.age-55-59-disputed-band`,
+      `el.e33e.retirement` and `el.e33f.retirement` — never to any rule carrying
+      reason_code `E33G_INCOME_60K_ADVISOR_CHECK` — and no fact containing "annual"
+      SHALL exist anywhere in any rule's `when` tree.
+    status: verified
+    ts: "2026-09-13T04:44+08:00"
+    probe: >-
+      python3 - <<'PY' reading
+      apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-020.signed.json
+      (`payload["rules"]`, 109 rules — never `payload["products"]`, 38 metadata
+      entries with no rules; `gte` nodes here carry `value`, singular), walks every
+      rule's `when` tree structurally and prints every `gte`(fact) pair, every
+      "income"/"annual" fact name, and whether reason_code
+      E33G_INCOME_60K_ADVISOR_CHECK appears anywhere.
+      PY
+    result: >-
+      sequence=20, 109 rules in payload.rules, 38 products in payload.products (no
+      "rules" key on any product). 21 gte() nodes total; the only income-named fact
+      is secondhome.passive_monthly_income_usd=3000 on exactly the three rule ids
+      named above (el.e33e.age-55-59-disputed-band, el.e33e.retirement,
+      el.e33f.retirement — reason codes E33E_AGE_55_59_ADVISOR_CHECK,
+      E33E_RETIREMENT_ELIGIBLE, E33F_RETIREMENT_ELIGIBLE). E33G_INCOME_60K_ADVISOR_CHECK
+      reason_code: not found anywhere in payload.rules. Facts containing "annual":
+      none (0 of 39 distinct facts referenced in any when-tree).
+  - text: WHEN the project typechecks, THEN it SHALL succeed.
+    status: verified
+    ts: "2026-09-13T04:47+08:00"
+    probe: "cd apps/mouth && npx tsc --noEmit"
+    result: "exit 0, no diagnostics."
+  - text: WHEN eslint runs against the changed source file, THEN it SHALL report 0 errors.
+    status: verified
+    ts: "2026-09-13T04:48+08:00"
+    probe: 'cd apps/mouth && npx eslint "src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts"'
+    result: >-
+      0 errors (engine-adapter.test.ts is excluded by this project's own eslint
+      ignore pattern for `src/**/*.test.{ts,tsx}` — running it directly prints only
+      the ignore-pattern warning, 0 errors, exit 0).
+  - text: WHEN the full visa-oracle frontend suite runs, THEN every test SHALL pass.
+    status: verified
+    ts: "2026-09-13T04:48+08:00"
+    probe: "cd apps/mouth && npx vitest run 'src/app/(visa-oracle)'"
+    result: "39 test files passed (39), 731 tests passed (731)."
+  - text: WHEN the backend interview walk-census pytest runs, THEN every walk SHALL pass.
+    status: verified
+    ts: "2026-09-13T04:49+08:00"
+    probe: >-
+      cd apps/backend-rag &&
+      /Users/nuzantara/nuzantara/apps/backend-rag/.venv/bin/python3 -m pytest
+      backend/tests/services/visa_engine/test_interview_walk_census.py
+    result: "17 passed."
+  - text: >-
+      WHEN the diff against origin/main is listed, THEN it SHALL name only
+      engine-adapter.ts, engine-adapter.test.ts and this brief — no walk fixture, no
+      generator, no rule pack.
+    status: verified
+    ts: "2026-09-13T04:52+08:00"
+    probe: "git diff --name-only origin/main...HEAD"
+    result: >-
+      apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+      apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+      evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d3d-2026091-d620814d/brief.yml
+pii: none
+self_report:
+  premise_verification: >-
+    Both premises the brief asked to re-derive, verified before writing any code:
+    (a) family_stepchild_sponsor_permit_confirmed has no producer anywhere in the
+    repo (tree.ts's question node, fact-mapper.ts's mapper and the corpus generator
+    all carry only a REMOVED-comment where it used to live, per PR-D4a/D3-4's own
+    trail) — TRUE, matches the brief; (b) the "no income fact exists" comment is
+    false as stated — TRUE, matches the brief's own finding — `secondhome.
+    passive_monthly_income_usd` exists and backs E33E/E33F retirement, a MONTHLY
+    figure distinct from E33G's ANNUAL USD 60,000. Neither premise required a STOP.
+  what_i_did_not_do: >-
+    Did not touch the `facts` field on `BuildEngineOutcomeOptions` or on `reason()`
+    (the sibling function used for SUPPORTED_CANDIDATES/NO_SUPPORTED_PATH) — only
+    `reviewReason`'s own now-fully-unused `facts` parameter was dropped, along with
+    updating its sole call site to stop passing `options.facts` to it;
+    `options.facts` itself remains live for `reason()` and the NEEDS_INPUT branch,
+    untouched. Did not touch tree.ts, fact-mapper.ts, flow.ts or any walk fixture —
+    D4d's lane. Did not push, open a PR, arm auto-merge or merge — commits are
+    local only on `agent/mini-pro2/mouth/shweb-w-oracle-d3d-20260913`. The
+    `OracleFacts` type itself needed no pruning: it is `Record<string, string>`
+    (tree.ts:91), not a field-by-field interface, so there was no separate
+    declaration to remove or hand off to D4d.


### PR DESCRIPTION
## What

**PR-D3d — retire copy that can no longer be reached, and withdraw a claim about the pack that was false.** Two follow-ups owed by earlier rounds, both confined to `engine-adapter.ts` and its test. No behaviour change reaches an applicant except the removal of a message that could no longer be produced.

`git diff --name-only origin/main...HEAD` → three files: `engine-adapter.ts`, `engine-adapter.test.ts`, and this PR's evidence brief. No walk fixture, no corpus generator, no rule pack — a sibling PR (D4d) owns the corpus and `flow.ts`/`fact-mapper.ts`/`tree.ts`.

## 1. The STEPCHILD sponsor-permit copy is dead, and is removed

PR-D4a (#6372) removed the question `family_stepchild_sponsor_permit_confirmed` from `tree.ts` — on the regulation, because E31D does not rest on the sponsor's permit. What it deliberately left behind, being another PR's file, were two review-copy constants and the branch that selected them:

- `STEPCHILD_SPONSOR_PERMIT_NO_REVIEW`
- `STEPCHILD_SPONSOR_PERMIT_UNSURE_REVIEW`
- the `stepchildSponsorPermitAnswer` ternary in `reviewReason`

Nothing can populate that fact any more, so the ternary could only ever fall through. **Unreachability is proven, not argued**: a new test asserts that a STEPCHILD walk reaching `DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW` gets the generic copy. Run against the branch with the dead code still in place it **fails** — it returns the removed KITAS/KITAP sentence; run after the deletion it **passes**. Red before, green after, on the same assertion.

`reviewReason`'s now-unused `facts` parameter goes with it, and its single call site is updated.

Why it matters beyond tidiness: that copy told an applicant *"A sponsor without a stay permit cannot sponsor the Family Reunification Visa — Stepchild (E31D)"* — a statement the fresh grader's reading found to be wrong, which is why D4a removed the question in the first place. Leaving it in the bundle leaves a wrong sentence one code path away from a user.

## 2. "No income fact exists" was false — in two places

Both of these asserted, in substance, that no income fact exists in any rule's `when` tree:

- `engine-adapter.ts`, the D3c/C-D5 comment above `E33G_INCOME_60K_ADVISOR_CHECK`
- `engine-adapter.test.ts`, the comment above the `NO_BACKING_KEYS` test

Measured against `rulepack-prod-020.signed.json`, the active pack:

```
secondhome.passive_monthly_income_usd   gte 3000
  → el.e33e.age-55-59-disputed-band, el.e33e.retirement, el.e33f.retirement
```

The test file contradicted its own comment two blocks earlier: `FIGURE_BACKED_BY_RULE` pins `E33F_RETIREMENT_ELIGIBLE` to exactly that fact.

**The true statement, which now replaces it**: no rule carries the reason code `E33G_INCOME_60K_ADVISOR_CHECK`, and no fact anywhere holds an **annual** income threshold. The pack's one income fact is a **monthly** floor of USD 3,000 backing E33E/E33F retirement — a different quantity from E33G's USD 60,000 per year. The comments now say the prior wording was false and name what replaces it, rather than softening it into a partial truth.

**The conclusion is unchanged**: E33G still states no figure. Only the reason given for it was too broad. Comments only — no copy, no verdict, no test assertion changes here.

## Measured

| | fresh `main` (`ac05dfc6f4`) | this branch |
|---|---|---|
| `vitest run 'src/app/(visa-oracle)'` | 39 files / **730** tests | 39 files / **731** tests |
| `pytest test_interview_walk_census.py` | **17 passed** | **17 passed** |
| `tsc --noEmit` | — | exit **0** |

The single added test is the STEPCHILD guard described above. The census is untouched because the corpus is untouched.

`eslint "src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts"` → 0 errors. The `.test.ts` file is not linted because this project's own `eslint.config.mjs` lists `src/**/*.test.{ts,tsx}` in `ignores` — stated rather than presented as a clean run.

Evidence gear: floor **1**, source **`none`**, brief declares gear **1**. Measured with both flags on the complete three-file diff:

```
python3 scripts/evidence_pack_lint.py --print-floor \
  --changed-files-file <files> --numstat-file <numstat>
```

## Bites

Bites: consumer = an applicant whose family relation is STEPCHILD and whose interview raises `DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW` — before this PR the review message they could be shown was keyed on a question that no longer exists and asserted a permit requirement E31D does not have; observation = `npx vitest run 'src/app/(visa-oracle)'` on this branch passes the new assertion that such a walk receives the generic review copy, and that same test fails on the pre-removal tree.

## Not done, declared

- The `OracleFacts` type needs no pruning: it is `Record<string, string>` (`tree.ts`), with no per-field declaration to remove.
- `BuildEngineOutcomeOptions.facts` and `reason()` are untouched — still consumed elsewhere.
- C2 of the #6372 row (a walk that reaches C6 with a non-`transit` `other_purpose`) is **not** here: it is corpus work and moved to PR-D4d by the imperator's ruling, so that two PRs never regenerate the same corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNwbSmS3XK5X6FNpCe8kZe
