### PR TITLE
fix(ci): the Detect Secrets step swallowed its own findings — print before re-raising

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1066,11 +1066,17 @@ jobs:
         # pipe/tee here on purpose (W101/W97 — a pipe can mask the upstream
         # exit code): the exit status is captured explicitly via `$?` and
         # re-raised, so a finding still fails this step exactly as before.
+        # The output is printed before the exit code is re-raised, so a
+        # failing run under `bash -e`'s command-substitution trap is no
+        # longer mute.
         run: |
           set -uo pipefail
+          set +e
           OUT="$(python scripts/detect_secrets_check_unaudited.py 2>&1)"
           RC=$?
+          set -e
           printf '%s\n' "$OUT"
+          echo "detect_secrets_check_unaudited rc=$RC"
           printf '%s\n' "$OUT" > /tmp/unaudited-findings.txt
           exit "$RC"
 


### PR DESCRIPTION
## What

The "Check for unaudited findings" step in `.github/workflows/security.yml` runs under GitHub Actions' default `bash -e`, with `set -uo pipefail` added at the top. The step does:

```
OUT="$(python scripts/detect_secrets_check_unaudited.py 2>&1)"
RC=$?
printf '%s\n' "$OUT"
```

When the checker script exits non-zero, the bare assignment `OUT="$(...)"` itself reports that non-zero exit status as the status of the "command" (there is no command after the substitution, just the assignment). Under `set -e`, that trips the trap immediately — the script aborts on the assignment line, before `RC=$?` and before `printf` ever run. The checker prints the first 20 unaudited findings (path + line) to stdout/stderr, and that output is thrown away entirely.

Two red runs today reproduce exactly this signature — the log shows `##[group]`, the command lines, `##[endgroup]`, then `##[error] exit code 1`, with nothing printed in between:
- run 34731804378
- run 34731961880

The sibling "Baseline triage summary" step in the same job does print its triage output (it does not use the `OUT="$(...)"` pattern), so today's finding was in fact recoverable from that step's log — this fix is about the *failing* step's own log being empty, which is where a reader looks first.

Fix: wrap the assignment in `set +e` / `set -e` so the command substitution's exit status is captured in `RC` without the `-e` trap firing early, then print `$OUT` and re-raise `$RC` exactly as before. Added a one-line `echo "detect_secrets_check_unaudited rc=$RC"` after the output so a green run also carries evidence the new shape executed. One sentence added to the step's existing comment noting the output is printed before the exit code is re-raised.

Exit-code semantics are unchanged: `exit "$RC"` is still the last line, so a finding still fails this step exactly as before. No other step touched; `pip install detect-secrets` is untouched.

## Verification

Minimal repro, run with `bash -e`:

Before (mirrors the current step's shape):
```
OUT="$(printf 'FINDINGS WOULD PRINT HERE\n'; exit 1)"
RC=$?
printf '%s\n' "$OUT"
exit "$RC"
```
Output: nothing printed, `exit=1`.

After (mirrors this PR's shape):
```
set +e
OUT="$(printf 'FINDINGS WOULD PRINT HERE\n'; exit 1)"
RC=$?
set -e
printf '%s\n' "$OUT"
echo "rc=$RC"
exit "$RC"
```
Output: `FINDINGS WOULD PRINT HERE`, `rc=1`, `exit=1`.

`actionlint` on the modified workflow: clean, no findings.
`python3 -c "import yaml; yaml.safe_load(open(...))"`: `yaml-ok`.

## Bites

Bites: the "Check for unaudited findings" step of security.yml — observation: on this PR's own run the step log shows the new line "detect_secrets_check_unaudited rc=0"; on the next red run the first 20 findings are printed above the error.

## Scope

`pip install detect-secrets` is unpinned and left as-is — a separate decision once today's finding is named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
