### PR TITLE
docs(regulatory): daily delta 2026-09-13, 0 new (nlm auth recovered)

### DIFF
--- a/research/regulatory/2026-09-13-delta.json
+++ b/research/regulatory/2026-09-13-delta.json
@@ -1,0 +1,36 @@
+{
+  "run_at": "2026-09-13T11:08:17+08:00",
+  "today": "2026-09-13",
+  "yesterday_seen_count": 24,
+  "yesterday_file_used": "2026-09-12-delta.json",
+  "new_today_count": 0,
+  "partial": false,
+  "unreachable_sources": [
+    {"url": "https://www.hukumonline.com/berita/", "reason": "http_403", "note": "HTTP 403 on fetch"},
+    {"url": "https://muc.co.id/article", "reason": "http_403", "note": "HTTP 403 on fetch"},
+    {"url": "https://ortax.org/news", "reason": "empty_shell", "note": "Soft-404 title \"Artikel tidak ditemukan\", no dated content"},
+    {"url": "https://ikpi.or.id/articles", "reason": "empty_shell", "note": "Nuxt SPA shell, 0 article/datePublished nodes in static HTML"},
+    {"url": "https://jdih.kemenkeu.go.id/peraturan", "reason": "timeout", "note": "curl HTTP:000, connection failed within 30s"},
+    {"url": "https://peraturan.bpk.go.id/Search?type=PerundangUndangan&jenis=PMK&tahun=2026", "reason": "empty_shell", "note": "Search UI shell only, zero result-count token or PMK title extractable from static HTML, JS-paginated"}
+  ],
+  "sources_checked_no_delta": [
+    {"url": "https://news.ddtc.co.id/", "reason": "checked_no_new", "note": "Headlines through 2026-09-13 10:00 read (DJP/Kemenkeu/Coretax procedural news); none is a tracked reg-type citation"},
+    {"url": "https://peraturan.go.id", "reason": "outside_window", "note": "Newest homepage entries PP 30/2026 and PP 31/2026 dated 02 Juli 2026 (\"2 bulan yang lalu\")"},
+    {"url": "https://www.imigrasi.go.id", "reason": "checked_no_new", "note": "Newest Siaran Pers 12 Sep 2026 (82 WNI dipulangkan dari Malaysia) is within window but is enforcement news, not a Permenimigrasi/Permenkumham citation"},
+    {"url": "https://www.pajak.go.id/peraturan", "reason": "outside_window", "note": "Newest entry KEP-185/PJ/2026 dated 2026-09-02, predates 48h window"},
+    {"url": "https://jdih.kemnaker.go.id/peraturan", "reason": "outside_window", "note": "Newest visible entries (default sort) UU Nomor 20 Tahun 2025 and older, nothing dated 2026-09"}
+  ],
+  "nb_query_errors": [],
+  "deltas": [],
+  "note": "nlm auth recovered today (was account-wide expired since 2026-09-06, cf. fact_nlm_auth_expired_2026_09_06.md) - all 4 NB-INTEL queries returned successfully. NB-INTEL-Tax surfaced PMK Nomor 49 Tahun 2026 / Perpres Nomor 68 Tahun 2025 (SPP-TDLN digital-VAT collection system) on follow-up, but the underlying acts are dated 2025 and 29 July 2026 respectively - outside the 48h publication window - and no independent web source corroborated the claimed 10-Sep-2026 operational go-live date. Dropped per hard rule 2 (no speculation, better miss than hallucinate), not carried as a delta.",
+  "seen_citations": [
+    "PMK Nomor 28 Tahun 2026","PMK Nomor 40 Tahun 2026","PMK Nomor 41 Tahun 2026","PMK Nomor 42 Tahun 2026",
+    "PMK Nomor 43 Tahun 2026","PMK Nomor 44 Tahun 2026","PMK Nomor 55 Tahun 2026","PMK Nomor 57 Tahun 2026",
+    "PMK Nomor 61 Tahun 2026","PP Nomor 20 Tahun 2026","PP Nomor 24 Tahun 2026",
+    "Peraturan Direktur Jenderal Pajak Nomor PER-8/PJ/2026","Peraturan Menteri Hukum Nomor 13 Tahun 2026",
+    "Permen PMK/Badan PMI Nomor 5 Tahun 2026","Permenaker No. 12 Tahun 2026; BN 2026 (598)",
+    "Permenaker Nomor 7 Tahun 2026","Permenaker Nomor 8 Tahun 2026","Permenaker Nomor 9 Tahun 2026",
+    "Permenkes Nomor 6 Tahun 2026","Perpres Nomor 26 Tahun 2026","Perpres Nomor 27 Tahun 2026",
+    "Perpres Nomor 3 Tahun 2026","UU Nomor 4 Tahun 2026","UU Nomor 5 Tahun 2026"
+  ]
+}


### PR DESCRIPTION
## Summary
Daily regulatory-watcher run for 2026-09-13 WITA, executed inline per operator request. `new_today_count: 0`, no Telegram alert sent (per hard rule: no daily empty pings).

## Highlights
- **nlm auth recovered**: account-wide `nlm` auth expired since 2026-09-06 (blocking NB-INTEL queries for a week) is now working again — all 4 NB-INTEL queries (Regulation/Press/Immigration/Tax) returned successfully today. `nb_query_errors: []`.
- 4/4 NB-INTEL queries: "nessuna novità" on the tracked reg-types.
- Web cross-check: 5 primary + 6 backup sources fetched, 6 unreachable (403/timeout/empty_shell — mostly expected per known issues), 5 checked with no delta (outside 48h window or non-reg-type content).
- One borderline case investigated and dropped: NB-INTEL-Tax surfaced PMK 49/2026 + Perpres 68/2025 (SPP-TDLN digital-VAT system) but the underlying acts predate the 48h window (29 Jul 2026 / 2025) and no web source corroborated the claimed 10-Sep-2026 go-live date — dropped per hard rule 2 (no speculation).

## Bites
Consumer: `research/regulatory/2026-09-13-delta.json` is the file Antonello reads at next manual check (per agent spec "Output handoff"). Observation made before reporting done: file written, `new_today_count: 0` confirmed by re-reading the committed JSON, no Telegram alert fired (consistent with the empty-delta hard rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)