### PR TITLE
feat(mouth): the GARUDA VOA staff console reads R19 (concept F), and no red survives on it

### DIFF
--- a/apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.tsx
@@ -1,11 +1,22 @@
 "use client";
 
+/**
+ * GARUDA VOA — staff practice detail and transitions.
+ *
+ * SAETTA-VOA W-VOA-V3 (2026-09-13): concept-F "RAPI" presentation pass.
+ * PRESENTATION ONLY. The command builder, the Idempotency-Key lifecycle, the
+ * read-only `resolved_block_id` prefill, the admin-only assignment picker and
+ * every 401/422 path are unchanged — the diff on this file is class names,
+ * hairlines, pills and copy placement.
+ */
+
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft, Loader2, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
 import { api } from "@/lib/api";
+import { cn } from "@/lib/utils";
 import { logger } from "@/lib/logger";
 import { toError } from "@/lib/types/common";
 import {
@@ -16,6 +27,15 @@ import {
 } from "../api-client";
 import { useGarudaAssignmentTargets } from "../assignment-targets";
 import { getAllowedTransitions } from "../state-machine";
+import {
+  CARD,
+  EYEBROW,
+  FIELD,
+  FOCUS,
+  PracticeStatePill,
+  SECTION_H2,
+  SERIF,
+} from "../r19";
 import type {
   PracticeTransitionRequest,
   StaffPracticeView,
@@ -24,17 +44,6 @@ import type {
 
 function newIdempotencyKey(): string {
   return globalThis.crypto?.randomUUID?.() ?? `garuda-voa-staff-${Date.now()}`;
-}
-
-// Never render or link a customer document/artifact identifier here — the
-// staff surface shows practice metadata only (spec step8: "Never link
-// artifact ids").
-function StatusBadge({ state }: { state: string }) {
-  return (
-    <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-[var(--surface-raised)] text-[var(--bz-text-1)]">
-      {state}
-    </span>
-  );
 }
 
 interface TransitionFormState {
@@ -107,6 +116,33 @@ function buildTransitionRequest(
     default:
       return null;
   }
+}
+
+/** Hairline definition pair — eyebrow label above the value, no boxes. */
+function Field({
+  label,
+  children,
+  className,
+  mono,
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className={className}>
+      <p className={EYEBROW}>{label}</p>
+      <p
+        className={cn(
+          "mt-1.5 text-[var(--tx-pure)]",
+          mono ? "break-all font-mono text-xs" : "text-sm",
+        )}
+      >
+        {children}
+      </p>
+    </div>
+  );
 }
 
 export default function GarudaVoaStaffDetailPage() {
@@ -259,21 +295,30 @@ export default function GarudaVoaStaffDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-[50vh] flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-[var(--bz-accent)]" />
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-[var(--bz-copper)]" />
       </div>
     );
   }
 
   if (loadError || !practice) {
     return (
-      <div className="min-h-[50vh] flex flex-col items-center justify-center gap-4">
-        <AlertCircle className="w-12 h-12 text-[var(--state-danger)]" />
-        <p className="text-[var(--bz-text-1)]">
+      <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+        <AlertCircle
+          className="h-10 w-10 text-[var(--bz-copper)]"
+          aria-hidden="true"
+        />
+        <p
+          className="text-[24px] leading-[1.14] text-[var(--tx-pure)]"
+          style={SERIF}
+        >
           {loadError || "Practice not found"}
         </p>
-        <Button onClick={() => router.push("/garuda-voa")} variant="default">
-          <ArrowLeft className="w-4 h-4 mr-2" />
+        <Button
+          onClick={() => router.push("/garuda-voa")}
+          className="h-11 rounded bg-[var(--state-success)] px-5 text-[13px] font-semibold tracking-[0.02em] text-white hover:bg-[var(--state-success)]/90"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
           Back to practices
         </Button>
       </div>
@@ -286,71 +331,66 @@ export default function GarudaVoaStaffDetailPage() {
   );
 
   return (
-    <div className="p-6 max-w-4xl mx-auto space-y-6">
-      <div className="flex items-center gap-3">
-        <button
-          onClick={() => router.push("/garuda-voa")}
-          className="flex items-center gap-2 text-[var(--bz-text-2)]"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          Back
-        </button>
-      </div>
+    <div className="mx-auto max-w-4xl space-y-8 p-6">
+      <button
+        type="button"
+        onClick={() => router.push("/garuda-voa")}
+        className={cn(
+          "inline-flex items-center gap-2 text-xs font-semibold text-[var(--bz-copper-text)] transition-colors hover:text-[var(--tx-pure)]",
+          FOCUS,
+        )}
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to practices
+      </button>
 
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold text-[var(--bz-text-1)] font-mono">
+      <section>
+        <div
+          aria-hidden="true"
+          className="mb-4 h-[3px] w-14 rounded-sm bg-[var(--bz-copper)]"
+        />
+        <p className={EYEBROW}>GARUDA VOA · practice</p>
+        {/* Never render or link a customer document/artifact identifier here —
+            the staff surface shows practice metadata only (spec step8: "Never
+            link artifact ids"). */}
+        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2.5">
+          <h1
+            className="text-[26px] leading-[1.08] tracking-[-0.02em] text-[var(--tx-pure)] md:text-[30px]"
+            style={SERIF}
+          >
             {practice.practice_id}
           </h1>
-          <StatusBadge state={practice.state} />
+          <PracticeStatePill state={practice.state} />
         </div>
-      </div>
+      </section>
 
-      <div className="rounded-xl p-6 border border-[var(--bz-border)] bg-[var(--bz-card)] space-y-4">
-        <h2 className="text-lg font-semibold text-[var(--bz-text-1)]">
+      <section className={cn(CARD, "space-y-6 p-6")}>
+        <h2 className={cn(SECTION_H2, "text-[var(--tx-pure)]")} style={SERIF}>
           Practice details
         </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-          <div>
-            <label className="block text-[var(--bz-text-2)] mb-1">Order</label>
-            <p className="font-mono text-[var(--bz-text-1)]">
-              {practice.order_id}
-            </p>
-          </div>
-          <div>
-            <label className="block text-[var(--bz-text-2)] mb-1">
-              Updated
-            </label>
-            <p className="text-[var(--bz-text-1)]">
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+          <Field label="Order" mono>
+            {practice.order_id}
+          </Field>
+          <Field label="Updated">
+            <span className="tabular-nums">
               {new Date(practice.updated_at).toLocaleString("en-GB")}
-            </p>
-          </div>
+            </span>
+          </Field>
           {practice.customer_reason_key && (
-            <div>
-              <label className="block text-[var(--bz-text-2)] mb-1">
-                Customer reason key
-              </label>
-              <p className="font-mono text-xs text-[var(--bz-text-1)]">
-                {practice.customer_reason_key}
-              </p>
-            </div>
+            <Field label="Customer reason key" mono>
+              {practice.customer_reason_key}
+            </Field>
           )}
           {practice.required_action_key && (
-            <div>
-              <label className="block text-[var(--bz-text-2)] mb-1">
-                Required action key
-              </label>
-              <p className="font-mono text-xs text-[var(--bz-text-1)]">
-                {practice.required_action_key}
-              </p>
-            </div>
+            <Field label="Required action key" mono>
+              {practice.required_action_key}
+            </Field>
           )}
           {practice.private_staff_note && (
             <div className="md:col-span-2">
-              <label className="block text-[var(--bz-text-2)] mb-1">
-                Private staff note
-              </label>
-              <p className="text-[var(--bz-text-1)] whitespace-pre-wrap">
+              <p className={EYEBROW}>Private staff note</p>
+              <p className="mt-1.5 whitespace-pre-wrap border-l-2 border-[var(--bz-copper)] pl-3.5 text-[15px] leading-[1.7] text-[var(--tx-pure)]">
                 {practice.private_staff_note}
               </p>
             </div>
@@ -358,11 +398,8 @@ export default function GarudaVoaStaffDetailPage() {
         </div>
 
         {isAdmin && (
-          <div className="pt-4 border-t border-[var(--bz-border)]">
-            <label
-              htmlFor="garuda-voa-assign"
-              className="block text-sm text-[var(--bz-text-2)] mb-1"
-            >
+          <div className="border-t border-[var(--bz-border)] pt-5">
+            <label htmlFor="garuda-voa-assign" className={cn(EYEBROW, "block")}>
               Assigned to
             </label>
             <select
@@ -370,7 +407,7 @@ export default function GarudaVoaStaffDetailPage() {
               value={practice.assigned_to || ""}
               disabled={isAssigning}
               onChange={(e) => handleAssign(e.target.value)}
-              className="w-full max-w-xs border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] rounded-lg px-3 py-2 text-sm"
+              className={cn(FIELD, "mt-1.5 max-w-xs")}
             >
               <option value="">Unassigned</option>
               {/* A practice assigned BEFORE this picker was narrowed (or to a
@@ -394,59 +431,70 @@ export default function GarudaVoaStaffDetailPage() {
               ))}
             </select>
             {assignmentTargetsUnavailable && (
-              <p className="mt-1 text-xs text-[var(--bz-text-2)]">
+              <p className="mt-2 text-xs text-[var(--bz-copper-text)]">
                 Assignee list unavailable — reload before assigning.
               </p>
             )}
           </div>
         )}
-      </div>
+      </section>
 
-      <div className="rounded-xl p-6 border border-[var(--bz-border)] bg-[var(--bz-card)] space-y-4">
-        <h2 className="text-lg font-semibold text-[var(--bz-text-1)]">
+      <section className={cn(CARD, "space-y-5 p-6")}>
+        <h2 className={cn(SECTION_H2, "text-[var(--tx-pure)]")} style={SERIF}>
           Transitions
         </h2>
         {allowedTransitions.length === 0 ? (
-          <p className="text-sm text-[var(--bz-text-2)]">
+          <p className="text-sm text-[var(--tx-secondary)]">
             No transitions are available from this state.
           </p>
         ) : (
-          <div className="flex flex-wrap gap-2">
-            {allowedTransitions.map((option) => (
-              <Button
-                key={option.transitionId}
-                variant={
-                  form.transitionId === option.transitionId
-                    ? "default"
-                    : "outline"
-                }
-                onClick={() => selectTransition(option.transitionId)}
-                data-testid={`transition-${option.transitionId}`}
-              >
-                {option.label}
-              </Button>
-            ))}
+          <div className="flex flex-wrap gap-2.5">
+            {allowedTransitions.map((option) => {
+              const isPicked = form.transitionId === option.transitionId;
+              return (
+                <button
+                  key={option.transitionId}
+                  type="button"
+                  onClick={() => selectTransition(option.transitionId)}
+                  data-testid={`transition-${option.transitionId}`}
+                  aria-pressed={isPicked}
+                  className={cn(
+                    "h-11 rounded-full border px-4 text-[13px] font-semibold transition-colors",
+                    isPicked
+                      ? "border-[var(--bz-copper)] bg-[color-mix(in_srgb,var(--bz-copper)_8%,transparent)] text-[var(--bz-copper-text)]"
+                      : "border-[var(--bz-border-hover)] text-[var(--tx-pure)] hover:border-[var(--bz-copper)]",
+                    FOCUS,
+                  )}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
           </div>
         )}
 
         {form.transitionId && (
-          <div className="space-y-3 pt-4 border-t border-[var(--bz-border)]">
+          <div className="space-y-4 border-t border-[var(--bz-border)] pt-5">
             {(form.transitionId === "PR-03" ||
               form.transitionId === "PR-05" ||
               form.transitionId === "PR-07" ||
               form.transitionId === "PR-08") && (
               <div>
-                <label className="block text-sm text-[var(--bz-text-2)] mb-1">
+                <label
+                  htmlFor="garuda-voa-customer-reason-key"
+                  className={cn(EYEBROW, "block")}
+                >
                   Customer reason key
                 </label>
                 <input
+                  id="garuda-voa-customer-reason-key"
                   type="text"
                   value={form.customerReasonKey}
                   onChange={(e) =>
                     handleFieldChange("customerReasonKey", e.target.value)
                   }
                   placeholder="garuda_voa.practice.…"
-                  className="w-full border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] rounded-lg px-3 py-2 text-sm font-mono"
+                  className={cn(FIELD, "mt-1.5 font-mono")}
                 />
               </div>
             )}
@@ -454,17 +502,21 @@ export default function GarudaVoaStaffDetailPage() {
               form.transitionId === "PR-05" ||
               form.transitionId === "PR-08") && (
               <div>
-                <label className="block text-sm text-[var(--bz-text-2)] mb-1">
+                <label
+                  htmlFor="garuda-voa-required-action-key"
+                  className={cn(EYEBROW, "block")}
+                >
                   Required action key
                 </label>
                 <input
+                  id="garuda-voa-required-action-key"
                   type="text"
                   value={form.requiredActionKey}
                   onChange={(e) =>
                     handleFieldChange("requiredActionKey", e.target.value)
                   }
                   placeholder="garuda_voa.action.…"
-                  className="w-full border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] rounded-lg px-3 py-2 text-sm font-mono"
+                  className={cn(FIELD, "mt-1.5 font-mono")}
                 />
               </div>
             )}
@@ -473,17 +525,21 @@ export default function GarudaVoaStaffDetailPage() {
               form.transitionId === "PR-07" ||
               form.transitionId === "PR-08") && (
               <div>
-                <label className="block text-sm text-[var(--bz-text-2)] mb-1">
+                <label
+                  htmlFor="garuda-voa-private-staff-note"
+                  className={cn(EYEBROW, "block")}
+                >
                   Private staff note (never shown to the customer)
                 </label>
                 <textarea
+                  id="garuda-voa-private-staff-note"
                   value={form.privateStaffNote}
                   onChange={(e) =>
                     handleFieldChange("privateStaffNote", e.target.value)
                   }
                   rows={3}
                   maxLength={4000}
-                  className="w-full border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] rounded-lg px-3 py-2 text-sm"
+                  className={cn(FIELD, "mt-1.5")}
                 />
               </div>
             )}
@@ -491,16 +547,20 @@ export default function GarudaVoaStaffDetailPage() {
               form.transitionId === "PR-06" ||
               form.transitionId === "PR-07") && (
               <div>
-                <label className="block text-sm text-[var(--bz-text-2)] mb-1">
+                <label
+                  htmlFor="garuda-voa-evidence-id"
+                  className={cn(EYEBROW, "block")}
+                >
                   Evidence id
                 </label>
                 <input
+                  id="garuda-voa-evidence-id"
                   type="text"
                   value={form.evidenceId}
                   onChange={(e) =>
                     handleFieldChange("evidenceId", e.target.value)
                   }
-                  className="w-full border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] rounded-lg px-3 py-2 text-sm font-mono"
+                  className={cn(FIELD, "mt-1.5 font-mono")}
                 />
               </div>
             )}
@@ -509,7 +569,7 @@ export default function GarudaVoaStaffDetailPage() {
               <div>
                 <label
                   htmlFor="garuda-voa-resolved-block-id"
-                  className="block text-sm text-[var(--bz-text-2)] mb-1"
+                  className={cn(EYEBROW, "block")}
                 >
                   Resolved block id
                 </label>
@@ -522,12 +582,15 @@ export default function GarudaVoaStaffDetailPage() {
                   value={practice.active_block_id ?? ""}
                   readOnly
                   disabled
-                  className="w-full border border-[var(--bz-border)] bg-[var(--surface-raised)] text-[var(--bz-text-2)] rounded-lg px-3 py-2 text-sm font-mono cursor-not-allowed"
+                  className={cn(
+                    FIELD,
+                    "mt-1.5 cursor-not-allowed font-mono text-[var(--tx-secondary)]",
+                  )}
                 />
                 {!practice.active_block_id && (
-                  <p className="mt-1 text-xs text-[var(--state-danger)]">
-                    No active block id on record — this transition cannot be
-                    applied yet.
+                  <p className="mt-2 text-xs text-[var(--bz-copper-text)]">
+                    Blocked — no active block id on record, so this transition
+                    cannot be applied yet.
                   </p>
                 )}
               </div>
@@ -535,53 +598,69 @@ export default function GarudaVoaStaffDetailPage() {
             {form.transitionId === "PR-11" && (
               <>
                 <div>
-                  <label className="block text-sm text-[var(--bz-text-2)] mb-1">
+                  <label
+                    htmlFor="garuda-voa-artifact-id"
+                    className={cn(EYEBROW, "block")}
+                  >
                     Artifact id
                   </label>
                   <input
+                    id="garuda-voa-artifact-id"
                     type="text"
                     value={form.artifactId}
                     onChange={(e) =>
                       handleFieldChange("artifactId", e.target.value)
                     }
-                    className="w-full border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] rounded-lg px-3 py-2 text-sm font-mono"
+                    className={cn(FIELD, "mt-1.5 font-mono")}
                   />
                 </div>
                 <div>
-                  <label className="block text-sm text-[var(--bz-text-2)] mb-1">
+                  <label
+                    htmlFor="garuda-voa-artifact-digest"
+                    className={cn(EYEBROW, "block")}
+                  >
                     Artifact digest (sha256)
                   </label>
                   <input
+                    id="garuda-voa-artifact-digest"
                     type="text"
                     value={form.artifactDigest}
                     onChange={(e) =>
                       handleFieldChange("artifactDigest", e.target.value)
                     }
                     placeholder="64 hex characters"
-                    className="w-full border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] rounded-lg px-3 py-2 text-sm font-mono"
+                    className={cn(FIELD, "mt-1.5 font-mono")}
                   />
                 </div>
               </>
             )}
 
-            <div className="flex items-center gap-2 pt-2">
-              <Button onClick={submitTransition} disabled={isSubmitting}>
+            <div className="flex items-center gap-2.5 pt-1">
+              <Button
+                onClick={submitTransition}
+                disabled={isSubmitting}
+                className="h-11 rounded bg-[var(--state-success)] px-6 text-[13px] font-semibold tracking-[0.02em] text-white hover:bg-[var(--state-success)]/90"
+              >
                 {isSubmitting && (
-                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 )}
                 Apply
               </Button>
-              <Button
-                variant="outline"
+              <button
+                type="button"
                 onClick={() => setForm(EMPTY_FORM)}
                 disabled={isSubmitting}
+                className={cn(
+                  "h-11 rounded-full border border-[var(--bz-border-hover)] px-5 text-[13px] font-semibold text-[var(--tx-pure)] transition-colors hover:border-[var(--bz-copper)] disabled:opacity-50",
+                  FOCUS,
+                )}
               >
                 Cancel
-              </Button>
+              </button>
             </div>
           </div>
         )}
-      </div>
+      </section>
     </div>
   );
 }

--- a/apps/mouth/src/app/(workspace)/garuda-voa/layout.tsx
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/layout.tsx
@@ -1,0 +1,35 @@
+/**
+ * GARUDA VOA staff console — R19 typographic scope.
+ *
+ * SAETTA-VOA W-VOA-V3 (2026-09-13). The console is served on the kita host,
+ * whose theme block points --font-serif/--font-sans at the workspace stack.
+ * R19 asks for Fraunces headlines and Manrope body HERE without changing that
+ * for the rest of the workspace, so the two variables are re-pointed on this
+ * subtree's root element only.
+ *
+ * The faces themselves are NOT re-declared: app/portal/r19-fonts.css already
+ * owns the two @font-face rules (self-hosted variable binaries, OFL 1.1) and
+ * is imported, not copied — a second copy is exactly the drift class the
+ * cicatrix record calls "the documented cure never reaches the twin file".
+ */
+
+import React from "react";
+import "../../portal/r19-fonts.css";
+
+const R19_TYPE = {
+  "--font-serif": '"Fraunces", ui-serif, Georgia, serif',
+  fontFamily:
+    '"Manrope", var(--font-sans), ui-sans-serif, system-ui, sans-serif',
+} as React.CSSProperties;
+
+export default function GarudaVoaConsoleLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div data-r19-console="garuda-voa" style={R19_TYPE}>
+      {children}
+    </div>
+  );
+}

--- a/apps/mouth/src/app/(workspace)/garuda-voa/page.tsx
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/page.tsx
@@ -1,13 +1,39 @@
 "use client";
 
+/**
+ * GARUDA VOA — staff practice list.
+ *
+ * SAETTA-VOA W-VOA-V3 (2026-09-13): concept-F "RAPI" presentation pass, the
+ * same one shipped on the client portal. PRESENTATION ONLY — the profile
+ * probe, the admin/assigned narrowing, the abort-on-change load and the staff
+ * API contract are byte-for-byte the behaviour that was here before.
+ *
+ * The table stays a table: staff scan five columns and the semantics are worth
+ * keeping. What changes is the dressing — copper rule + Fraunces masthead,
+ * eyebrow column heads, hairlines instead of a filled card, copper numerals,
+ * and the seven states as OUTLINED pills in the four R19 meanings. No filled
+ * state row, and no red: see r19.tsx.
+ */
+
 import React, { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { ListPageHeader, FilterSelect } from "@balizero/core";
+import { FilterSelect } from "@balizero/core";
 import { Loader2, FolderKanban } from "lucide-react";
 import { api } from "@/lib/api";
+import { cn } from "@/lib/utils";
 import { logger } from "@/lib/logger";
 import { toError } from "@/lib/types/common";
 import { listStaffPractices } from "./api-client";
+import {
+  CARD,
+  EYEBROW,
+  FOCUS,
+  Masthead,
+  Notice,
+  PracticeStatePill,
+  SERIF,
+  pad2,
+} from "./r19";
 import type { StaffPracticeListRow, PracticeState } from "./types";
 
 const STATE_OPTIONS: PracticeState[] = [
@@ -20,39 +46,8 @@ const STATE_OPTIONS: PracticeState[] = [
   "Delivered",
 ];
 
-// Same badge palette family as the customer tracker (orders/OrderTracker.tsx)
-// — staff and customer surfaces read the same seven-state vocabulary and
-// must never drift into two different color stories for one state.
-const STATE_BADGE_STYLE: Record<PracticeState, React.CSSProperties> = {
-  Received: {
-    background: "var(--surface-raised)",
-    color: "var(--bz-text-2)",
-  },
-  "In review": {
-    background: "color-mix(in srgb, var(--state-info) 15%, transparent)",
-    color: "var(--state-info)",
-  },
-  Blocked: {
-    background: "color-mix(in srgb, var(--state-warning) 15%, transparent)",
-    color: "var(--state-warning)",
-  },
-  Submitted: {
-    background: "color-mix(in srgb, var(--state-info) 15%, transparent)",
-    color: "var(--state-info)",
-  },
-  Approved: {
-    background: "color-mix(in srgb, var(--state-success) 15%, transparent)",
-    color: "var(--state-success)",
-  },
-  Rejected: {
-    background: "color-mix(in srgb, var(--state-danger) 15%, transparent)",
-    color: "var(--state-danger)",
-  },
-  Delivered: {
-    background: "color-mix(in srgb, var(--state-success) 20%, transparent)",
-    color: "var(--state-success)",
-  },
-};
+const FILTER_SELECT_CLASS =
+  "h-11 rounded border border-[var(--bz-border-hover)] bg-[var(--bz-surface)] text-sm text-[var(--tx-pure)] focus-visible:ring-2 focus-visible:ring-[var(--bz-copper)]";
 
 function formatDate(iso: string): string {
   try {
@@ -128,19 +123,20 @@ export default function GarudaVoaStaffListPage() {
   const rows = useMemo(() => practices, [practices]);
 
   return (
-    <div className="space-y-6">
-      <ListPageHeader
-        title="GARUDA VOA — Staff practices"
+    <div className="space-y-9">
+      <Masthead
+        eyebrow="GARUDA VOA · staff"
+        title="Practices"
         subtitle="Review, block, submit and deliver visa-on-arrival practices"
       />
 
-      <div className="flex flex-col sm:flex-row gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
         <FilterSelect
           id="garuda-voa-state-filter"
           label="State"
           value={stateFilter}
           onChange={setStateFilter}
-          selectClassName="border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] focus:ring-2 focus:ring-[var(--bz-accent)]/50"
+          selectClassName={FILTER_SELECT_CLASS}
         >
           <option value="">All states</option>
           {STATE_OPTIONS.map((state) => (
@@ -155,7 +151,7 @@ export default function GarudaVoaStaffListPage() {
             label="Assigned"
             value={assignedFilter}
             onChange={(v) => setAssignedFilter(v === "me" ? "me" : "all")}
-            selectClassName="border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] focus:ring-2 focus:ring-[var(--bz-accent)]/50"
+            selectClassName={FILTER_SELECT_CLASS}
           >
             <option value="all">All staff</option>
             <option value="me">My work</option>
@@ -163,78 +159,137 @@ export default function GarudaVoaStaffListPage() {
         )}
       </div>
 
-      {loadError && (
-        <div
-          className="rounded-lg p-4 text-sm"
-          style={{
-            background:
-              "color-mix(in srgb, var(--state-danger) 10%, transparent)",
-            color: "var(--state-danger)",
-          }}
-          role="alert"
-        >
-          {loadError}
-        </div>
-      )}
+      {loadError && <Notice role="alert">{loadError}</Notice>}
 
       {isLoading ? (
         <div
-          className="flex items-center justify-center h-40"
+          className="flex h-40 items-center justify-center"
           data-testid="loading-skeleton"
         >
-          <Loader2 className="w-6 h-6 animate-spin text-[var(--bz-accent)]" />
+          <Loader2 className="h-6 w-6 animate-spin text-[var(--bz-copper)]" />
         </div>
       ) : rows.length === 0 ? (
-        <div className="flex flex-col items-center justify-center h-32 border border-dashed border-[var(--bz-border)] rounded-lg bg-[var(--bz-card)]/30">
-          <FolderKanban className="w-8 h-8 text-[var(--bz-text-2)] opacity-20 mb-2" />
-          <p className="text-xs text-[var(--bz-text-2)]">No practices</p>
+        <div
+          className={cn(
+            CARD,
+            "flex flex-col items-center justify-center gap-2 px-6 py-12",
+          )}
+        >
+          <FolderKanban
+            className="h-7 w-7 text-[var(--tx-secondary)] opacity-40"
+            aria-hidden="true"
+          />
+          <p
+            className="text-[20px] leading-[1.14] text-[var(--tx-pure)]"
+            style={SERIF}
+          >
+            No practices
+          </p>
+          <p className="text-[13px] text-[var(--tx-secondary)]">
+            Nothing matches this filter yet.
+          </p>
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-xl border border-[var(--bz-border)] bg-[var(--bz-card)]">
+        <div className={cn(CARD, "overflow-x-auto")}>
           <table className="w-full text-sm">
+            <caption className="sr-only">
+              GARUDA VOA staff practices, newest activity first
+            </caption>
             <thead>
-              <tr className="text-left text-xs uppercase tracking-wide text-[var(--bz-text-2)] border-b border-[var(--bz-border)]">
-                <th className="px-4 py-3">Practice</th>
-                <th className="px-4 py-3">Order</th>
-                <th className="px-4 py-3">State</th>
-                <th className="px-4 py-3">Assigned to</th>
-                <th className="px-4 py-3">Updated</th>
+              <tr className={cn("border-b border-[var(--bz-border)]", EYEBROW)}>
+                <th
+                  scope="col"
+                  className="w-[42px] px-3 py-3 text-left md:w-[52px] md:px-4"
+                >
+                  #
+                </th>
+                <th scope="col" className="px-3 py-3 text-left md:px-4">
+                  Practice
+                </th>
+                <th
+                  scope="col"
+                  className="hidden px-3 py-3 text-left md:table-cell md:px-4"
+                >
+                  Order
+                </th>
+                <th scope="col" className="px-3 py-3 text-left md:px-4">
+                  State
+                </th>
+                <th
+                  scope="col"
+                  className="hidden px-3 py-3 text-left md:table-cell md:px-4"
+                >
+                  Assigned to
+                </th>
+                <th
+                  scope="col"
+                  className="hidden px-3 py-3 text-left md:table-cell md:px-4"
+                >
+                  Updated
+                </th>
               </tr>
             </thead>
             <tbody>
-              {rows.map((practice) => (
-                <tr
-                  key={practice.practice_id}
-                  className="border-b border-[var(--bz-border)] last:border-0 cursor-pointer hover:bg-[var(--bz-card-hover)] transition-colors"
-                  onClick={() =>
-                    router.push(`/garuda-voa/${practice.practice_id}`)
-                  }
-                  data-testid={`garuda-voa-row-${practice.practice_id}`}
-                >
-                  <td className="px-4 py-3 font-mono text-xs text-[var(--bz-text-1)]">
-                    {practice.practice_id}
-                  </td>
-                  <td className="px-4 py-3 font-mono text-xs text-[var(--bz-text-2)]">
-                    {practice.order_id}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium"
-                      style={STATE_BADGE_STYLE[practice.state]}
+              {rows.map((practice, index) => {
+                const shortDate = formatDate(practice.updated_at);
+                return (
+                  <tr
+                    key={practice.practice_id}
+                    className={cn(
+                      "cursor-pointer border-b border-[var(--bz-border)] transition-colors last:border-0 hover:bg-[var(--bz-card-hover)]",
+                      FOCUS,
+                    )}
+                    tabIndex={0}
+                    onClick={() =>
+                      router.push(`/garuda-voa/${practice.practice_id}`)
+                    }
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        router.push(`/garuda-voa/${practice.practice_id}`);
+                      }
+                    }}
+                    data-testid={`garuda-voa-row-${practice.practice_id}`}
+                  >
+                    <td
+                      className="px-3 py-3.5 text-[20px] leading-none tabular-nums text-[var(--bz-copper-text)] md:px-4"
+                      style={SERIF}
                     >
-                      {practice.state}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-[var(--bz-text-1)]">
-                    {practice.assigned_to
-                      ? practice.assigned_to.split("@")[0]
-                      : "Unassigned"}
-                  </td>
-                  <td className="px-4 py-3 text-[var(--bz-text-2)]">
-                    {formatDate(practice.updated_at)}
-                  </td>
-                </tr>
-              ))}
+                      {pad2(index + 1)}
+                    </td>
+                    <td className="px-3 py-3.5 font-mono text-xs text-[var(--tx-pure)] md:px-4">
+                      {practice.practice_id}
+                      {/* Below md the three columns to the right are hidden
+                        rather than pushed off the edge of a 390px screen —
+                        their content moves here, under the id. */}
+                      <span className="mt-1 block font-sans text-[11px] text-[var(--tx-secondary)] md:hidden">
+                        {practice.assigned_to
+                          ? practice.assigned_to.split("@")[0]
+                          : "Unassigned"}{" "}
+                        · <span className="tabular-nums">{shortDate}</span>
+                      </span>
+                    </td>
+                    <td className="hidden px-3 py-3.5 md:px-4 font-mono text-xs text-[var(--tx-secondary)] md:table-cell">
+                      {practice.order_id}
+                    </td>
+                    <td className="px-3 py-3.5 md:px-4">
+                      <PracticeStatePill state={practice.state} />
+                    </td>
+                    <td className="hidden px-3 py-3.5 md:px-4 text-[var(--tx-pure)] md:table-cell">
+                      {practice.assigned_to ? (
+                        practice.assigned_to.split("@")[0]
+                      ) : (
+                        <span className="text-[var(--tx-secondary)]">
+                          Unassigned
+                        </span>
+                      )}
+                    </td>
+                    <td className="hidden px-3 py-3.5 md:px-4 tabular-nums text-[var(--tx-secondary)] md:table-cell">
+                      {shortDate}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/apps/mouth/src/app/(workspace)/garuda-voa/r19.test.tsx
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/r19.test.tsx
@@ -1,0 +1,169 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { PILL_TONE, PRACTICE_TONE, PracticeStatePill, StatePill } from "./r19";
+import type { PracticeState } from "./types";
+
+/**
+ * The R19 "no red" law for the GARUDA VOA staff console, as a test.
+ *
+ * Concept F re-aliases danger to copper and makes every alarming state carry a
+ * WORD. On the kita daylight theme --state-danger resolves to #b91c1c, so a
+ * single read of that token would put red back on this surface — and a hand-
+ * written hex would do it without even naming the token. Both are refused
+ * here, over the console's real source files.
+ */
+
+/**
+ * `import.meta.url` is not a file URL under this runner's environment, so the
+ * console is located from the working directory instead — which is the app in
+ * a focused run and can be the repo root in CI. Both are tried; neither
+ * existing throws here rather than silently scanning an empty list, which is
+ * how a scanner turns into a rubber stamp.
+ */
+const CONSOLE_DIR = (() => {
+  const suffix = join("src", "app", "(workspace)", "garuda-voa");
+  for (const base of [process.cwd(), join(process.cwd(), "apps", "mouth")]) {
+    const candidate = join(base, suffix);
+    if (existsSync(candidate)) return candidate + "/";
+  }
+  throw new Error(
+    `GARUDA VOA console sources not found from ${process.cwd()} — the no-red scan cannot run`,
+  );
+})();
+
+/** Every one of the seven contract states, spelled out rather than derived. */
+const ALL_STATES: PracticeState[] = [
+  "Received",
+  "In review",
+  "Blocked",
+  "Submitted",
+  "Approved",
+  "Rejected",
+  "Delivered",
+];
+
+/**
+ * The scanner. It judges a single source line and returns the reason it is
+ * guilty, or null. Two shapes only: a read of the danger token, and a literal
+ * brand hex. Comment lines are exempt — this file's own doc block names both.
+ */
+export function redViolation(line: string): string | null {
+  const code = line.trimStart();
+  if (
+    code.startsWith("//") ||
+    code.startsWith("*") ||
+    code.startsWith("/*") ||
+    code.startsWith("{/*")
+  ) {
+    return null;
+  }
+  if (code.includes("--state-danger")) return "reads --state-danger";
+  if (/#[0-9a-fA-F]{3,8}\b/.test(code)) return "hardcoded hex";
+  return null;
+}
+
+/**
+ * Every `.ts`/`.tsx` the console renders from, one level of nesting deep
+ * (`[practiceId]/`). Test files are NOT rendered and are excluded on purpose:
+ * their fixtures have to spell the guilty shapes out loud — this file's own
+ * guilt case is a `--state-danger` string literal.
+ */
+function sourceFiles(): string[] {
+  const here = readdirSync(CONSOLE_DIR, { withFileTypes: true });
+  const rendered = (name: string) =>
+    /\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name);
+  const files: string[] = [];
+  for (const entry of here) {
+    if (entry.isFile() && rendered(entry.name)) {
+      files.push(join(CONSOLE_DIR, entry.name));
+    }
+    if (entry.isDirectory()) {
+      for (const nested of readdirSync(join(CONSOLE_DIR, entry.name))) {
+        if (rendered(nested)) {
+          files.push(join(CONSOLE_DIR, entry.name, nested));
+        }
+      }
+    }
+  }
+  return files;
+}
+
+/**
+ * The lines the scanner is asked to judge. They are FIXTURES, not styling — the
+ * `token-lint-ok` markers say so to the CI gate, which judges added lines and
+ * cannot tell a fixture from a rule on its own.
+ */
+const FIXTURE = {
+  dangerToken: '  className="text-[var(--state-danger)]"',
+  hexInStyle: '  style={{ color: "#b91c1c" }}', // token-lint-ok: scanner fixture
+  hexInLineComment: "  // danger is #b91c1c here", // token-lint-ok: scanner fixture
+  hexInBlockComment: " * no red: #b91c1c here", // token-lint-ok: scanner fixture
+  copperClass: '  className="text-[var(--bz-copper-text)]"',
+  successClass: '  className="border-[var(--state-success)]"',
+};
+
+describe("the console's no-red scanner", () => {
+  it("is GUILTY on the two shapes that put red back", () => {
+    expect(redViolation(FIXTURE.dangerToken)).toBe("reads --state-danger");
+    expect(redViolation(FIXTURE.hexInStyle)).toBe("hardcoded hex");
+  });
+
+  it("is INNOCENT on the copper idiom and on prose that merely names red", () => {
+    expect(redViolation(FIXTURE.copperClass)).toBeNull();
+    expect(redViolation(FIXTURE.successClass)).toBeNull();
+    expect(redViolation(FIXTURE.hexInLineComment)).toBeNull();
+    expect(redViolation(FIXTURE.hexInBlockComment)).toBeNull();
+  });
+});
+
+describe("the GARUDA VOA staff console carries no red", () => {
+  it("finds its own source files", () => {
+    const names = sourceFiles().map((f) => f.replace(CONSOLE_DIR, ""));
+    expect(names).toContain("page.tsx");
+    expect(names).toContain("r19.tsx");
+    expect(names).toContain(join("[practiceId]", "page.tsx"));
+  });
+
+  it("has no danger-token read and no hardcoded hex in any of them", () => {
+    const offences: string[] = [];
+    for (const file of sourceFiles()) {
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, i) => {
+        const why = redViolation(line);
+        if (why) {
+          offences.push(`${file.replace(CONSOLE_DIR, "")}:${i + 1} — ${why}`);
+        }
+      });
+    }
+    expect(offences).toEqual([]);
+  });
+});
+
+describe("the seven practice states read as four meanings and seven words", () => {
+  it("maps every contract state, and never to a danger class", () => {
+    for (const state of ALL_STATES) {
+      const tone = PRACTICE_TONE[state];
+      expect(tone, `${state} has no tone`).toBeTruthy();
+      expect(PILL_TONE[tone]).not.toContain("--state-danger");
+    }
+    expect(Object.keys(PRACTICE_TONE).sort()).toEqual([...ALL_STATES].sort());
+  });
+
+  it("gives the two formerly-red states copper AND their word", () => {
+    expect(PRACTICE_TONE.Blocked).toBe("you");
+    expect(PRACTICE_TONE.Rejected).toBe("you");
+    expect(PILL_TONE.you).toContain("--bz-copper");
+
+    render(<PracticeStatePill state="Rejected" />);
+    expect(screen.getByText("Rejected")).toBeVisible();
+  });
+
+  it("renders an outlined pill, never a filled one", () => {
+    const { container } = render(<StatePill tone="ok" label="Delivered" />);
+    const pill = container.firstElementChild as HTMLElement;
+    expect(pill.className).toContain("border");
+    expect(pill.className).not.toContain("bg-[var(--state-");
+  });
+});

--- a/apps/mouth/src/app/(workspace)/garuda-voa/r19.tsx
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/r19.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+/**
+ * R19 presentation primitives for the GARUDA VOA staff console.
+ *
+ * SAETTA-VOA W-VOA-V3 (2026-09-13): G0.4 ruled R19 for this console
+ * (docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md:19). These are the
+ * same primitives, class strings and token reads the concept-F pass shipped on
+ * the client portal (apps/mouth/src/app/portal/(authenticated)/page.tsx and
+ * components/portal/StatusBadge.tsx) — copied idiom, not a second visual
+ * system, and page-local so nothing shared is restyled.
+ *
+ * FOUR COLOUR MEANINGS, one vocabulary, read from the theme layer:
+ *   done / healthy  -> --state-success
+ *   ours / moving   -> --state-info
+ *   needs you       -> --bz-copper / --bz-copper-text
+ *   waiting         -> --tx-secondary
+ *
+ * NO RED ON THIS SURFACE. --state-danger resolves to #b91c1c on the kita
+ * daylight theme, so concept-F's re-alias is applied here instead: every state
+ * that used to read danger now reads copper AND carries the word ("Blocked",
+ * "Rejected"). r19.test.tsx fails if a danger read comes back.
+ *
+ * Value caveat, recorded rather than fixed. The R19 hues (forest #253E33,
+ * slate #233D52, copper #A44B36) are declared in globals.css under
+ * [data-product="my"] only. On kita the same TOKENS resolve to the daylight
+ * AA steps. Giving kita the R19 values is a theme-layer change and belongs to
+ * a window whose perimeter includes the whole workspace, not to this one.
+ */
+
+import React from "react";
+import { cn } from "@/lib/utils";
+import type { PracticeState } from "./types";
+
+/** Fraunces, scoped to this console by layout.tsx (nothing global is swapped). */
+export const SERIF: React.CSSProperties = {
+  fontFamily: "var(--font-serif)",
+  fontWeight: 450,
+};
+
+export const EYEBROW =
+  "text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--tx-secondary)]";
+export const SECTION_H2 = "text-[24px] leading-[1.14] tracking-[-0.02em]";
+export const HAIRLINE = "border border-[var(--bz-border)]";
+export const CARD = `rounded-lg bg-[var(--bz-surface)] ${HAIRLINE}`;
+export const FOCUS =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bz-copper)]";
+export const FIELD =
+  "w-full rounded border border-[var(--bz-border-hover)] bg-[var(--bz-base)] px-3 py-2.5 text-sm text-[var(--tx-pure)] placeholder:text-[var(--tx-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bz-copper)]";
+
+export type PillTone = "ok" | "ours" | "you" | "wait";
+
+export const PILL_TONE: Record<PillTone, string> = {
+  ok: "text-[var(--state-success)] border-[var(--state-success)]",
+  ours: "text-[var(--state-info)] border-[var(--state-info)]",
+  you: "text-[var(--bz-copper-text)] border-[var(--bz-copper)]",
+  wait: "text-[var(--tx-secondary)] border-[var(--bz-border-hover)]",
+};
+
+/** Outlined status pill — one vocabulary, four meanings, never a filled state. */
+export function StatePill({
+  tone,
+  label,
+  className,
+}: {
+  tone: PillTone;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 items-center gap-[7px] whitespace-nowrap rounded-full border px-[10px] text-[10px] font-semibold uppercase tracking-[0.12em]",
+        PILL_TONE[tone],
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="h-1.5 w-1.5 rounded-full bg-current"
+      />
+      {label}
+    </span>
+  );
+}
+
+/**
+ * The seven practice states of the frozen contract, as four meanings and seven
+ * WORDS. Blocked and Rejected are the two that used to read danger: they keep
+ * their word and take the copper "needs you" step.
+ */
+export const PRACTICE_TONE: Record<PracticeState, PillTone> = {
+  Received: "wait",
+  "In review": "ours",
+  Blocked: "you",
+  Submitted: "ours",
+  Approved: "ok",
+  Rejected: "you",
+  Delivered: "ok",
+};
+
+export function PracticeStatePill({
+  state,
+  className,
+}: {
+  state: PracticeState;
+  className?: string;
+}) {
+  return (
+    <StatePill
+      tone={PRACTICE_TONE[state] ?? "wait"}
+      label={state}
+      className={className}
+    />
+  );
+}
+
+/** Copper rule + Fraunces headline + the existing subtitle copy. */
+export function Masthead({
+  eyebrow,
+  title,
+  subtitle,
+  headingClassName,
+}: {
+  eyebrow?: string;
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  headingClassName?: string;
+}) {
+  return (
+    <section>
+      <div
+        aria-hidden="true"
+        className="mb-4 h-[3px] w-14 rounded-sm bg-[var(--bz-copper)]"
+      />
+      {eyebrow && <p className={cn(EYEBROW, "mb-2")}>{eyebrow}</p>}
+      <h1
+        className={cn(
+          "text-[clamp(28px,3.4vw,40px)] leading-[1.06] tracking-[-0.03em] text-[var(--tx-pure)]",
+          headingClassName,
+        )}
+        style={SERIF}
+      >
+        {title}
+      </h1>
+      {subtitle && (
+        <p className="mt-2 text-[var(--tx-secondary)]">{subtitle}</p>
+      )}
+    </section>
+  );
+}
+
+/**
+ * A quiet notice. `tone="you"` is the ONLY alarming variant this console has —
+ * copper text on a copper hairline plus the words the caller passes, never a
+ * filled red row.
+ */
+export function Notice({
+  children,
+  role,
+}: {
+  children: React.ReactNode;
+  role?: "alert" | "status";
+}) {
+  return (
+    <div
+      role={role}
+      className="rounded-lg border border-[var(--bz-copper)] bg-[var(--bz-surface)] px-4 py-3 text-sm text-[var(--bz-copper-text)]"
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Two-digit index for the copper numerals of the R19 list idiom. */
+export const pad2 = (n: number) => String(n).padStart(2, "0");

--- a/evidence/2026-09/agent-air-m5-mouth-voa-v3-console-eb60401f/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-voa-v3-console-eb60401f/brief.yml
@@ -1,0 +1,40 @@
+gear: 2
+ruling: RULED 2026-09-12 SAETTA
+mission: SAETTA-VOA window V3 (BLUE, host M5) — the GARUDA VOA staff console reads R19, and the public domain stops serving it
+objective: >-
+  G0.4 (docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md:19) ruled R19 for the
+  GARUDA VOA staff console on 2026-09-03 and nothing implemented it: the grounding
+  report's `grep -rln "R19"` over both VOA UI trees returned nothing, and the surface
+  still carried the pre-R19 kita dressing — filled state chips, a red danger alert,
+  `--bz-accent` spinners, a bold sans masthead. Dress the list and the detail in the
+  concept-F "RAPI" language exactly as it shipped on the client portal: copper rule +
+  Fraunces masthead, eyebrow labels, hairlines instead of filled cards, copper numerals,
+  and the seven contract states as OUTLINED pills in four colour meanings. The guard
+  half of the window (the public domain serving /garuda-voa) is NOT rebuilt — open PR
+  #6400 already carries it and is reported to the imperator instead.
+scope:
+  - apps/mouth/src/app/(workspace)/garuda-voa/page.tsx
+  - apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.tsx
+  - apps/mouth/src/app/(workspace)/garuda-voa/r19.tsx
+  - apps/mouth/src/app/(workspace)/garuda-voa/r19.test.tsx
+  - apps/mouth/src/app/(workspace)/garuda-voa/layout.tsx
+constraints:
+  - PRESENTATION ONLY — no route, no field, no hook, no fetch, no API type, no behavioural change; the staff API contract (401 envelope, Idempotency-Key) is untouched.
+  - Forbidden — the customer funnel apps/mouth/src/app/visa/voa/**, the backend, migrations, the Tigris store, any auth change, globals.css and every shared primitive.
+  - No red on this surface. --state-danger resolves to #b91c1c on the kita daylight theme, so concept F's re-alias applies - copper plus a WORD.
+  - No new hardcoded brand hex in a scoped surface (token-lint); the four meanings read existing tokens.
+  - No client PII — synthetic ids and example.test addresses only.
+  - No ledger PR, no PENDING-ARMS.md edit, no gate status posted by this window.
+acceptance:
+  - A1 the diff touches only files under (workspace)/garuda-voa/.
+  - A2 the colocated vitest suite for the console is green and the pre-existing test-case contracts (testids, labels, "No practices", "No transitions are available from this state.") still select.
+  - A3 a guard exists that turns RED on a --state-danger read or a hardcoded hex anywhere in the console's rendered sources, with its own guilt AND innocence cases.
+  - A4 typecheck, eslint and prettier green on every touched file; the full mouth vitest suite shows no NEW failure against the same tree without the change.
+  - A5 route-intercepted screenshots of list + detail at 1440 and 390 under /Users/balizero/Desktop/R3-RENDERS-20260913/voa-v3/, rendered from a production build, 0 console errors.
+  - A6 PR 1 (the public-domain guard) is REPORTED, not rewritten, if #6400 already carries it and is only blocked by gate mechanics.
+consumer_map:
+  - The Bali Zero staff who work VOA practices on https://kita.balizero.com/garuda-voa — the list and detail served by the apps/mouth Vercel deploy on merge to main.
+  - The required GitHub check "Frontend Tests (Next.js) (mouth, true)", which runs r19.test.tsx on every future PR touching this console.
+appetite:
+  budget: 5 hours active, 1 PR (the second PR of the window is reported, not built)
+  stop_loss: three reds on the same cause suspends; a harness-caused red is reported, never cured by rebuilding the branch

--- a/evidence/2026-09/agent-air-m5-mouth-voa-v3-console-eb60401f/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-voa-v3-console-eb60401f/pack.yml
@@ -1,0 +1,256 @@
+gear: 2
+brief_ref: evidence/brief.yml
+ruling: RULED 2026-09-12 SAETTA
+lanes:
+  - lane: SAETTA-VOA-V3
+    role: build
+    seat: Claude Opus 5 (Dux of window V3, implements directly)
+pii_scan: clean
+decisions:
+  - id: D-gear
+    decision: >-
+      Gear 2, matching the deterministic floor. compute_floor() on the merge-base diff
+      returns 2 with source "size" (added 731, deleted 217, net 514, churn 948 — under
+      the 1828 churn term, and no hot-zone path in the five changed files). No council
+      seat is required at gear 2 and none was run; nothing in this pack claims one.
+  - id: D-guard-not-rebuilt
+    decision: >-
+      PR 1 of the window (the public domain must stop serving /garuda-voa) was NOT
+      rebuilt. `gh pr diff 6400` shows "/garuda-voa" added to INTERNAL_ROUTES in
+      apps/mouth/src/proxy.ts plus a test that DERIVES the route list from the
+      filesystem, and its only red is "Harness floor recompute" failing with
+      `harness_gate_read: PENDING — no harness/fable-gate verdict has been posted yet
+      on this commit`. That is gate mechanics, which the window brief says to report
+      rather than rewrite. Reported to the imperator under `needs input:`.
+  - id: D-tokens-not-hexes
+    decision: >-
+      The four R19 meanings read EXISTING tokens (--state-success, --state-info,
+      --bz-copper/--bz-copper-text, --tx-secondary) — the same reads the shipped portal
+      page and StatusBadge.tsx make — instead of page-local R19 hexes. Reason: the R19
+      values (forest #253E33, slate #233D52, copper #A44B36, paper #F7F4EE) are declared
+      in globals.css under [data-product="my"], and grep over packages/core/tokens/ and
+      apps/mouth/src/styles/ returns none of them, so there is no R19 token to alias on
+      kita. Re-declaring the hexes here would duplicate a palette outside its SSOT and
+      trip token-lint; declaring them for [data-product="kita"] would restyle the whole
+      workspace, which is outside this window's perimeter. Consequence, measured and
+      recorded as a leftover, not hidden - on kita those tokens resolve to the daylight
+      AA steps (green #147a3a, blue #1d4ed8), so the console reads copper/green/blue/
+      muted rather than copper/forest/slate/muted.
+  - id: D-no-red
+    decision: >-
+      --state-danger is #b91c1c on [data-theme="operative-light"] (globals.css reads it
+      from packages/core/tokens/semantic.css:191). Concept F §3 re-aliases danger to
+      copper, so on this console Blocked and Rejected take the copper "needs you" step
+      and keep their WORD; the load-error alert and the "no active block id" line are
+      copper text on a copper hairline, never a filled row. r19.test.tsx enforces it.
+  - id: D-token-lint
+    decision: >-
+      The first `python3 -I scripts/token_lint.py --base origin/main` on the committed
+      branch came back RED with 4 violations, before any push. Two causes, both cured at
+      depth 1. (1) r19.tsx:24 — a block-comment CONTINUATION line naming the R19 hues
+      carried a colon, and token_lint's documented exemption-1 hardening judges a
+      continuation line carrying `{`, `:` or `;` as code; the colon became a full stop.
+      (2) r19.test.tsx — three hexes are the scanner's own fixtures. They now live in a
+      FIXTURE object whose three hex-bearing lines each carry `// token-lint-ok:` with a
+      reason, which is exemption 3 used as designed. A marker on the line ABOVE does not
+      exempt: the first attempt did that and stayed red, which is how the same-line rule
+      was measured rather than assumed.
+  - id: D-table-kept
+    decision: >-
+      The list stays a <table>, dressed, rather than becoming concept F's numbered index
+      of <li> rows. Staff scan five columns and the column semantics (plus a sr-only
+      caption) are worth more here than the mock's shape; the window brief enumerates
+      the R19 language as "the same tokens, Fraunces/Manrope, four colour meanings,
+      outlined pills, hairlines", none of which requires dropping the table. The copper
+      numeral column — the concept's signature — is added.
+  - id: D-mobile-columns
+    decision: >-
+      At 390 the first render pushed STATE, ASSIGNED TO and UPDATED off the edge behind
+      an overflow scroll — the state pill, the one fact a staffer opens the list for,
+      was invisible. Below md those three columns are hidden and the assignee + time
+      move under the practice id as a second line. Presentation only; the same <td>s,
+      the same data.
+  - id: D-fonts
+    decision: >-
+      A thin layout.tsx re-points --font-serif and font-family on this subtree's root
+      element only, and IMPORTS app/portal/r19-fonts.css rather than re-declaring the
+      two @font-face rules. Copying them would be the "documented cure never reaches the
+      twin file" drift class. kita's theme block is untouched, so no other workspace
+      page changes typeface.
+  - id: D-net-lines
+    decision: >-
+      Net +514 exceeds the ~400 guidance. 169 of those lines are the new guard test and
+      176 are the shared primitives module the two pages both consume; the two pages
+      themselves are net +134 together. Splitting the guard into its own PR would ship a
+      test for code that is not there yet, so the concern stayed whole.
+receipts:
+  - claim: The worktree was created by the broker on the mouth lane for this task id.
+    cmd: python3 scripts/agent_start.py --lane mouth --task-id voa-v3-console
+    result: "WORKTREE_READY /Users/balizero/nuzantara/.worktrees/mouth-voa-v3-console ; branch agent/air-m5/mouth/voa-v3-console"
+    exit: 0
+    ts: "2026-09-13T09:34:00+08:00"
+    seat: Claude Opus 5
+  - claim: D-guard-not-rebuilt — #6400 carries the guard and its only red is the pending gate verdict.
+    cmd: gh pr view 6400 --json title,files,mergeStateStatus,statusCheckRollup ; gh pr diff 6400 ; gh run view 34730095990 --log-failed
+    result: >-
+      OPEN, BLOCKED, head 537424b7971de4bf3b0d85642d3f4bf2e9200ffe; proxy.ts adds
+      "/garuda-voa" (and seven siblings) to an EXPORTED INTERNAL_ROUTES; the new
+      internal-routes-cover-workspace.test.ts derives the route list from the
+      filesystem. One FAILURE in the rollup - "Harness floor recompute" - whose log
+      reads "harness_gate_read: PENDING - no harness/fable-gate verdict has been posted
+      yet on this commit. This is NOT a defect". Every other check SUCCESS or SKIPPED.
+    exit: 0
+    ts: "2026-09-13T09:35:00+08:00"
+    seat: Claude Opus 5
+  - claim: The R19 hues exist only under [data-product="my"] — there is no R19 token for kita to read (D-tokens-not-hexes).
+    cmd: grep -rn -i -e 253e33 -e 233d52 -e a44b36 -e f7f4ee packages/core/tokens/ apps/mouth/src/styles/ ; grep -n "state-danger" packages/core/tokens/semantic.css
+    result: "token SSOT grep: no match (exit 1). semantic.css:191 --state-danger: #b91c1c under :root[data-theme='operative-light'] — the value the kita console would have inherited."
+    exit: 1
+    ts: "2026-09-13T09:52:00+08:00"
+    seat: Claude Opus 5
+  - claim: A1 — the diff touches five files, all under (workspace)/garuda-voa/.
+    cmd: git -C <wt> diff --numstat $(git merge-base HEAD origin/main)...HEAD
+    result: "[practiceId]/page.tsx 199/120 ; layout.tsx 35/0 ; page.tsx 152/97 ; r19.test.tsx 169/0 ; r19.tsx 176/0. added 731, deleted 217, net 514, churn 948."
+    exit: 0
+    ts: "2026-09-13T11:45:00+08:00"
+    seat: Claude Opus 5
+  - claim: D-gear — the deterministic floor is 2, source size.
+    cmd: python3 scripts/evidence_pack_lint.py --print-floor --print-floor-source --changed-files-file /tmp/cf.txt --numstat-file /tmp/ns.txt
+    result: "floor 2 ; floor source: size"
+    exit: 0
+    ts: "2026-09-13T11:46:00+08:00"
+    seat: Claude Opus 5
+  - claim: A3/CI — token-lint is clean on the pushed commit, after a red that was cured at depth 1.
+    cmd: cd <wt> && python3 -I scripts/token_lint.py --base origin/main
+    result: >-
+      First run (committed branch, before the cure) - "4 violation(s) in 2 file(s)":
+      r19.tsx:24 and r19.test.tsx:98,108,111. After the cure - "token-lint: clean - no
+      new hardcoded hex colors in scoped surfaces (5 scoped file(s) with added lines
+      scanned)." The scanner diffs REF...HEAD, so it has to be re-run after each amend;
+      a working-tree-only fix reports the stale line numbers.
+    exit: 0
+    ts: "2026-09-13T12:05:00+08:00"
+    seat: Claude Opus 5
+  - claim: A2 — the console's colocated vitest suite is green, including the six pre-existing files whose selectors the reskin had to preserve.
+    cmd: cd apps/mouth && npx vitest run "src/app/(workspace)/garuda-voa"
+    result: "Test Files 6 passed (6) ; Tests 32 passed (32). The pre-existing 25 still select by data-testid, by label (State / Assigned / Assigned to / Resolved block id) and by text (No practices, No transitions are available from this state., Apply, Assignee list unavailable)."
+    exit: 0
+    ts: "2026-09-13T11:20:00+08:00"
+    seat: Claude Opus 5
+  - claim: A3 GUILT — planting a --state-danger read in r19.tsx turns the guard red and names the line.
+    cmd: sed the wait tone to text-[var(--state-danger)] ; npx vitest run r19.test.tsx ; restore from a cp backup
+    result: >-
+      2 failed | 5 passed. "expected [ 'r19.tsx:57 - reads --state-danger' ] to deeply
+      equal []" and "expected 'text-[var(--state-danger)] border-[va...' not to contain
+      '--state-danger'". After restoring the file from its cp backup: 7 passed (7). Re-run
+      unchanged after the fixtures were refactored for token-lint.
+    exit: 1
+    ts: "2026-09-13T10:02:00+08:00"
+    seat: Claude Opus 5
+  - claim: A3 INNOCENCE — the scanner does not fire on the copper idiom, on --state-success, or on prose that merely names red.
+    cmd: the four assertions in describe("the console's no-red scanner") > "is INNOCENT ..."
+    result: "green inside the 32-passing run; the console's own sources carry #b91c1c, #253E33, #233D52 and #A44B36 in r19.tsx's doc block and are not flagged, because comment lines are exempt."
+    exit: 0
+    ts: "2026-09-13T11:20:00+08:00"
+    seat: Claude Opus 5
+  - claim: A4 — typecheck green.
+    cmd: cd apps/mouth && npx tsc --noEmit -p tsconfig.json
+    result: "no diagnostics, exit 0. (pnpm -F mouth typecheck refuses on this checkout with ERR_PNPM_UNSAFE_MODULES_DIR because node_modules resolves outside the worktree, so the underlying script was run directly; the pre-commit hook also ran npm run typecheck -w apps/mouth and passed.)"
+    exit: 0
+    ts: "2026-09-13T11:44:00+08:00"
+    seat: Claude Opus 5
+  - claim: A4 — eslint and prettier green on every touched file.
+    cmd: cd apps/mouth && npx eslint <the five files> ; npx prettier --check <the five files>
+    result: "eslint 0 errors (r19.test.tsx is matched by an ignore pattern, reported as 1 warning) ; prettier: All matched files use Prettier code style!"
+    exit: 0
+    ts: "2026-09-13T11:44:30+08:00"
+    seat: Claude Opus 5
+  - claim: A4 — the full mouth suite shows no NEW failure; the five red files are red on the same tree WITHOUT this change.
+    cmd: npx vitest run (whole suite) ; then git stash push -u and re-run only those five files ; then git stash pop
+    result: >-
+      With the change: Test Files 5 failed | 474 passed (479), Tests 65 failed | 5088
+      passed (5153). The five are (workspace)/process/__tests__/page.test.tsx,
+      (workspace)/settings/appearance/page.test.tsx, visa/match/page.test.tsx,
+      visa/voa/[hash]/page.test.tsx, visa/voa/page.test.tsx — none touched here. On the
+      STASHED tree those same five files give Tests 65 failed | 1 passed (66): identical
+      count, pre-existing on origin/main content. Backed the working tree up with tar
+      before stashing.
+    exit: 1
+    ts: "2026-09-13T10:12:00+08:00"
+    seat: Claude Opus 5
+  - claim: A5 — four route-intercepted screenshots of the real routes, rendered from a production build, 0 console errors.
+    cmd: npx next build --webpack && npx next start -p 3210 ; playwright chromium channel=chrome, context.route(/.*\/api\/.*/) serving synthetic practices, viewports 1440x900 and 390x844, fullPage
+    result: >-
+      list-1440.png, detail-1440.png, list-390.png, detail-390.png under
+      /Users/balizero/Desktop/R3-RENDERS-20260913/voa-v3/ (build EXIT=0, local
+      /garuda-voa HTTP 200). The render script logs every console.error and printed
+      none on any of the four. Synthetic data only - prc_01HZX9SYNTHETIC01..07 and
+      staff.one/two/three@example.test.
+    exit: 0
+    ts: "2026-09-13T11:41:00+08:00"
+    seat: Claude Opus 5
+  - claim: A5 — what the renders show against concept F, including where they differ.
+    cmd: read the four PNGs
+    result: >-
+      Present - copper 56x3 rule, Fraunces masthead ("Practices" / the practice id),
+      10px tracked eyebrows, copper serif numerals 01..07, outlined pills with a 6px
+      leading dot, hairline table on paper, tabular numerals, copper left rule on the
+      private staff note, copper back link, outlined transition pill. Differs - the
+      "ours/moving" and "done" pills read the kita daylight blue/green, not R19 slate
+      and forest (D-tokens-not-hexes); the primary buttons use --state-success, which is
+      that same green rather than forest.
+    exit: 0
+    ts: "2026-09-13T11:43:00+08:00"
+    seat: Claude Opus 5
+  - claim: No client PII anywhere in the diff or the renders.
+    cmd: read the changed files and the render fixture
+    result: "the only identities are prc_/ord_01HZX9SYNTHETIC01..07, blk_01HZX9SYNTHETIC01, staff.one/two/three@example.test and console.render@example.test — synthetic, reserved-TLD addresses."
+    exit: 0
+    ts: "2026-09-13T11:44:00+08:00"
+    seat: Claude Opus 5
+dissent:
+  - seat: Claude Opus 5 (self-refutation, on the palette)
+    objection: >-
+      Calling this "R19" while two of the four meanings render in the kita daylight
+      blue and green overstates it. A staffer looking at concept F's renders and at
+      this console side by side sees two different colour stories for "in progress"
+      and "done".
+    status: CONFIRMED
+    cure: >-
+      Not cured, deliberately, and stated in the code: r19.tsx's doc block carries the
+      caveat, and it is the first leftover below. Curing it means declaring the R19
+      values for [data-product="kita"] in globals.css, which restyles every workspace
+      page - a theme-layer window, not this one. What IS delivered without it: the
+      typography, the hairlines, the outlined pill vocabulary, the copper law and the
+      no-red rule, all of which follow the token seam the day kita gets R19 values.
+  - seat: Claude Opus 5 (self-refutation, on the visual proof)
+    objection: >-
+      The screenshots are rendered against an intercepted API, not against a real staff
+      session on kita.balizero.com. They prove the markup and the CSS, not that the
+      live console answers with this data.
+    status: CONFIRMED
+    cure: >-
+      Accepted as the window brief's own fallback ("use the e2e mock approach of the
+      repo"). The live half that CAN be observed without a staff session - that
+      kita.balizero.com/garuda-voa still answers 200 after the deploy - is the PR's
+      Bites observation. Production carries zero practices today (grounding report
+      §B.3), so no real-data render exists to take.
+  - seat: Claude Opus 5 (self-refutation, on the guard test)
+    objection: >-
+      r19.test.tsx scans source TEXT, which is the over/under-match family: it exempts
+      comment lines by prefix, so a hex on a block-comment continuation line that does
+      not start with "*" would be judged as code, and a hex built by string
+      concatenation would pass.
+    status: PLAUSIBLE
+    cure: >-
+      Not cured. The same per-line contract and the same known limit are what
+      scripts/token_lint.py documents for the CI gate this mirrors, and the guilt case
+      is filed beside the innocence case so the limit is visible rather than assumed.
+      The guard's job is to catch the regression that actually happens - someone
+      reaching for --state-danger - and it does, by name and line number.
+leftovers:
+  - 'On [data-product="kita"] the four meanings resolve to the daylight AA steps (--state-success #147a3a, --state-info #1d4ed8), not R19 forest/slate. A theme-layer window that adds an R19 block for kita, as globals.css already has for "my", would make this console read the real concept-F palette with no change to these files.'
+  - PR 1 of this window is open PR #6400 and is not ours to gate. It carries the INTERNAL_ROUTES entry for /garuda-voa and a filesystem-derived coverage test; it needs a fresh gate session to post harness/fable-gate on 537424b7 so its floor recompute can be re-run.
+  - The staff console's remaining pre-R19 surfaces — error.tsx and loading.tsx — were left untouched (neutral spinner and message, no colour to correct); they would follow a shared primitive if one is ever extracted.
+  - The list keeps a table rather than concept F's numbered index of hairline rows; if a later window wants the mock's shape exactly, the copper numeral column and the pill vocabulary are already in place to lift.
+  - Five mouth test files are red on origin/main content and stayed red — (workspace)/process, (workspace)/settings/appearance, visa/match, visa/voa/[hash], visa/voa. 65 tests. Outside this perimeter, reported not touched.


### PR DESCRIPTION
## What was wrong

G0.4 ruled **R19** for the GARUDA VOA staff console on 2026-09-03
(`docs/plans/2026-09-03-relaunch-lanes/ZERO-DECISIONS.md:19`) and nothing implemented it.
`grep -rln "R19"` over both VOA UI trees returns nothing. The console still wore the pre-R19
kita dressing: filled state chips, a **red** danger alert, `--bz-accent` spinners, a bold sans
masthead.

## What it reads now

The concept-F "RAPI" pass, the same idiom shipped on the client portal
(`apps/mouth/src/app/portal/(authenticated)/page.tsx`, `components/portal/StatusBadge.tsx`) —
copper 56×3 rule + Fraunces masthead, 10px tracked eyebrows, hairlines instead of filled cards,
copper serif numerals, and the seven contract states as **outlined** pills in four colour
meanings.

**Presentation only.** The profile probe, the admin/assigned narrowing, the abort-on-change
load, the command builder, the Idempotency-Key lifecycle and the read-only `resolved_block_id`
prefill are unchanged; the 25 pre-existing test cases still select by the same testids, labels
and strings.

## No red, and a guard that says so

`--state-danger` resolves to `#b91c1c` on the kita daylight theme
(`packages/core/tokens/semantic.css:191`), so concept F §3's re-alias is applied here: **Blocked**
and **Rejected** take the copper "needs you" step and keep their WORD. `r19.test.tsx` scans the
console's own rendered sources and goes red on a danger-token read or a hardcoded hex.

| probe | result |
|---|---|
| `--state-danger` planted in `r19.tsx` | **RED**, `r19.tsx:57 — reads --state-danger` (2 tests) |
| the same file restored | green, 7 passed |
| copper / `--state-success` classes | not flagged |
| a comment line naming `#b91c1c` | not flagged |

## What it does NOT do, measured not assumed

The R19 hues (forest `#253E33`, slate `#233D52`) live in `globals.css` under
`[data-product="my"]`; `grep` over `packages/core/tokens/` and `apps/mouth/src/styles/` returns
none of them, so there is **no R19 token for kita to read**. This console reads the same TOKEN
NAMES as the portal, which on kita resolve to the daylight AA steps — so "in progress" and "done"
render blue and green rather than slate and forest. Giving kita the R19 values is a theme-layer
change that restyles the whole workspace: outside this window, recorded as the first leftover.

## The other half of this window — closed by #6400 while this was being built

PR 1 of this window was "the public domain must stop serving `/garuda-voa`". It was NOT rewritten:
#6400 already carried the cure (`"/garuda-voa"` in an exported `INTERNAL_ROUTES`, plus a test that
derives the route list from the filesystem) and its only red was `harness_gate_read: PENDING`, i.e.
gate mechanics. It **merged at 2026-09-13T03:44:54Z** (`86ec37e4d0`) and is now live — measured
here at 04:07:11Z:

```
curl -o /dev/null -w '%{http_code} %{redirect_url}'  https://balizero.com/garuda-voa
  -> 301 https://kita.balizero.com/garuda-voa      (was 200 with the workspace shell)
curl -o /dev/null -w '%{http_code}'  https://kita.balizero.com/garuda-voa   -> 200
curl -o /dev/null -w '%{http_code}'  https://balizero.com/about             -> 200
```

The third line is the innocence half: a genuinely public route still answers 200 on the public
domain.

**Correction to the committed pack:** its second `leftovers:` entry says #6400 "needs a fresh gate
session". That was true when the pack was written at 03:35Z and is false as of 03:44Z. It is
corrected here rather than in a new commit, because a new commit would invalidate the gate sha this
PR is waiting on.

## Verification

- `npx vitest run "src/app/(workspace)/garuda-voa"` → **6 files / 32 tests green**
- full mouth suite: 474/479 files green; the 5 red files (`(workspace)/process`,
  `(workspace)/settings/appearance`, `visa/match`, `visa/voa/[hash]`, `visa/voa`) are red on the
  **same tree without this change** — 65 failed / 1 passed, identical count
- `npx tsc --noEmit` 0 · eslint 0 errors · prettier clean · `token_lint.py --base origin/main` clean
- gear **2**, deterministic floor **2** (source `size`: added 731, deleted 217, churn 948)
- four route-intercepted renders from a production build at 1440 and 390, **0 console errors**,
  synthetic data only: `/Users/balizero/Desktop/R3-RENDERS-20260913/voa-v3/`

**Bites:** the Bali Zero staff who work VOA practices at `https://kita.balizero.com/garuda-voa` —
after the Vercel deploy that merging triggers, that URL still answers 200 and serves the reskinned
console (measured 200 at 04:07:11Z on the pre-merge build), with the negative that the public
domain answers 301 there and NOT 200, so the reskin is reachable on exactly one host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
