### PR TITLE
feat(visaoracle): ask the sponsor category on the reaching tile and give the corpus walks that answer it (PR-D4d)

### DIFF
--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_pt_pma_sponsor_government.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_invest_pt_pma_sponsor_government.json
@@ -1,35 +1,36 @@
 {
-  "label": "onshore/other",
+  "label": "offshore/invest/pt_pma/sponsor_government",
   "asked": [
     "in_indonesia",
-    "permit_expiry",
     "holds_stay_permit",
-    "current_status_code",
     "overstay_days",
-    "wants_onshore_conversion",
-    "application_channel",
     "nationalities",
     "birth_date",
     "category",
     "trip_scope",
-    "other_purpose",
-    "other_paid_activity",
     "sponsor_category",
-    "work_payer",
-    "work_sponsor_confirmed",
+    "investment_vehicle",
+    "investment_pt_pma",
+    "investment_capital_idr",
+    "investment_paid_up_capital_idr",
+    "investment_role",
+    "family_sponsor_confirmed",
+    "wants_onshore_conversion",
     "stay_days",
-    "entry_pattern",
     "review_gate"
   ],
   "overrides": {
     "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": true },
-    "immigration.current_status_code": { "status": "KNOWN", "value": "A1" },
-    "immigration.current_status_expiry": {
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
       "status": "KNOWN",
-      "value": "2026-12-31"
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "immigration.last_entry_date": {
       "status": "UNKNOWN",
@@ -38,10 +39,10 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["EMPLOYMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["INVESTMENT"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.requested_product_code": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -50,7 +51,10 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "work.employer_is_indonesian_entity": { "status": "KNOWN", "value": true },
+    "work.employer_is_indonesian_entity": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "work.serves_indonesian_clients": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -60,22 +64,22 @@
       "reason": "NOT_ASKED"
     },
     "work.indonesian_work_sponsor_confirmed": {
-      "status": "KNOWN",
-      "value": true
-    },
-    "investment.pt_pma_committed": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "investment.pt_pma_committed": { "status": "KNOWN", "value": true },
     "investment.investment_capital_idr": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 1000000000
     },
     "investment.paid_up_capital_idr": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 1000000000
     },
-    "investment.proposed_role": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "investment.proposed_role": {
+      "status": "KNOWN",
+      "value": "SHAREHOLDER_DIRECTOR"
+    },
     "family.relation_to_sponsor": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -104,11 +108,11 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "sponsor.type": { "status": "KNOWN", "value": "GOVERNMENT" },
     "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -129,7 +133,10 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "process.application_channel": { "status": "KNOWN", "value": "OFFSHORE" },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.wants_onshore_conversion": { "status": "KNOWN", "value": true },
     "commercial.service_fee_budget_idr": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other.json
@@ -10,6 +10,7 @@
     "trip_scope",
     "other_purpose",
     "other_paid_activity",
+    "sponsor_category",
     "work_payer",
     "work_sponsor_confirmed",
     "stay_days",
@@ -106,7 +107,7 @@
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
     "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_no_paid_activity_medical.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_no_paid_activity_medical.json
@@ -1,22 +1,16 @@
 {
-  "label": "onshore/other",
+  "label": "offshore/other/no_paid_activity/medical",
   "asked": [
     "in_indonesia",
-    "permit_expiry",
     "holds_stay_permit",
-    "current_status_code",
     "overstay_days",
-    "wants_onshore_conversion",
-    "application_channel",
     "nationalities",
     "birth_date",
     "category",
     "trip_scope",
     "other_purpose",
     "other_paid_activity",
-    "sponsor_category",
-    "work_payer",
-    "work_sponsor_confirmed",
+    "family_sponsor_confirmed",
     "stay_days",
     "entry_pattern",
     "review_gate"
@@ -25,11 +19,14 @@
     "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": true },
-    "immigration.current_status_code": { "status": "KNOWN", "value": "A1" },
-    "immigration.current_status_expiry": {
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
       "status": "KNOWN",
-      "value": "2026-12-31"
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "immigration.last_entry_date": {
       "status": "UNKNOWN",
@@ -38,7 +35,7 @@
     "immigration.overstay_days": { "status": "KNOWN", "value": 0 },
     "immigration.violation_history": { "status": "KNOWN", "value": [] },
     "immigration.renewal_paid": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.purposes": { "status": "KNOWN", "value": ["EMPLOYMENT"] },
+    "intent.purposes": { "status": "KNOWN", "value": ["OTHER"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
@@ -50,7 +47,10 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "work.employer_is_indonesian_entity": { "status": "KNOWN", "value": true },
+    "work.employer_is_indonesian_entity": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "work.serves_indonesian_clients": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -60,8 +60,8 @@
       "reason": "NOT_ASKED"
     },
     "work.indonesian_work_sponsor_confirmed": {
-      "status": "KNOWN",
-      "value": true
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "investment.pt_pma_committed": {
       "status": "UNKNOWN",
@@ -104,11 +104,11 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "family.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "family.sponsor_confirmed": { "status": "KNOWN", "value": true },
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "sponsor.type": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -129,8 +129,14 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "process.application_channel": { "status": "KNOWN", "value": "OFFSHORE" },
-    "process.wants_onshore_conversion": { "status": "KNOWN", "value": true },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "commercial.service_fee_budget_idr": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_employer_no.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_employer_no.json
@@ -10,6 +10,7 @@
     "trip_scope",
     "other_purpose",
     "other_paid_activity",
+    "sponsor_category",
     "work_payer",
     "work_sponsor_confirmed",
     "stay_days",
@@ -106,7 +107,7 @@
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
     "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_sponsor_government.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_sponsor_government.json
@@ -1,13 +1,9 @@
 {
-  "label": "onshore/other",
+  "label": "offshore/other/paid/sponsor_government",
   "asked": [
     "in_indonesia",
-    "permit_expiry",
     "holds_stay_permit",
-    "current_status_code",
     "overstay_days",
-    "wants_onshore_conversion",
-    "application_channel",
     "nationalities",
     "birth_date",
     "category",
@@ -25,11 +21,14 @@
     "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": true },
-    "immigration.current_status_code": { "status": "KNOWN", "value": "A1" },
-    "immigration.current_status_expiry": {
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
       "status": "KNOWN",
-      "value": "2026-12-31"
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "immigration.last_entry_date": {
       "status": "UNKNOWN",
@@ -108,7 +107,7 @@
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "sponsor.type": { "status": "KNOWN", "value": "GOVERNMENT" },
     "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -129,8 +128,14 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "process.application_channel": { "status": "KNOWN", "value": "OFFSHORE" },
-    "process.wants_onshore_conversion": { "status": "KNOWN", "value": true },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "commercial.service_fee_budget_idr": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_sponsor_unsure.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_other_paid_sponsor_unsure.json
@@ -10,6 +10,7 @@
     "trip_scope",
     "other_purpose",
     "other_paid_activity",
+    "sponsor_category",
     "work_payer",
     "work_sponsor_confirmed",
     "stay_days",
@@ -106,7 +107,7 @@
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
+    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
     "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_work_sponsor_government.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_work_sponsor_government.json
@@ -1,35 +1,32 @@
 {
-  "label": "onshore/other",
+  "label": "offshore/work/sponsor_government",
   "asked": [
     "in_indonesia",
-    "permit_expiry",
     "holds_stay_permit",
-    "current_status_code",
     "overstay_days",
-    "wants_onshore_conversion",
-    "application_channel",
     "nationalities",
     "birth_date",
     "category",
     "trip_scope",
-    "other_purpose",
-    "other_paid_activity",
     "sponsor_category",
     "work_payer",
+    "work_indonesia_compensation",
     "work_sponsor_confirmed",
     "stay_days",
-    "entry_pattern",
     "review_gate"
   ],
   "overrides": {
     "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": true },
-    "immigration.current_status_code": { "status": "KNOWN", "value": "A1" },
-    "immigration.current_status_expiry": {
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
       "status": "KNOWN",
-      "value": "2026-12-31"
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "immigration.last_entry_date": {
       "status": "UNKNOWN",
@@ -41,7 +38,7 @@
     "intent.purposes": { "status": "KNOWN", "value": ["EMPLOYMENT"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.requested_product_code": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -55,10 +52,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "work.indonesia_source_compensation": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "work.indonesia_source_compensation": { "status": "KNOWN", "value": true },
     "work.indonesian_work_sponsor_confirmed": {
       "status": "KNOWN",
       "value": true
@@ -108,7 +102,7 @@
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "sponsor.type": { "status": "KNOWN", "value": "GOVERNMENT" },
     "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -129,8 +123,14 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "process.application_channel": { "status": "KNOWN", "value": "OFFSHORE" },
-    "process.wants_onshore_conversion": { "status": "KNOWN", "value": true },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "commercial.service_fee_budget_idr": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_work_sponsor_individual.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_work_sponsor_individual.json
@@ -1,35 +1,32 @@
 {
-  "label": "onshore/other",
+  "label": "offshore/work/sponsor_individual",
   "asked": [
     "in_indonesia",
-    "permit_expiry",
     "holds_stay_permit",
-    "current_status_code",
     "overstay_days",
-    "wants_onshore_conversion",
-    "application_channel",
     "nationalities",
     "birth_date",
     "category",
     "trip_scope",
-    "other_purpose",
-    "other_paid_activity",
     "sponsor_category",
     "work_payer",
+    "work_indonesia_compensation",
     "work_sponsor_confirmed",
     "stay_days",
-    "entry_pattern",
     "review_gate"
   ],
   "overrides": {
     "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": true },
-    "immigration.current_status_code": { "status": "KNOWN", "value": "A1" },
-    "immigration.current_status_expiry": {
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
       "status": "KNOWN",
-      "value": "2026-12-31"
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "immigration.last_entry_date": {
       "status": "UNKNOWN",
@@ -41,7 +38,7 @@
     "intent.purposes": { "status": "KNOWN", "value": ["EMPLOYMENT"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.requested_product_code": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -55,10 +52,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "work.indonesia_source_compensation": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "work.indonesia_source_compensation": { "status": "KNOWN", "value": true },
     "work.indonesian_work_sponsor_confirmed": {
       "status": "KNOWN",
       "value": true
@@ -108,7 +102,7 @@
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "sponsor.type": { "status": "KNOWN", "value": "INDIVIDUAL" },
     "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -129,8 +123,14 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "process.application_channel": { "status": "KNOWN", "value": "OFFSHORE" },
-    "process.wants_onshore_conversion": { "status": "KNOWN", "value": true },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "commercial.service_fee_budget_idr": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_work_sponsor_unsure.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/offshore_work_sponsor_unsure.json
@@ -1,35 +1,32 @@
 {
-  "label": "onshore/other",
+  "label": "offshore/work/sponsor_unsure",
   "asked": [
     "in_indonesia",
-    "permit_expiry",
     "holds_stay_permit",
-    "current_status_code",
     "overstay_days",
-    "wants_onshore_conversion",
-    "application_channel",
     "nationalities",
     "birth_date",
     "category",
     "trip_scope",
-    "other_purpose",
-    "other_paid_activity",
     "sponsor_category",
     "work_payer",
+    "work_indonesia_compensation",
     "work_sponsor_confirmed",
     "stay_days",
-    "entry_pattern",
     "review_gate"
   ],
   "overrides": {
     "person.birth_date": { "status": "KNOWN", "value": "2000-11-11" },
     "person.nationalities": { "status": "KNOWN", "value": ["IT"] },
     "person.marital_status": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": true },
-    "immigration.current_status_code": { "status": "KNOWN", "value": "A1" },
-    "immigration.current_status_expiry": {
+    "immigration.currently_in_indonesia": { "status": "KNOWN", "value": false },
+    "immigration.current_status_code": {
       "status": "KNOWN",
-      "value": "2026-12-31"
+      "value": "NO_STAY_PERMIT"
+    },
+    "immigration.current_status_expiry": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
     },
     "immigration.last_entry_date": {
       "status": "UNKNOWN",
@@ -41,7 +38,7 @@
     "intent.purposes": { "status": "KNOWN", "value": ["EMPLOYMENT"] },
     "intent.stay_days": { "status": "KNOWN", "value": 121 },
     "intent.desired_entry_date": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "intent.entry_pattern": { "status": "KNOWN", "value": "SINGLE" },
+    "intent.entry_pattern": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "intent.requested_product_code": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -55,10 +52,7 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "work.indonesia_source_compensation": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
-    },
+    "work.indonesia_source_compensation": { "status": "KNOWN", "value": true },
     "work.indonesian_work_sponsor_confirmed": {
       "status": "KNOWN",
       "value": true
@@ -108,7 +102,7 @@
     "study.level": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.admission_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
     "study.sponsor_confirmed": { "status": "UNKNOWN", "reason": "NOT_ASKED" },
-    "sponsor.type": { "status": "KNOWN", "value": "NONE" },
+    "sponsor.type": { "status": "UNKNOWN", "reason": "UNVERIFIED" },
     "secondhome.bank_deposit_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
@@ -129,8 +123,14 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
-    "process.application_channel": { "status": "KNOWN", "value": "OFFSHORE" },
-    "process.wants_onshore_conversion": { "status": "KNOWN", "value": true },
+    "process.application_channel": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "process.wants_onshore_conversion": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "commercial.service_fee_budget_idr": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_interview_walk_census.py
@@ -391,6 +391,14 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "offshore/invest/merit": ("SUPPORTED_CANDIDATES", ("C2",)),
     "offshore/invest/property": ("SUPPORTED_CANDIDATES", ("E33",)),
     "offshore/invest/pt_pma": ("SUPPORTED_CANDIDATES", ("C2",)),
+    # PR-D4d (seq-21 corpus prep, unsigned — activation caveat in the PR
+    # body): `el.e33c.world-figure-invitation` needs INVESTMENT purpose +
+    # `sponsor.type eq GOVERNMENT`, so this is the `invest` walk that would
+    # exercise it once seq-21 activates. Under the pack ACTUALLY signed
+    # today (rulepack-prod-020, which reads no sponsor.type condition for
+    # any INVESTMENT-purpose product), `sponsor.type` is a silent extra fact
+    # and the walk answers exactly like its `pt_pma` sibling: C2.
+    "offshore/invest/pt_pma/sponsor_government": ("SUPPORTED_CANDIDATES", ("C2",)),
     "offshore/invest/undecided": ("SUPPORTED_CANDIDATES", ("C2",)),
     # C1 gate (PR-D3): below-threshold walks for D3-1's re-route. Owner
     # ruling 2026-09-13 CLOSED the twin-base dead end this pattern first
@@ -422,10 +430,27 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     # clear those gates is verified separately (report only, not a new
     # pinned walk here).
     "offshore/other/no_paid_activity": ("NO_SUPPORTED_PATH", ()),
+    # C6 regression walk (PR-D4d, coordinator-authorised scope addition):
+    # PR-D4a repurposed `offshore/other/no_paid_activity` (above) to prove
+    # the TRANSIT route instead, which silently dropped C6 from this
+    # census — the rule itself never moved. `other_purpose = "medical"` (no
+    # special-case mapping anywhere in fact-mapper.ts) plus
+    # `other_paid_activity = "no"` keeps the purpose OTHER, so
+    # `el.c6.social` answers again.
+    "offshore/other/no_paid_activity/medical": ("SUPPORTED_CANDIDATES", ("C6",)),
     # C1 gate (PR-D3): the two negative D3-2 facts.
     "offshore/other": ("SUPPORTED_CANDIDATES", ("E23",)),
     "offshore/other/paid/employer_no": ("NO_SUPPORTED_PATH", ()),
     "offshore/other/paid/sponsor_unsure": ("NEEDS_INPUT", ()),
+    # PR-D4d, work item 1 end to end: `other_paid_activity === "yes"` could
+    # not answer `sponsor.type` at all before this PR. This walk answers
+    # GOVERNMENT down that newly-added question — the second reachable path
+    # (besides `work`) into seq-21's `el.e33a/b.government-*`/
+    # `el.e23v.trade-office` (unsigned — activation caveat in the PR body).
+    # Under the pack signed today, no EMPLOYMENT-purpose rule reads
+    # sponsor.type, so the walk answers exactly like its `employer_no`
+    # sibling's purpose-mate: E23.
+    "offshore/other/paid/sponsor_government": ("SUPPORTED_CANDIDATES", ("E23",)),
     "offshore/remote": ("NO_SUPPORTED_PATH", ()),
     "offshore/retirement/bank_deposit": ("NO_SUPPORTED_PATH", ()),
     # D3-3 (PR-D3): now ALSO asks `family_sponsor_confirmed` (default "yes"),
@@ -475,6 +500,24 @@ EXPECTED_OUTCOME: dict[str, tuple[str, tuple[str, ...]]] = {
     "offshore/study": ("SUPPORTED_CANDIDATES", ("E30", "E30A")),
     "offshore/tourism": ("SUPPORTED_CANDIDATES", ("C1",)),
     "offshore/work": ("SUPPORTED_CANDIDATES", ("E23",)),
+    # PR-D4d (seq-21 corpus prep, unsigned — activation caveat in the PR
+    # body). `el.e33a/b.government-*`/`el.e23v.trade-office` share an
+    # IDENTICAL condition (EMPLOYMENT + sponsor.type eq GOVERNMENT), so this
+    # one walk is the reachability proof for all three at once; the sibling
+    # walk right below swaps in INDIVIDUAL for `el.e23u.diplomatic-
+    # household` (E23U is the diplomat's household assistant — the sponsor
+    # is an INDIVIDUAL, there is no `DIPLOMATIC` sponsor value). Under the
+    # pack signed today, neither value is read by any rule, so both answer
+    # exactly like the unmodified `offshore/work` walk above: E23.
+    "offshore/work/sponsor_government": ("SUPPORTED_CANDIDATES", ("E23",)),
+    "offshore/work/sponsor_individual": ("SUPPORTED_CANDIDATES", ("E23",)),
+    # Work item 2, fourth bullet: leaving `sponsor.type` genuinely
+    # UNRESOLVED (`unsure` -> UNVERIFIED) on a reaching tile must be
+    # silence, never a hold — `offshore/work` above already proves the
+    # honest-negative half (`NONE`, the question's first option). Under the
+    # pack signed today this is a non-event (no EMPLOYMENT-purpose rule
+    # reads sponsor.type yet), and it answers identically: E23.
+    "offshore/work/sponsor_unsure": ("SUPPORTED_CANDIDATES", ("E23",)),
     "onshore/business": ("NO_SUPPORTED_PATH", ()),
     # D4a: the onshore family/diaspora walks default to SPOUSE — same
     # `family_sponsor_status_code` fix as the offshore SPOUSE/=IT walks
@@ -700,26 +743,44 @@ def outcomes(walks: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return _evaluate_walks(walks)
 
 
-def test_corpus_is_the_76_real_interview_walks(walks: dict[str, dict[str, Any]]) -> None:
+def test_corpus_is_the_82_real_interview_walks(walks: dict[str, dict[str, Any]]) -> None:
     """An empty or shrunken corpus fails loudly: a census that passes because
     nobody fed it any walks is the green-but-dead shape (cicatrix #2).
 
-    43 before PR-3, 61 before PR-5, 67 before PR-D3, 78 before D4a. PR-5's 6
-    new walks are the 5 offshore `retirement` bases plus the onshore neutral
-    `retirement` walk, each replayed with `birth_date` overridden to
-    `RETIREMENT_AGE_64_BIRTH_DATE` (age 64 on `CORPUS_TODAY`) instead of the
-    corpus-wide default 25 — the generator's own age dimension, not a new
-    tree branch. PR-D3's 11 new walks are real new branches: the two
-    invest-vehicle below-threshold routes, the three declared-paid-activity
-    branches, the retirement property/bank_deposit/undecided branches that
-    used to dead-end, and the two STEPCHILD sponsor-permit answers — see
-    `generate-walk-corpus.ts`. D4a (owner ruling SHWEB-20260911, THIS PR)
-    REMOVES those same two STEPCHILD sponsor-permit walks: the D3-4 hold and
-    the question they exercised had no pack requirement behind them for
+    43 before PR-3, 61 before PR-5, 67 before PR-D3, 78 before D4a, 76 before
+    PR-D4d. PR-5's 6 new walks are the 5 offshore `retirement` bases plus the
+    onshore neutral `retirement` walk, each replayed with `birth_date`
+    overridden to `RETIREMENT_AGE_64_BIRTH_DATE` (age 64 on `CORPUS_TODAY`)
+    instead of the corpus-wide default 25 — the generator's own age
+    dimension, not a new tree branch. PR-D3's 11 new walks are real new
+    branches: the two invest-vehicle below-threshold routes, the three
+    declared-paid-activity branches, the retirement
+    property/bank_deposit/undecided branches that used to dead-end, and the
+    two STEPCHILD sponsor-permit answers — see `generate-walk-corpus.ts`.
+    D4a REMOVES those same two STEPCHILD sponsor-permit walks: the D3-4 hold
+    and the question they exercised had no pack requirement behind them for
     E31D (fresh grader review) and were retired, so the corpus shrinks
-    78 -> 76. Every OTHER walk in the corpus is unchanged, byte-for-byte."""
+    78 -> 76. PR-D4d (THIS PR) adds 6: one walk per seq-21 product with the
+    `sponsor.type` value that product's rule requires (`offshore/work/
+    sponsor_government` covers E33A/E33B/E23V at once — identical
+    condition; `offshore/work/sponsor_individual` covers E23U;
+    `offshore/invest/pt_pma/sponsor_government` covers E33C, INVESTMENT
+    purpose), one proving work item 1's new `other`+paid question end to
+    end (`offshore/other/paid/sponsor_government`), one proving an
+    unresolved answer is silence not a hold (`offshore/work/
+    sponsor_unsure`), and the C6 regression walk
+    (`offshore/other/no_paid_activity/medical`, coordinator-authorised scope
+    addition) — corpus grows 76 -> 82. Every OTHER walk in the corpus is
+    unchanged, byte-for-byte, EXCEPT the four `other`-tile walks whose
+    `other_paid_activity` already resolves (`offshore/other`,
+    `onshore/other`, `offshore/other/paid/employer_no`, `offshore/other/
+    paid/sponsor_unsure`): work item 1 makes their branch ask
+    `sponsor_category` for the first time, so their wire `sponsor.type`
+    moves UNKNOWN(NOT_ASKED) -> KNOWN(NONE) — a byte change with no state
+    change, verified by `test_every_walk_ends_in_its_pinned_outcome` staying
+    green on their unmoved EXPECTED_OUTCOME entries."""
 
-    assert len(walks) == 76, f"expected 76 interview walks, found {len(walks)}"
+    assert len(walks) == 82, f"expected 82 interview walks, found {len(walks)}"
     assert sorted(walks) == sorted(EXPECTED_OUTCOME), "corpus and EXPECTED_OUTCOME disagree"
     for label, spec in walks.items():
         assert spec["asked"], f"{label}: walk carries no asked-question history"
@@ -731,7 +792,7 @@ def test_every_walk_ends_in_its_pinned_outcome(outcomes: dict[str, dict[str, Any
     assert not violations, "interview-walk outcomes moved:\n  " + "\n  ".join(violations)
 
 
-def test_walk_state_census_is_2_dead_ends_15_no_paths_and_59_answers(
+def test_walk_state_census_is_2_dead_ends_15_no_paths_and_65_answers(
     outcomes: dict[str, dict[str, Any]],
 ) -> None:
     """The headline number of the decisiveness wave. Every PR that changes it
@@ -741,8 +802,15 @@ def test_walk_state_census_is_2_dead_ends_15_no_paths_and_59_answers(
     widening landed; 11/10/22 with PR-2's reorder on top; 0/10/51 over a
     43 → 61 corpus with PR-3's interview; 2/10/55 over a 61 → 67 corpus with
     PR-5's age dimension on top; 2/14/62 over a 67 → 78 corpus with PR-D3
-    (module docstring). D4a (owner ruling SHWEB-20260911, THIS PR) has two
-    parts:
+    (module docstring); 2/15/59 over a 78 → 76 corpus with D4a. PR-D4d (THIS
+    PR) adds 6 new walks, all SUPPORTED_CANDIDATES on the pack signed
+    TODAY (rulepack-prod-020 — none of them exercise a rule that reads
+    `sponsor.type` yet; that is seq-21, unsigned): 2/15/59 -> 2/15/65 over a
+    76 -> 82 corpus. No existing walk's STATE moves — the four `other`-tile
+    walks whose wire `sponsor.type` changes bytes (see the corpus-count
+    test above) keep their pinned (state, candidates) exactly, which is
+    what `test_every_walk_ends_in_its_pinned_outcome` proves. D4a (owner
+    ruling SHWEB-20260911) had two parts:
 
     1. The sponsor-status fix: one walk's STATE moves —
        `offshore/other/no_paid_activity` was SUPPORTED_CANDIDATES [C6]
@@ -763,7 +831,8 @@ def test_walk_state_census_is_2_dead_ends_15_no_paths_and_59_answers(
        [C1, E31D] — are retired along with the question and hold they
        exercised. Corpus 78 → 76, SUPPORTED_CANDIDATES 61 → 59.
 
-    Net over both parts: 2/14/62 → 2/15/59."""
+    D4a net over both parts: 2/14/62 → 2/15/59. PR-D4d (THIS PR) adds 6:
+    2/15/59 → 2/15/65."""
 
     census = dict(Counter(outcome["state"] for outcome in outcomes.values()))
     assert (
@@ -772,7 +841,7 @@ def test_walk_state_census_is_2_dead_ends_15_no_paths_and_59_answers(
         == {
             "NEEDS_INPUT": 2,
             "NO_SUPPORTED_PATH": 15,
-            "SUPPORTED_CANDIDATES": 59,
+            "SUPPORTED_CANDIDATES": 65,
         }
     )
     assert census["NEEDS_INPUT"] == 2

--- a/apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts
+++ b/apps/mouth/scripts/visa-oracle/generate-walk-corpus.ts
@@ -439,6 +439,95 @@ export function enumerateScenarios(): Scenario[] {
   // requirement for the sponsor's own permit exists for E31D). They would
   // now be byte-identical to the base STEPCHILD walk below.
 
+  // PR-D4d: seq-21 (unsigned — see the PR body's activation caveat) gives
+  // E33A/E33B/E33C/E23U/E23V their first SUPPORT/HARD_FILTER rules on
+  // `sponsor.type`, and every one of them was previously exercised by no
+  // walk at all: the corpus's only reaching-tile walks answer this fact's
+  // FIRST option, `NONE` (`offshore/work` unchanged above). One walk per
+  // product with the value that product's rule requires (evidence brief
+  // table): `el.e33a`/`el.e33b`/`el.e23v` share an IDENTICAL condition
+  // (`intersects EMPLOYMENT AND sponsor.type eq GOVERNMENT`), so a single
+  // `work` walk answering GOVERNMENT exercises all three; `el.e23u` needs
+  // INDIVIDUAL instead (E23U is the diplomat's household assistant, not a
+  // `DIPLOMATIC` sponsor value — no such value exists); `el.e33c` needs
+  // INVESTMENT purpose, not EMPLOYMENT, so it is reached via `invest` with
+  // a non-Second-Home vehicle (`pt_pma`, the corpus's own first vehicle)
+  // instead of `work`.
+  scenarios.push({
+    label: "offshore/work/sponsor_government",
+    overrides: { ...base, category: "work", sponsor_category: "GOVERNMENT" },
+  });
+  scenarios.push({
+    label: "offshore/work/sponsor_individual",
+    overrides: { ...base, category: "work", sponsor_category: "INDIVIDUAL" },
+  });
+  scenarios.push({
+    label: "offshore/invest/pt_pma/sponsor_government",
+    overrides: {
+      ...base,
+      category: "invest",
+      investment_vehicle: "pt_pma",
+      sponsor_category: "GOVERNMENT",
+    },
+  });
+
+  // Work item 1 end to end: before this PR, `other_paid_activity === "yes"`
+  // never asked `sponsor_category` at all — `offshore/other/paid/
+  // employer_no` (added PR-D3) is the walk the PR-D4b pre-sign review named
+  // as the one that dead-ended on this exact gap (cured there by widening
+  // `on_unknown` to `NO_EFFECT`, not by adding a question). This walk
+  // answers GOVERNMENT down the branch work item 1 adds — the SECOND
+  // reachable path (besides `work`) into E33A/E33B/E23V — proving the new
+  // question is not just present but actually answerable end to end.
+  scenarios.push({
+    label: "offshore/other/paid/sponsor_government",
+    overrides: {
+      ...base,
+      category: "other",
+      other_paid_activity: "yes",
+      sponsor_category: "GOVERNMENT",
+    },
+  });
+
+  // Work item 2, third/fourth bullets. The honest-negative half (`NONE`
+  // giving a decisive non-hold result) is already proven by `offshore/work`
+  // above — the corpus's own unmodified default walk, sponsor_category's
+  // first option — so it is measured, not duplicated, in the PR body. This
+  // walk proves the other half: leaving the fact genuinely UNRESOLVED
+  // (`unsure` -> UNVERIFIED) on a reaching tile must be silence under
+  // seq-21's `on_unknown: NO_EFFECT` (the D4b cure), never a NEEDS_INPUT
+  // hold.
+  scenarios.push({
+    label: "offshore/work/sponsor_unsure",
+    overrides: { ...base, category: "work", sponsor_category: "unsure" },
+  });
+
+  // C6 regression walk (coordinator-authorised scope addition, 2026-09-13).
+  // PR-D4a changed `other_purpose = "transit"` to map to the TRANSIT
+  // purpose instead of OTHER. The corpus's only `other_purpose` walk,
+  // `offshore/other/no_paid_activity`, answers `transit` by default (first
+  // option) — `test_d4a_transit_purpose_positively_reaches_d1` now pins
+  // exactly that route to D1, so it must not be repurposed here — which
+  // means no walk any longer exercises `el.c6.social` (unchanged, still
+  // SUPPORTED on `intent.purposes ∩ OTHER`). `medical` is the next
+  // `other_purpose` option: no special-case mapping anywhere in
+  // fact-mapper.ts reads it (only `transit` does), so it falls through to
+  // the plain OTHER purpose, and it is a natural, honest interview answer
+  // ("here for medical treatment, not employed"). `other_paid_activity:
+  // "no"` is required too — the branch this PR's work item 1 changed does
+  // NOT touch this one (verified: `other_paid_activity === "yes"` is a
+  // disjoint arm from this walk's "no") — keeping the purpose OTHER (D3-2),
+  // which is what makes `el.c6.social` reachable at all.
+  scenarios.push({
+    label: "offshore/other/no_paid_activity/medical",
+    overrides: {
+      ...base,
+      category: "other",
+      other_paid_activity: "no",
+      other_purpose: "medical",
+    },
+  });
+
   return scenarios;
 }
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/activity-boundary.test.ts
@@ -350,12 +350,17 @@ const WALKS: readonly WalkCase[] = [
     // `transit`: D4a (owner ruling SHWEB-20260911) released `transit` —
     // `mapPurposes` now maps it to a real, pack-decided purpose — so it can
     // no longer stand in for "an undecidable other_purpose value" here.
+    // `sponsor_category` (PR-D4d) is now asked between `other_paid_activity`
+    // and `work_payer` on this branch — the value is incidental to this
+    // row's own concern (`other_purpose`'s hold), so `NONE` (the question's
+    // first option) is used, same as the neutral rows above.
     name: "other · paid activity yes — engine reroutes to employment; other_purpose still holds",
     category: "other",
     tripScope: "single",
     branch: [
       ["other_purpose", "medical"],
       ["other_paid_activity", "yes"],
+      ["sponsor_category", "NONE"],
       ["work_payer", "yes"],
       ["work_sponsor_confirmed", "yes"],
       ["stay_days", "30"],

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   CATEGORY_TO_PURPOSE,
   SCHEMA_VERSION,
+  SPONSOR_TYPES,
   mapCurrentStatusExpiry,
   mapCurrentlyInIndonesia,
   mapDisclosedReviewFlags,
@@ -767,19 +768,28 @@ describe("mapSponsorType — sponsor_category -> sponsor.type", () => {
     });
   });
 
-  it("is reachable (and answers KNOWN) on every category branch that asks it", () => {
-    // The categories where the sponsor discriminates (design choice, see
-    // FIXED_CATEGORY_QUESTIONS/getCategoryQuestionIds in flow.ts): work,
-    // remote, study, invest, retirement, family — and, since 2026-09-06,
-    // diaspora, which now serves the FAMILY question set verbatim (owner
-    // ruling 4) and therefore inherits its `sponsor_category`. `second_home`
-    // deliberately does NOT ask it: no E33 rule reads `sponsor.type`, and
-    // every question carries `notSure: { mode: "human-review" }`, so a
-    // ceremonial one could only add review volume. Derived from the flow
+  it("is reachable (and answers KNOWN) on every category branch that asks it unconditionally", () => {
+    // The categories where the sponsor discriminates for EVERY facts value
+    // (design choice, see FIXED_CATEGORY_QUESTIONS/getCategoryQuestionIds in
+    // flow.ts): work, remote, study, invest, retirement, family — and, since
+    // 2026-09-06, diaspora, which now serves the FAMILY question set
+    // verbatim (owner ruling 4) and therefore inherits its
+    // `sponsor_category`. `other` is deliberately EXCLUDED from this list
+    // (PR-D4d): it asks the question only down its `other_paid_activity ===
+    // "yes"` branch — see the dedicated describe block below.
+    // `second_home` does NOT ask it at all — not because no rule reads
+    // `sponsor.type` (the ACTIVE pack's `hf.e33a/b/c` do, and PR-D4d's
+    // pack-vocabulary pin below proves it), but because Zero's ruling 3
+    // (2026-09-06) stands: every extra question here carries `notSure: {
+    // mode: "human-review" }`, so a ceremonial one could only add review
+    // volume for a fact measured (PR-D4d) to change no `second_home`
+    // walk's outcome on the pack in force today. Derived from the flow
     // graph itself, not hardcoded, so this test breaks if a branch's
     // question list changes without this describe block being revisited.
-    const categoriesAsking = CATEGORY_KEYS.filter((category) =>
-      getCategoryQuestionIds({ category }).includes("sponsor_category"),
+    const categoriesAsking = CATEGORY_KEYS.filter(
+      (category) =>
+        category !== "other" &&
+        getCategoryQuestionIds({ category }).includes("sponsor_category"),
     );
     expect([...categoriesAsking].sort()).toEqual(
       [
@@ -801,17 +811,140 @@ describe("mapSponsorType — sponsor_category -> sponsor.type", () => {
     }
   });
 
-  it("is never asked on categories where the sponsor doesn't discriminate", () => {
-    for (const category of [
-      "tourism",
-      "business",
-      "second_home",
-      "other",
-    ] as const) {
+  it("is never asked on categories where the sponsor never discriminates", () => {
+    for (const category of ["tourism", "business", "second_home"] as const) {
       expect(getCategoryQuestionIds({ category })).not.toContain(
         "sponsor_category",
       );
     }
+  });
+
+  it("`other`: asked only down the other_paid_activity=yes branch (PR-D4d)", () => {
+    // `yes` is EMPLOYMENT purpose (D3-2) and is the second reachable path
+    // (besides `work`) into seq-21's sponsor.type-gated rules
+    // (el.e33a/b.government-*, el.e23u.diplomatic-household,
+    // el.e23v.trade-office). `no`/`unsure` stay OTHER purpose, which none
+    // of those rules cover, so they must not gain the question.
+    expect(
+      getCategoryQuestionIds({
+        category: "other",
+        other_paid_activity: "yes",
+      }),
+    ).toContain("sponsor_category");
+    for (const other_paid_activity of ["no", "unsure"] as const) {
+      expect(
+        getCategoryQuestionIds({ category: "other", other_paid_activity }),
+      ).not.toContain("sponsor_category");
+    }
+    expect(getCategoryQuestionIds({ category: "other" })).not.toContain(
+      "sponsor_category",
+    );
+
+    const result = mapFacts({
+      category: "other",
+      other_paid_activity: "yes",
+      sponsor_category: "GOVERNMENT",
+    });
+    expect(result.facts["sponsor.type"]).toEqual({
+      status: "KNOWN",
+      value: "GOVERNMENT",
+    });
+  });
+});
+
+describe("sponsor.type vocabulary — pack ⊆ SPONSOR_TYPES, one direction only (PR-D4d)", () => {
+  const PACKS_DIR = path.resolve(
+    REPO_ROOT,
+    "apps/backend-rag/backend/services/visa_engine/contracts/packs",
+  );
+
+  /**
+   * Every production pack on disk, not just the highest sequence — same
+   * posture as engine-adapter.test.ts's `productionPackFiles()`: "a pack is
+   * written before it is activated", so a DRAFT that names a sponsor.type
+   * value the UI cannot produce must fail here the moment it lands, not
+   * only once signed. Reads `.source.json` (every sequence ever authored
+   * carries one; the matching `.signed.json`, when it exists, nests the
+   * identical rule list one level deeper under `payload` and is not read
+   * separately here for that reason).
+   */
+  function productionPackFiles(): string[] {
+    const files = fs
+      .readdirSync(PACKS_DIR)
+      .filter((name) => /^rulepack-prod-\d+\.source\.json$/.test(name))
+      .map((name) => path.join(PACKS_DIR, name));
+    if (files.length === 0) {
+      throw new Error(`no production packs found under ${PACKS_DIR}`);
+    }
+    return files;
+  }
+
+  function sponsorTypeValuesInPack(file: string): string[] {
+    const values = new Set<string>();
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        node.forEach(walk);
+        return;
+      }
+      if (node === null || typeof node !== "object") return;
+      const record = node as Record<string, unknown>;
+      if (record.fact === "sponsor.type") {
+        if (typeof record.value === "string") values.add(record.value);
+        if (Array.isArray(record.values)) {
+          for (const v of record.values) {
+            if (typeof v === "string") values.add(v);
+          }
+        }
+      }
+      Object.values(record).forEach(walk);
+    };
+    walk(JSON.parse(fs.readFileSync(file, "utf-8")));
+    return [...values];
+  }
+
+  function allPackSponsorTypeValues(): Set<string> {
+    const values = new Set<string>();
+    for (const file of productionPackFiles()) {
+      for (const value of sponsorTypeValuesInPack(file)) values.add(value);
+    }
+    return values;
+  }
+
+  /**
+   * ONE direction only, deliberately not a bidirectional deep-equal (D4a's
+   * technique elsewhere in this file) — that pin would be red TODAY:
+   * `EMPLOYER`/`INVESTMENT` are declared UI-only values no pack rule
+   * compares against, and being unread is not itself a defect. The failure
+   * THIS pin guards against is the other direction: a pack value the UI has
+   * no way to ever send, which makes that rule unreachable through the
+   * funnel however the pack itself reads — the exact class of gap this PR
+   * closes for the `other` tile.
+   */
+  it("every sponsor.type value any production pack compares against is one SPONSOR_TYPES can send", () => {
+    const packValues = allPackSponsorTypeValues();
+    // Guard the guard: a glob or walker that silently matched nothing would
+    // make the assertion below vacuously true.
+    expect(packValues.size).toBeGreaterThan(0);
+    const unreachable = [...packValues].filter(
+      (value) => !(SPONSOR_TYPES as readonly string[]).includes(value),
+    );
+    expect(unreachable).toEqual([]);
+  });
+
+  it("EMPLOYER: UI-only — mapSponsorType still sends it KNOWN, but no production-pack rule compares against it", () => {
+    expect(mapSponsorType({ sponsor_category: "EMPLOYER" })).toEqual({
+      status: "KNOWN",
+      value: "EMPLOYER",
+    });
+    expect(allPackSponsorTypeValues().has("EMPLOYER")).toBe(false);
+  });
+
+  it("INVESTMENT: UI-only — mapSponsorType still sends it KNOWN, but no production-pack rule compares against it", () => {
+    expect(mapSponsorType({ sponsor_category: "INVESTMENT" })).toEqual({
+      status: "KNOWN",
+      value: "INVESTMENT",
+    });
+    expect(allPackSponsorTypeValues().has("INVESTMENT")).toBe(false);
   });
 });
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -217,7 +217,12 @@ const CURRENT_STATUS_CODES = [
 // boundary for `family.sponsor_status_code` in `mapFamilySponsorStatus`.
 // Not the same list as `CURRENT_STATUS_CODES` above, which is the non-E
 // ITK/visit-class catalogue.
-const SPONSOR_TYPES = [
+// Exported (PR-D4d) as the subject of fact-mapper.test.ts's pack-vocabulary
+// pin: every `sponsor.type` value a production pack compares against must be
+// one this list can send, or that rule is unreachable through the funnel —
+// see that test for the ONE-direction reasoning (`EMPLOYER`/`INVESTMENT` are
+// declared UI-only and are NOT expected to appear in any pack).
+export const SPONSOR_TYPES = [
   "NONE",
   "INDIVIDUAL",
   "EMPLOYER",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -756,10 +756,24 @@ export function getCategoryQuestionIds(facts: OracleFacts): readonly string[] {
     ];
   }
 
-  // Second Home (owner ruling 3, 2026-09-06). No `sponsor_category`: no
-  // E33 rule reads `sponsor.type`, and every extra question carries
-  // `notSure: { mode: "human-review" }`, so a ceremonial one can only add
-  // review volume without ever changing an outcome.
+  // Second Home (owner ruling 3, 2026-09-06; comment corrected PR-D4d —
+  // the prior wording ("no E33 rule reads sponsor.type") was false: the
+  // ACTIVE pack (rulepack-prod-020.signed.json) carries three HARD_FILTERs
+  // on `sponsor.type` — `hf.e33a.sponsor-not-government`, `hf.e33b`/
+  // `hf.e33c.sponsor-not-government-or-none` — all `on_unknown:
+  // NEEDS_INPUT`. They just never reach this tile: E33A/E33B/E33C's own
+  // `covered_purposes` do not include SECOND_HOME (E33A: EMPLOYMENT/
+  // TOURISM/FAMILY; E33B: +BUSINESS_MEETINGS/INVESTMENT; E33C: INVESTMENT/
+  // BUSINESS_MEETINGS/TOURISM/FAMILY), so `hit_policy:
+  // COVER_ALL_DECLARED_PURPOSES` excludes all three as candidates before
+  // their HARD_FILTER is ever evaluated — measured PR-D4d on all three
+  // `second_home` corpus walks (offshore/property, offshore/bank_deposit,
+  // onshore), `sponsor.type` UNKNOWN(NOT_ASKED): every one still resolves
+  // `SUPPORTED_CANDIDATES [E33]` (the separate, plain E33 product), missing
+  // facts empty. Ruling stands regardless (imperator, 2026-09-13):
+  // `second_home` keeps its omission until Zero decides — every extra
+  // question here carries `notSure: { mode: "human-review" }`, so asking
+  // one a rule cannot use would only add review volume.
   if (category === "second_home") {
     const branch = facts.secondhome_basis;
     const branchQuestions =
@@ -878,12 +892,21 @@ export function getCategoryQuestionIds(facts: OracleFacts): readonly string[] {
   // instead of holding on a bare ACTIVITY_BOUNDARY flag. `no` and `unsure`
   // keep today's `family_sponsor_confirmed` question: `el.c6.social` (the
   // OTHER-purpose rule) still needs it, and neither branch changes purpose.
+  //
+  // `sponsor_category` joined the `yes` arm only (PR-D4d): an EMPLOYMENT-
+  // purpose walk down THIS branch is the other reachable path (besides
+  // `work`) into `el.e33a/b.government-*`, `el.e23u.diplomatic-household`
+  // and `el.e23v.trade-office` (seq-21, unsigned) — all keyed on
+  // `sponsor.type`, none readable before this. `no`/`unsure` stay OTHER
+  // purpose, which none of those rules cover, so they must NOT gain the
+  // question — asking it there would only add review volume for a fact no
+  // rule on that path reads.
   if (category === "other") {
     return [
       "other_purpose",
       "other_paid_activity",
       ...(facts.other_paid_activity === "yes"
-        ? ["work_payer", "work_sponsor_confirmed"]
+        ? ["sponsor_category", "work_payer", "work_sponsor_confirmed"]
         : ["family_sponsor_confirmed"]),
       "stay_days",
       "entry_pattern",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.ts
@@ -463,12 +463,14 @@ export const QUESTIONS: Record<string, OracleQuestion> = {
    * family/work/study "is the sponsor confirmed?" booleans elsewhere in
    * this file, and it is not the sponsor's identity either — just the
    * category. Maps to the single optional `sponsor.type`
-   * FactPath (spec staged-rollout field). No rule in the currently
-   * active pack reads it yet; the question exists to collect the fact
-   * ahead of the rules that will (design doc §4, category-conditional
-   * questions). Asked only where the category makes the sponsor
-   * discriminating — see `FIXED_CATEGORY_QUESTIONS`/`getCategoryQuestionIds`
-   * in flow.ts for exactly which categories include it. */
+   * FactPath (spec staged-rollout field). Corrected PR-D4d: the prior
+   * claim here ("no rule in the currently active pack reads it yet") was
+   * false — the ACTIVE pack (rulepack-prod-020.signed.json) already carries
+   * five conditions on `sponsor.type` (`el.e30e/e30f-student-support`,
+   * `hf.e33a/b/c`), and a draft pack (seq-21, unsigned) adds seven more.
+   * Asked only where the category makes the sponsor discriminating — see
+   * `FIXED_CATEGORY_QUESTIONS`/`getCategoryQuestionIds` in flow.ts for
+   * exactly which categories include it. */
   sponsor_category: {
     id: "sponsor_category",
     i18nKey: "q.sponsor_category",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/walk-corpus-determinism.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/walk-corpus-determinism.test.ts
@@ -47,8 +47,17 @@ import {
  * 78 → 76 on D4a (owner ruling SHWEB-20260911, 2026-09-13): those same two
  * STEPCHILD sponsor-permit walks are retired — no pack requirement for the
  * sponsor's own permit exists for E31D (fresh grader review), so the
- * question and hold they exercised are gone. */
-const EXPECTED_WALK_COUNT = 76;
+ * question and hold they exercised are gone. 76 → 82 on PR-D4d
+ * (2026-09-13): 6 new walks — one per seq-21 product with the sponsor.type
+ * value that product's rule requires (`offshore/work/sponsor_government`
+ * covers E33A/E33B/E23V at once, `offshore/work/sponsor_individual` covers
+ * E23U, `offshore/invest/pt_pma/sponsor_government` covers E33C), one
+ * proving work item 1's new `other`+paid question end to end
+ * (`offshore/other/paid/sponsor_government`), one proving an unresolved
+ * answer is silence not a hold (`offshore/work/sponsor_unsure`), and the
+ * C6 regression walk (`offshore/other/no_paid_activity/medical`) — see
+ * generate-walk-corpus.ts. */
+const EXPECTED_WALK_COUNT = 82;
 
 function jsonFilesIn(dir: string): string[] {
   return readdirSync(dir)

--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d4d-2026091-5a45de84/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d4d-2026091-5a45de84/brief.yml
@@ -1,0 +1,104 @@
+gear: 2
+gear_reason: >-
+  Measured with the inputs CI uses — `scripts/evidence_pack_lint.py --print-floor
+  --changed-files-file <f> --numstat-file <n>` returns 2 (18 files touched, run against this
+  branch's real working-tree diff off `ac05dfc6f4`). Taking the floor without `--numstat-file`
+  under-reports it to 1 — measured in this same session — and that omission has been rejected
+  three times in this mandate (#6240, PR-O2's brief, PR-D3c's brief). No digit is typed: re-run
+  both invocations to check.
+task_id: shweb-w-oracle-d4d-20260913
+mandate_id: SHWEB-20260911/W-ORACLE/PR-D4d
+colour: BLUE
+l_level: L1
+gate_class: opus
+objective: >-
+  seq-21 (PR #6362, prepared and unsigned) gives five products — E33A, E33B, E33C, E23U, E23V —
+  their first SUPPORT/HARD_FILTER rules, all gated on `sponsor.type`. It changes no corpus
+  verdict, not because the question is missing (`work`/`remote`/`study`/`invest`/`retirement`/
+  `family`/`diaspora` already ask it) but because every walk that answers it answers `NONE`
+  (measured: 61/76 KNOWN NONE, 15/76 UNKNOWN NOT_ASKED, zero of anything else). This PR closes
+  the one tile that really is missing the question — `other`'s `other_paid_activity === "yes"`
+  branch, EMPLOYMENT purpose (D3-2), the second reachable path (besides `work`) into
+  E33A/E33B/E23V — and gives the corpus 6 new walks that answer something else: GOVERNMENT/
+  INDIVIDUAL for the five seq-21 products, one honest `unsure`, and a C6 regression walk
+  (coordinator-authorised scope addition) restoring the census entry PR-D4a silently dropped when
+  `other_purpose = "transit"` was repointed to the TRANSIT purpose. `second_home` keeps its
+  omission (Zero's ruling 3 stands) — measured instead of changed: the three `NEEDS_INPUT` E33
+  hard filters in the pack signed TODAY never reach a `second_home` walk at all, because
+  E33A/E33B/E33C's own `covered_purposes` exclude SECOND_HOME.
+scope:
+  - apps/mouth — the visa-oracle interview (`flow.ts`, `tree.ts` comment, `fact-mapper.ts`'s
+    exported `SPONSOR_TYPES`), the walk-corpus generator, and every test file touched
+  - apps/backend-rag/backend/tests/services/visa_engine — the walk corpus fixtures and the census
+    test (`EXPECTED_OUTCOME`, the two named/counted assertions)
+  - this brief
+constraints:
+  - Frontend + corpus only. No rule-pack edit (seq-21 stays Zero's to sign), no
+    `evaluate_path.py`, no `evaluator.py`.
+  - >-
+    `engine-adapter.ts` and `engine-adapter.test.ts` are NOT touched: a sibling PR (D3d) owns
+    them. Verified — `git diff --name-only ac05dfc6f4...HEAD -- '*engine-adapter*'` returns empty.
+  - >-
+    `second_home` does NOT gain `sponsor_category` — Zero's ruling 3 (2026-09-06) stands. The
+    three E33 HARD_FILTERs' actual effect on that tile is MEASURED (engine-level, against the
+    signed pack) and reported as a finding, not resolved.
+  - Every corpus addition goes through `generate-walk-corpus.ts`; no fixture is hand-edited.
+  - No PII in any file added or edited; no real client data in any walk or fixture.
+  - Never touched `VISA_ENGINE_EVALUATE_MODE`; no pack signed or activated.
+acceptance:
+  - text: >-
+      WHEN the visa-oracle frontend suite runs, THEN every test SHALL pass, including the new
+      pack-vocabulary pin and the updated `other`-branch/corpus-count tests this PR adds.
+    status: verified
+    probe: "cd apps/mouth && npx vitest run 'src/app/(visa-oracle)'"
+    result: "Test Files 39 passed (39) | Tests 740 passed (740)"
+  - text: WHEN the project typechecks, THEN it SHALL succeed.
+    status: verified
+    probe: "cd apps/mouth && npx tsc --noEmit"
+    result: "exit 0, zero errors"
+  - text: WHEN the project lints, THEN it SHALL report zero errors.
+    status: verified
+    probe: "cd apps/mouth && npx eslint ."
+    result: "exit 0 — 147 pre-existing warnings outside this PR's files, 0 errors, 0 in any touched file"
+  - text: >-
+      WHEN the backend walk-census test runs, THEN every one of the 82 walks SHALL match its
+      pinned EXPECTED_OUTCOME and the state census SHALL read 2/15/65.
+    status: verified
+    probe: >-
+      cd apps/backend-rag && PYTHONPATH=. .venv/bin/pytest
+      backend/tests/services/visa_engine/test_interview_walk_census.py
+    result: "17 passed (before this PR's corpus regen: 17 passed at 76 walks, 2/15/59)"
+  - text: >-
+      WHEN the corpus's `sponsor.type` distribution is read directly off disk (the brief's own
+      premise, re-measured rather than trusted), THEN it SHALL show only NONE and NOT_ASKED before
+      this PR's additions — the fact this PR exists to change.
+    status: verified
+    probe: |
+      grep -h -o '"sponsor.type"[^}]*}' apps/backend-rag/backend/tests/services/visa_engine/gold_coverage/fixtures/walks/*.json \
+        | sed 's/.*"status"//' | sort | uniq -c
+    result: "61 KNOWN NONE, 15 UNKNOWN NOT_ASKED, zero of anything else, on the pre-regen 76-walk corpus"
+  - text: >-
+      WHEN a `second_home` walk with `sponsor.type` UNKNOWN is evaluated against the pack signed
+      TODAY, THEN none of the three `on_unknown: NEEDS_INPUT` E33 hard filters SHALL hold it —
+      the measurement this PR reports instead of resolving.
+    status: verified
+    probe: |
+      cd apps/backend-rag && PYTHONPATH=. .venv/bin/python - <<'PY'
+      from backend.tests.services.visa_engine.test_interview_walk_census import _engine_decision, _load_walks
+      walks = _load_walks()
+      for label in ["offshore/second_home/bank_deposit", "offshore/second_home/property", "onshore/second_home"]:
+          d = _engine_decision(walks[label]["overrides"], label)
+          print(label, d.state, d.missing_facts, [c.product_code for c in d.candidates])
+      PY
+    result: >-
+      all three: SUPPORTED_CANDIDATES, missing_facts=(), candidates=['E33'] — sponsor.type stays
+      UNKNOWN(NOT_ASKED) throughout, because E33A/E33B/E33C's covered_purposes exclude
+      SECOND_HOME, so they are never candidates in the first place
+pii: none
+self_report:
+  note: >-
+    Reachable products (union of EXPECTED_OUTCOME candidates) move 16 -> 17 on the LIVE pack —
+    only C6 is new; E33A/E33B/E33C/E23U/E23V are NOT among them, because seq-21 is unsigned and
+    inert. Merging this PR does not activate seq-21 or move the funnel census beyond the C6
+    restoration — that distinction, the second_home finding, and the corpus/state triples at both
+    instants are this session's own record; the probes above are reproducible.


### PR DESCRIPTION
## What

**PR-D4d — the sponsor category is asked where it decides, and the corpus finally answers it with something other than "none".**

seq-21 (#6362, prepared and unsigned) gives five products their first SUPPORT rules — E33A, E33B, E33C, E23U, E23V — every one gated on `sponsor.type`. Replayed against the corpus it changes **no verdict at all**. This PR removes the reason for that, and the reason turned out not to be the one in the mandate.

## The premise, corrected by measurement

The brief for this work said the products were unreachable because *no tile that reaches them asks `sponsor_category`*. Half right. Measured on `flow.ts`:

| asks `sponsor_category` | does not |
|---|---|
| work, remote, study, invest, retirement, family, diaspora | tourism, business, second_home, **other** |

`work` (the EMPLOYMENT emitter for E33A/E33B/E23U/E23V) and `invest` (the INVESTMENT emitter for E33C) **already ask**. Only the `other` tile's paid branch was missing it.

The real cause was the corpus. Before this PR, over 76 walks:

```
grep -h -o '"sponsor.type"[^}]*}' .../gold_coverage/fixtures/walks/*.json | sed 's/.*"status"//' | sort | uniq -c
   61   "KNOWN", "value": "NONE"
   15   "UNKNOWN", "reason": "NOT_ASKED"
```

Zero walks said GOVERNMENT, INDIVIDUAL or EDUCATION. **Every walk that answered the question answered "no sponsor".** That single fact explains all three symptoms at once: seq-21's inertness, the pre-cure false SUPPORT (61 walks carrying `NONE`, which `el.e33b`/`el.e33c` used to accept), and "reachable stays flat" after the cure.

After this PR: **3 × GOVERNMENT, 1 × INDIVIDUAL, 65 × NONE, 12 × NOT_ASKED, 1 × UNVERIFIED.**

## What changed

**1. The `other` tile's paid branch asks the question.** `getCategoryQuestionIds`'s `other` branch gains `sponsor_category` on `other_paid_activity === "yes"` only — the branch that emits EMPLOYMENT (D3-2) and so can reach E33A/E33B/E23U/E23V. The `no`/`unsure` branch stays on OTHER, reaches none of those rules, and does not gain the question.

**2. Six new corpus walks**, all through `generate-walk-corpus.ts`, never hand-written into fixtures: one per product's required sponsor value (GOVERNMENT for E33A/E33B/E33C/E23V, **INDIVIDUAL** for E23U — there is no `DIPLOMATIC` value in the pack or the UI; E23U is the diplomat's household assistant and the diplomat is an individual sponsor), one down the new `other`+paid branch, an `unsure` walk, and the C6 regression walk below.

**3. The pack vocabulary is pinned — one-directionally, and here is why.** `SPONSOR_TYPES` has six values; the pack knows four (`EDUCATION, GOVERNMENT, INDIVIDUAL, NONE`). `EMPLOYER` and `INVESTMENT` are UI-only, and `enumFact` sends them to the engine as KNOWN values no rule compares against: every ELIGIBILITY test is silently false while `neq`/`not_in` HARD_FILTERs fire. That is the right outcome for an employer-sponsored applicant, but right by coincidence rather than construction. A bidirectional deep-equal — D4a's technique for the stay-permit catalogue — would be **red today and wrong**. The pin asserts `pack vocabulary ⊆ SPONSOR_TYPES`, so the failure it catches is the one that matters: a future pack value the UI cannot produce, which silently makes a rule unreachable. `EMPLOYER` and `INVESTMENT` are named in the test as declared UI-only values.

**4. Two comments asserted the opposite of the active pack.** Both said, in substance, that no rule reads `sponsor.type`. `rulepack-prod-020.signed.json` — live in production — carries five conditions on it (`el.e30e`, `el.e30f`, `hf.e33a`, `hf.e33b`, `hf.e33c`), all `on_unknown: NEEDS_INPUT`. Corrected in `tree.ts` and `flow.ts`.

**Also discharges C2 of the #6372 row (C6 regression walk).** PR-D4a mapped `other_purpose = "transit"` to the TRANSIT purpose, and the corpus's only `other_purpose` walk answered `transit` — so C6 left the census with no regression net, though `el.c6.social` is unchanged. A walk with a non-`transit` `other_purpose` on the `paid = no` branch restores it.

## Measured, at both instants

| | `origin/main` (`ac05dfc6f4`) | this branch |
|---|---|---|
| walks | 76 | 82 |
| SUPPORTED_CANDIDATES | 59 | 65 |
| NO_SUPPORTED_PATH | 15 | 15 |
| NEEDS_INPUT | 2 | 2 |
| reachable products | 16 | **17** |

**No pre-existing walk changed verdict** — zero, verified by diffing `EXPECTED_OUTCOME` key by key across the two instants, not by eyeballing a total. Four `other`-tile fixtures changed wire bytes only (`sponsor.type` UNKNOWN → KNOWN(NONE)) because the tile now asks; their pinned outcomes are untouched.

**The one product gained is C6** — the regression walk. **E33A, E33B, E33C, E23U and E23V are NOT reachable by this measurement, and that is the honest state**: merging a pack does not activate it, seq-21 is unsigned (#6362, Zero signs), and until it is active these walks exercise the frontend faithfully while the funnel census cannot move. The census number that will show those five products is **conditional on activation** and is not claimed here.

## A finding for Zero, not resolved here

The `second_home` tile's omission of this question rests on a comment that is now false — it said no E33 rule reads `sponsor.type`, and three E33 HARD_FILTERs do, all `on_unknown: NEEDS_INPUT`. **Zero's ruling 3 (2026-09-06) stands and the question is not added.** Measured instead, on all three `second_home` fixtures against the signed pack:

```
offshore/second_home/bank_deposit  -> SUPPORTED_CANDIDATES  candidates=['E33']  missing=()
offshore/second_home/property      -> SUPPORTED_CANDIDATES  candidates=['E33']  missing=()
onshore/second_home                -> SUPPORTED_CANDIDATES  candidates=['E33']  missing=()
```

`sponsor.type` stays UNKNOWN throughout and no hard filter fires — because `E33A`/`E33B`/`E33C`'s `covered_purposes` exclude `SECOND_HOME` (`['EMPLOYMENT','TOURISM','FAMILY']`, `['EMPLOYMENT','BUSINESS_MEETINGS','INVESTMENT','TOURISM','FAMILY']`, `['INVESTMENT','BUSINESS_MEETINGS','TOURISM','FAMILY']`), so `hit_policy: COVER_ALL_DECLARED_PURPOSES` drops them as candidates before their filters are evaluated. **The decision holds; the reason recorded for it did not.** Decision pending Zero.

## Gates

`tsc --noEmit` exit **0** · `eslint .` **0 errors** (147 pre-existing warnings, none in a touched file) · `vitest run 'src/app/(visa-oracle)'` 39 files / **740 passed** (baseline on `ac05dfc6f4`: 39 / 730) · `pytest test_interview_walk_census.py` **17 passed** at both instants.

Evidence gear: floor **2**, source **size**, brief declares **2**. Measured with both flags on the full 19-file diff — and reproduced at **1** without `--numstat-file`, which is the exact under-report that has failed this gate three times in this mandate.

## Correction of record

The brief for this work told the implementer that pack rules live under `payload.products[].rules`. **That is wrong**, and the implementer caught it rather than working around it: across all 33 pack files in the repo, source and signed, `rules` is a flat list under `payload` (109 in seq-20) and no `products[]` entry ever carries a `rules` key — `payload.products` is 38 metadata-only entries. The substance the brief drew from that file was independently correct; only the navigation path was wrong. Recorded here because a wrong reader of this file returns an empty result that reads exactly like a true negative.

## Bites

Bites: consumer = an applicant on the `other` tile who declares paid activity — their interview emits EMPLOYMENT and can reach E33A/E33B/E23U/E23V, and until now it never asked who sponsors them, so `sponsor.type` arrived UNKNOWN on every one of those rules; observation = on this branch `pytest backend/tests/services/visa_engine/test_interview_walk_census.py` passes with `offshore/other/paid/sponsor_government` in `EXPECTED_OUTCOME`, a walk that cannot exist without the question, and the corpus now carries 3 GOVERNMENT and 1 INDIVIDUAL `sponsor.type` answers where it carried none.

## Not done, declared

- The seq-21 pack was **not** evaluated live: no signed envelope exists for it and constructing one is signing-adjacent. Its effects are stated from direct JSON inspection of the unmerged commit and marked conditional throughout — never as a live measurement.
- `engine-adapter.ts` untouched (PR-D3d owns it); no rule pack touched.
- A broader `pytest backend/tests/services/visa_engine/` run is not clean, and the unclean part is pre-existing and environmental. **No count is given here, because the count is a property of the host and not of this branch**: on the machine this PR was built on, every error came from `test_evaluate_endpoint.py` (`asyncpg.exceptions.TooManyColumnsError: tables can have at most 1600 columns`) plus one failure in `test_visa_engine_retention_fk_registry.py` (a deployed-schema assertion); the reviewing host additionally errored in `test_shadow_evidence.py` and `test_shadow_match.py`, for the same Postgres reason. The files are named instead of tallied. What matters and is stable: **nothing in `gold_coverage/` or the walk census is among them**, and the counts this PR does state — the corpus triple, vitest, the census — were each measured in the session that reports them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNwbSmS3XK5X6FNpCe8kZe

