### PR TITLE
docs(evidence): carry the floor command instead of churn figures in the RISYNC brief (SHWEB W-ORACLE)

### DIFF
--- a/evidence/2026-09/agent-mini-pro2-mouth-shweb-risync-schema-202609-f8072ef1/brief.yml
+++ b/evidence/2026-09/agent-mini-pro2-mouth-shweb-risync-schema-202609-f8072ef1/brief.yml
@@ -6,12 +6,14 @@ gate_class: opus
 l_level: L2
 gear_note: >-
   Declared 3 to match the floor computed by
-  `scripts/evidence_pack_lint.py --print-floor --changed-files-file
-  <changed> --numstat-file <numstat>` (source: size), re-run after the LAST
-  commit (150c8d36e4). Total churn 3,185 across 5 files
-  (schema.d.ts 2,894; sitemap.test.ts 185; test_generate_openapi_schema_pin.py
-  60; generate_openapi.py 45; the pin file 1), above SIZE_GEAR3_THRESHOLD
-  (1828).
+  `python3 scripts/evidence_pack_lint.py <evidence dir> --print-floor
+  --changed-files-file <changed> --numstat-file <numstat>` (source: size),
+  re-run after the LAST commit (150c8d36e4). No bare churn figure is recorded
+  here, on purpose — this PR's own commits kept moving it, so any number
+  typed would be stale before it is read (`pack.yml` in this same directory
+  carries the same note, for the same reason). The measurement IS the
+  command, reproducible at whatever head it runs on, over the 5 CODE files
+  (evidence/*.yml excluded), above SIZE_GEAR3_THRESHOLD (1828).
 base_sha: 88ef221d632a3e463b80cc439fbe39f473f37a12 # pragma: allowlist secret (a git commit SHA, not a credential)
 objective: >-
   PR-RISYNC of the Visa Oracle rebuild (mandate SHWEB-20260911).


### PR DESCRIPTION
## Summary
- Discharges `.claude/skills/modus/PENDING-ARMS.md` #6402 row condition C4: `evidence/2026-09/agent-mini-pro2-mouth-shweb-risync-schema-202609-f8072ef1/brief.yml`'s `gear_note` quoted churn figures (total churn 3,185, plus a per-file insertion/deletion breakdown) that do not reproduce across observers — the same defect `pack.yml` in the same directory was already cured of.
- Replaces the bare figures with the measuring command (`python3 scripts/evidence_pack_lint.py <evidence dir> --print-floor --changed-files-file F --numstat-file N`), mirroring `pack.yml`'s already-cured wording; keeps the `SIZE_GEAR3_THRESHOLD (1828)` constant and the stable 5-file count.
- No other key in the brief (gear, base_sha, task_id, spec, constraints, acceptance) is touched. YAML validated with `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"`.
- Split from a combined attempt: `scripts/ci/evidence_paths.py --resolve brief` is ambiguous when two dated evidence briefs land in one PR, so this discharges only the #6402/C4 hunk; the #6384/C1 hunk shipped as a separate PR (`agent/air-m5/docs/tidy-d4d-brief-6384-c1`).

## Test plan
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" evidence/2026-09/agent-mini-pro2-mouth-shweb-risync-schema-202609-f8072ef1/brief.yml`
- [x] `scripts/ci/evidence_paths.py --resolve brief` resolves this PR's own brief unambiguously
- [x] `scripts/evidence_pack_lint.py <dir> --print-floor --changed-files-file F --numstat-file N` runs clean (exit 0) against this PR's own diff
- [x] `scripts/evidence_pack_lint.py <dir>/pack.yml --changed-files-file F --numstat-file N` still reports clean

Bites: scripts/pending_arms_report.py and the imperator's closing ledger rows for #6384 C1 and #6402 C4 — the two briefs on origin/main carry the floor command and no bare churn figure (grep for "files touched" and for "insertions" in both briefs returns 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
