### PR TITLE
docs(evidence): carry the floor command instead of a stale file count in the D4d brief (SHWEB W-ORACLE)

### DIFF
--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d4d-2026091-5a45de84/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d4d-2026091-5a45de84/brief.yml
@@ -1,11 +1,13 @@
 gear: 2
 gear_reason: >-
-  Measured with the inputs CI uses — `scripts/evidence_pack_lint.py --print-floor
-  --changed-files-file <f> --numstat-file <n>` returns 2 (18 files touched, run against this
-  branch's real working-tree diff off `ac05dfc6f4`). Taking the floor without `--numstat-file`
-  under-reports it to 1 — measured in this same session — and that omission has been rejected
-  three times in this mandate (#6240, PR-O2's brief, PR-D3c's brief). No digit is typed: re-run
-  both invocations to check.
+  Measured with the inputs CI uses — the floor is computed with
+  `python3 scripts/evidence_pack_lint.py <evidence dir> --print-floor
+  --changed-files-file <f> --numstat-file <n>` on the 3-dot changed files and
+  numstat, run against this branch's real diff off `ac05dfc6f4`. Taking the
+  floor without `--numstat-file` under-reports it — measured in this same
+  session — and that omission has been rejected three times in this mandate
+  (#6240, PR-O2's brief, PR-D3c's brief). No digit is typed: re-run the
+  command to check.
 task_id: shweb-w-oracle-d4d-20260913
 mandate_id: SHWEB-20260911/W-ORACLE/PR-D4d
 colour: BLUE


### PR DESCRIPTION
## Summary
- Discharges `.claude/skills/modus/PENDING-ARMS.md` #6384 row condition C1: `evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d4d-2026091-5a45de84/brief.yml`'s `gear_reason` quoted "18 files touched" while the gated head had 19 — the digit moves between commits.
- Replaces the bare figure with the measuring command (`python3 scripts/evidence_pack_lint.py <evidence dir> --print-floor --changed-files-file F --numstat-file N`, on the 3-dot changed files and numstat), so the claim reproduces instead of going stale.
- No other key in the brief (gear, task_id, scope, constraints, acceptance) is touched. YAML validated with `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"`.
- Split from a combined attempt: `scripts/ci/evidence_paths.py --resolve brief` is ambiguous when two dated evidence briefs land in one PR, so this discharges only the #6384/C1 hunk; the #6402/C4 hunk ships as a separate PR (`agent/air-m5/docs/tidy-risync-brief-6402-c4`).

## Test plan
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" evidence/2026-09/agent-mini-pro2-mouth-shweb-w-oracle-d4d-2026091-5a45de84/brief.yml`
- [x] `scripts/ci/evidence_paths.py --resolve brief` resolves this PR's own brief unambiguously
- [x] `scripts/evidence_pack_lint.py <dir> --print-floor --changed-files-file F --numstat-file N` runs clean (exit 0) against this PR's own diff

Bites: scripts/pending_arms_report.py and the imperator's closing ledger rows for #6384 C1 and #6402 C4 — the two briefs on origin/main carry the floor command and no bare churn figure (grep for "files touched" and for "insertions" in both briefs returns 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
