### PR TITLE
feat(mouth): the Oracle names the answer that put a case with a person (PR-O4 / Δ2)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -137,6 +137,16 @@
     }
   ],
   "results": {
+    "evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/pack.yml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/pack.yml",
+        "hashed_secret": "c0c17e6690cca84aa85c3ec37e63af5b48881c2e",
+        "is_verified": false,
+        "line_number": 20,
+        "is_secret": false
+      }
+    ],
     "evidence/2026-09/agent-mini-pro2-mouth-shweb-w2-c4c-guardscope-20-efba4038/brief.yml": [
       {
         "type": "Base64 High Entropy String",

--- a/apps/mouth/e2e/visa-oracle-v2.spec.ts
+++ b/apps/mouth/e2e/visa-oracle-v2.spec.ts
@@ -650,6 +650,62 @@ test.describe("Visa Oracle v2 integration — page Page", () => {
     );
   });
 
+  // PR-O4 / Δ2 (spec §3): a held visitor reads a DEMONSTRATED cause, edits
+  // the answer behind it, and never reads a configuration string.
+  test("a held walk names the answer that caused it and edits back to that question", async ({
+    page,
+  }) => {
+    await seedVerdictResume(page, { ...VERDICT_FACTS, trip_scope: "unsure" });
+    await page.route("**/api/visa-oracle/evaluate**", (route) => {
+      const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
+      return fulfillJson(route, {
+        ...response,
+        decision: {
+          ...response.decision,
+          review_reasons: [
+            {
+              code: "DISCLOSED_UNCERTAINTY_REVIEW",
+              rule_ids: [],
+              source_refs: [],
+            },
+            { code: "DECISIVE_SOURCE_STALE", rule_ids: [], source_refs: [] },
+          ],
+        },
+      });
+    });
+    await page.goto("/visa-oracle");
+    await expectEngineState(page, "HUMAN_REVIEW_REQUIRED");
+
+    // The two holds are separated: one about this applicant's answers, one
+    // about our own sources.
+    await expect(
+      page.getByRole("heading", {
+        name: translate("en", "outcome.review_group_case.title"),
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: translate("en", "outcome.review_group_system.title"),
+      }),
+    ).toBeVisible();
+
+    const cause = page.locator('[data-review-cause="trip_scope"]');
+    await expect(cause).toHaveCount(1);
+    await expect(cause).toContainText(translate("en", "q.trip_scope"));
+    // The source hold attributes nothing to the applicant.
+    await expect(page.locator("[data-review-cause]")).toHaveCount(1);
+
+    // A visitor never reads an internal configuration string (A2).
+    expect(await page.content()).not.toContain("is not configured");
+
+    await cause.getByRole("button").click();
+    await expect(
+      page.getByRole("heading", {
+        name: translate("en", "q.trip_scope"),
+      }),
+    ).toBeVisible();
+  });
+
   test("minor handoff requires guardian confirmation before separate WhatsApp consent", async ({
     page,
   }) => {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/ConfirmationCard.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/ConfirmationCard.tsx
@@ -98,7 +98,14 @@ export function formatFactDisplay(
   return option ? translate(language, option.labelI18nKey as I18nKey) : value;
 }
 
-function assumptionDisplay(language: Language, questionId: string): string {
+/** The human sentence for an assumption: the question's own dedicated copy
+ * when one exists, else the generic sentence NAMING the question. Exported
+ * because the OutcomeSheet's receipt renders the same assumptions and must
+ * not fall through to the raw `assumption.<id>` key (PR-O4). */
+export function assumptionDisplay(
+  language: Language,
+  questionId: string,
+): string {
   const key = `assumption.${questionId}` as I18nKey;
   const specific = translate(language, key);
   if (specific !== key) return specific;

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/ConsentHandoff.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/ConsentHandoff.test.tsx
@@ -223,8 +223,14 @@ describe("ConsentHandoff", () => {
   });
 
   it.each([
-    ["en", "WhatsApp contact is not configured."],
-    ["id", "Kontak WhatsApp belum dikonfigurasi."],
+    [
+      "en",
+      "WhatsApp is not available from this page right now. You can finish the interview and print or save your result at the end.",
+    ],
+    [
+      "id",
+      "WhatsApp belum tersedia dari halaman ini saat ini. Anda dapat menyelesaikan wawancara lalu mencetak atau menyimpan hasil Anda di akhir.",
+    ],
   ] as const)(
     "does not promise a nonexistent result when %s consultation is unavailable",
     (language, message) => {
@@ -396,7 +402,7 @@ describe("ConsentHandoff", () => {
       />,
     );
     expect(screen.getByRole("status")).toHaveTextContent(
-      "WhatsApp handoff is not configured",
+      "WhatsApp is not available from this page right now. You can print or save this result and bring it to a Bali Zero consultant.",
     );
     expect(screen.queryByRole("checkbox")).toBeNull();
 
@@ -408,7 +414,44 @@ describe("ConsentHandoff", () => {
       />,
     );
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Pengalihan WhatsApp belum dikonfigurasi",
+      "WhatsApp belum tersedia dari halaman ini saat ini. Anda dapat mencetak atau menyimpan hasil ini dan membawanya ke konsultan Bali Zero.",
+    );
+  });
+
+  // PR-O4 / Δ2: the visitor no longer reads the configuration string, so the
+  // misconfiguration must still reach US. A hidden defect with no witness is
+  // the worse of the two failures.
+  it.each([["not-a-phone"], [""], ["+62"]])(
+    "reports the unconfigured handoff internally while the visitor reads no configuration string (%j)",
+    (whatsappNumber) => {
+      const { container } = render(
+        <ConsentHandoff
+          language="en"
+          state="HUMAN_REVIEW_REQUIRED"
+          whatsappNumber={whatsappNumber}
+        />,
+      );
+
+      expect(container.textContent).not.toContain("is not configured");
+      expect(emitVisaOracleTelemetry).toHaveBeenCalledWith({
+        event: "visa_oracle_v2_handoff_unconfigured",
+        state: "HUMAN_REVIEW_REQUIRED",
+      });
+    },
+  );
+
+  it("reports nothing internally once a valid number is configured", () => {
+    render(
+      <ConsentHandoff
+        language="en"
+        state="HUMAN_REVIEW_REQUIRED"
+        whatsappNumber="628123456789"
+      />,
+    );
+    expect(emitVisaOracleTelemetry).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "visa_oracle_v2_handoff_unconfigured",
+      }),
     );
   });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/ConsentHandoff.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/ConsentHandoff.tsx
@@ -61,8 +61,9 @@ const COPY = {
       "This consent receipt stays in this browser session for up to 2 hours. No CRM record is created by this screen.",
     open: "Open WhatsApp",
     unavailable:
-      "WhatsApp handoff is not configured. You can still print or save this result.",
-    consultationUnavailable: "WhatsApp contact is not configured.",
+      "WhatsApp is not available from this page right now. You can print or save this result and bring it to a Bali Zero consultant.",
+    consultationUnavailable:
+      "WhatsApp is not available from this page right now. You can finish the interview and print or save your result at the end.",
     qr: "QR code for the consented WhatsApp handoff",
     message: "Hello Bali Zero. I consent to discuss my Visa Oracle result.",
     consultationMessage:
@@ -85,8 +86,9 @@ const COPY = {
       "Tanda terima persetujuan ini tersimpan di sesi browser ini hingga 2 jam. Layar ini tidak membuat catatan CRM.",
     open: "Buka WhatsApp",
     unavailable:
-      "Pengalihan WhatsApp belum dikonfigurasi. Anda tetap dapat mencetak atau menyimpan hasil ini.",
-    consultationUnavailable: "Kontak WhatsApp belum dikonfigurasi.",
+      "WhatsApp belum tersedia dari halaman ini saat ini. Anda dapat mencetak atau menyimpan hasil ini dan membawanya ke konsultan Bali Zero.",
+    consultationUnavailable:
+      "WhatsApp belum tersedia dari halaman ini saat ini. Anda dapat menyelesaikan wawancara lalu mencetak atau menyimpan hasil Anda di akhir.",
     qr: "Kode QR untuk pengalihan WhatsApp yang telah disetujui",
     message: "Halo Bali Zero. Saya setuju membahas hasil Visa Oracle saya.",
     consultationMessage:
@@ -252,6 +254,23 @@ export function ConsentHandoff({
       if (timer !== null) clearTimeout(timer);
     };
   }, [activeReceipt, now, scope, storage]);
+
+  /**
+   * PR-O4 / Δ2: the visitor now reads a neutral sentence instead of
+   * "WhatsApp handoff is not configured", so the only remaining witness that
+   * `NEXT_PUBLIC_VISA_ORACLE_WHATSAPP_NUMBER` never reached this component is
+   * this internal event. Hiding the defect from the reader without reporting
+   * it to us would turn a visible misconfiguration into a silent one (scar
+   * family #2, Esiste≠Armato). Carries the terminal state only — the same
+   * closed, PII-free boundary as every other event here.
+   */
+  useEffect(() => {
+    if (number !== null) return;
+    emitVisaOracleTelemetry({
+      event: "visa_oracle_v2_handoff_unconfigured",
+      ...(scope.context === "ASSESSMENT" ? { state: scope.state } : {}),
+    });
+  }, [number, scope]);
 
   const message = useMemo(
     () => buildMinimalMessage(language, scope),

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
@@ -1,10 +1,18 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 import type { ComponentProps } from "react";
-import { OutcomeSheet } from "./OutcomeSheet";
+import {
+  OutcomeSheet,
+  SYSTEM_REVIEW_REASON_CODES,
+  demonstratedReviewCauses,
+} from "./OutcomeSheet";
+import { REVIEW_REASON_COPY } from "../_lib/engine-adapter";
+import { mapDisclosedReviewFlags } from "../_lib/fact-mapper";
 import type { Language } from "../_lib/flow";
 import type {
+  HumanReviewOutcome,
   OutcomeCandidate,
+  OutcomeReason,
   OutcomeState,
   OutcomeViewModel,
 } from "../_lib/outcome-view-model";
@@ -418,5 +426,231 @@ describe("OutcomeSheet — honest five-state rendering", () => {
     expect(container.querySelector(".oracle-outcome-actions")).toHaveClass(
       "oracle-no-print",
     );
+  });
+});
+
+// PR-O4 / Δ2 (spec §3): a held visitor must read a DEMONSTRATED cause, and a
+// hold that is ours must not be worded — or grouped — as something they did.
+describe("OutcomeSheet — PR-O4 review causes", () => {
+  const reviewReasonFor = (code: string): OutcomeReason => ({
+    code,
+    message: text(`Copy for ${code}`, `Salinan untuk ${code}`),
+    sourceIds: [],
+  });
+
+  const reviewOutcome = (
+    codes: readonly [string, ...string[]],
+  ): HumanReviewOutcome => ({
+    ...common(),
+    state: "HUMAN_REVIEW_REQUIRED",
+    candidates: [],
+    reviewReasons: [
+      reviewReasonFor(codes[0]),
+      ...codes.slice(1).map(reviewReasonFor),
+    ],
+  });
+
+  function renderReview(
+    codes: readonly [string, ...string[]],
+    facts: Record<string, string>,
+    props: Partial<ComponentProps<typeof OutcomeSheet>> = {},
+    language: Language = "en",
+  ) {
+    return render(
+      <OutcomeSheet
+        language={language}
+        outcome={reviewOutcome(codes)}
+        facts={facts}
+        {...props}
+      />,
+    );
+  }
+
+  it("names the question the visitor answered “Not sure” and edits back to it", () => {
+    const onEditMissingInput = vi.fn();
+    const { container } = renderReview(
+      ["DISCLOSED_UNCERTAINTY_REVIEW"],
+      { category: "business", trip_scope: "unsure" },
+      { onEditMissingInput },
+    );
+
+    expect(
+      screen.getByText(
+        "You answered “Not sure” to: Is this your only purpose for the trip?",
+      ),
+    ).toBeInTheDocument();
+    expect(container.querySelectorAll("[data-review-cause]")).toHaveLength(1);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Edit your answer to: Is this your only purpose for the trip?",
+      }),
+    );
+    expect(onEditMissingInput).toHaveBeenCalledWith("trip_scope");
+  });
+
+  it("names the same cause in Indonesian", () => {
+    renderReview(
+      ["DISCLOSED_UNCERTAINTY_REVIEW"],
+      { trip_scope: "unsure" },
+      {},
+      "id",
+    );
+    expect(
+      screen.getByText(
+        "Anda menjawab “Tidak yakin” pada: Apakah ini satu-satunya tujuan perjalanan Anda?",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("quotes the answer itself when the hold is an undecidable activity", () => {
+    renderReview(["DISCLOSED_ACTIVITY_BOUNDARY_REVIEW"], {
+      category: "business",
+      business_activity: "training",
+    });
+    expect(
+      screen.getByText(
+        "You answered “Giving or receiving training” to: What will you mainly do on the business trip?",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("attributes a disclosure hold to the review gate the visitor ticked", () => {
+    const { container } = renderReview(["DISCLOSED_HEALTH_CONCERN_REVIEW"], {
+      review_gate: "health_flag",
+    });
+    expect(
+      container.querySelector('[data-review-cause="review_gate"]'),
+    ).not.toBeNull();
+  });
+
+  it("attributes nothing when no answer of this walk demonstrates the code", () => {
+    const { container } = renderReview(
+      ["DISCLOSED_MULTI_PURPOSE_TRIP_REVIEW"],
+      {
+        category: "business",
+        trip_scope: "single",
+      },
+    );
+    expect(container.querySelectorAll("[data-review-cause]")).toHaveLength(0);
+    expect(
+      screen.getByText("Copy for DISCLOSED_MULTI_PURPOSE_TRIP_REVIEW"),
+    ).toBeInTheDocument();
+  });
+
+  it("groups a source hold as ours and never attributes it to an answer", () => {
+    const { container } = renderReview(["DECISIVE_SOURCE_STALE"], {
+      category: "business",
+      trip_scope: "unsure",
+    });
+    expect(
+      screen.getByRole("heading", {
+        name: "Checks on our side, not on your answers",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", {
+        name: "What a person will check about your case",
+      }),
+    ).toBeNull();
+    expect(container.querySelectorAll("[data-review-cause]")).toHaveLength(0);
+  });
+
+  it("renders both groups under their own headings when both are held", () => {
+    renderReview(
+      ["DISCLOSED_UNCERTAINTY_REVIEW", "SAFETY_CRITICAL_SOURCE_STALE"],
+      { trip_scope: "unsure" },
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: "What a person will check about your case",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: "Checks on our side, not on your answers",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  // Guard, not decoration: a new source/system code added to the copy map
+  // would otherwise render silently under "about your case" — the exact
+  // mis-attribution PR-O4 exists to remove.
+  it("classifies every source/system code the copy map knows", () => {
+    const unclassified = Object.keys(REVIEW_REASON_COPY).filter(
+      (code) =>
+        /^(DECISIVE_|SAFETY_CRITICAL_|MINOR_GUARDIAN_PRIVACY)/.test(code) &&
+        !SYSTEM_REVIEW_REASON_CODES.has(code),
+    );
+    expect(unclassified).toEqual([]);
+  });
+
+  // The attribution mirrors `mapDisclosedReviewFlags`; if either side drifts,
+  // this goes red rather than showing a cause the engine never held on.
+  it.each<[string, string, Record<string, string>]>([
+    ["DISCLOSED_UNCERTAINTY_REVIEW", "NOT_CERTAIN", { trip_scope: "unsure" }],
+    [
+      "DISCLOSED_ACTIVITY_BOUNDARY_REVIEW",
+      "ACTIVITY_BOUNDARY",
+      { business_activity: "training" },
+    ],
+    [
+      "DISCLOSED_MULTI_PURPOSE_TRIP_REVIEW",
+      "MULTI_PURPOSE_TRIP",
+      { trip_scope: "multiple" },
+    ],
+    [
+      "DISCLOSED_CRIMINAL_RECORD_REVIEW",
+      "CRIMINAL_RECORD",
+      { review_gate: "criminal_record" },
+    ],
+  ])(
+    "only attributes %s when the mapper really raises %s",
+    (code, flag, facts) => {
+      expect(demonstratedReviewCauses(code, facts).length).toBeGreaterThan(0);
+      expect(mapDisclosedReviewFlags(facts)).toContain(flag);
+      expect(demonstratedReviewCauses(code, {})).toEqual([]);
+    },
+  );
+
+  it("names the question in the assumptions receipt instead of a raw key", () => {
+    render(
+      <OutcomeSheet
+        language="en"
+        outcome={{
+          ...reviewOutcome(["DISCLOSED_UNCERTAINTY_REVIEW"]),
+          assumptions: [
+            {
+              id: "assumption-1",
+              questionId: "trip_scope",
+              editable: true,
+            },
+          ],
+        }}
+        facts={{ trip_scope: "unsure" }}
+      />,
+    );
+    expect(
+      screen.getByText(
+        "You marked “Not sure” for “Is this your only purpose for the trip?”; no value was inferred.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("assumption.trip_scope")).toBeNull();
+  });
+
+  // flow.ts's EDIT resets the whole interview when its target is absent from
+  // history, and `facts` is pruned to history — so a cause is only ever
+  // offered for a question this walk actually asked.
+  it("never attributes a question this walk did not answer", () => {
+    expect(
+      demonstratedReviewCauses("DISCLOSED_MULTI_PURPOSE_TRIP_REVIEW", {
+        category: "business",
+      }),
+    ).toEqual([]);
+    expect(
+      demonstratedReviewCauses("DISCLOSED_UNCERTAINTY_REVIEW", {
+        not_a_question: "unsure",
+      }),
+    ).toEqual([]);
   });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
@@ -36,7 +36,12 @@ import {
   type ServiceAvailabilityStatus,
 } from "../_lib/outcome-view-model";
 import { translate, type I18nKey } from "../_lib/i18n";
-import { DISPLAY_ORDER, formatFactDisplay } from "./ConfirmationCard";
+import { ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS } from "../_lib/fact-mapper";
+import {
+  DISPLAY_ORDER,
+  assumptionDisplay,
+  formatFactDisplay,
+} from "./ConfirmationCard";
 
 export interface OutcomeSheetProps {
   language: Language;
@@ -131,14 +136,227 @@ function buildShareSummary(
   return lines.join("\n");
 }
 
+/**
+ * PR-O4 / Δ2 (spec §3, D6 "Δ2: SÌ"): review codes whose hold is about OUR
+ * sources or OUR process, never about anything the applicant answered. The
+ * spec names the three families — `DECISIVE_*`, `SAFETY_CRITICAL_*`,
+ * `MINOR_GUARDIAN_PRIVACY` — and PR-O2 documents `CLIENT_UNABLE_TO_VERIFY_
+ * DETAIL` (outcome-fallbacks.ts) as the client-side technical exception of
+ * the same kind. They render under their own heading so a reader can tell a
+ * hold we owe them from a hold their own answers caused.
+ *
+ * Every other code — known or not — renders under the neutral "about your
+ * case" heading, which is true of any review reason and never says the
+ * applicant did something wrong. That is the fail-closed direction: an
+ * unclassified new code can at worst be under-specific, never mis-attributed
+ * to the visitor. `OutcomeSheet.test.tsx` pins the three families against
+ * `REVIEW_REASON_COPY` so a new source/system code cannot ship unclassified.
+ */
+export const SYSTEM_REVIEW_REASON_CODES: ReadonlySet<string> = new Set([
+  "DECISIVE_PRIMARY_SOURCE_NOT_APPLICABLE",
+  "DECISIVE_SOURCE_FRESHNESS_UNKNOWN",
+  "DECISIVE_SOURCE_STALE",
+  "SAFETY_CRITICAL_PRIMARY_SOURCE_NOT_APPLICABLE",
+  "SAFETY_CRITICAL_SOURCE_FRESHNESS_UNKNOWN",
+  "SAFETY_CRITICAL_SOURCE_STALE",
+  "MINOR_GUARDIAN_PRIVACY_REVIEW",
+  "CLIENT_UNABLE_TO_VERIFY_DETAIL",
+]);
+
+/** One answer of this interview that demonstrably triggered a review code. */
+export interface DemonstratedReviewCause {
+  questionId: string;
+  value: string;
+}
+
+/**
+ * Review codes raised by a `review_gate` checklist item, keyed by the item
+ * the applicant actually ticked. `fact-mapper.ts::mapDisclosedReviewFlags`
+ * reads the same CSV fact and `evaluate_path.py::_DISCLOSED_REVIEW_REASON_
+ * CODES` turns each flag into the code on the left, so ticking the item IS
+ * the demonstrated cause. Mirrored rather than imported because the mapper's
+ * own table is module-private; `OutcomeSheet.test.tsx` re-derives every row
+ * through `mapDisclosedReviewFlags` so a drift in either file goes red.
+ */
+const REVIEW_GATE_CAUSE_ITEM: Readonly<Record<string, string>> = {
+  DISCLOSED_CRIMINAL_RECORD_REVIEW: "criminal_record",
+  DISCLOSED_HEALTH_CONCERN_REVIEW: "health_flag",
+  DISCLOSED_PRIOR_VISA_REFUSAL_REVIEW: "prior_refusal",
+  DISCLOSED_PEP_OR_SANCTIONS_REVIEW: "pep_or_sanctions",
+  DISCLOSED_SOURCE_OF_FUNDS_REVIEW: "source_of_funds_unclear",
+  DISCLOSED_DIPLOMATIC_PASSPORT_REVIEW: "diplomatic_passport",
+  DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW: "ambiguous_sponsor",
+  DISCLOSED_UNCERTAINTY_REVIEW: "not_certain",
+  DISCLOSED_ACTIVITY_BOUNDARY_REVIEW: "activity_boundary",
+};
+
+/**
+ * The answers of THIS interview that demonstrably raised `code` — never a
+ * guess, never a plausible-looking cause. Each branch mirrors the exact
+ * trigger `fact-mapper.ts::mapDisclosedReviewFlags` uses to raise the flag
+ * the backend turns into this code, so a cause shown here is one the
+ * applicant can act on. When nothing demonstrates the code (a backend-only
+ * trigger, or a relation-driven hold the interview cannot attribute to one
+ * answer), this returns `[]` and only the code's own copy is shown — an
+ * unexplained hold is better than an invented explanation.
+ *
+ * Every returned `questionId` is a key of `facts`, and `flow.ts::pruneFacts`
+ * keeps `facts` a subset of the questions this walk actually asked — so
+ * reopening one is always `EDIT` on a node present in history, which
+ * truncates back to it and keeps every prerequisite. `EDIT` on a never-asked
+ * question resets the whole interview (flow.ts `EDIT` case): that is why the
+ * guard below is `facts[id] !== undefined`, not `QUESTIONS[id] !== undefined`.
+ */
+export function demonstratedReviewCauses(
+  code: string,
+  facts: OracleFacts,
+): DemonstratedReviewCause[] {
+  const causes = new Map<string, string>();
+  const add = (questionId: string) => {
+    const value = facts[questionId];
+    if (value === undefined || !QUESTIONS[questionId]) return;
+    causes.set(questionId, value);
+  };
+
+  if (code === "DISCLOSED_UNCERTAINTY_REVIEW") {
+    for (const [questionId, value] of Object.entries(facts)) {
+      if (value === "unsure") add(questionId);
+    }
+  }
+  if (code === "DISCLOSED_ACTIVITY_BOUNDARY_REVIEW") {
+    for (const [questionId, decidable] of Object.entries(
+      ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS,
+    ) as [string, readonly string[]][]) {
+      const answer = facts[questionId];
+      if (answer !== undefined && !decidable.includes(answer)) add(questionId);
+    }
+  }
+  if (code === "DISCLOSED_MULTI_PURPOSE_TRIP_REVIEW") {
+    if (facts.trip_scope === "multiple") add("trip_scope");
+  }
+  if (code === "DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW") {
+    // Only the "unsure" half of the NARROW-1 trigger is attributable: the
+    // other half is the STEPCHILD relation itself, which no single answer
+    // demonstrates.
+    for (const questionId of [
+      "family_sponsor_status_code",
+      "family_sponsor_confirmed",
+    ]) {
+      if (facts[questionId] === "unsure") add(questionId);
+    }
+  }
+  const gateItem = REVIEW_GATE_CAUSE_ITEM[code];
+  if (gateItem && (facts.review_gate?.split(",") ?? []).includes(gateItem)) {
+    add("review_gate");
+  }
+
+  return [...causes].map(([questionId, value]) => ({ questionId, value }));
+}
+
+function ReviewCauseList({
+  language,
+  facts,
+  causes,
+  onEditMissingInput,
+}: {
+  language: Language;
+  facts: OracleFacts;
+  causes: readonly DemonstratedReviewCause[];
+  onEditMissingInput?: (questionId: string) => void;
+}) {
+  if (causes.length === 0) return null;
+  return (
+    <ul className="oracle-action-list">
+      {causes.map((cause) => {
+        const question = QUESTIONS[cause.questionId];
+        const prompt = translate(
+          language,
+          questionPromptI18nKey(question, facts) as I18nKey,
+        );
+        return (
+          <li key={cause.questionId} data-review-cause={cause.questionId}>
+            <span>
+              {cause.value === "unsure"
+                ? translate(language, "outcome.review_cause_unsure", {
+                    question: prompt,
+                  })
+                : translate(language, "outcome.review_cause_answer", {
+                    question: prompt,
+                    answer: formatFactDisplay(
+                      language,
+                      cause.questionId,
+                      cause.value,
+                    ),
+                  })}
+            </span>
+            {onEditMissingInput && (
+              <button
+                type="button"
+                className="oracle-confirmation__edit"
+                aria-label={translate(
+                  language,
+                  "outcome.review_cause_edit_aria",
+                  { question: prompt },
+                )}
+                onClick={() => onEditMissingInput(cause.questionId)}
+              >
+                {translate(language, "confirmation.edit")}
+              </button>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function ReviewReasonGroup({
+  language,
+  titleKey,
+  reasons,
+  sources,
+  facts,
+  onEditMissingInput,
+}: {
+  language: Language;
+  titleKey: I18nKey;
+  reasons: readonly OutcomeReason[];
+  sources: ReadonlyMap<string, OutcomeSource>;
+  facts: OracleFacts;
+  onEditMissingInput?: (questionId: string) => void;
+}) {
+  if (reasons.length === 0) return null;
+  return (
+    <>
+      <h2 className="oracle-outcome__section-title">
+        {translate(language, titleKey)}
+      </h2>
+      <ReasonList
+        language={language}
+        reasons={reasons}
+        sources={sources}
+        causeFacts={facts}
+        onEditMissingInput={onEditMissingInput}
+      />
+    </>
+  );
+}
+
 function ReasonList({
   language,
   reasons,
   sources,
+  causeFacts,
+  onEditMissingInput,
 }: {
   language: Language;
   reasons: readonly OutcomeReason[];
   sources: ReadonlyMap<string, OutcomeSource>;
+  /** Supplied only under HUMAN_REVIEW: the interview whose answers may be
+   * shown as the demonstrated cause of each reason. Absent elsewhere — a
+   * candidate's support reason is not something the applicant "caused". */
+  causeFacts?: OracleFacts;
+  onEditMissingInput?: (questionId: string) => void;
 }) {
   if (reasons.length === 0) return null;
   return (
@@ -164,6 +382,14 @@ function ReasonList({
                 );
               })}
             </span>
+          )}
+          {causeFacts && (
+            <ReviewCauseList
+              language={language}
+              facts={causeFacts}
+              causes={demonstratedReviewCauses(reason.code, causeFacts)}
+              onEditMissingInput={onEditMissingInput}
+            />
           )}
         </li>
       ))}
@@ -425,6 +651,14 @@ export function OutcomeSheet({
           return true;
         })
       : [];
+  const reviewReasons =
+    outcome.state === "HUMAN_REVIEW_REQUIRED" ? outcome.reviewReasons : [];
+  const systemReviewReasons = reviewReasons.filter((reason) =>
+    SYSTEM_REVIEW_REASON_CODES.has(reason.code),
+  );
+  const caseReviewReasons = reviewReasons.filter(
+    (reason) => !SYSTEM_REVIEW_REASON_CODES.has(reason.code),
+  );
   const [checkedDocs, setCheckedDocs] = useState<Set<string>>(new Set());
   const [shareState, setShareState] = useState<
     "idle" | "copied" | "shared" | "failed"
@@ -555,10 +789,21 @@ export function OutcomeSheet({
       {outcome.state === "HUMAN_REVIEW_REQUIRED" && (
         <section>
           <p>{translate(language, "outcome.human_review_body")}</p>
-          <ReasonList
+          <ReviewReasonGroup
             language={language}
-            reasons={outcome.reviewReasons}
+            titleKey={"outcome.review_group_case.title" as I18nKey}
+            reasons={caseReviewReasons}
             sources={sourceIndex}
+            facts={facts}
+            onEditMissingInput={onEditMissingInput}
+          />
+          <ReviewReasonGroup
+            language={language}
+            titleKey={"outcome.review_group_system.title" as I18nKey}
+            reasons={systemReviewReasons}
+            sources={sourceIndex}
+            facts={facts}
+            onEditMissingInput={onEditMissingInput}
           />
         </section>
       )}
@@ -710,12 +955,12 @@ export function OutcomeSheet({
           <ul>
             {outcome.assumptions.map((assumption) => (
               <li key={assumption.id}>
+                {/* Never the raw `assumption.<id>` key: an unsure answer
+                    whose question has no dedicated copy still gets the
+                    generic sentence, with the question named in it. */}
                 {assumption.message
                   ? localized(assumption.message, language)
-                  : translate(
-                      language,
-                      `assumption.${assumption.questionId}` as I18nKey,
-                    )}
+                  : assumptionDisplay(language, assumption.questionId)}
               </li>
             ))}
           </ul>

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
@@ -818,6 +818,12 @@ const en = {
     "The decision service cannot verify this case right now. No fallback path has been fabricated.",
   "outcome.human_review_body":
     "Your case needs a person’s judgment — nothing here was guessed on your behalf.",
+  "outcome.review_group_case.title": "What a person will check about your case",
+  "outcome.review_group_system.title":
+    "Checks on our side, not on your answers",
+  "outcome.review_cause_unsure": "You answered “Not sure” to: {{question}}",
+  "outcome.review_cause_answer": "You answered “{{answer}}” to: {{question}}",
+  "outcome.review_cause_edit_aria": "Edit your answer to: {{question}}",
   "outcome.overstay_reassurance":
     "Overstay is fixable. It is not the end of your story here.",
 
@@ -1648,6 +1654,15 @@ const id: Record<Keys, string> = {
     "Layanan keputusan belum dapat memverifikasi kasus ini. Tidak ada jalur cadangan yang dibuat-buat.",
   "outcome.human_review_body":
     "Kasus Anda butuh penilaian manusia — tidak ada yang ditebak atas nama Anda.",
+  "outcome.review_group_case.title":
+    "Yang akan diperiksa seseorang pada kasus Anda",
+  "outcome.review_group_system.title":
+    "Pemeriksaan di pihak kami, bukan pada jawaban Anda",
+  "outcome.review_cause_unsure":
+    "Anda menjawab “Tidak yakin” pada: {{question}}",
+  "outcome.review_cause_answer":
+    "Anda menjawab “{{answer}}” pada: {{question}}",
+  "outcome.review_cause_edit_aria": "Ubah jawaban Anda pada: {{question}}",
   "outcome.overstay_reassurance":
     "Overstay bisa diselesaikan. Ini bukan akhir cerita Anda di sini.",
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/telemetry.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/telemetry.ts
@@ -8,6 +8,11 @@ export const VISA_ORACLE_TELEMETRY_EVENTS = [
   "visa_oracle_v2_parity_mismatch",
   "visa_oracle_v2_consent_granted",
   "visa_oracle_v2_handoff_opened",
+  // PR-O4 / Δ2: the contact panel stopped showing the visitor a
+  // configuration string, so this is the only remaining signal that the
+  // WhatsApp number never reached ConsentHandoff. Carries the terminal state
+  // at most — no number, no facts.
+  "visa_oracle_v2_handoff_unconfigured",
 ] as const;
 
 export type VisaOracleTelemetryEvent =

--- a/evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/brief.yml
@@ -1,0 +1,46 @@
+gear: 2
+ruling: RULED 2026-09-12 SAETTA
+mission: SAETTA-VO window W-VO-B (BLUE, host M5) — the Oracle says WHY a person must look (PR-O4 / scope delta Δ2)
+objective: >-
+  A visitor whose Visa Oracle interview ends in HUMAN_REVIEW_REQUIRED reads a
+  DEMONSTRATED cause, not one flat list of sentences. The OutcomeSheet now
+  splits the review reasons in two groups under their own headings — the holds
+  about this applicant's own case, and the holds about our sources and our
+  process (DECISIVE_*, SAFETY_CRITICAL_*, MINOR_GUARDIAN_PRIVACY_REVIEW,
+  CLIENT_UNABLE_TO_VERIFY_DETAIL) — and, under an applicant-attributable hold,
+  names the answers of THIS interview that raised it ("You answered 'Not sure'
+  to: <question>") with an edit link back to that question. The contact panel
+  stops showing a visitor the string "WhatsApp handoff is not configured": it
+  renders a neutral, honest sentence and reports the misconfiguration
+  internally instead. Copy source is the code's own copy map and the
+  interview's own answers; the component invents no sentence and no number.
+scope:
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/ConsentHandoff.tsx
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/ConsentHandoff.test.tsx
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/ConfirmationCard.tsx
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/telemetry.ts
+  - apps/mouth/e2e/visa-oracle-v2.spec.ts
+constraints:
+  - oracle.css is READ-ONLY even under Δ2 (D6 verbatim) — no new class, no new custom property, only classes that already exist.
+  - No engine file, no rule pack, no flow.ts/tree.ts, no fact-mapper.ts write, no Decision schema change.
+  - Never invent a contact number and never a positive fixture for it (D3 = "NON ORA").
+  - Every rendered cause must be demonstrated by a fact of THIS interview; nothing plausible-looking.
+  - An edit link is offered only for a question this walk actually answered — flow.ts's EDIT resets the whole interview on an absent target.
+  - No client PII in any artifact; synthetic interview only.
+  - No ledger PR, no PENDING-ARMS.md edit, no gate status posted by this window.
+acceptance:
+  - A1 a HUMAN_REVIEW walk renders a named cause (not only the generic code sentence) in EN and in ID.
+  - A2 the string "is not configured" appears zero times in the rendered HTML of the Oracle route while an internal alert fires.
+  - A3 an answer-attributable hold offers an edit link that returns to the exact question and does not violate its prerequisites.
+  - A4 source/system holds are grouped and worded as system/source facts, never as something the applicant did.
+  - A5 screenshots of a held-for-review outcome at 1440x900 and 390x844, light and dark, keyboard focus visible, reduced motion respected.
+consumer_map:
+  - The live balizero.com/visa-oracle verdict screen served by the apps/mouth Vercel deploy on merge to main — OracleShell renders OutcomeSheet for every HUMAN_REVIEW_REQUIRED decision the ENFORCE engine returns.
+  - The required GitHub check "Frontend Tests (Next.js) (mouth, true)", which runs OutcomeSheet.test.tsx and ConsentHandoff.test.tsx on every future PR touching this route.
+  - e2e/visa-oracle-v2.spec.ts, which now pins the grouped block and the edit round-trip on a real browser walk.
+appetite:
+  budget: 5h active, 1 PR
+  stop_loss: three reds on the same cause suspends; a harness-caused red is reported, never cured by rebuilding the branch

--- a/evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/pack.yml
@@ -1,0 +1,225 @@
+gear: 2
+brief_ref: evidence/brief.yml
+ruling: RULED 2026-09-12 SAETTA
+lanes:
+  - lane: SAETTA-VO-W-VO-B
+    role: build
+    seat: Claude Opus 5 (Dux of window vo-b-why, implements directly)
+  - lane: vo-b-review-cause-ground-truth
+    role: ground_truth
+    seat: session (M5) — the ground truth of every sentence this PR renders is code already on origin/main, not a notebook
+    nb: >-
+      origin/main @ e4acad358d3bf4103061984ea216e6e8418c463e, four files read verbatim:
+      _lib/engine-adapter.ts (REVIEW_REASON_COPY, 29 codes, KNOWN_UNMAPPED empty — this PR
+      adds no sentence to it and changes none), _lib/fact-mapper.ts
+      (mapDisclosedReviewFlags + ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS — the triggers the
+      attribution mirrors), services/visa_engine/evaluate_path.py
+      (_DISCLOSED_REVIEW_REASON_CODES, flag -> review code), and
+      docs/plans/mouth-final-20260911/evidence/02-DECISIONI-ZERO-snapshot-20260911.md
+      (D3 "NON ORA", D5 criterion (c), D6 "Δ2: SÌ").
+    query_hash: "2d1c86776676dac50e0e9d201dbf486e66614e562bb707d03dd71fd3f50e5889"
+    note: >-
+      query_hash = sha256 of the four files concatenated in that order, taken with
+      `for f in <the four>; do git show origin/main:"$f"; done | shasum -a 256`. Per-file
+      digests are in the receipt below, so a drift in any one of them is locatable. No new
+      legal or regulatory claim is introduced by this PR: the two genuinely new sentences
+      are the two group headings and the neutral contact fallback, none of which asserts
+      anything about Indonesian immigration law.
+pii_scan: clean
+decisions:
+  - id: D-gear
+    decision: >-
+      Gear 2. The deterministic floor computed by evidence_pack_lint.py
+      --print-floor on the merge-base diff is 2 (8 files, +641/-17: churn far
+      below the 1828 SIZE term, no hot-zone path). The window brief's own
+      judgement is also 2, so gear = max(2, 2) = 2 and no council is owed.
+  - id: D-groups
+    decision: >-
+      Two groups, not three, and the SECOND one is the closed list. Membership of
+      "checks on our side" is exactly the spec's three families (DECISIVE_*,
+      SAFETY_CRITICAL_*, MINOR_GUARDIAN_PRIVACY_REVIEW) plus PR-O2's documented
+      client-side technical exception CLIENT_UNABLE_TO_VERIFY_DETAIL. Everything
+      else falls in the first group, whose heading ("What a person will check
+      about your case") is true of ANY review code and blames nobody — so an
+      unclassified future code can at worst be under-specific, never
+      mis-attributed to the visitor. A test re-derives the three families from
+      REVIEW_REASON_COPY so a new source/system code cannot ship unclassified.
+  - id: D-cause
+    decision: >-
+      A cause is rendered only when an answer of THIS interview demonstrates it.
+      Each branch of demonstratedReviewCauses mirrors the exact trigger
+      fact-mapper.ts::mapDisclosedReviewFlags uses to raise the flag that
+      evaluate_path.py::_DISCLOSED_REVIEW_REASON_CODES turns into the code:
+      any "unsure" fact (NOT_CERTAIN), a classified answer outside
+      ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS (ACTIVITY_BOUNDARY, imported from the
+      mapper rather than copied), trip_scope="multiple" (MULTI_PURPOSE_TRIP),
+      the two sponsor facts answered "unsure" (the attributable half of
+      AMBIGUOUS_SPONSOR), and the ticked review_gate item for the six
+      self-disclosure codes. When nothing demonstrates the code — a
+      backend-only trigger, or the STEPCHILD relation half of AMBIGUOUS_SPONSOR
+      — the list is empty and only the code's own copy is shown. An unexplained
+      hold beats an invented explanation.
+  - id: D-edit
+    decision: >-
+      The edit link reuses the existing onEditMissingInput slot (flow.ts EDIT),
+      and is offered only for a questionId present in `facts`. flow.ts's EDIT
+      resets the WHOLE interview when its target is absent from history, and
+      pruneFacts keeps `facts` a subset of the questions this walk asked — so
+      "present in facts" is exactly the prerequisite-safe condition. Pinned by a
+      test that asserts no cause is produced for an unanswered question.
+  - id: D-handoff
+    decision: >-
+      The two "not configured" strings are replaced by a neutral sentence that
+      states what the visitor CAN do (print/save the result, bring it to a
+      consultant). No number is invented and no positive fixture is added:
+      D3 is "NON ORA" and the number stays Zero's. Recorded in leftovers.
+  - id: D-alert
+    decision: >-
+      Hiding the misconfiguration from the reader without reporting it to us
+      would turn a visible defect into a silent one (cicatrix family #2). One
+      event name, visa_oracle_v2_handoff_unconfigured, is added to
+      telemetry.ts's closed list and fired from ConsentHandoff when the number
+      is absent or invalid. telemetry.ts is one file beyond the report's listed
+      perimeter — a 5-line additive change inside the same route group, needed
+      by acceptance A2's second half, declared here rather than taken silently.
+      It carries the terminal state at most: no number, no facts.
+  - id: D-receipt
+    decision: >-
+      The OutcomeSheet's assumptions receipt rendered the RAW key
+      "assumption.trip_scope" for any unsure answer whose question has no
+      dedicated copy — visible in the first capture of this very window, on the
+      same sheet, for the same "unsure" case the window exists to explain.
+      ConfirmationCard already had the correct fallback (the specific key, else
+      the generic sentence NAMING the question); it is exported and reused
+      instead of being duplicated. One word changed in ConfirmationCard.tsx
+      (function -> export function), no behaviour change there.
+  - id: D-css
+    decision: >-
+      No CSS. The new block reuses classes that already exist in oracle.css
+      (oracle-outcome__section-title, oracle-reason-list, oracle-action-list,
+      oracle-confirmation__edit); focus-visible and prefers-reduced-motion come
+      from that file's existing global rules. oracle.css is READ-ONLY under D6
+      and was not opened. A styling need would be a further delta to report.
+  - id: D-a11y
+    decision: >-
+      Several edit buttons can appear on one sheet, so each carries an
+      aria-label naming its own question while the visible label stays the
+      existing "Edit" string. The existing axe-clean keyboard journeys (EN and
+      ID) in e2e/visa-oracle-v2.spec.ts pass unchanged over the new markup.
+receipts:
+  - claim: The worktree was created by the broker on the mouth lane for this task id.
+    cmd: python3 scripts/agent_start.py --lane mouth --task-id vo-b-why
+    result: "WORKTREE_READY /Users/balizero/nuzantara/.worktrees/mouth-vo-b-why ; branch agent/air-m5/mouth/vo-b-why ; base e4acad358d3bf4103061984ea216e6e8418c463e"
+    exit: 0
+    ts: "2026-09-13T09:33:00+08:00"
+    seat: Claude Opus 5
+  - claim: The ground-truth lane's per-file digests, so a drift is locatable and not merely detectable.
+    cmd: 'for f in <engine-adapter.ts fact-mapper.ts evaluate_path.py 02-DECISIONI-ZERO-snapshot-20260911.md>; do git show origin/main:"$f" | shasum -a 256; done'
+    result: "engine-adapter.ts d6a7b723a6f02f0c182e00cdc79e7e1fdbb94d7ec2a8e12339d159cd7071767b ; fact-mapper.ts 43505b1a95084cd485cb50f0f997f721dd7984a6d8bfcf200dbddc42879c1480 ; evaluate_path.py 32fc622b57295f8a2a0e06fd9046f84536419585397a962327372ef7706e22eb ; 02-DECISIONI-ZERO-snapshot e86065b0c8336ab3c49eee674d6e62a65d1132cab9991ecdabca30aa120a07e6"
+    exit: 0
+    ts: "2026-09-13T10:02:00+08:00"
+    seat: Claude Opus 5
+  - claim: D-gear - the deterministic floor for this diff is 2.
+    cmd: python3 scripts/evidence_pack_lint.py --print-floor --print-floor-source --changed-files-file <cf> --numstat-file <ns> ; --print-measured
+    result: "floor 2 ; measured: 8 files, +641/-17, commit count unmeasured"
+    exit: 0
+    ts: "2026-09-13T09:53:00+08:00"
+    seat: Claude Opus 5
+  - claim: A1/A3/A4 - the grouped block, the demonstrated causes, the EN and ID copy and the prerequisite-safe edit are pinned by unit tests.
+    cmd: cd apps/mouth && ./node_modules/.bin/vitest run "src/app/(visa-oracle)"
+    result: "Test Files 39 passed (39) ; Tests 759 passed (759). OutcomeSheet.test.tsx carries 10 new cases incl. the EN and ID cause sentences, the source-hold grouping, the classification-exhaustiveness guard over REVIEW_REASON_COPY, and the mapDisclosedReviewFlags mirror."
+    exit: 0
+    ts: "2026-09-13T09:50:49+08:00"
+    seat: Claude Opus 5
+  - claim: A2 - the internal alert fires exactly when the number is missing or invalid, and never when it is configured.
+    cmd: cd apps/mouth && ./node_modules/.bin/vitest run ".../ConsentHandoff.test.tsx"
+    result: 'green; the new cases assert container.textContent has no "is not configured" and that visa_oracle_v2_handoff_unconfigured is emitted for "not-a-phone", "" and "+62", and is NOT emitted for 628123456789.'
+    exit: 0
+    ts: "2026-09-13T09:43:44+08:00"
+    seat: Claude Opus 5
+  - claim: A1/A3/A4 on a real browser - a held walk names the answer, groups the two kinds of hold, and the edit returns to that exact question.
+    cmd: ./node_modules/.bin/playwright test --config=<scratchpad>/pw.config.cjs (external server on 127.0.0.1:3111, channel chrome)
+    result: '19 passed (14.7s) for the whole e2e/visa-oracle-v2.spec.ts, including the new "a held walk names the answer that caused it and edits back to that question" and both axe-clean keyboard-only journeys (EN, ID) over the new markup.'
+    exit: 0
+    ts: "2026-09-13T09:58:30+08:00"
+    seat: Claude Opus 5
+  - claim: A2 measured on a real server whose WhatsApp number is genuinely absent - the visitor reads no configuration string.
+    cmd: next build + next start -p 3111 WITHOUT NEXT_PUBLIC_VISA_ORACLE_WHATSAPP_NUMBER ; playwright page.content() searched for "is not configured" on all four captures
+    result: 'CONFIG_STRING_HITS=0. The panel renders "WhatsApp is not available from this page right now. You can print or save this result and bring it to a Bali Zero consultant."'
+    exit: 0
+    ts: "2026-09-13T09:54:10+08:00"
+    seat: Claude Opus 5
+  - claim: A5 - eight captures of a held-for-review outcome, two viewports x light/dark x (full page, keyboard focus), reduced motion forced.
+    cmd: playwright chromium channel=chrome, colorScheme light|dark, reducedMotion "reduce", viewports 1440x900 and 390x844, evaluate route mocked with review_reasons [DISCLOSED_UNCERTAINTY_REVIEW, DECISIVE_SOURCE_STALE], synthetic interview (trip_scope answered "Not sure")
+    result: "held-review-{light,dark}-{1440x900,390x844}.png and held-review-keyboard-focus-{light,dark}-{1440x900,390x844}.png under /Users/balizero/Desktop/R3-RENDERS-20260913/vo-b/. The focus ring on the Edit button of the demonstrated cause is visible in all four focus captures."
+    exit: 0
+    ts: "2026-09-13T09:54:10+08:00"
+    seat: Claude Opus 5
+  - claim: Typecheck, lint and formatting are green on every touched file.
+    cmd: cd apps/mouth && ./node_modules/.bin/tsc --noEmit -p tsconfig.json ; ./node_modules/.bin/eslint <touched> ; ../../node_modules/.bin/prettier --check <touched>
+    result: "tsc exit 0 ; eslint 0 errors (the two .test.tsx files are matched by an ignore pattern, reported as warnings) ; prettier clean on every file this window touched. pnpm -F mouth typecheck refuses on a worktree (ERR_PNPM_UNSAFE_MODULES_DIR, node_modules symlinks to the main checkout), so the underlying binary was run directly."
+    exit: 0
+    ts: "2026-09-13T09:50:40+08:00"
+    seat: Claude Opus 5
+  - claim: The e2e run's two WhatsApp reds were the local build, not this change - named before any gesture and then proven.
+    cmd: first run with the number set only at RUNTIME (2 failed / 17 passed) ; error-context.md read ; rebuild with NEXT_PUBLIC_VISA_ORACLE_WHATSAPP_NUMBER set at BUILD time ; rerun
+    result: "The snapshot showed the neutral unavailable panel, i.e. number===null in the component: NEXT_PUBLIC_* is inlined at build time, and the repo's own playwright webServer therefore sets it on the BUILD command. After rebuilding with it, 19/19 pass."
+    exit: 0
+    ts: "2026-09-13T09:58:30+08:00"
+    seat: Claude Opus 5
+  - claim: The e2e privacy-policy test rewrote two committed screenshots as a side effect; they were restored, so this PR carries no unrelated binary churn.
+    cmd: git -C <wt> checkout -- docs/audits/screenshots/visa-oracle-v2/visa-oracle-privacy-v1-{desktop,mobile-320}.png ; git status --porcelain
+    result: "Only the 8 intended files plus the evidence directory remain modified/untracked."
+    exit: 0
+    ts: "2026-09-13T10:00:00+08:00"
+    seat: Claude Opus 5
+dissent:
+  - seat: Claude Opus 5 (self-refutation, on the attribution)
+    objection: >-
+      demonstratedReviewCauses MIRRORS fact-mapper.ts's triggers instead of
+      sharing one implementation with it, because the mapper's REVIEW_FLAG_MAP
+      is module-private and fact-mapper.ts is outside this window's write
+      perimeter. A mirror can drift, and a drifted mirror would name an answer
+      the engine did not actually hold on.
+    status: CONFIRMED
+    cure: >-
+      Only partly cured, deliberately. The one table that IS exported
+      (ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS) is imported rather than copied, and
+      a test re-derives four representative rows through the real
+      mapDisclosedReviewFlags so a drift on either side goes red. The remaining
+      risk is a code whose trigger changes without either side being touched;
+      it degrades to "no cause shown", never to a wrong cause, because the
+      attribution is a predicate over the interview's own facts. Folding the two
+      into one exported helper is a fact-mapper change and a separate mandate —
+      recorded in leftovers.
+  - seat: Claude Opus 5 (self-refutation, on the perimeter)
+    objection: >-
+      Two files outside the report's listed perimeter are edited: telemetry.ts
+      (+5 lines, one event name) and ConfirmationCard.tsx (+8/-1, exporting an
+      existing helper). Either could be called a silent widening.
+    status: CONFIRMED
+    cure: >-
+      Not hidden: both are declared here (D-alert, D-receipt) and in the PR
+      body. Neither changes behaviour for any existing caller, both are inside
+      the (visa-oracle) group this mission owns exclusively, and both exist to
+      satisfy an acceptance criterion of THIS window (A2's internal alert; the
+      raw i18n key visible in this window's own proof). The alternative to the
+      second one was duplicating an 8-line helper into OutcomeSheet.tsx.
+  - seat: Claude Opus 5 (self-refutation, on size)
+    objection: >-
+      +641/-17 is above the "~400 net lines" guidance of the PR contract.
+    status: PLAUSIBLE
+    cure: >-
+      Not split. 338 of the 641 added lines are tests (OutcomeSheet.test.tsx
+      235, ConsentHandoff.test.tsx 47, e2e 56) and a large share of the rest is
+      the rationale comments this repo requires on a guard. The customer-visible
+      concern is single (why a person must look, and the contact panel that goes
+      with it); splitting the tests from the code they pin would ship an
+      unpinned behaviour first.
+leftovers:
+  - "D3 stays open: NEXT_PUBLIC_VISA_ORACLE_WHATSAPP_NUMBER is still unset on Vercel mouth Production. Until Zero sets it (number + consent are his), every visitor sees the neutral panel and visa_oracle_v2_handoff_unconfigured fires on every held result. The window may only ship the neutral fallback."
+  - 'DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW is attributed only when a sponsor fact was answered "unsure"; the STEPCHILD-relation half of NARROW-1''s trigger has no single answer to name, so those walks still read the code''s own copy with no cause line.'
+  - "CONFLICTING_IMMIGRATION_STATUS_REVIEW has no trigger in fact-mapper.ts at all today, so it can never carry a demonstrated cause from the frontend."
+  - "Folding demonstratedReviewCauses and mapDisclosedReviewFlags into one exported helper needs a fact-mapper.ts change — a separate mandate, see the first dissent."
+  - "The shared apps/mouth/node_modules/.bin/tsx shim now points into .worktrees/mouth-vo-c-doors (a sibling window's pnpm store), so `npm run build` in any mouth worktree dies on its llms prebuild; `next build` directly is unaffected. Cicatrix family #5, sibling race on the shared checkout — imperator-level, not cured from inside this window."
+  - "Only the EN screenshots were captured; the ID rendering of the same block is pinned by the unit test and by the axe-clean keyboard-only ID e2e journey, not by an image."

--- a/evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/pack.yml
@@ -173,6 +173,18 @@ receipts:
     exit: 0
     ts: "2026-09-13T10:00:00+08:00"
     seat: Claude Opus 5
+  - claim: The Detect Secrets red was this PR's own pack digest, named from the job log before any gesture, then cured at depth 1.
+    cmd: gh api .../jobs/103656272077/logs ; detect-secrets scan evidence/.../pack.yml ; surgical insert into .secrets.baseline ; python3 scripts/detect_secrets_check_unaudited.py
+    result: "Residue by file: 1 evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/pack.yml, type Hex High Entropy String, line 20 = the ground_truth lane's query_hash. Audited in place (is_secret false, +10 lines, JSON re-parsed OK, no reserialization of the other 8265 entries). check_unaudited: All findings audited (8266 total)."
+    exit: 0
+    ts: "2026-09-13T10:12:00+08:00"
+    seat: Claude Opus 5
+  - claim: The Harness floor recompute red is the expected PENDING gate read, not a code red.
+    cmd: gh pr checks 6404
+    result: "2 reds at the first push: Detect Secrets (cured above) and Harness floor recompute, which stays red with harness_gate_read PENDING until a fresh gate posts harness/fable-gate on the head sha. The GATE reruns it, not this window. Every other check passed (38 green)."
+    exit: 0
+    ts: "2026-09-13T10:05:00+08:00"
+    seat: Claude Opus 5
 dissent:
   - seat: Claude Opus 5 (self-refutation, on the attribution)
     objection: >-
@@ -222,4 +234,6 @@ leftovers:
   - "CONFLICTING_IMMIGRATION_STATUS_REVIEW has no trigger in fact-mapper.ts at all today, so it can never carry a demonstrated cause from the frontend."
   - "Folding demonstratedReviewCauses and mapDisclosedReviewFlags into one exported helper needs a fact-mapper.ts change — a separate mandate, see the first dissent."
   - "The shared apps/mouth/node_modules/.bin/tsx shim now points into .worktrees/mouth-vo-c-doors (a sibling window's pnpm store), so `npm run build` in any mouth worktree dies on its llms prebuild; `next build` directly is unaffected. Cicatrix family #5, sibling race on the shared checkout — imperator-level, not cured from inside this window."
+  - "Detect Secrets went red on this PR's own pack: every ground_truth lane's query_hash is a 64-char sha256, which detect-secrets reads as a Hex High Entropy String. Auto-triage has a content-keyed rule for a pack's measured_at: line but none for query_hash:, so the digest was hand-audited in .secrets.baseline (+10 lines, is_secret false). The durable cure is a query_hash: rule mirroring the measured_at: one in scripts/detect_secrets_auto_triage.py — a guard change, separate mandate."
+  - "evidence_pack_lint emits an acceptance-probe NOTICE naming three kbli_filiera probes that belong to the STALE repo-root evidence/brief.yml (the KBLI L2 PR-A brief), not to this window's brief. It resolves brief_ref against the repo root when run locally; in CI the harness stages this PR's own brief at that path. Cosmetic locally, but the stale root brief.yml/pack.yml pair is a trap for every window that lints locally."
   - "Only the EN screenshots were captured; the ID rendering of the same block is pinned by the unit test and by the axe-clean keyboard-only ID e2e journey, not by an image."


### PR DESCRIPTION
## What a visitor gets

A Visa Oracle interview that ends in `HUMAN_REVIEW_REQUIRED` used to render one flat list of
sentences. Nothing told the reader which hold their own answer caused and which one is ours to
clear, and nothing pointed back at the answer to change. Below it, the contact panel could tell a
stranger **"WhatsApp handoff is not configured."**

After this PR the same walk reads:

> **What a person will check about your case**
> One of your answers was marked "unsure," and a person needs to confirm that answer before any path can be confirmed.
>   · *You answered “Not sure” to: Is this your only purpose for the trip?* **[Edit]**
>
> **Checks on our side, not on your answers**
> This result relies on a regulatory source confirmed out of date — replacing it with a current source is what a person must do before this result can stand.

and, where the number is missing, *"WhatsApp is not available from this page right now. You can
print or save this result and bring it to a Bali Zero consultant."*

This is **PR-O4 / scope delta Δ2**, authorized by **D6 — "Δ2: SÌ"** in
`docs/plans/mouth-final-20260911/evidence/02-DECISIONI-ZERO-snapshot-20260911.md`, and it closes
D5's third criterion for the classes it can demonstrate.

## Bites

**CONSUMER:** the `OutcomeSheet` rendered by `OracleShell` for every `HUMAN_REVIEW_REQUIRED`
decision on `balizero.com/visa-oracle` (ENFORCE, seq-20) — plus the required check
*Frontend Tests (Next.js) (mouth, true)* and `e2e/visa-oracle-v2.spec.ts`, both shipped in this PR.

**OBSERVATION, made before writing this:** a production build of this branch, served on
`127.0.0.1:3111`, with the evaluate route answering `HUMAN_REVIEW_REQUIRED` with
`[DISCLOSED_UNCERTAINTY_REVIEW, DECISIVE_SOURCE_STALE]` over a synthetic interview that answered
*trip_scope* with "Not sure":

- the two headings and the attributed cause render, and the cause carries an Edit button that
  returns the interview to the *trip_scope* question — `playwright test … 19 passed (14.7s)` on the
  whole `visa-oracle-v2` spec, including the new case and both axe-clean keyboard-only journeys
  (EN and ID) over the new markup;
- on a build where `NEXT_PUBLIC_VISA_ORACLE_WHATSAPP_NUMBER` is genuinely absent,
  `page.content()` contains **"is not configured" zero times** across all four captures, while the
  component emits `visa_oracle_v2_handoff_unconfigured`;
- eight screenshots (1440×900 and 390×844, light and dark, full page and keyboard-focused) are at
  `/Users/balizero/Desktop/R3-RENDERS-20260913/vo-b/`.

## How a cause is proven, not guessed

`demonstratedReviewCauses(code, facts)` mirrors, per code, the exact trigger
`fact-mapper.ts::mapDisclosedReviewFlags` uses to raise the flag that
`evaluate_path.py::_DISCLOSED_REVIEW_REASON_CODES` turns into that code — any `"unsure"` fact, an
answer outside `ACTIVITY_BOUNDARY_DECIDABLE_ANSWERS` (imported from the mapper, not copied),
`trip_scope = "multiple"`, the two sponsor facts answered "unsure", and the ticked `review_gate`
item for the six self-disclosure codes. When nothing demonstrates the code the list is empty and
only the code's own copy shows: an unexplained hold beats an invented explanation. A test
re-derives four representative rows through the real `mapDisclosedReviewFlags`, and a second test
re-derives the `DECISIVE_*` / `SAFETY_CRITICAL_*` / `MINOR_GUARDIAN_PRIVACY` families from
`REVIEW_REASON_COPY`, so neither the mirror nor the classification can drift silently.

An edit link is offered only for a `questionId` present in `facts`. `flow.ts`'s `EDIT` **resets the
whole interview** when its target is absent from history, and `pruneFacts` keeps `facts` a subset of
the questions this walk asked — so "present in facts" *is* the prerequisite-safe condition.

## Declared, not slipped in

- `_lib/telemetry.ts` (+5) — one event name in the closed list. Hiding the misconfiguration from
  the reader without reporting it to us would turn a visible defect into a silent one (cicatrix
  family #2). It carries the terminal state at most: no number, no facts.
- `ConfirmationCard.tsx` (+8/−1) — `assumptionDisplay` exported and reused. The assumptions receipt
  on this same sheet was rendering the raw key `assumption.trip_scope` for exactly the "unsure"
  case this window exists to explain; `ConfirmationCard` already had the correct fallback.
- **Not touched:** `oracle.css` (READ-ONLY under D6 — the block reuses classes that already exist,
  and `:focus-visible` / `prefers-reduced-motion` come from that file's global rules), any engine
  file, any rule pack, `flow.ts`/`tree.ts`, `fact-mapper.ts`.
- **No number invented and no positive contact fixture added** — D3 is still "NON ORA".

## Gates

- `vitest run "src/app/(visa-oracle)"` → **39 files, 759 tests passed**.
- `tsc --noEmit -p apps/mouth/tsconfig.json` → exit 0. eslint 0 errors, prettier clean on every
  touched file. (`pnpm -F mouth typecheck` refuses on a worktree — `ERR_PNPM_UNSAFE_MODULES_DIR` —
  so the underlying binary was run directly.)
- `playwright` on `e2e/visa-oracle-v2.spec.ts` → **19 passed**.
- Gear **2**, floor **2** measured with
  `evidence_pack_lint.py --print-floor` on the merge-base diff (8 files, +641/−17: no hot-zone
  path, churn far below 1828). Pack lints clean.
  Evidence: `evidence/2026-09/agent-air-m5-mouth-vo-b-why-eef1d557/`.

**An earlier e2e run showed 2 reds on the WhatsApp consent tests; the cause was named before any
gesture and then proven:** `NEXT_PUBLIC_*` is inlined at *build* time, and that build had the number
only in the runtime env — which is exactly why this repo's own playwright `webServer` puts it on the
`build` command. Rebuilt with it, 19/19.

## Still open

- **D3**: `NEXT_PUBLIC_VISA_ORACLE_WHATSAPP_NUMBER` is unset on Vercel `mouth` Production. Until
  Zero sets it (number + consent are his), every held visitor sees the neutral panel and the new
  internal event fires on every held result.
- `DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW` is attributed only when a sponsor fact was answered
  "unsure"; the STEPCHILD-relation half of the NARROW-1 trigger has no single answer to name.
- `CONFLICTING_IMMIGRATION_STATUS_REVIEW` has no frontend trigger at all today, so it can never
  carry a demonstrated cause from here.
- Folding `demonstratedReviewCauses` and `mapDisclosedReviewFlags` into one exported helper needs a
  `fact-mapper.ts` change — a separate mandate, recorded as this pack's first dissent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
